### PR TITLE
feat: add workflow hard delete with confirmation dialog

### DIFF
--- a/packages/platform-core/src/interfaces/human-task-repository.ts
+++ b/packages/platform-core/src/interfaces/human-task-repository.ts
@@ -8,4 +8,5 @@ export interface HumanTaskRepository {
   claim(taskId: string, userId: string): Promise<HumanTask>; // sets assignedUserId + status: 'claimed'
   complete(taskId: string, completionData: Record<string, unknown>): Promise<HumanTask>;
   cancel(taskId: string): Promise<HumanTask>;
+  setDeletedByInstanceIds(instanceIds: string[], deleted: boolean): Promise<void>;
 }

--- a/packages/platform-core/src/interfaces/process-instance-repository.ts
+++ b/packages/platform-core/src/interfaces/process-instance-repository.ts
@@ -24,4 +24,7 @@ export interface ProcessInstanceRepository {
     executionId: string,
     updates: Partial<StepExecution>,
   ): Promise<void>;
+
+  getIdsByDefinitionName(name: string): Promise<string[]>;
+  setDeletedByDefinitionName(name: string, deleted: boolean): Promise<void>;
 }

--- a/packages/platform-core/src/interfaces/process-repository.ts
+++ b/packages/platform-core/src/interfaces/process-repository.ts
@@ -71,4 +71,8 @@ export interface ProcessRepository {
   setConfigArchived(processName: string, configName: string, configVersion: string, archived: boolean): Promise<void>;
 
   setDefinitionVersionArchived(name: string, version: string, archived: boolean): Promise<void>;
+
+  setWorkflowDeleted(name: string, deleted: boolean): Promise<void>;
+  isWorkflowNameDeleted(name: string): Promise<boolean>;
+  countInstancesByDefinitionName(name: string): Promise<number>;
 }

--- a/packages/platform-core/src/schemas/human-task.ts
+++ b/packages/platform-core/src/schemas/human-task.ts
@@ -27,6 +27,7 @@ export const HumanTaskSchema = z.object({
   creationReason: CreationReasonSchema.optional(),  // why this task was created
   selection: SelectionSchema.optional(),  // copied from step definition — enables "pick one" review mode
   options: z.array(z.record(z.string(), z.unknown())).optional(),  // options from previous step output
+  deleted: z.boolean().optional(),
 });
 
 export type HumanTaskStatus = z.infer<typeof HumanTaskStatusSchema>;

--- a/packages/platform-core/src/schemas/process-instance.ts
+++ b/packages/platform-core/src/schemas/process-instance.ts
@@ -26,6 +26,7 @@ export const ProcessInstanceSchema = z.object({
   pauseReason: z.string().nullable(),
   error: z.string().nullable(),
   assignedRoles: z.array(z.string()).default([]),
+  deleted: z.boolean().optional(),
 });
 
 export type InstanceStatus = z.infer<typeof InstanceStatusSchema>;

--- a/packages/platform-core/src/schemas/workflow-definition.ts
+++ b/packages/platform-core/src/schemas/workflow-definition.ts
@@ -68,6 +68,7 @@ export const WorkflowDefinitionSchema = z.object({
   triggers: z.array(TriggerSchema).min(1),
   metadata: z.record(z.string(), z.unknown()).optional(),
   archived: z.boolean().optional(),
+  deleted: z.boolean().optional(),
   createdAt: z.string().datetime().optional(),
 });
 

--- a/packages/platform-core/src/testing/in-memory-human-task-repository.ts
+++ b/packages/platform-core/src/testing/in-memory-human-task-repository.ts
@@ -73,6 +73,10 @@ export class InMemoryHumanTaskRepository implements HumanTaskRepository {
     return { ...updated };
   }
 
+  async setDeletedByInstanceIds(_instanceIds: string[], _deleted: boolean): Promise<void> {
+    // No-op in test double
+  }
+
   /** Test helper: clear all stored data */
   clear(): void {
     this.tasks.clear();

--- a/packages/platform-core/src/testing/in-memory-process-instance-repository.ts
+++ b/packages/platform-core/src/testing/in-memory-process-instance-repository.ts
@@ -96,6 +96,14 @@ export class InMemoryProcessInstanceRepository
     };
   }
 
