### PR TITLE
Fix heartbeat crash on invalid definitions

### DIFF
--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -89,6 +89,8 @@ export type {
   AuthService,
   AuthUser,
   ProcessRepository,
+  DefinitionListResult,
+  InvalidDefinitionEntry,
   ProcessInstanceRepository,
   HumanTaskRepository,
   HandoffRepository,

--- a/packages/platform-core/src/interfaces/index.ts
+++ b/packages/platform-core/src/interfaces/index.ts
@@ -1,6 +1,6 @@
 export type { AuditRepository } from './audit-repository.js';
 export type { AuthService, AuthUser } from './auth-service.js';
-export type { ProcessRepository } from './process-repository.js';
+export type { ProcessRepository, DefinitionListResult, InvalidDefinitionEntry } from './process-repository.js';
 export type { ProcessInstanceRepository } from './process-instance-repository.js';
 export type { HumanTaskRepository } from './human-task-repository.js';
 export type { HandoffRepository } from './handoff-repository.js';

--- a/packages/platform-core/src/interfaces/process-repository.ts
+++ b/packages/platform-core/src/interfaces/process-repository.ts
@@ -1,5 +1,16 @@
+import type { ZodError } from 'zod';
 import type { ProcessDefinition } from '../schemas/process-definition.js';
 import type { ProcessConfig } from '../schemas/process-config.js';
+
+export interface InvalidDefinitionEntry {
+  data: unknown;
+  error: ZodError;
+}
+
+export interface DefinitionListResult {
+  valid: ProcessDefinition[];
+  invalid: InvalidDefinitionEntry[];
+}
 
 export interface ProcessRepository {
   getProcessDefinition(
@@ -7,7 +18,7 @@ export interface ProcessRepository {
     version: string,
   ): Promise<ProcessDefinition | null>;
   saveProcessDefinition(definition: ProcessDefinition): Promise<void>;
-  listProcessDefinitions(): Promise<ProcessDefinition[]>;
+  listProcessDefinitions(): Promise<DefinitionListResult>;
   getProcessConfig(
     processName: string,
     configName: string,

--- a/packages/platform-core/src/testing/in-memory-process-repository.ts
+++ b/packages/platform-core/src/testing/in-memory-process-repository.ts
@@ -2,6 +2,7 @@ import type {
   ProcessRepository,
   ProcessDefinition,
   ProcessConfig,
+  DefinitionListResult,
 } from '../index.js';
 
 /**
@@ -31,8 +32,8 @@ export class InMemoryProcessRepository implements ProcessRepository {
     );
   }
 
-  async listProcessDefinitions(): Promise<ProcessDefinition[]> {
-    return Array.from(this.definitions.values());
+  async listProcessDefinitions(): Promise<DefinitionListResult> {
+    return { valid: Array.from(this.definitions.values()), invalid: [] };
   }
 
   async getProcessConfig(

--- a/packages/platform-infra/src/firestore/process-repository.ts
+++ b/packages/platform-infra/src/firestore/process-repository.ts
@@ -3,6 +3,7 @@ import {
   type ProcessRepository,
   type ProcessDefinition,
   type ProcessConfig,
+  type DefinitionListResult,
 } from '@mediforce/platform-core';
 import {
   collection,
@@ -105,11 +106,25 @@ export class FirestoreProcessRepository implements ProcessRepository {
     await setDoc(docRef, definition);
   }
 
-  async listProcessDefinitions(): Promise<ProcessDefinition[]> {
+  async listProcessDefinitions(): Promise<DefinitionListResult> {
     const snapshot = await getDocs(
       collection(this.db, this.definitionsCollection),
     );
-    return snapshot.docs.map((d) => ProcessDefinitionSchema.parse(d.data()));
+    const result: DefinitionListResult = { valid: [], invalid: [] };
+    for (const docSnap of snapshot.docs) {
+      const raw = docSnap.data();
+      const parsed = ProcessDefinitionSchema.safeParse(raw);
+      if (parsed.success) {
+        result.valid.push(parsed.data);
+      } else {
+        console.warn(
+          `[process-repository] Invalid definition document ${docSnap.id}:`,
+          parsed.error.format(),
+        );
+        result.invalid.push({ data: raw, error: parsed.error });
+      }
+    }
+    return result;
   }
 
   async getProcessConfig(

--- a/packages/platform-ui/src/app/api/cron/heartbeat/route.ts
+++ b/packages/platform-ui/src/app/api/cron/heartbeat/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const skipped: SkippedEntry[] = [];
 
   try {
-    const definitions = await processRepo.listProcessDefinitions();
+    const { valid: definitions } = await processRepo.listProcessDefinitions();
 
     // Filter to non-archived definitions that have at least one cron trigger
     const cronDefinitions = definitions.filter(


### PR DESCRIPTION
## Summary
- `listProcessDefinitions()` now returns `{ valid, invalid }` instead of throwing when a Firestore document fails zod schema validation
- Invalid documents are logged with a warning and collected in `invalid[]` — no data lost, callers decide what to use
- Heartbeat endpoint uses `valid` only, so one malformed definition no longer crashes the entire cron job

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 792 passed
- [x] `pnpm test:e2e` — 2 passed
- [x] `pnpm test:e2e:auth` — 48 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)