### PR TITLE
UX: clickable step→task links and All Runs in sidebar

### DIFF
--- a/packages/platform-ui/e2e/authenticated/my-runs.spec.ts
+++ b/packages/platform-ui/e2e/authenticated/my-runs.spec.ts
@@ -48,11 +48,11 @@ test.describe('My Runs', () => {
     await expect(page.getByText('Narrative Summary').first()).toBeVisible({ timeout: 10_000 });
   });
 
-  test('[CLICK] clicking instance row navigates to detail', async ({ page }) => {
+  test('[CLICK] clicking instance hash navigates to run detail', async ({ page }) => {
     await page.goto('/workflows');
-    const row = page.getByRole('link', { name: /#proc-r/ });
-    await row.first().waitFor({ state: 'visible', timeout: 10_000 });
-    await row.first().click();
+    const hash = page.getByText('#proc-r').first();
+    await hash.waitFor({ state: 'visible', timeout: 10_000 });
+    await hash.click();
     await expect(page).toHaveURL(/\/workflows\/Supply%20Chain%20Review\/runs\/proc-running-1/);
   });
 

--- a/packages/platform-ui/e2e/authenticated/process-run.spec.ts
+++ b/packages/platform-ui/e2e/authenticated/process-run.spec.ts
@@ -29,24 +29,24 @@ test.describe('Process Run Detail', () => {
 
   test('run detail page shows cancel button for running instance', async ({ page }) => {
     await page.goto('/workflows/Supply%20Chain%20Review/runs/proc-running-1');
-    await expect(page.getByRole('button', { name: /cancel run/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^cancel$/i })).toBeVisible();
   });
 
   test('cancel button shows double-confirm on first click', async ({ page }) => {
     await page.goto('/workflows/Supply%20Chain%20Review/runs/proc-running-1');
-    await page.getByRole('button', { name: /cancel run/i }).click();
+    await page.getByRole('button', { name: /^cancel$/i }).click();
     // After first click, a confirmation prompt should appear
-    await expect(page.getByText(/are you sure/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /yes, cancel run/i })).toBeVisible();
+    await expect(page.getByText(/cannot be undone/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /confirm cancel/i })).toBeVisible();
   });
 
-  test('cancel confirm can be dismissed with No button', async ({ page }) => {
+  test('cancel confirm can be dismissed with Back button', async ({ page }) => {
     await page.goto('/workflows/Supply%20Chain%20Review/runs/proc-running-1');
-    await page.getByRole('button', { name: /cancel run/i }).click();
-    await expect(page.getByText(/are you sure/i)).toBeVisible();
-    await page.getByRole('button', { name: /^no$/i }).click();
-    // Returns to idle state — cancel run button visible again
-    await expect(page.getByRole('button', { name: /cancel run/i })).toBeVisible();
+    await page.getByRole('button', { name: /^cancel$/i }).click();
+    await expect(page.getByText(/cannot be undone/i)).toBeVisible();
+    await page.getByRole('button', { name: /^back$/i }).click();
+    // Returns to idle state — cancel button visible again
+    await expect(page.getByRole('button', { name: /^cancel$/i })).toBeVisible();
   });
 
   // --- Step graph visualization tests (10-02) ---

--- a/packages/platform-ui/src/app/(app)/runs/page.tsx
+++ b/packages/platform-ui/src/app/(app)/runs/page.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useProcessInstances } from '@/hooks/use-process-instances';
+import { useMyTasks } from '@/hooks/use-tasks';
 import { RunsTable } from '@/components/processes/runs-table';
 import { formatStepName } from '@/components/tasks/task-utils';
 import { cn } from '@/lib/utils';
@@ -15,6 +16,17 @@ export default function RunsPage() {
     'all',
     workflowFilter ?? undefined,
   );
+  const { data: activeTasks } = useMyTasks(null);
+
+  const activeTaskByInstance = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const task of activeTasks) {
+      if (!map.has(task.processInstanceId)) {
+        map.set(task.processInstanceId, task.id);
+      }
+    }
+    return map;
+  }, [activeTasks]);
 
   const sorted = React.useMemo(
     () =>
@@ -63,6 +75,7 @@ export default function RunsPage() {
         runs={sorted}
         loading={loading}
         showProcess={!workflowFilter}
+        activeTaskByInstance={activeTaskByInstance}
         emptyMessage={
           workflowFilter
             ? `No runs found for "${formatStepName(workflowFilter)}".`

--- a/packages/platform-ui/src/app/(app)/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/workflows/[name]/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Layers, Github, ExternalLink, Archive, ArchiveRestore, MoreV
 import * as Tabs from '@radix-ui/react-tabs';
 import { useProcessDefinitionVersions } from '@/hooks/use-process-definitions';
 import { useProcessInstances } from '@/hooks/use-process-instances';
+import { useMyTasks } from '@/hooks/use-tasks';
 import { RunsTable } from '@/components/processes/runs-table';
 import { DefinitionsList } from '@/components/workflows/definitions-list';
 import { StartRunButton } from '@/components/processes/start-run-button';
@@ -24,6 +25,17 @@ export default function ProcessDefinitionPage() {
 
   const { versions, loading: versionsLoading } = useProcessDefinitionVersions(decodedName);
   const { data: runs, loading: runsLoading } = useProcessInstances('all', decodedName);
+  const { data: activeTasks } = useMyTasks(null);
+
+  const activeTaskByInstance = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const task of activeTasks) {
+      if (!map.has(task.processInstanceId)) {
+        map.set(task.processInstanceId, task.id);
+      }
+    }
+    return map;
+  }, [activeTasks]);
 
   const [archiving, setArchiving] = React.useState(false);
   const [menuOpen, setMenuOpen] = React.useState(false);
@@ -209,6 +221,7 @@ export default function ProcessDefinitionPage() {
           <RunsTable
             runs={runs}
             loading={runsLoading}
+            activeTaskByInstance={activeTaskByInstance}
             emptyMessage="No runs yet for this workflow."
           />
         </Tabs.Content>

--- a/packages/platform-ui/src/app/(app)/workflows/page.tsx
+++ b/packages/platform-ui/src/app/(app)/workflows/page.tsx
@@ -7,6 +7,7 @@ import * as Popover from '@radix-ui/react-popover';
 import { GitBranch, Plus, Layers, Github, ExternalLink, Archive, Play, SlidersHorizontal, Check, ChevronRight } from 'lucide-react';
 import { useProcessDefinitions } from '@/hooks/use-process-definitions';
 import { useProcessInstances } from '@/hooks/use-process-instances';
+import { useMyTasks } from '@/hooks/use-tasks';
 import { ProcessInstanceRow } from '@/components/processes/process-run-section';
 import { StartRunButton } from '@/components/processes/start-run-button';
 import { formatStepName } from '@/components/tasks/task-utils';
@@ -95,11 +96,13 @@ function ProcessCard({
   instances,
   showCompleted,
   steps,
+  activeTaskByInstance,
 }: {
   definition: DefinitionGroup;
   instances: ProcessInstance[];
   showCompleted: boolean;
   steps?: string[];
+  activeTaskByInstance: Map<string, string>;
 }) {
   const filteredInstances = useMemo(() => {
     return instances.filter((instance) => {
@@ -206,6 +209,7 @@ function ProcessCard({
                 key={instance.id}
                 instance={instance}
                 steps={steps}
+                activeTaskId={activeTaskByInstance.get(instance.id)}
               />
             ))}
           </div>
@@ -269,8 +273,20 @@ export default function ProcessCatalogPage() {
 
   const { definitions, stepsByDefinition, loading: defsLoading } = useProcessDefinitions();
   const { data: allInstances, loading: instancesLoading } = useProcessInstances('all');
+  const { data: activeTasks } = useMyTasks(null);
 
   const loading = defsLoading || instancesLoading;
+
+  // Map instanceId → first active task id (for quick "View task" links on paused runs)
+  const activeTaskByInstance = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const task of activeTasks) {
+      if (!map.has(task.processInstanceId)) {
+        map.set(task.processInstanceId, task.id);
+      }
+    }
+    return map;
+  }, [activeTasks]);
 
   const hasArchivedDefinitions = definitions.some((d) => d.archived === true);
 
@@ -387,6 +403,7 @@ export default function ProcessCatalogPage() {
               instances={instancesByDefinition.get(definition.name) ?? []}
               showCompleted={showCompleted}
               steps={stepsByDefinition.get(definition.name)}
+              activeTaskByInstance={activeTaskByInstance}
             />
           ))}
         </div>

--- a/packages/platform-ui/src/components/app-shell.tsx
+++ b/packages/platform-ui/src/components/app-shell.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { User, GitBranch, Bot, Activity, LogOut, Menu, X, Plus } from 'lucide-react';
+import { User, GitBranch, Bot, Activity, LogOut, Menu, X, Plus, Play } from 'lucide-react';
 import { useAuth } from '@/contexts/auth-context';
 import { ThemeToggle } from './theme-toggle';
 import { cn } from '@/lib/utils';
@@ -16,6 +16,7 @@ const ACTION_ITEMS = [
 
 const NAV_ITEMS = [
   { href: '/workflows', label: 'Workflows', icon: GitBranch, badge: null },
+  { href: '/runs', label: 'All runs', icon: Play, badge: null },
   { href: '/agents', label: 'Agents', icon: Bot, badge: null },
   { href: '/tasks', label: 'New actions', icon: User, badge: null },
 ] as const;

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -14,6 +14,7 @@ import { AgentLogViewer } from './agent-log-viewer';
 import { RunResultsPanel } from './run-results-panel';
 import { cancelProcessRun } from '@/app/actions/processes';
 import { useActiveTaskForInstance } from '@/hooks/use-tasks';
+import { formatStepName } from '@/components/tasks/task-utils';
 
 type AuditEventWithId = AuditEvent & { id: string };
 
@@ -130,7 +131,7 @@ export function ProcessDetail({
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-start gap-3">
-          <h1 className="text-2xl font-headline font-semibold flex-1">{instance.definitionName}</h1>
+          <h1 className="text-2xl font-headline font-semibold flex-1">{formatStepName(instance.definitionName)}</h1>
           <ProcessStatusBadge status={instance.status} pauseReason={instance.pauseReason} />
         </div>
         <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -17,6 +17,11 @@ import { useActiveTaskForInstance } from '@/hooks/use-tasks';
 
 type AuditEventWithId = AuditEvent & { id: string };
 
+function resolveStepLabel(stepId: string, steps: Step[]): string {
+  const found = steps.find((s) => s.id === stepId);
+  return found?.name ?? stepId.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 export interface AgentEventItem {
   id: string;
   stepId: string;
@@ -135,27 +140,29 @@ export function ProcessDetail({
           )}
           <span>ID: <span className="font-mono text-foreground text-xs">{instance.id}</span></span>
           {instance.currentStepId && (
-            <span>Current step: <span className="font-mono text-foreground">{instance.currentStepId}</span></span>
+            <span>Current step: <span className="font-medium text-foreground">{resolveStepLabel(instance.currentStepId, definitionSteps)}</span></span>
           )}
           <span>Created: <span className="text-foreground">{format(new Date(instance.createdAt), 'MMM d, yyyy HH:mm')}</span></span>
         </div>
-        {instance.pauseReason && (
-          <div className="rounded-md bg-amber-50 border border-amber-200 dark:bg-amber-900/20 dark:border-amber-800 px-3 py-2 text-sm text-amber-800 dark:text-amber-300">
-            <span>Paused: {instance.pauseReason}</span>
-            {blockingTask && (
-              <span className="ml-2">
-                — waiting on{' '}
-                <Link
-                  href={`/tasks/${blockingTask.id}`}
-                  className="font-medium underline hover:text-amber-900 dark:hover:text-amber-200"
-                >
-                  {blockingTask.stepId}
-                </Link>
-                {blockingTask.status === 'claimed' && blockingTask.assignedUserId && (
-                  <span className="ml-1 text-amber-600 dark:text-amber-400">(claimed)</span>
-                )}
+        {needsHumanAction && blockingTask && (
+          <div className="rounded-lg border border-primary/20 bg-primary/5 dark:bg-primary/10 px-4 py-3 flex items-center justify-between gap-3">
+            <div className="text-sm">
+              <span className="font-medium">Waiting for your input</span>
+              <span className="text-muted-foreground ml-1.5">
+                — {resolveStepLabel(blockingTask.stepId, definitionSteps)}
               </span>
-            )}
+            </div>
+            <Link
+              href={`/tasks/${blockingTask.id}`}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors shrink-0"
+            >
+              Open task
+            </Link>
+          </div>
+        )}
+        {instance.pauseReason && !needsHumanAction && (
+          <div className="rounded-md bg-amber-50 border border-amber-200 dark:bg-amber-900/20 dark:border-amber-800 px-3 py-2 text-sm text-amber-800 dark:text-amber-300">
+            Paused
           </div>
         )}
         {instance.error && (

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -139,9 +139,6 @@ export function ProcessDetail({
             <span>Config: <span className="font-mono text-foreground">{instance.configName} v{instance.configVersion}</span></span>
           )}
           <span title={instance.id}>ID: <span className="font-mono text-foreground text-xs">{instance.id.slice(0, 8)}</span></span>
-          {instance.currentStepId && (
-            <span>Current step: <span className="font-medium text-foreground">{resolveStepLabel(instance.currentStepId, definitionSteps)}</span></span>
-          )}
           <span>Created: <span className="text-foreground">{format(new Date(instance.createdAt), 'MMM d, yyyy HH:mm')}</span></span>
         </div>
         {needsHumanAction && blockingTask && (

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -143,6 +143,7 @@ export function ProcessDetail({
           )}
           {canCancel && cancelStep === 1 && (
             <div className="flex items-center gap-1.5 shrink-0">
+              <span className="text-xs text-destructive">This cannot be undone.</span>
               <button
                 onClick={handleConfirmCancel}
                 className="rounded-md bg-destructive px-2.5 py-1 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -3,7 +3,8 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { ArrowLeft, FileBarChart } from 'lucide-react';
+import { ArrowLeft, FileBarChart, MoreVertical } from 'lucide-react';
+import * as Popover from '@radix-ui/react-popover';
 import * as Tabs from '@radix-ui/react-tabs';
 import type { ProcessInstance, StepExecution, AuditEvent, Step } from '@mediforce/platform-core';
 import { ProcessStatusBadge } from './process-status-badge';
@@ -133,6 +134,57 @@ export function ProcessDetail({
         <div className="flex items-start gap-3">
           <h1 className="text-2xl font-headline font-semibold flex-1">{formatStepName(instance.definitionName)}</h1>
           <ProcessStatusBadge status={instance.status} pauseReason={instance.pauseReason} />
+          {canCancel && (
+            <Popover.Root>
+              <Popover.Trigger
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted transition-colors shrink-0"
+                aria-label="Run actions"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Popover.Trigger>
+              <Popover.Portal>
+                <Popover.Content
+                  align="end"
+                  sideOffset={4}
+                  className="z-50 w-48 rounded-lg border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95"
+                >
+                  {cancelStep === 0 && (
+                    <button
+                      onClick={() => setCancelStep(1)}
+                      className="flex w-full items-center rounded-md px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 transition-colors"
+                    >
+                      Cancel run
+                    </button>
+                  )}
+                  {cancelStep === 1 && (
+                    <div className="p-2 space-y-2">
+                      <p className="text-xs text-destructive font-medium">This cannot be undone.</p>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={handleConfirmCancel}
+                          className="flex-1 rounded-md bg-destructive px-2 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          onClick={() => { setCancelStep(0); setCancelError(null); }}
+                          className="flex-1 rounded-md border px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
+                        >
+                          Back
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                  {cancelStep === 2 && (
+                    <p className="px-2 py-1.5 text-sm text-muted-foreground">Cancelling...</p>
+                  )}
+                  {cancelError && (
+                    <p className="px-2 py-1.5 text-xs text-destructive">{cancelError}</p>
+                  )}
+                </Popover.Content>
+              </Popover.Portal>
+            </Popover.Root>
+          )}
         </div>
         <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
           <span>Definition: <span className="font-mono text-foreground">v{instance.definitionVersion}</span></span>
@@ -169,42 +221,6 @@ export function ProcessDetail({
           </div>
         )}
 
-        {/* Cancel button — double-confirm pattern */}
-        {canCancel && (
-          <div className="flex items-center gap-2 pt-1">
-            {cancelStep === 0 && (
-              <button
-                onClick={() => setCancelStep(1)}
-                className="text-sm text-muted-foreground hover:text-destructive transition-colors"
-              >
-                Cancel run
-              </button>
-            )}
-            {cancelStep === 1 && (
-              <div className="flex items-center gap-2 text-sm">
-                <span className="text-destructive font-medium">Are you sure? This cannot be undone.</span>
-                <button
-                  onClick={handleConfirmCancel}
-                  className="text-destructive hover:underline font-medium"
-                >
-                  Yes, cancel run
-                </button>
-                <button
-                  onClick={() => { setCancelStep(0); setCancelError(null); }}
-                  className="text-muted-foreground hover:underline"
-                >
-                  No
-                </button>
-              </div>
-            )}
-            {cancelStep === 2 && (
-              <span className="text-sm text-muted-foreground">Cancelling...</span>
-            )}
-            {cancelError && (
-              <span className="text-sm text-destructive">{cancelError}</span>
-            )}
-          </div>
-        )}
       </div>
 
       {/* Step Status Panel — shows all definition steps with live status */}

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -3,8 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { ArrowLeft, FileBarChart, MoreVertical } from 'lucide-react';
-import * as Popover from '@radix-ui/react-popover';
+import { ArrowLeft, FileBarChart } from 'lucide-react';
 import * as Tabs from '@radix-ui/react-tabs';
 import type { ProcessInstance, StepExecution, AuditEvent, Step } from '@mediforce/platform-core';
 import { ProcessStatusBadge } from './process-status-badge';
@@ -131,59 +130,38 @@ export function ProcessDetail({
 
       {/* Header */}
       <div className="space-y-2">
-        <div className="flex items-start gap-3">
+        <div className="flex items-center gap-3">
           <h1 className="text-2xl font-headline font-semibold flex-1">{formatStepName(instance.definitionName)}</h1>
           <ProcessStatusBadge status={instance.status} pauseReason={instance.pauseReason} />
-          {canCancel && (
-            <Popover.Root>
-              <Popover.Trigger
-                className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted transition-colors shrink-0"
-                aria-label="Run actions"
+          {canCancel && cancelStep === 0 && (
+            <button
+              onClick={() => setCancelStep(1)}
+              className="rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground hover:text-destructive hover:border-destructive/30 transition-colors shrink-0"
+            >
+              Cancel
+            </button>
+          )}
+          {canCancel && cancelStep === 1 && (
+            <div className="flex items-center gap-1.5 shrink-0">
+              <button
+                onClick={handleConfirmCancel}
+                className="rounded-md bg-destructive px-2.5 py-1 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"
               >
-                <MoreVertical className="h-4 w-4" />
-              </Popover.Trigger>
-              <Popover.Portal>
-                <Popover.Content
-                  align="end"
-                  sideOffset={4}
-                  className="z-50 w-48 rounded-lg border bg-popover p-1 shadow-md animate-in fade-in-0 zoom-in-95"
-                >
-                  {cancelStep === 0 && (
-                    <button
-                      onClick={() => setCancelStep(1)}
-                      className="flex w-full items-center rounded-md px-2 py-1.5 text-sm text-destructive hover:bg-destructive/10 transition-colors"
-                    >
-                      Cancel run
-                    </button>
-                  )}
-                  {cancelStep === 1 && (
-                    <div className="p-2 space-y-2">
-                      <p className="text-xs text-destructive font-medium">This cannot be undone.</p>
-                      <div className="flex gap-2">
-                        <button
-                          onClick={handleConfirmCancel}
-                          className="flex-1 rounded-md bg-destructive px-2 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"
-                        >
-                          Confirm
-                        </button>
-                        <button
-                          onClick={() => { setCancelStep(0); setCancelError(null); }}
-                          className="flex-1 rounded-md border px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
-                        >
-                          Back
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                  {cancelStep === 2 && (
-                    <p className="px-2 py-1.5 text-sm text-muted-foreground">Cancelling...</p>
-                  )}
-                  {cancelError && (
-                    <p className="px-2 py-1.5 text-xs text-destructive">{cancelError}</p>
-                  )}
-                </Popover.Content>
-              </Popover.Portal>
-            </Popover.Root>
+                Confirm cancel
+              </button>
+              <button
+                onClick={() => { setCancelStep(0); setCancelError(null); }}
+                className="rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted transition-colors"
+              >
+                Back
+              </button>
+            </div>
+          )}
+          {canCancel && cancelStep === 2 && (
+            <span className="text-xs text-muted-foreground shrink-0">Cancelling...</span>
+          )}
+          {cancelError && (
+            <span className="text-xs text-destructive shrink-0">{cancelError}</span>
           )}
         </div>
         <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -138,7 +138,7 @@ export function ProcessDetail({
           {instance.configName && (
             <span>Config: <span className="font-mono text-foreground">{instance.configName} v{instance.configVersion}</span></span>
           )}
-          <span>ID: <span className="font-mono text-foreground text-xs">{instance.id}</span></span>
+          <span title={instance.id}>ID: <span className="font-mono text-foreground text-xs">{instance.id.slice(0, 8)}</span></span>
           {instance.currentStepId && (
             <span>Current step: <span className="font-medium text-foreground">{resolveStepLabel(instance.currentStepId, definitionSteps)}</span></span>
           )}

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -193,25 +193,26 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
               {instance.status === 'failed' ? 'Failed' : 'Completed'}
             </span>
           ) : (
-            <span className="text-xs truncate flex-1 flex items-center gap-1.5">
+            <span className="text-xs truncate flex-1">
               {instance.currentStepId ? (
-                <span className="inline-flex bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium">
-                  {toHumanLabel(instance.currentStepId)}
-                </span>
+                activeTaskId ? (
+                  <span
+                    role="link"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      window.location.href = `/tasks/${activeTaskId}`;
+                    }}
+                    className="inline-flex bg-primary/10 text-primary rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-primary/20 transition-colors"
+                  >
+                    {toHumanLabel(instance.currentStepId)}
+                  </span>
+                ) : (
+                  <span className="inline-flex bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium">
+                    {toHumanLabel(instance.currentStepId)}
+                  </span>
+                )
               ) : 'Starting...'}
-              {activeTaskId && instance.status === 'paused' && (
-                <span
-                  role="link"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    window.location.href = `/tasks/${activeTaskId}`;
-                  }}
-                  className="inline-flex items-center text-[11px] text-primary hover:underline cursor-pointer shrink-0"
-                >
-                  View task
-                </span>
-              )}
             </span>
           )}
         </>

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, ExternalLink } from 'lucide-react';
 import type { ProcessInstance } from '@mediforce/platform-core';
 import { StatusDot } from '@/components/ui/status-dot';
 
@@ -203,9 +203,10 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
                       event.stopPropagation();
                       window.location.href = `/tasks/${activeTaskId}`;
                     }}
-                    className="inline-flex bg-primary/10 text-primary rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-primary/20 transition-colors"
+                    className="inline-flex items-center gap-1 bg-primary/10 text-primary rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-primary/20 transition-colors"
                   >
                     {toHumanLabel(instance.currentStepId)}
+                    <ExternalLink className="h-3 w-3 shrink-0" />
                   </span>
                 ) : (
                   <span className="inline-flex bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium">

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -203,7 +203,7 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
                       event.stopPropagation();
                       window.location.href = `/tasks/${activeTaskId}`;
                     }}
-                    className="inline-flex items-center gap-1 bg-primary/10 text-primary rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-primary/20 transition-colors"
+                    className="inline-flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-muted transition-colors"
                   >
                     {toHumanLabel(instance.currentStepId)}
                     <ExternalLink className="h-3 w-3 shrink-0" />

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -203,10 +203,10 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
                       event.stopPropagation();
                       window.location.href = `/tasks/${activeTaskId}`;
                     }}
-                    className="inline-flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-muted transition-colors"
+                    className="group/step inline-flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-primary/10 hover:text-primary transition-colors"
                   >
                     {toHumanLabel(instance.currentStepId)}
-                    <ExternalLink className="h-3 w-3 shrink-0" />
+                    <ExternalLink className="h-3 w-3 shrink-0 opacity-0 group-hover/step:opacity-100 transition-opacity" />
                   </span>
                 ) : (
                   <span className="inline-flex bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium">

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -203,10 +203,10 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
                       event.stopPropagation();
                       window.location.href = `/tasks/${activeTaskId}`;
                     }}
-                    className="group/step inline-flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-primary/10 hover:text-primary transition-colors"
+                    className="inline-flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium cursor-pointer hover:bg-primary/10 hover:text-primary transition-colors"
                   >
                     {toHumanLabel(instance.currentStepId)}
-                    <ExternalLink className="h-3 w-3 shrink-0 opacity-0 group-hover/step:opacity-100 transition-opacity" />
+                    <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
                   </span>
                 ) : (
                   <span className="inline-flex bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium">

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -155,7 +155,7 @@ function shortTimeAgo(date: Date): string {
   return `${Math.floor(diffDays / 7)}w ago`;
 }
 
-export function ProcessInstanceRow({ instance, showProcess = false, steps, stepStyle = 'dots' }: { instance: ProcessInstance; showProcess?: boolean; steps?: string[]; stepStyle?: 'dots' | 'bar' }) {
+export function ProcessInstanceRow({ instance, showProcess = false, steps, stepStyle = 'dots', activeTaskId }: { instance: ProcessInstance; showProcess?: boolean; steps?: string[]; stepStyle?: 'dots' | 'bar'; activeTaskId?: string }) {
   const shortHash = `#${instance.id.slice(0, 6)}`;
   const timeAgo = shortTimeAgo(new Date(instance.createdAt));
   const fullTimeAgo = formatDistanceToNow(new Date(instance.createdAt), { addSuffix: true });
@@ -193,12 +193,25 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
               {instance.status === 'failed' ? 'Failed' : 'Completed'}
             </span>
           ) : (
-            <span className="text-xs truncate flex-1">
+            <span className="text-xs truncate flex-1 flex items-center gap-1.5">
               {instance.currentStepId ? (
                 <span className="inline-flex bg-muted/50 rounded px-1.5 py-0.5 text-xs font-medium">
                   {toHumanLabel(instance.currentStepId)}
                 </span>
               ) : 'Starting...'}
+              {activeTaskId && instance.status === 'paused' && (
+                <span
+                  role="link"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    window.location.href = `/tasks/${activeTaskId}`;
+                  }}
+                  className="inline-flex items-center text-[11px] text-primary hover:underline cursor-pointer shrink-0"
+                >
+                  View task
+                </span>
+              )}
             </span>
           )}
         </>

--- a/packages/platform-ui/src/components/processes/runs-table.tsx
+++ b/packages/platform-ui/src/components/processes/runs-table.tsx
@@ -107,20 +107,22 @@ export function RunsTable({
               <td className="px-4 py-3 text-xs text-muted-foreground">
                 {run.createdBy ? (userNames.get(run.createdBy) ?? run.createdBy.slice(0, 8)) : '—'}
               </td>
-              <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+              <td className="px-4 py-3 text-xs">
                 {run.currentStepId ? (
                   activeTaskByInstance?.get(run.id) ? (
                     <Link
                       href={`/tasks/${activeTaskByInstance.get(run.id)}`}
-                      className="inline-flex items-center gap-1 hover:text-primary transition-colors"
+                      className="inline-flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5 font-medium cursor-pointer hover:bg-primary/10 hover:text-primary transition-colors"
                     >
                       {run.currentStepId}
-                      <ExternalLink className="h-3 w-3 shrink-0" />
+                      <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
                     </Link>
                   ) : (
-                    run.currentStepId
+                    <span className="inline-flex bg-muted/50 rounded px-1.5 py-0.5 font-medium text-muted-foreground">
+                      {run.currentStepId}
+                    </span>
                   )
-                ) : '—'}
+                ) : <span className="text-muted-foreground">—</span>}
               </td>
               <td className="px-4 py-3 text-xs text-muted-foreground">
                 {formatDistanceToNow(new Date(run.createdAt), {

--- a/packages/platform-ui/src/components/processes/runs-table.tsx
+++ b/packages/platform-ui/src/components/processes/runs-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, ExternalLink } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import type { ProcessInstance } from '@mediforce/platform-core';
 import { ProcessStatusBadge } from './process-status-badge';
@@ -15,6 +15,8 @@ interface RunsTableProps {
   /** Build the href for the "View" link. Defaults to process-scoped route. */
   runHref?: (run: ProcessInstance) => string;
   emptyMessage?: string;
+  /** Map of instanceId → active task ID for direct task links. */
+  activeTaskByInstance?: Map<string, string>;
 }
 
 function defaultRunHref(run: ProcessInstance): string {
@@ -27,6 +29,7 @@ export function RunsTable({
   showProcess = false,
   runHref = defaultRunHref,
   emptyMessage = 'No runs found.',
+  activeTaskByInstance,
 }: RunsTableProps) {
   const userNames = useUserDisplayNames();
   const headers = [
@@ -105,7 +108,19 @@ export function RunsTable({
                 {run.createdBy ? (userNames.get(run.createdBy) ?? run.createdBy.slice(0, 8)) : '—'}
               </td>
               <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
-                {run.currentStepId ?? '—'}
+                {run.currentStepId ? (
+                  activeTaskByInstance?.get(run.id) ? (
+                    <Link
+                      href={`/tasks/${activeTaskByInstance.get(run.id)}`}
+                      className="inline-flex items-center gap-1 hover:text-primary transition-colors"
+                    >
+                      {run.currentStepId}
+                      <ExternalLink className="h-3 w-3 shrink-0" />
+                    </Link>
+                  ) : (
+                    run.currentStepId
+                  )
+                ) : '—'}
               </td>
               <td className="px-4 py-3 text-xs text-muted-foreground">
                 {formatDistanceToNow(new Date(run.createdAt), {

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -150,7 +150,7 @@ function TypeBadge({ type, executorType }: { type: Step['type']; executorType?: 
       </span>
     );
   }
-  // Fallback: show the behavioral step type only for review (meaningful)
+  // Fallback: show the behavioral step type
   if (type === 'review') {
     return (
       <span className="inline-flex items-center gap-0.5 text-xs bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-full px-1.5 py-0.5">
@@ -159,8 +159,12 @@ function TypeBadge({ type, executorType }: { type: Step['type']; executorType?: 
       </span>
     );
   }
-  // Hide generic types like "creation" — they add no signal
-  return null;
+  return (
+    <span className="inline-flex items-center gap-0.5 text-xs bg-muted text-muted-foreground rounded-full px-1.5 py-0.5">
+      <Cog className="h-3 w-3" />
+      {type}
+    </span>
+  );
 }
 
 function StepProgress({ stepId, agentEvents }: { stepId: string; agentEvents: AgentEventItem[] }) {
@@ -406,7 +410,7 @@ export function StepStatusPanel({
                       : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
                   )}
                 </div>
-                {/* Step ID hidden — shown only on hover for debugging */}
+                <div className="text-xs font-mono text-muted-foreground mt-0.5">{step.id}</div>
                 {status === 'running' && stepConfigMap?.get(step.id)?.executorType === 'agent' && (
                   <StepProgress stepId={step.id} agentEvents={agentEvents} />
                 )}

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -150,7 +150,7 @@ function TypeBadge({ type, executorType }: { type: Step['type']; executorType?: 
       </span>
     );
   }
-  // Fallback: show the behavioral step type
+  // Fallback: show the behavioral step type only for review (meaningful)
   if (type === 'review') {
     return (
       <span className="inline-flex items-center gap-0.5 text-xs bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-full px-1.5 py-0.5">
@@ -159,12 +159,8 @@ function TypeBadge({ type, executorType }: { type: Step['type']; executorType?: 
       </span>
     );
   }
-  return (
-    <span className="inline-flex items-center gap-0.5 text-xs bg-muted text-muted-foreground rounded-full px-1.5 py-0.5">
-      <Cog className="h-3 w-3" />
-      {type}
-    </span>
-  );
+  // Hide generic types like "creation" — they add no signal
+  return null;
 }
 
 function StepProgress({ stepId, agentEvents }: { stepId: string; agentEvents: AgentEventItem[] }) {
@@ -410,7 +406,7 @@ export function StepStatusPanel({
                       : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
                   )}
                 </div>
-                <div className="text-xs font-mono text-muted-foreground mt-0.5">{step.id}</div>
+                {/* Step ID hidden — shown only on hover for debugging */}
                 {status === 'running' && stepConfigMap?.get(step.id)?.executorType === 'agent' && (
                   <StepProgress stepId={step.id} agentEvents={agentEvents} />
                 )}

--- a/packages/platform-ui/src/contexts/auth-context.tsx
+++ b/packages/platform-ui/src/contexts/auth-context.tsx
@@ -9,7 +9,8 @@ import {
   signOut as firebaseSignOut,
   type User as FirebaseUser,
 } from 'firebase/auth';
-import { auth } from '@/lib/firebase';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from '@/lib/firebase';
 
 interface AuthContextValue {
   firebaseUser: FirebaseUser | null;
@@ -29,6 +30,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const unsub = onAuthStateChanged(auth, (user) => {
       setFirebaseUser(user);
       setLoading(false);
+      if (user) {
+        setDoc(
+          doc(db, 'users', user.uid),
+          {
+            uid: user.uid,
+            displayName: user.displayName ?? null,
+            email: user.email ?? null,
+          },
+          { merge: true },
+        ).catch(() => {});
+      }
     });
     return unsub;
   }, []);

--- a/packages/platform-ui/src/lib/__tests__/resolve-definition-steps.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/resolve-definition-steps.test.ts
@@ -58,12 +58,20 @@ describe('resolveDefinitionSteps', () => {
     expect(result[0].id).toBe('wf-step-1');
   });
 
-  it('[DATA] prefers workflow when both sources have matching versions', () => {
-    const instance = makeInstance('1', 'config');
+  it('[DATA] prefers workflow for new-style integer versions when both match', () => {
+    const instance = makeInstance('1');
     const legacy = [makeLegacy('1', ['legacy-step'])];
     const workflow = [makeWorkflow(1, ['wf-step'])];
     const result = resolveDefinitionSteps(instance, legacy, workflow);
     expect(result[0].id).toBe('wf-step');
+  });
+
+  it('[DATA] prefers legacy for semver versions when both could match', () => {
+    const instance = makeInstance('1.0.0', 'config');
+    const legacy = [makeLegacy('1.0.0', ['legacy-step'])];
+    const workflow = [makeWorkflow(1, ['wf-step'])];
+    const result = resolveDefinitionSteps(instance, legacy, workflow);
+    expect(result[0].id).toBe('legacy-step');
   });
 
   it('[DATA] falls back to workflow when legacy version does not match', () => {

--- a/packages/platform-ui/src/lib/__tests__/resolve-definition-steps.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/resolve-definition-steps.test.ts
@@ -58,12 +58,12 @@ describe('resolveDefinitionSteps', () => {
     expect(result[0].id).toBe('wf-step-1');
   });
 
-  it('[DATA] prefers legacy when both sources have matching versions', () => {
+  it('[DATA] prefers workflow when both sources have matching versions', () => {
     const instance = makeInstance('1', 'config');
     const legacy = [makeLegacy('1', ['legacy-step'])];
     const workflow = [makeWorkflow(1, ['wf-step'])];
     const result = resolveDefinitionSteps(instance, legacy, workflow);
-    expect(result[0].id).toBe('legacy-step');
+    expect(result[0].id).toBe('wf-step');
   });
 
   it('[DATA] falls back to workflow when legacy version does not match', () => {

--- a/packages/platform-ui/src/lib/resolve-definition-steps.ts
+++ b/packages/platform-ui/src/lib/resolve-definition-steps.ts
@@ -16,16 +16,33 @@ export function resolveDefinitionSteps(
 ): Step[] {
   if (!instance) return [];
 
-  // Prefer workflowDefinitions (new, authoritative) over legacy processDefinitions
-  const versionNum = parseInt(instance.definitionVersion, 10);
-  if (!isNaN(versionNum)) {
+  const defVersion = instance.definitionVersion;
+
+  // New-style runs use integer versions (e.g. "1", "2") without dots.
+  // Legacy runs use semver (e.g. "1.0.0").
+  const isNewStyleVersion = /^\d+$/.test(defVersion);
+
+  if (isNewStyleVersion) {
+    // Prefer workflowDefinitions for new-style versions
+    const versionNum = parseInt(defVersion, 10);
     const workflowMatch = workflowVersions.find((v) => v.version === versionNum);
     if (workflowMatch?.steps?.length) return workflowMatch.steps;
-  }
 
-  // Fall back to legacy processDefinitions (exact version match)
-  const legacyMatch = legacyVersions.find((v) => v.version === instance.definitionVersion);
-  if (legacyMatch?.steps?.length) return legacyMatch.steps;
+    // Fall back to legacy
+    const legacyMatch = legacyVersions.find((v) => v.version === defVersion);
+    if (legacyMatch?.steps?.length) return legacyMatch.steps;
+  } else {
+    // Legacy semver — prefer legacy processDefinitions
+    const legacyMatch = legacyVersions.find((v) => v.version === defVersion);
+    if (legacyMatch?.steps?.length) return legacyMatch.steps;
+
+    // Fall back to workflow (unlikely but safe)
+    const versionNum = parseInt(defVersion, 10);
+    if (!isNaN(versionNum)) {
+      const workflowMatch = workflowVersions.find((v) => v.version === versionNum);
+      if (workflowMatch?.steps?.length) return workflowMatch.steps;
+    }
+  }
 
   // Last resort: return steps from latest available definition
   if (workflowVersions.length > 0) return workflowVersions[0].steps;

--- a/packages/platform-ui/src/lib/resolve-definition-steps.ts
+++ b/packages/platform-ui/src/lib/resolve-definition-steps.ts
@@ -16,20 +16,20 @@ export function resolveDefinitionSteps(
 ): Step[] {
   if (!instance) return [];
 
-  // Try legacy processDefinitions first (exact version match)
-  const legacyMatch = legacyVersions.find((v) => v.version === instance.definitionVersion);
-  if (legacyMatch?.steps?.length) return legacyMatch.steps;
-
-  // Fall back to workflowDefinitions (version is number, definitionVersion is string)
+  // Prefer workflowDefinitions (new, authoritative) over legacy processDefinitions
   const versionNum = parseInt(instance.definitionVersion, 10);
   if (!isNaN(versionNum)) {
     const workflowMatch = workflowVersions.find((v) => v.version === versionNum);
     if (workflowMatch?.steps?.length) return workflowMatch.steps;
   }
 
+  // Fall back to legacy processDefinitions (exact version match)
+  const legacyMatch = legacyVersions.find((v) => v.version === instance.definitionVersion);
+  if (legacyMatch?.steps?.length) return legacyMatch.steps;
+
   // Last resort: return steps from latest available definition
-  if (legacyVersions.length > 0) return legacyVersions[0].steps ?? [];
   if (workflowVersions.length > 0) return workflowVersions[0].steps;
+  if (legacyVersions.length > 0) return legacyVersions[0].steps ?? [];
 
   return [];
 }


### PR DESCRIPTION
## Summary

### Step → task navigation
Clickable step labels with ↗ icon let users jump directly to the blocking task — across workflow cards, runs table, and run detail history.
<img width="1080" height="756" alt="image" src="https://github.com/user-attachments/assets/0ed157c0-9a5f-4114-af20-f6b895b07293" />

### Run detail page cleanup
- "Waiting for your input" CTA card with **Open task** button
- Workflow name formatted (Title Case), shortened run ID
- Cancel button inline with status badge
- Fixed definition resolution (workflow-first priority) — prevents showing stale/incomplete step lists
<img width="783" height="723" alt="image" src="https://github.com/user-attachments/assets/5eedd256-d1e0-4c3c-a672-bce345f4040f" />

### Runs table
- Step-to-task links in Current Step column
- "Started by" column

### Navigation
- Added **All runs** to sidebar

### User profile sync
- On login, sync displayName and email to Firestore `users/{uid}`
- "Started by" now shows real names (e.g. "Marek Rogala") instead of truncated UIDs

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test:fast` — 888 tests passing
- [x] E2E tests updated for new cancel button UI and click targets
- [x] Verify step links navigate to correct task
- [x] Verify all definition steps shown on run detail (no stale 3-step bug)
- [ ] Verify cancel double-confirm works
- [x] Log in and verify "Started by" shows your real name