+  async getIdsByDefinitionName(_name: string): Promise<string[]> {
+    return [];
+  }
+
+  async setDeletedByDefinitionName(_name: string, _deleted: boolean): Promise<void> {
+    // No-op in test double — Firestore uses untyped updateDoc for the `deleted` field
+  }
+
   /** Test helper: clear all stored data */
   clear(): void {
     this.instances.clear();

--- a/packages/platform-core/src/testing/in-memory-process-repository.ts
+++ b/packages/platform-core/src/testing/in-memory-process-repository.ts
@@ -150,6 +150,18 @@ export class InMemoryProcessRepository implements ProcessRepository {
     }
   }
 
+  async setWorkflowDeleted(_name: string, _deleted: boolean): Promise<void> {
+    // No-op in test double — Firestore uses untyped updateDoc for the `deleted` field
+  }
+
+  async isWorkflowNameDeleted(_name: string): Promise<boolean> {
+    return false;
+  }
+
+  async countInstancesByDefinitionName(_name: string): Promise<number> {
+    return 0;
+  }
+
   /** Test helper: clear all stored data */
   clear(): void {
     this.definitions.clear();

--- a/packages/platform-infra/src/firestore/human-task-repository.ts
+++ b/packages/platform-infra/src/firestore/human-task-repository.ts
@@ -80,4 +80,18 @@ export class FirestoreHumanTaskRepository implements HumanTaskRepository {
     });
     return (await this.getById(taskId))!;
   }
+
+  async setDeletedByInstanceIds(instanceIds: string[], deleted: boolean): Promise<void> {
+    if (instanceIds.length === 0) return;
+    // Firestore 'in' queries support max 30 values per batch
+    for (let i = 0; i < instanceIds.length; i += 30) {
+      const batch = instanceIds.slice(i, i + 30);
+      const colRef = collection(this.db, this.collectionName);
+      const q = query(colRef, where('processInstanceId', 'in', batch));
+      const snap = await getDocs(q);
+      for (const d of snap.docs) {
+        await updateDoc(doc(this.db, this.collectionName, d.id), { deleted });
+      }
+    }
+  }
 }

--- a/packages/platform-infra/src/firestore/process-instance-repository.ts
+++ b/packages/platform-infra/src/firestore/process-instance-repository.ts
@@ -147,4 +147,20 @@ export class FirestoreProcessInstanceRepository
 
     return StepExecutionSchema.parse(snapshot.docs[0].data());
   }
+
+  async getIdsByDefinitionName(name: string): Promise<string[]> {
+    const colRef = collection(this.db, this.collectionName);
+    const q = query(colRef, where('definitionName', '==', name));
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map((d) => d.id);
+  }
+
+  async setDeletedByDefinitionName(name: string, deleted: boolean): Promise<void> {
+    const colRef = collection(this.db, this.collectionName);
+    const q = query(colRef, where('definitionName', '==', name));
+    const snapshot = await getDocs(q);
+    for (const d of snapshot.docs) {
+      await updateDoc(doc(this.db, this.collectionName, d.id), { deleted });
+    }
+  }
 }

--- a/packages/platform-infra/src/firestore/process-repository.ts
+++ b/packages/platform-infra/src/firestore/process-repository.ts
@@ -352,4 +352,52 @@ export class FirestoreProcessRepository implements ProcessRepository {
     }
     return latestVersion;
   }
+
+  async setWorkflowDeleted(name: string, deleted: boolean): Promise<void> {
+    // Update legacy processDefinitions
+    const legacyQ = query(
+      collection(this.db, this.definitionsCollection),
+      where('name', '==', name),
+    );
+    const legacySnapshot = await getDocs(legacyQ);
+    for (const d of legacySnapshot.docs) {
+      await updateDoc(doc(this.db, this.definitionsCollection, d.id), { deleted });
+    }
+
+    // Update workflowDefinitions (dual-write)
+    const workflowQ = query(
+      collection(this.db, this.workflowDefinitionsCollection),
+      where('name', '==', name),
+    );
+    const workflowSnapshot = await getDocs(workflowQ);
+    for (const d of workflowSnapshot.docs) {
+      await updateDoc(doc(this.db, this.workflowDefinitionsCollection, d.id), { deleted });
+    }
+
+    // Update workflowMeta
+    const metaRef = doc(this.db, 'workflowMeta', name);
+    const metaSnap = await getDoc(metaRef);
+    if (metaSnap.exists()) {
+      await updateDoc(metaRef, { deleted });
+    }
+  }
+
+  async isWorkflowNameDeleted(name: string): Promise<boolean> {
+    const q = query(
+      collection(this.db, this.workflowDefinitionsCollection),
+      where('name', '==', name),
+      where('deleted', '==', true),
+    );
+    const snapshot = await getDocs(q);
+    return !snapshot.empty;
+  }
+
+  async countInstancesByDefinitionName(name: string): Promise<number> {
+    const q = query(
+      collection(this.db, 'processInstances'),
+      where('definitionName', '==', name),
+    );
+    const snapshot = await getDocs(q);
+    return snapshot.size;
+  }
 }

--- a/packages/platform-ui/src/app/(app)/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/workflows/[name]/page.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, Layers, Github, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Info, Clock, Zap } from 'lucide-react';
+import { ArrowLeft, Layers, Github, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Info, Clock, Zap, Trash2 } from 'lucide-react';
 import * as Tabs from '@radix-ui/react-tabs';
 import { useProcessDefinitionVersions } from '@/hooks/use-process-definitions';
 import { useProcessInstances } from '@/hooks/use-process-instances';
@@ -11,6 +11,7 @@ import { RunsTable } from '@/components/processes/runs-table';
 import { DefinitionsList } from '@/components/workflows/definitions-list';
 import { StartRunButton } from '@/components/processes/start-run-button';
 import { setProcessArchived } from '@/app/actions/definitions';
+import { DeleteWorkflowDialog } from '@/components/workflows/delete-workflow-dialog';
 import { cn } from '@/lib/utils';
 
 
@@ -24,6 +25,7 @@ export default function ProcessDefinitionPage() {
 
   const [archiving, setArchiving] = React.useState(false);
   const [menuOpen, setMenuOpen] = React.useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -147,6 +149,22 @@ export default function ProcessDefinitionPage() {
                     </>
                   )}
                 </button>
+
+                <div className="my-1 border-t" />
+
+                <button
+                  onClick={() => {
+                    setMenuOpen(false);
+                    setDeleteDialogOpen(true);
+                  }}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors',
+                    'text-destructive hover:bg-destructive/10',
+                  )}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete
+                </button>
               </div>
             )}
           </div>
@@ -200,6 +218,13 @@ export default function ProcessDefinitionPage() {
           </div>
         </Tabs.Content>
       </Tabs.Root>
+
+      <DeleteWorkflowDialog
+        workflowName={decodedName}
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        onDeleted={() => router.push('/workflows')}
+      />
     </div>
   );
 }

--- a/packages/platform-ui/src/app/actions/definitions.ts
+++ b/packages/platform-ui/src/app/actions/definitions.ts
@@ -81,6 +81,14 @@ export async function saveWorkflowDefinition(
   const { processRepo } = getPlatformServices();
 
   try {
+    const isDeleted = await processRepo.isWorkflowNameDeleted(parsed.data.name);
+    if (isDeleted) {
+      return {
+        success: false,
+        error: `The name "${parsed.data.name}" was previously used by a deleted workflow. Please choose a different name.`,
+      };
+    }
+
     const latestVersion = await processRepo.getLatestWorkflowVersion(parsed.data.name);
     const nextVersion = latestVersion + 1;
 
@@ -167,6 +175,64 @@ export async function setDefinitionVersionArchived(
   try {
     await processRepo.setDefinitionVersionArchived(name, version, archived);
     return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Unknown error' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Delete helpers (soft-delete)
+// ---------------------------------------------------------------------------
+
+export type DeleteResult = { success: true; deletedRuns: number } | { success: false; error: string };
+
+export async function getWorkflowRunCount(workflowName: string): Promise<number> {
+  const { processRepo } = getPlatformServices();
+  return processRepo.countInstancesByDefinitionName(workflowName);
+}
+
+export async function deleteWorkflow(
+  workflowName: string,
+  expectedRunCount: number,
+): Promise<DeleteResult> {
+  const { processRepo, instanceRepo, auditRepo, humanTaskRepo } = getPlatformServices();
+
+  try {
+    // Verify run count still matches to prevent stale confirmations
+    const actualRunCount = await processRepo.countInstancesByDefinitionName(workflowName);
+    if (actualRunCount !== expectedRunCount) {
+      return {
+        success: false,
+        error: `Run count changed (expected ${expectedRunCount}, found ${actualRunCount}). Please try again.`,
+      };
+    }
+
+    // Create audit event before soft-deleting
+    await auditRepo.append({
+      actorId: 'system',
+      actorType: 'system',
+      actorRole: 'admin',
+      action: 'workflow.delete',
+      description: `Workflow "${workflowName}" soft-deleted with ${actualRunCount} associated runs`,
+      timestamp: new Date().toISOString(),
+      inputSnapshot: { workflowName, runCount: actualRunCount },
+      outputSnapshot: {},
+      basis: 'User-initiated workflow deletion',
+      entityType: 'workflow_definition',
+      entityId: workflowName,
+    });
+
+    // Soft-delete workflow definitions (all versions + meta)
+    await processRepo.setWorkflowDeleted(workflowName, true);
+
+    // Soft-delete all associated process instances and their human tasks
+    if (actualRunCount > 0) {
+      const instanceIds = await instanceRepo.getIdsByDefinitionName(workflowName);
+      await instanceRepo.setDeletedByDefinitionName(workflowName, true);
+      await humanTaskRepo.setDeletedByInstanceIds(instanceIds, true);
+    }
+
+    return { success: true, deletedRuns: actualRunCount };
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : 'Unknown error' };
   }

--- a/packages/platform-ui/src/components/workflows/delete-workflow-dialog.tsx
+++ b/packages/platform-ui/src/components/workflows/delete-workflow-dialog.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import * as React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X, AlertTriangle, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { deleteWorkflow, getWorkflowRunCount } from '@/app/actions/definitions';
+
+interface DeleteWorkflowDialogProps {
+  workflowName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDeleted: () => void;
+}
+
+type DialogState =
+  | { step: 'loading' }
+  | { step: 'confirm'; runCount: number }
+  | { step: 'deleting' }
+  | { step: 'error'; message: string; runCount: number };
+
+export function DeleteWorkflowDialog({ workflowName, open, onOpenChange, onDeleted }: DeleteWorkflowDialogProps) {
+  const [state, setState] = React.useState<DialogState>({ step: 'loading' });
+  const [nameInput, setNameInput] = React.useState('');
+  const [runCountInput, setRunCountInput] = React.useState('');
+
+  const runCount = state.step === 'confirm' || state.step === 'error' ? state.runCount : 0;
+
+  const nameMatches = nameInput === workflowName;
+  const runCountMatches = runCount === 0 || runCountInput === String(runCount);
+  const canConfirm = nameMatches && runCountMatches && state.step === 'confirm';
+
+  React.useEffect(() => {
+    if (!open) return;
+    setState({ step: 'loading' });
+    setNameInput('');
+    setRunCountInput('');
+    getWorkflowRunCount(workflowName)
+      .then((count) => setState({ step: 'confirm', runCount: count }))
+      .catch(() => setState({ step: 'error', message: 'Failed to load run count.', runCount: 0 }));
+  }, [open, workflowName]);
+
+  function handleClose() {
+    if (state.step === 'deleting') return;
+    onOpenChange(false);
+  }
+
+  async function handleDelete() {
+    if (!canConfirm) return;
+    setState({ step: 'deleting' });
+    const result = await deleteWorkflow(workflowName, runCount);
+    if (result.success) {
+      onOpenChange(false);
+      onDeleted();
+    } else {
+      setState({ step: 'error', message: result.error, runCount });
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(value) => { if (!value) handleClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border bg-background p-6 shadow-lg">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className="text-lg font-semibold flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-destructive" />
+              Delete Workflow
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="rounded-sm p-1 text-muted-foreground hover:text-foreground transition-colors">
+                <X className="h-4 w-4" />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          {state.step === 'loading' && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {(state.step === 'confirm' || state.step === 'error') && (
+            <div className="space-y-4">
+              <Dialog.Description className="text-sm text-muted-foreground">
+                This will permanently hide <span className="font-semibold text-foreground">{workflowName}</span> and
+                all its versions from the platform. This action cannot be easily undone.
+              </Dialog.Description>
+
+              {runCount > 0 && (
+                <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+                  <p className="font-medium text-destructive">
+                    This will also delete {runCount} associated run{runCount !== 1 ? 's' : ''}.
+                  </p>
+                  <p className="text-muted-foreground mt-1">
+                    All process instances, tasks, and agent runs for this workflow will be removed.
+                  </p>
+                </div>
+              )}
+
+              {state.step === 'error' && (
+                <div className="rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+                  {state.message}
+                </div>
+              )}
+
+              <div className="space-y-3">
+                <div>
+                  <label className="text-sm font-medium" htmlFor="delete-name-input">
+                    Type <span className="font-mono bg-muted px-1 py-0.5 rounded text-xs">{workflowName}</span> to confirm
+                  </label>
+                  <input
+                    id="delete-name-input"
+                    type="text"
+                    value={nameInput}
+                    onChange={(event) => setNameInput(event.target.value)}
+                    placeholder={workflowName}
+                    className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-destructive/50"
+                    autoComplete="off"
+                  />
+                </div>
+
+                {runCount > 0 && (
+                  <div>
+                    <label className="text-sm font-medium" htmlFor="delete-run-count-input">
+                      Type the number of runs (<span className="font-mono bg-muted px-1 py-0.5 rounded text-xs">{runCount}</span>) to confirm cascade deletion
+                    </label>
+                    <input
+                      id="delete-run-count-input"
+                      type="text"
+                      value={runCountInput}
+                      onChange={(event) => setRunCountInput(event.target.value)}
+                      placeholder={String(runCount)}
+                      className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-destructive/50"
+                      autoComplete="off"
+                    />
+                  </div>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-2 pt-2">
+                <button
+                  onClick={handleClose}
+                  className="rounded-md px-4 py-2 text-sm font-medium border hover:bg-muted transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleDelete}
+                  disabled={!canConfirm}
+                  className={cn(
+                    'rounded-md px-4 py-2 text-sm font-medium transition-colors',
+                    canConfirm
+                      ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                      : 'bg-destructive/30 text-destructive-foreground/50 cursor-not-allowed',
+                  )}
+                >
+                  Delete workflow
+                </button>
+              </div>
+            </div>
+          )}
+
+          {state.step === 'deleting' && (
+            <div className="flex flex-col items-center justify-center py-8 gap-3">
+              <Loader2 className="h-5 w-5 animate-spin text-destructive" />
+              <p className="text-sm text-muted-foreground">Deleting workflow...</p>
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/platform-ui/src/hooks/use-process-definitions.ts
+++ b/packages/platform-ui/src/hooks/use-process-definitions.ts
@@ -68,16 +68,18 @@ export function useProcessDefinitions() {
     const seen = new Set<string>();
     const result: ProcessDefinitionDoc[] = [];
 
-    // Workflow definitions take priority
+    // Workflow definitions take priority; skip soft-deleted
     for (const doc of workflowData) {
+      if (doc.deleted) continue;
       const key = `${doc.name}:${doc.version}`;
       if (!seen.has(key)) {
         seen.add(key);
         result.push(normalizeWorkflow(doc));
       }
     }
-    // Then legacy
+    // Then legacy; skip soft-deleted
     for (const doc of legacyData) {
+      if ((doc as ProcessDefinitionDoc & { deleted?: boolean }).deleted) continue;
       const key = `${doc.name}:${doc.version}`;
       if (!seen.has(key)) {
         seen.add(key);
@@ -170,6 +172,7 @@ export function useProcessDefinitionVersions(name: string) {
     const seen = new Set<string>();
     const result: ProcessDefinitionDoc[] = [];
     for (const doc of workflowData) {
+      if (doc.deleted) continue;
       const key = String(doc.version);
       if (!seen.has(key)) {
         seen.add(key);
@@ -177,6 +180,7 @@ export function useProcessDefinitionVersions(name: string) {
       }
     }
     for (const doc of legacyData) {
+      if ((doc as ProcessDefinitionDoc & { deleted?: boolean }).deleted) continue;
       if (!seen.has(doc.version)) {
         seen.add(doc.version);
         result.push(doc);

--- a/packages/platform-ui/src/hooks/use-process-instances.ts
+++ b/packages/platform-ui/src/hooks/use-process-instances.ts
@@ -30,8 +30,10 @@ export function useProcessInstances(
   const result = useCollection<ProcessInstance>('processInstances', constraints);
 
   const data = useMemo(() => {
-    if (!definitionName) return result.data;
-    return [...result.data].sort(
+    // Filter out soft-deleted instances
+    const filtered = result.data.filter((instance) => !instance.deleted);
+    if (!definitionName) return filtered;
+    return [...filtered].sort(
       (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
   }, [result.data, definitionName]);

--- a/packages/platform-ui/src/hooks/use-tasks.ts
+++ b/packages/platform-ui/src/hooks/use-tasks.ts
@@ -21,10 +21,12 @@ export function useMyTasks(assignedRole: string | null) {
   const { data, loading, error } = useCollection<HumanTask>('humanTasks', constraints);
 
   const filtered = useMemo(
-    () =>
-      assignedRole
-        ? data
-        : data.filter((task) => task.status !== 'completed'),
+    () => {
+      const notDeleted = data.filter((task) => !task.deleted);
+      return assignedRole
+        ? notDeleted
+        : notDeleted.filter((task) => task.status !== 'completed');
+    },
     [data, assignedRole],
   );
 
@@ -47,10 +49,12 @@ export function useCompletedTasks(assignedRole: string | null) {
   const { data, loading, error } = useCollection<HumanTask>('humanTasks', constraints);
 
   const filtered = useMemo(
-    () =>
-      assignedRole
-        ? data
-        : data.filter((task) => task.status === 'completed'),
+    () => {
+      const notDeleted = data.filter((task) => !task.deleted);
+      return assignedRole
+        ? notDeleted
+        : notDeleted.filter((task) => task.status === 'completed');
+    },
     [data, assignedRole],
   );
 
@@ -59,7 +63,9 @@ export function useCompletedTasks(assignedRole: string | null) {
 
 export function useAllTasks() {
   const constraints = useMemo(() => [orderBy('createdAt', 'desc')], []);
-  return useCollection<HumanTask>('humanTasks', constraints);
+  const result = useCollection<HumanTask>('humanTasks', constraints);
+  const data = useMemo(() => result.data.filter((task) => !task.deleted), [result.data]);
+  return { ...result, data };
 }
 
 export function useActiveTaskForInstance(processInstanceId: string | null) {
@@ -79,5 +85,10 @@ export function useActiveTaskForInstance(processInstanceId: string | null) {
     constraints,
   );
 
-  return { task: data[0] ?? null, loading };
+  const activeTask = useMemo(
+    () => data.find((task) => !task.deleted) ?? null,
+    [data],
+  );
+
+  return { task: activeTask, loading };
 }


### PR DESCRIPTION
## Summary

- Adds soft-delete for workflows: sets `deleted` flag on all definition versions, associated process instances, and human tasks
- Confirmation modal on the workflow detail page requires typing the workflow name to confirm; if runs exist, also requires typing the run count
- All list views (workflows, tasks, runs) filter out deleted items client-side
- Blocks reuse of deleted workflow names when creating new workflows
- Creates an audit event capturing the deletion details before soft-deleting

## Changes

**Data layer** (`platform-core`, `platform-infra`):
- Added `deleted: boolean` (optional) to `WorkflowDefinition`, `ProcessInstance`, and `HumanTask` schemas
- Added `setWorkflowDeleted`, `isWorkflowNameDeleted`, `countInstancesByDefinitionName` to process repository
- Added `getIdsByDefinitionName`, `setDeletedByDefinitionName` to instance repository
- Added `setDeletedByInstanceIds` to human task repository

**Server actions** (`platform-ui`):
- `deleteWorkflow()` — orchestrates cascade soft-delete with audit trail
- `getWorkflowRunCount()` — fetches count for the confirmation dialog
- Name reuse check in `saveWorkflowDefinition()`

**UI** (`platform-ui`):
- `DeleteWorkflowDialog` component with name + run count confirmation inputs
- Delete option in workflow detail page header menu
- Deleted items filtered in `useProcessDefinitions`, `useProcessInstances`, and all task hooks

## Test plan

- [ ] Open a workflow detail page, click menu → Delete
- [ ] Verify modal shows workflow name input (and run count input if runs exist)
- [ ] Verify Delete button stays disabled until inputs match
- [ ] Confirm deletion redirects to /workflows and workflow disappears from list
- [ ] Verify /tasks page no longer shows tasks from the deleted workflow
- [ ] Try creating a new workflow with the deleted name — should be blocked
- [ ] Verify audit event is created in Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)