### PR TITLE
feat: workflow secrets — user-scoped encrypted env vars per workflow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -42,6 +42,16 @@ service cloud.firestore {
         allow create, update: if request.auth != null;
         allow delete: if request.auth != null;
       }
+
+      // Workflow secrets: only namespace members (server actions enforce this via Admin SDK;
+      // these rules are defense-in-depth for client SDK access)
+      match /workflowSecrets/{workflowName} {
+        allow read: if request.auth != null
+          && exists(/databases/$(database)/documents/namespaces/$(handle)/members/$(request.auth.uid));
+        allow create, update: if request.auth != null
+          && exists(/databases/$(database)/documents/namespaces/$(handle)/members/$(request.auth.uid));
+        allow delete: if false;
+      }
     }
 
     // Users: read by authenticated, write by authenticated (org admins add to organizations[])

--- a/packages/agent-queue/src/queue-client.ts
+++ b/packages/agent-queue/src/queue-client.ts
@@ -1,4 +1,4 @@
-import { Queue, QueueEvents } from 'bullmq';
+import type { Queue, QueueEvents } from 'bullmq';
 import { getRedisConnection } from './connection.js';
 import { QUEUE_NAME, DockerJobResultSchema } from './schemas.js';
 import type { DockerJobData, DockerJobResult } from './schemas.js';
@@ -6,8 +6,9 @@ import type { DockerJobData, DockerJobResult } from './schemas.js';
 let sharedQueue: Queue | null = null;
 let sharedQueueEvents: QueueEvents | null = null;
 
-function getQueue(): Queue {
+async function getQueue(): Promise<Queue> {
   if (!sharedQueue) {
+    const { Queue } = await import(/* webpackIgnore: true */ 'bullmq');
     sharedQueue = new Queue(QUEUE_NAME, {
       connection: getRedisConnection(),
       defaultJobOptions: {
@@ -19,8 +20,9 @@ function getQueue(): Queue {
   return sharedQueue;
 }
 
-function getQueueEvents(): QueueEvents {
+async function getQueueEvents(): Promise<QueueEvents> {
   if (!sharedQueueEvents) {
+    const { QueueEvents } = await import(/* webpackIgnore: true */ 'bullmq');
     sharedQueueEvents = new QueueEvents(QUEUE_NAME, {
       connection: getRedisConnection(),
     });
@@ -35,8 +37,8 @@ function getQueueEvents(): QueueEvents {
  * — the async queue is invisible to consuming code.
  */
 export async function enqueueDockerJob(data: DockerJobData): Promise<DockerJobResult> {
-  const queue = getQueue();
-  const queueEvents = getQueueEvents();
+  const queue = await getQueue();
+  const queueEvents = await getQueueEvents();
 
   const jobId = `${data.processInstanceId}:${data.stepId}:${Date.now()}`;
 

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -22,7 +22,6 @@ export { ClaudeCodeAgentPlugin } from './plugins/claude-code-agent-plugin.js';
 export { MockClaudeCodeAgentPlugin } from './plugins/mock-claude-code-agent-plugin.js';
 export { OpenCodeAgentPlugin } from './plugins/opencode-agent-plugin.js';
 export { ScriptContainerPlugin } from './plugins/script-container-plugin.js';
-export { getDockerSpawnStrategy, LocalDockerSpawnStrategy, QueuedDockerSpawnStrategy } from './plugins/docker-spawn-strategy.js';
 export type { DockerSpawnStrategy, DockerSpawnRequest, DockerSpawnResult } from './plugins/docker-spawn-strategy.js';
 
 // Runner

--- a/packages/agent-runtime/src/interfaces/agent-plugin.ts
+++ b/packages/agent-runtime/src/interfaces/agent-plugin.ts
@@ -53,6 +53,8 @@ export interface WorkflowAgentContext {
   step: WorkflowStep;
   llm: LlmClient;
   getPreviousStepOutputs: () => Promise<Record<string, unknown>>;
+  /** Pre-fetched workflow secrets for {{TEMPLATE}} resolution */
+  workflowSecrets?: Record<string, string>;
 }
 
 // EmitFn: platform assigns id and sequence — plugin provides type, payload, timestamp

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -397,11 +397,12 @@ export abstract class BaseContainerAgentPlugin implements AgentPlugin {
       cwd: process.cwd(),
     });
 
-    // Resolve env vars from definition-level + step-level env
+    // Resolve env vars from definition-level + step-level env + workflow secrets
     if (isWorkflowAgentContext(this.context)) {
       this.resolvedEnv = resolveStepEnv(
         this.context.workflowDefinition.env,
         this.context.step.env,
+        this.context.workflowSecrets,
       );
     } else {
       const stepConfig = this.context.config.stepConfigs.find(

--- a/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
+++ b/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
@@ -113,7 +113,7 @@ export class LocalDockerSpawnStrategy implements DockerSpawnStrategy {
  */
 export class QueuedDockerSpawnStrategy implements DockerSpawnStrategy {
   async spawn(request: DockerSpawnRequest): Promise<DockerSpawnResult> {
-    const { enqueueDockerJob } = await import('@mediforce/agent-queue');
+    const { enqueueDockerJob } = await import(/* webpackIgnore: true */ '@mediforce/agent-queue');
 
     // Collect all files from outputDir to send through Redis
     const inputFiles: Record<string, string> = {};

--- a/packages/agent-runtime/src/plugins/resolve-env.ts
+++ b/packages/agent-runtime/src/plugins/resolve-env.ts
@@ -2,7 +2,10 @@
  * Resolves step-level env vars from config.
  *
  * Merge order: config-level env (defaults) ← step-level env (overrides).
- * Template syntax: "{{SECRET_NAME}}" is resolved from process.env.
+ * Template syntax: "{{SECRET_NAME}}" is resolved from:
+ *   1. Workflow secrets (Firestore, per-namespace per-workflow)
+ *   2. process.env[SECRET_NAME]
+ *   3. process.env[DOCKER_SECRET_NAME]
  * Literal values are passed through as-is.
  */
 
@@ -15,16 +18,21 @@ export interface ResolvedEnv {
 
 const TEMPLATE_REGEX = /^\{\{(\w+)\}\}$/;
 
-function resolveValue(value: string): string {
+function resolveValue(value: string, workflowSecrets?: Record<string, string>): string {
   const match = TEMPLATE_REGEX.exec(value);
   if (!match) return value;
 
   const secretName = match[1];
-  // Try the exact name first, then fall back to DOCKER_ prefixed version
+  // 1. Try workflow secrets (user-provided, per-workflow)
+  if (workflowSecrets && secretName in workflowSecrets && workflowSecrets[secretName] !== '') {
+    return workflowSecrets[secretName];
+  }
+  // 2. Try the exact name from server env, then DOCKER_ prefixed version
   const resolved = process.env[secretName] || process.env[`DOCKER_${secretName}`];
   if (resolved === undefined || resolved === '') {
     throw new Error(
-      `Env var template "{{${secretName}}}" references server secret "${secretName}" (or "DOCKER_${secretName}") which is not set`,
+      `Env var template "{{${secretName}}}" references secret "${secretName}" which is not set. ` +
+      `Configure it in workflow secrets or set server env "${secretName}" (or "DOCKER_${secretName}")`,
     );
   }
   return resolved;
@@ -33,13 +41,14 @@ function resolveValue(value: string): string {
 export function resolveStepEnv(
   configEnv: Record<string, string> | undefined,
   stepEnv: Record<string, string> | undefined,
+  workflowSecrets?: Record<string, string>,
 ): ResolvedEnv {
   const merged = { ...configEnv, ...stepEnv };
   const vars: Record<string, string> = {};
   const injectedKeys: string[] = [];
 
   for (const [key, value] of Object.entries(merged)) {
-    vars[key] = resolveValue(value);
+    vars[key] = resolveValue(value, workflowSecrets);
     injectedKeys.push(key);
   }
 

--- a/packages/agent-runtime/src/plugins/script-container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/script-container-plugin.ts
@@ -126,8 +126,9 @@ export class ScriptContainerPlugin implements AgentPlugin {
       );
     }
 
-    // Resolve env vars from definition-level + step-level env
-    this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv);
+    // Resolve env vars from definition-level + step-level env + workflow secrets
+    const workflowSecrets = isWorkflowAgentContext(context) ? context.workflowSecrets : undefined;
+    this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv, workflowSecrets);
   }
 
   async run(emit: EmitFn): Promise<void> {

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -45,6 +45,7 @@ export {
   NamespaceTypeSchema,
   NamespaceSchema,
   NamespaceMemberSchema,
+  WorkflowSecretsSchema,
 } from './schemas/index.js';
 
 // Types (re-exported from schemas for convenience)
@@ -95,6 +96,7 @@ export type {
   NamespaceType,
   Namespace,
   NamespaceMember,
+  WorkflowSecrets,
 } from './schemas/index.js';
 
 // Interfaces (repository and service contracts)

--- a/packages/platform-core/src/schemas/index.ts
+++ b/packages/platform-core/src/schemas/index.ts
@@ -136,3 +136,8 @@ export {
   AgentDefinitionSchema,
   type AgentDefinition,
 } from './agent-definition.js';
+
+export {
+  WorkflowSecretsSchema,
+  type WorkflowSecrets,
+} from './workflow-secret.js';

--- a/packages/platform-core/src/schemas/workflow-secret.ts
+++ b/packages/platform-core/src/schemas/workflow-secret.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const WorkflowSecretsSchema = z.object({
+  workflowName: z.string().min(1),
+  namespace: z.string().min(1),
+  secrets: z.record(z.string(), z.string()),
+  updatedAt: z.string().datetime(),
+});
+
+export type WorkflowSecrets = z.infer<typeof WorkflowSecretsSchema>;

--- a/packages/platform-infra/src/crypto/secrets-cipher.ts
+++ b/packages/platform-infra/src/crypto/secrets-cipher.ts
@@ -1,0 +1,49 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+function getKey(): Buffer {
+  const raw = process.env.SECRETS_ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error(
+      'SECRETS_ENCRYPTION_KEY env var is not set. Required for workflow secrets encryption.',
+    );
+  }
+  const buf = Buffer.from(raw, 'hex');
+  if (buf.length !== 32) {
+    throw new Error(
+      `SECRETS_ENCRYPTION_KEY must be 64 hex chars (32 bytes). Got ${raw.length} chars.`,
+    );
+  }
+  return buf;
+}
+
+/** Encrypt a plaintext string. Returns "iv:ciphertext:authTag" in hex. */
+export function encrypt(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString('hex')}:${encrypted.toString('hex')}:${authTag.toString('hex')}`;
+}
+
+/** Decrypt a string produced by encrypt(). */
+export function decrypt(encoded: string): string {
+  const key = getKey();
+  const [ivHex, ciphertextHex, authTagHex] = encoded.split(':');
+  if (!ivHex || !ciphertextHex || !authTagHex) {
+    throw new Error('Invalid encrypted value format — expected "iv:ciphertext:authTag"');
+  }
+  const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(ivHex, 'hex'), {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(ciphertextHex, 'hex')),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
+}

--- a/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
+++ b/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
@@ -1,0 +1,78 @@
+import {
+  WorkflowSecretsSchema,
+  type WorkflowSecrets,
+} from '@mediforce/platform-core';
+import {
+  doc,
+  getDoc,
+  setDoc,
+  deleteDoc,
+  type Firestore,
+} from 'firebase/firestore';
+import { encrypt, decrypt } from '../crypto/secrets-cipher.js';
+
+/**
+ * Stores workflow secrets per namespace.
+ * Values are AES-256-GCM encrypted at rest.
+ *
+ * Path: namespaces/{handle}/workflowSecrets/{workflowName}
+ */
+export class FirestoreWorkflowSecretsRepository {
+  constructor(private readonly db: Firestore) {}
+
+  private docRef(namespace: string, workflowName: string) {
+    return doc(this.db, 'namespaces', namespace, 'workflowSecrets', workflowName);
+  }
+
+  private decryptSecrets(encrypted: Record<string, string>): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(encrypted)) {
+      result[key] = decrypt(value);
+    }
+    return result;
+  }
+
+  private encryptSecrets(plaintext: Record<string, string>): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(plaintext)) {
+      result[key] = encrypt(value);
+    }
+    return result;
+  }
+
+  async getSecrets(namespace: string, workflowName: string): Promise<Record<string, string>> {
+    const snapshot = await getDoc(this.docRef(namespace, workflowName));
+    if (!snapshot.exists()) return {};
+    const data = snapshot.data();
+    if (!data?.secrets || typeof data.secrets !== 'object') return {};
+    const parsed = WorkflowSecretsSchema.parse(data);
+    return this.decryptSecrets(parsed.secrets);
+  }
+
+  async getSecretKeys(namespace: string, workflowName: string): Promise<string[]> {
+    const snapshot = await getDoc(this.docRef(namespace, workflowName));
+    if (!snapshot.exists()) return [];
+    const data = snapshot.data();
+    if (!data?.secrets || typeof data.secrets !== 'object') return [];
+    const parsed = WorkflowSecretsSchema.parse(data);
+    return Object.keys(parsed.secrets);
+  }
+
+  async setSecrets(
+    namespace: string,
+    workflowName: string,
+    secrets: Record<string, string>,
+  ): Promise<void> {
+    const data: WorkflowSecrets = {
+      workflowName,
+      namespace,
+      secrets: this.encryptSecrets(secrets),
+      updatedAt: new Date().toISOString(),
+    };
+    await setDoc(this.docRef(namespace, workflowName), data);
+  }
+
+  async deleteSecrets(namespace: string, workflowName: string): Promise<void> {
+    await deleteDoc(this.docRef(namespace, workflowName));
+  }
+}

--- a/packages/platform-infra/src/index.ts
+++ b/packages/platform-infra/src/index.ts
@@ -22,4 +22,5 @@ export { SendGridNotificationService } from './notifications/sendgrid-notificati
 export { WebhookNotificationService } from './notifications/webhook-notification-service.js';
 export { FirestoreAgentDefinitionRepository } from './firestore/agent-definition-repository.js';
 export { FirestoreNamespaceRepository } from './firestore/namespace-repository.js';
+export { FirestoreWorkflowSecretsRepository } from './firestore/workflow-secrets-repository.js';
 

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/definitions/[version]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/definitions/[version]/page.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { ArrowLeft, Pencil, X, Save, User, Bot, Terminal } from 'lucide-react';
 import { stringify as yamlStringify, parse as yamlParse } from 'yaml';
 import { useWorkflowDefinitions } from '@/hooks/use-workflow-definitions';
+import { useAuth } from '@/contexts/auth-context';
 import { usePlugins } from '@/hooks/use-plugins';
 import { WorkflowDiagram } from '@/components/workflows/workflow-diagram';
 import { saveWorkflowDefinition } from '@/app/actions/definitions';
@@ -492,13 +493,16 @@ function toSlug(name: string): string {
 function StepEditor({ step, allSteps, onChange }: { step: WorkflowStep; allSteps: WorkflowStep[]; onChange: (patch: Partial<WorkflowStep>) => void }) {
   const isNewStep = step.id.startsWith('new-step-');
   const { plugins } = usePlugins();
+  const { firebaseUser } = useAuth();
   const { handle, name: workflowNameParam } = useParams<{ handle: string; name: string }>();
   const [secretKeys, setSecretKeys] = useState<string[]>([]);
   useEffect(() => {
-    if (handle && workflowNameParam) {
-      getWorkflowSecretKeys(handle, decodeURIComponent(workflowNameParam)).then(setSecretKeys).catch(() => {});
+    if (handle && workflowNameParam && firebaseUser) {
+      getWorkflowSecretKeys(handle, decodeURIComponent(workflowNameParam), firebaseUser.uid)
+        .then(setSecretKeys)
+        .catch((error) => console.error('Failed to load secret keys:', error));
     }
-  }, [handle, workflowNameParam]);
+  }, [handle, workflowNameParam, firebaseUser]);
   const inlineInput = 'w-full bg-transparent border-0 border-b border-transparent hover:border-muted-foreground/20 focus:border-primary px-0 py-0.5 focus:outline-none transition-colors';
   const selectInline = 'bg-transparent text-xs text-right border-0 border-b border-transparent hover:border-muted-foreground/20 focus:border-primary px-0 py-0 focus:outline-none transition-colors cursor-pointer';
   const otherSteps = allSteps.filter((s) => s.id !== step.id);

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/definitions/[version]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/definitions/[version]/page.tsx
@@ -9,6 +9,7 @@ import { useWorkflowDefinitions } from '@/hooks/use-workflow-definitions';
 import { usePlugins } from '@/hooks/use-plugins';
 import { WorkflowDiagram } from '@/components/workflows/workflow-diagram';
 import { saveWorkflowDefinition } from '@/app/actions/definitions';
+import { getWorkflowSecretKeys } from '@/app/actions/workflow-secrets';
 import { StartRunButton } from '@/components/processes/start-run-button';
 import { VersionLabel } from '@/components/ui/version-label';
 import { cn } from '@/lib/utils';
@@ -491,6 +492,13 @@ function toSlug(name: string): string {
 function StepEditor({ step, allSteps, onChange }: { step: WorkflowStep; allSteps: WorkflowStep[]; onChange: (patch: Partial<WorkflowStep>) => void }) {
   const isNewStep = step.id.startsWith('new-step-');
   const { plugins } = usePlugins();
+  const { handle, name: workflowNameParam } = useParams<{ handle: string; name: string }>();
+  const [secretKeys, setSecretKeys] = useState<string[]>([]);
+  useEffect(() => {
+    if (handle && workflowNameParam) {
+      getWorkflowSecretKeys(handle, decodeURIComponent(workflowNameParam)).then(setSecretKeys).catch(() => {});
+    }
+  }, [handle, workflowNameParam]);
   const inlineInput = 'w-full bg-transparent border-0 border-b border-transparent hover:border-muted-foreground/20 focus:border-primary px-0 py-0.5 focus:outline-none transition-colors';
   const selectInline = 'bg-transparent text-xs text-right border-0 border-b border-transparent hover:border-muted-foreground/20 focus:border-primary px-0 py-0 focus:outline-none transition-colors cursor-pointer';
   const otherSteps = allSteps.filter((s) => s.id !== step.id);
@@ -790,14 +798,34 @@ function StepEditor({ step, allSteps, onChange }: { step: WorkflowStep; allSteps
                 className="bg-transparent text-xs font-mono text-muted-foreground border-0 border-b border-transparent hover:border-muted-foreground/20 focus:border-primary px-0 py-0 focus:outline-none transition-colors w-24"
               />
               <span className="text-xs text-muted-foreground">=</span>
-              <input
-                value={val}
-                onChange={(e) => {
-                  const newEnv = { ...step.env, [key]: e.target.value };
-                  onChange({ env: newEnv });
-                }}
-                className="bg-transparent text-xs font-mono border-0 border-b border-transparent hover:border-muted-foreground/20 focus:border-primary px-0 py-0 focus:outline-none transition-colors flex-1"
-              />
+              <div className="relative flex-1 group">
+                <input
+                  value={val}
+                  onChange={(e) => {
+                    const newEnv = { ...step.env, [key]: e.target.value };
+                    onChange({ env: newEnv });
+                  }}
+                  className="bg-transparent text-xs font-mono border-0 border-b border-transparent hover:border-muted-foreground/20 focus:border-primary px-0 py-0 focus:outline-none transition-colors w-full"
+                />
+                {secretKeys.length > 0 && !val.startsWith('{{') && (
+                  <select
+                    value=""
+                    onChange={(e) => {
+                      if (e.target.value) {
+                        const newEnv = { ...step.env, [key]: `{{${e.target.value}}}` };
+                        onChange({ env: newEnv });
+                      }
+                    }}
+                    className="absolute right-0 top-0 h-full opacity-0 group-hover:opacity-100 focus:opacity-100 bg-transparent text-xs cursor-pointer transition-opacity w-5"
+                    title="Insert secret reference"
+                  >
+                    <option value="">🔑</option>
+                    {secretKeys.map((sk) => (
+                      <option key={sk} value={sk}>{sk}</option>
+                    ))}
+                  </select>
+                )}
+              </div>
               <button
                 onClick={() => {
                   const newEnv = { ...step.env };

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, Layers, Github, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Info, Clock, Zap, Trash2, ArrowRightLeft } from 'lucide-react';
+import { ArrowLeft, Layers, Github, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Info, Clock, Zap, Trash2, ArrowRightLeft, KeyRound } from 'lucide-react';
 import * as Tabs from '@radix-ui/react-tabs';
 import { useProcessDefinitionVersions } from '@/hooks/use-process-definitions';
 import { useProcessInstances } from '@/hooks/use-process-instances';
@@ -18,6 +18,7 @@ import { formatCron } from '@/lib/format-cron';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/auth-context';
 import { useAllUserNamespaces } from '@/hooks/use-all-user-namespaces';
+import { WorkflowSecretsEditor } from '@/components/workflows/workflow-secrets-editor';
 
 
 export default function ProcessDefinitionPage() {
@@ -225,7 +226,7 @@ export default function ProcessDefinitionPage() {
       {/* Tabs */}
       <Tabs.Root defaultValue="runs" className="flex flex-1 flex-col">
         <Tabs.List className="flex border-b px-6 gap-0">
-          {['runs', 'definitions'].map((tab) => (
+          {['runs', 'definitions', 'secrets'].map((tab) => (
             <Tabs.Trigger
               key={tab}
               value={tab}
@@ -234,9 +235,14 @@ export default function ProcessDefinitionPage() {
                 'text-muted-foreground border-transparent',
                 'data-[state=active]:text-foreground data-[state=active]:border-primary',
                 'hover:text-foreground',
+                tab === 'secrets' && 'flex items-center gap-1.5',
               )}
             >
-              {tab === 'runs' ? `Runs${runs.length > 0 ? ` (${runs.length})` : ''}` : 'Definitions'}
+              {tab === 'runs'
+                ? `Runs${runs.length > 0 ? ` (${runs.length})` : ''}`
+                : tab === 'secrets'
+                  ? <><KeyRound className="h-3.5 w-3.5" />Secrets</>
+                  : 'Definitions'}
             </Tabs.Trigger>
           ))}
         </Tabs.List>
@@ -267,6 +273,16 @@ export default function ProcessDefinitionPage() {
         <Tabs.Content value="definitions" className="flex-1 p-6">
           <div className="max-w-2xl">
             <DefinitionsList workflowName={decodedName} />
+          </div>
+        </Tabs.Content>
+
+        {/* Secrets tab */}
+        <Tabs.Content value="secrets" className="flex-1 p-6">
+          <div className="max-w-2xl">
+            <WorkflowSecretsEditor
+              namespace={handle}
+              workflowName={decodedName}
+            />
           </div>
         </Tabs.Content>
       </Tabs.Root>

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -279,10 +279,13 @@ export default function ProcessDefinitionPage() {
         {/* Secrets tab */}
         <Tabs.Content value="secrets" className="flex-1 p-6">
           <div className="max-w-2xl">
-            <WorkflowSecretsEditor
-              namespace={handle}
-              workflowName={decodedName}
-            />
+            {firebaseUser && (
+              <WorkflowSecretsEditor
+                namespace={handle}
+                workflowName={decodedName}
+                userId={firebaseUser.uid}
+              />
+            )}
           </div>
         </Tabs.Content>
       </Tabs.Root>

--- a/packages/platform-ui/src/app/actions/workflow-secrets.ts
+++ b/packages/platform-ui/src/app/actions/workflow-secrets.ts
@@ -1,19 +1,33 @@
 'use server';
 
-import { getFirestoreDb, FirestoreWorkflowSecretsRepository } from '@mediforce/platform-infra';
+import {
+  getFirestoreDb,
+  FirestoreWorkflowSecretsRepository,
+  FirestoreNamespaceRepository,
+} from '@mediforce/platform-infra';
 import { getPlatformServices } from '@/lib/platform-services';
 
 function getRepo() {
-  // Ensure Firebase is initialized before accessing Firestore
   getPlatformServices();
   return new FirestoreWorkflowSecretsRepository(getFirestoreDb());
+}
+
+async function requireNamespaceMember(namespace: string, userId: string): Promise<void> {
+  getPlatformServices();
+  const namespaceRepo = new FirestoreNamespaceRepository(getFirestoreDb());
+  const member = await namespaceRepo.getMember(namespace, userId);
+  if (!member) {
+    throw new Error('Not a member of this namespace');
+  }
 }
 
 /** Get secret keys only (safe for client — no values exposed) */
 export async function getWorkflowSecretKeys(
   namespace: string,
   workflowName: string,
+  userId: string,
 ): Promise<string[]> {
+  await requireNamespaceMember(namespace, userId);
   return getRepo().getSecretKeys(namespace, workflowName);
 }
 
@@ -21,7 +35,9 @@ export async function getWorkflowSecretKeys(
 export async function getWorkflowSecrets(
   namespace: string,
   workflowName: string,
+  userId: string,
 ): Promise<Record<string, string>> {
+  await requireNamespaceMember(namespace, userId);
   return getRepo().getSecrets(namespace, workflowName);
 }
 
@@ -30,14 +46,14 @@ export async function saveWorkflowSecrets(
   namespace: string,
   workflowName: string,
   secrets: Record<string, string>,
+  userId: string,
 ): Promise<void> {
+  await requireNamespaceMember(namespace, userId);
   await getRepo().setSecrets(namespace, workflowName, secrets);
 }
 
-/** Get secrets for runtime resolution (called from execute-agent-step) */
-export async function getWorkflowSecretsForRuntime(
+/** Get secrets for runtime resolution (called server-side from execute-agent-step — no user auth needed) */
+export const getWorkflowSecretsForRuntime = async (
   namespace: string,
   workflowName: string,
-): Promise<Record<string, string>> {
-  return getRepo().getSecrets(namespace, workflowName);
-}
+): Promise<Record<string, string>> => getRepo().getSecrets(namespace, workflowName);

--- a/packages/platform-ui/src/app/actions/workflow-secrets.ts
+++ b/packages/platform-ui/src/app/actions/workflow-secrets.ts
@@ -1,0 +1,43 @@
+'use server';
+
+import { getFirestoreDb, FirestoreWorkflowSecretsRepository } from '@mediforce/platform-infra';
+import { getPlatformServices } from '@/lib/platform-services';
+
+function getRepo() {
+  // Ensure Firebase is initialized before accessing Firestore
+  getPlatformServices();
+  return new FirestoreWorkflowSecretsRepository(getFirestoreDb());
+}
+
+/** Get secret keys only (safe for client — no values exposed) */
+export async function getWorkflowSecretKeys(
+  namespace: string,
+  workflowName: string,
+): Promise<string[]> {
+  return getRepo().getSecretKeys(namespace, workflowName);
+}
+
+/** Get full secrets (values included) — for the secrets management page */
+export async function getWorkflowSecrets(
+  namespace: string,
+  workflowName: string,
+): Promise<Record<string, string>> {
+  return getRepo().getSecrets(namespace, workflowName);
+}
+
+/** Save all secrets atomically */
+export async function saveWorkflowSecrets(
+  namespace: string,
+  workflowName: string,
+  secrets: Record<string, string>,
+): Promise<void> {
+  await getRepo().setSecrets(namespace, workflowName, secrets);
+}
+
+/** Get secrets for runtime resolution (called from execute-agent-step) */
+export async function getWorkflowSecretsForRuntime(
+  namespace: string,
+  workflowName: string,
+): Promise<Record<string, string>> {
+  return getRepo().getSecrets(namespace, workflowName);
+}

--- a/packages/platform-ui/src/app/actions/workflow-secrets.ts
+++ b/packages/platform-ui/src/app/actions/workflow-secrets.ts
@@ -14,11 +14,18 @@ function getRepo() {
 
 async function requireNamespaceMember(namespace: string, userId: string): Promise<void> {
   getPlatformServices();
-  const namespaceRepo = new FirestoreNamespaceRepository(getFirestoreDb());
+  const db = getFirestoreDb();
+  const namespaceRepo = new FirestoreNamespaceRepository(db);
+
+  // Check member doc first
   const member = await namespaceRepo.getMember(namespace, userId);
-  if (!member) {
-    throw new Error('Not a member of this namespace');
-  }
+  if (member) return;
+
+  // Fallback: personal namespaces created before members subcollection may lack a member doc
+  const ns = await namespaceRepo.getNamespace(namespace);
+  if (ns?.type === 'personal' && ns.linkedUserId === userId) return;
+
+  throw new Error('Not a member of this namespace');
 }
 
 /** Get secret keys only (safe for client — no values exposed) */

--- a/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
@@ -30,14 +30,15 @@ function parseEnvText(text: string): Array<{ key: string; value: string }> | nul
 interface WorkflowSecretsEditorProps {
   namespace: string;
   workflowName: string;
+  userId: string;
 }
 
-export function WorkflowSecretsEditor({ namespace, workflowName }: WorkflowSecretsEditorProps) {
+export function WorkflowSecretsEditor({ namespace, workflowName, userId }: WorkflowSecretsEditorProps) {
   const [secrets, setSecrets] = React.useState<Array<{ key: string; value: string }>>([]);
   const [loading, setLoading] = React.useState(true);
   const [saving, setSaving] = React.useState(false);
   const [dirty, setDirty] = React.useState(false);
-  const [revealedKeys, setRevealedKeys] = React.useState<Set<string>>(new Set());
+  const [revealedIndices, setRevealedIndices] = React.useState<Set<number>>(new Set());
   const [saveMessage, setSaveMessage] = React.useState<string | null>(null);
   const [bulkMode, setBulkMode] = React.useState(false);
   const [bulkText, setBulkText] = React.useState('');
@@ -46,14 +47,14 @@ export function WorkflowSecretsEditor({ namespace, workflowName }: WorkflowSecre
   React.useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    getWorkflowSecrets(namespace, workflowName).then((data) => {
+    getWorkflowSecrets(namespace, workflowName, userId).then((data) => {
       if (cancelled) return;
       const entries = Object.entries(data).map(([key, value]) => ({ key, value }));
       setSecrets(entries);
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [namespace, workflowName]);
+  }, [namespace, workflowName, userId]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -65,7 +66,7 @@ export function WorkflowSecretsEditor({ namespace, workflowName }: WorkflowSecre
         record[trimmedKey] = value;
       }
     }
-    await saveWorkflowSecrets(namespace, workflowName, record);
+    await saveWorkflowSecrets(namespace, workflowName, record, userId);
     setDirty(false);
     setSaving(false);
     setSaveMessage('Secrets saved');
@@ -87,11 +88,11 @@ export function WorkflowSecretsEditor({ namespace, workflowName }: WorkflowSecre
     setDirty(true);
   };
 
-  const toggleReveal = (key: string) => {
-    setRevealedKeys((prev) => {
+  const toggleReveal = (index: number) => {
+    setRevealedIndices((prev) => {
       const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
       return next;
     });
   };
@@ -138,7 +139,7 @@ export function WorkflowSecretsEditor({ namespace, workflowName }: WorkflowSecre
               />
               <div className="relative">
                 <input
-                  type={revealedKeys.has(row.key) ? 'text' : 'password'}
+                  type={revealedIndices.has(index) ? 'text' : 'password'}
                   value={row.value}
                   onChange={(event) => updateRow(index, 'value', event.target.value)}
                   placeholder="secret value"
@@ -146,10 +147,10 @@ export function WorkflowSecretsEditor({ namespace, workflowName }: WorkflowSecre
                 />
                 <button
                   type="button"
-                  onClick={() => toggleReveal(row.key)}
+                  onClick={() => toggleReveal(index)}
                   className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                 >
-                  {revealedKeys.has(row.key) ? (
+                  {revealedIndices.has(index) ? (
                     <EyeOff className="h-3.5 w-3.5" />
                   ) : (
                     <Eye className="h-3.5 w-3.5" />

--- a/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
@@ -65,18 +65,25 @@ export function WorkflowSecretsEditor({ namespace, workflowName, userId }: Workf
   const handleSave = async () => {
     setSaving(true);
     setSaveMessage(null);
-    const record: Record<string, string> = {};
-    for (const { key, value } of secrets) {
-      const trimmedKey = key.trim();
-      if (trimmedKey !== '') {
-        record[trimmedKey] = value;
+    try {
+      const record: Record<string, string> = {};
+      for (const { key, value } of secrets) {
+        const trimmedKey = key.trim();
+        if (trimmedKey !== '') {
+          record[trimmedKey] = value;
+        }
       }
+      await saveWorkflowSecrets(namespace, workflowName, record, userId);
+      setDirty(false);
+      setSaveMessage('Secrets saved');
+      setTimeout(() => setSaveMessage(null), 3000);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      setSaveMessage(`Error: ${message}`);
+      console.error('Failed to save workflow secrets:', error);
+    } finally {
+      setSaving(false);
     }
-    await saveWorkflowSecrets(namespace, workflowName, record, userId);
-    setDirty(false);
-    setSaving(false);
-    setSaveMessage('Secrets saved');
-    setTimeout(() => setSaveMessage(null), 3000);
   };
 
   const addRow = () => {
@@ -272,7 +279,7 @@ export function WorkflowSecretsEditor({ namespace, workflowName, userId }: Workf
         )}
 
         {saveMessage && (
-          <span className="text-sm text-green-600 dark:text-green-400">{saveMessage}</span>
+          <span className={`text-sm ${saveMessage.startsWith('Error:') ? 'text-destructive' : 'text-green-600 dark:text-green-400'}`}>{saveMessage}</span>
         )}
       </div>
     </div>

--- a/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
@@ -47,12 +47,18 @@ export function WorkflowSecretsEditor({ namespace, workflowName, userId }: Workf
   React.useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    getWorkflowSecrets(namespace, workflowName, userId).then((data) => {
-      if (cancelled) return;
-      const entries = Object.entries(data).map(([key, value]) => ({ key, value }));
-      setSecrets(entries);
-      setLoading(false);
-    });
+    getWorkflowSecrets(namespace, workflowName, userId)
+      .then((data) => {
+        if (cancelled) return;
+        const entries = Object.entries(data).map(([key, value]) => ({ key, value }));
+        setSecrets(entries);
+        setLoading(false);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error('Failed to load workflow secrets:', error);
+        setLoading(false);
+      });
     return () => { cancelled = true; };
   }, [namespace, workflowName, userId]);
 

--- a/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-secrets-editor.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import * as React from 'react';
+import { Eye, EyeOff, Plus, Trash2, Save, Info, ClipboardPaste } from 'lucide-react';
+import { getWorkflowSecrets, saveWorkflowSecrets } from '@/app/actions/workflow-secrets';
+
+/** Parse .env-style text into key-value pairs. Handles KEY=VALUE, KEY="VALUE", KEY='VALUE', comments, blank lines. */
+function parseEnvText(text: string): Array<{ key: string; value: string }> | null {
+  const lines = text.split('\n').filter((line) => {
+    const trimmed = line.trim();
+    return trimmed !== '' && !trimmed.startsWith('#');
+  });
+  if (lines.length === 0) return null;
+
+  const parsed: Array<{ key: string; value: string }> = [];
+  for (const line of lines) {
+    const match = line.match(/^\s*([\w.]+)\s*=\s*(.*)$/);
+    if (!match) return null; // not env format — abort
+    const key = match[1];
+    let value = match[2].trim();
+    // Strip surrounding quotes
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    parsed.push({ key, value });
+  }
+  return parsed.length > 0 ? parsed : null;
+}
+
+interface WorkflowSecretsEditorProps {
+  namespace: string;
+  workflowName: string;
+}
+
+export function WorkflowSecretsEditor({ namespace, workflowName }: WorkflowSecretsEditorProps) {
+  const [secrets, setSecrets] = React.useState<Array<{ key: string; value: string }>>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [saving, setSaving] = React.useState(false);
+  const [dirty, setDirty] = React.useState(false);
+  const [revealedKeys, setRevealedKeys] = React.useState<Set<string>>(new Set());
+  const [saveMessage, setSaveMessage] = React.useState<string | null>(null);
+  const [bulkMode, setBulkMode] = React.useState(false);
+  const [bulkText, setBulkText] = React.useState('');
+  const [bulkPreview, setBulkPreview] = React.useState<Array<{ key: string; value: string }> | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getWorkflowSecrets(namespace, workflowName).then((data) => {
+      if (cancelled) return;
+      const entries = Object.entries(data).map(([key, value]) => ({ key, value }));
+      setSecrets(entries);
+      setLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [namespace, workflowName]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveMessage(null);
+    const record: Record<string, string> = {};
+    for (const { key, value } of secrets) {
+      const trimmedKey = key.trim();
+      if (trimmedKey !== '') {
+        record[trimmedKey] = value;
+      }
+    }
+    await saveWorkflowSecrets(namespace, workflowName, record);
+    setDirty(false);
+    setSaving(false);
+    setSaveMessage('Secrets saved');
+    setTimeout(() => setSaveMessage(null), 3000);
+  };
+
+  const addRow = () => {
+    setSecrets((prev) => [...prev, { key: '', value: '' }]);
+    setDirty(true);
+  };
+
+  const removeRow = (index: number) => {
+    setSecrets((prev) => prev.filter((_, idx) => idx !== index));
+    setDirty(true);
+  };
+
+  const updateRow = (index: number, field: 'key' | 'value', newValue: string) => {
+    setSecrets((prev) => prev.map((row, idx) => (idx === index ? { ...row, [field]: newValue } : row)));
+    setDirty(true);
+  };
+
+  const toggleReveal = (key: string) => {
+    setRevealedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-3 animate-pulse">
+        <div className="h-4 w-32 rounded bg-muted" />
+        <div className="h-10 rounded bg-muted" />
+        <div className="h-10 rounded bg-muted" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30 p-3 text-sm text-blue-800 dark:text-blue-300">
+        <Info className="h-4 w-4 mt-0.5 shrink-0" />
+        <span>
+          Secrets defined here are available in workflow step env vars using{' '}
+          <code className="rounded bg-blue-100 dark:bg-blue-900/50 px-1 py-0.5 font-mono text-xs">{'{{KEY}}'}</code>{' '}
+          syntax. They persist across definition versions.
+        </span>
+      </div>
+
+      {secrets.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No secrets configured yet.</p>
+      ) : (
+        <div className="space-y-2">
+          {/* Header */}
+          <div className="grid grid-cols-[1fr_1fr_72px] gap-2 text-xs font-medium text-muted-foreground px-1">
+            <span>Key</span>
+            <span>Value</span>
+            <span />
+          </div>
+          {secrets.map((row, index) => (
+            <div key={index} className="grid grid-cols-[1fr_1fr_72px] gap-2 items-center">
+              <input
+                type="text"
+                value={row.key}
+                onChange={(event) => updateRow(index, 'key', event.target.value)}
+                placeholder="SECRET_NAME"
+                className="h-9 rounded-md border bg-background px-3 text-sm font-mono"
+              />
+              <div className="relative">
+                <input
+                  type={revealedKeys.has(row.key) ? 'text' : 'password'}
+                  value={row.value}
+                  onChange={(event) => updateRow(index, 'value', event.target.value)}
+                  placeholder="secret value"
+                  className="h-9 w-full rounded-md border bg-background px-3 pr-9 text-sm font-mono"
+                />
+                <button
+                  type="button"
+                  onClick={() => toggleReveal(row.key)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  {revealedKeys.has(row.key) ? (
+                    <EyeOff className="h-3.5 w-3.5" />
+                  ) : (
+                    <Eye className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeRow(index)}
+                className="h-9 w-9 flex items-center justify-center rounded-md border text-muted-foreground hover:text-destructive hover:border-destructive transition-colors"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {bulkMode ? (
+        <div className="space-y-2 rounded-md border p-3 bg-muted/30">
+          <p className="text-xs text-muted-foreground">
+            Paste <code className="font-mono">.env</code> content — one <code className="font-mono">KEY=value</code> per line:
+          </p>
+          <textarea
+            value={bulkText}
+            onChange={(event) => {
+              setBulkText(event.target.value);
+              setBulkPreview(parseEnvText(event.target.value));
+            }}
+            placeholder={'VIKING_LOGIN=user@example.com\nVIKING_PASSWORD=s3cret'}
+            rows={5}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono resize-y"
+            autoFocus
+          />
+          {bulkPreview && (
+            <p className="text-xs text-green-600 dark:text-green-400">
+              Detected {bulkPreview.length} variable{bulkPreview.length !== 1 ? 's' : ''}: {bulkPreview.map((p) => p.key).join(', ')}
+            </p>
+          )}
+          {bulkText.trim() !== '' && !bulkPreview && (
+            <p className="text-xs text-destructive">
+              Could not parse — expected KEY=value format, one per line
+            </p>
+          )}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={!bulkPreview}
+              onClick={() => {
+                if (!bulkPreview) return;
+                const existingKeys = new Set(secrets.map((s) => s.key));
+                const merged = [...secrets];
+                for (const entry of bulkPreview) {
+                  const idx = merged.findIndex((s) => s.key === entry.key);
+                  if (idx >= 0) {
+                    merged[idx] = entry; // overwrite existing
+                  } else {
+                    merged.push(entry);
+                  }
+                }
+                setSecrets(merged);
+                setDirty(true);
+                setBulkMode(false);
+                setBulkText('');
+                setBulkPreview(null);
+              }}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-sm hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            >
+              Import {bulkPreview?.length ?? 0} variable{(bulkPreview?.length ?? 0) !== 1 ? 's' : ''}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setBulkMode(false); setBulkText(''); setBulkPreview(null); }}
+              className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-2 pt-2">
+        <button
+          type="button"
+          onClick={addRow}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add secret
+        </button>
+
+        {!bulkMode && (
+          <button
+            type="button"
+            onClick={() => setBulkMode(true)}
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent transition-colors"
+          >
+            <ClipboardPaste className="h-3.5 w-3.5" />
+            Paste .env
+          </button>
+        )}
+
+        {dirty && (
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-sm hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            <Save className="h-3.5 w-3.5" />
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        )}
+
+        {saveMessage && (
+          <span className="text-sm text-green-600 dark:text-green-400">{saveMessage}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -8,6 +8,7 @@
 import { getPlatformServices } from './platform-services';
 import type { WorkflowAgentContext } from '@mediforce/agent-runtime';
 import type { WorkflowDefinition, WorkflowStep } from '@mediforce/platform-core';
+import { getWorkflowSecretsForRuntime } from '../app/actions/workflow-secrets';
 
 export interface WorkflowAgentStepResult {
   instanceId: string;
@@ -83,6 +84,11 @@ export async function executeAgentStep(
     reviewerType: 'none',
   });
 
+  // Pre-fetch workflow secrets for {{TEMPLATE}} resolution
+  const workflowSecrets = workflowDefinition.namespace
+    ? await getWorkflowSecretsForRuntime(workflowDefinition.namespace, workflowDefinition.name)
+    : {};
+
   const workflowAgentContext: WorkflowAgentContext = {
     stepId,
     processInstanceId: instanceId,
@@ -92,6 +98,7 @@ export async function executeAgentStep(
     workflowDefinition,
     step: workflowStep,
     llm: llmClient,
+    workflowSecrets,
     getPreviousStepOutputs: async () => {
       const executions = await instanceRepo.getStepExecutions(instanceId);
       const result: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- Adds **per-workflow, per-namespace secrets** stored in Firestore with AES-256-GCM encryption at rest
- New resolution chain: `{{TEMPLATE}}` → workflow secrets (Firestore) → `process.env` → `DOCKER_` prefix → error
- UI: "Secrets" tab on workflow detail page with masked values, bulk `.env` paste import, and secret picker in step env editor
- Bonus: fixes bullmq webpack warnings via lazy dynamic imports

## Motivation
Workflow definitions use `{{TEMPLATE}}` syntax for secrets (e.g. `{{VIKING_LOGIN}}`). Previously these resolved **only** from server `process.env`, meaning every user's credentials had to live in `.env.local`. Users need to manage their own secrets per workflow without touching server config.

## Review guide

**Commit 1 — bullmq fix** (3 files): lazy-import bullmq so webpack never parses `child-processor.js`

**Commit 2 — workflow secrets** (15 files), best reviewed in this order:
1. `platform-core/src/schemas/workflow-secret.ts` — tiny zod schema
2. `platform-infra/src/crypto/secrets-cipher.ts` — AES-256-GCM encrypt/decrypt
3. `platform-infra/src/firestore/workflow-secrets-repository.ts` — Firestore CRUD with encryption
4. `agent-runtime/src/plugins/resolve-env.ts` — new 3-step resolution chain
5. `agent-runtime/src/interfaces/agent-plugin.ts` — `workflowSecrets` on context
6. `platform-ui/src/components/workflows/workflow-secrets-editor.tsx` — standalone UI component
7. Remaining: threading through plugins, execute-agent-step pre-fetch, page tab additions

## Setup
Requires `SECRETS_ENCRYPTION_KEY` (64 hex chars / 32 bytes) in `.env.local`:
```
SECRETS_ENCRYPTION_KEY=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
```

## Test plan
- [ ] Typecheck passes (`pnpm typecheck`)
- [ ] All 886 unit tests pass (`pnpm test:fast`)
- [ ] Secrets tab loads on workflow detail page
- [ ] Add secrets via "Paste .env" bulk import
- [ ] Verify values are encrypted in Firestore (check via Firebase console)
- [ ] Run workflow — step resolves `{{SECRET}}` from Firestore secrets
- [ ] Secret picker dropdown appears in step env editor when secrets exist
- [ ] Missing `SECRETS_ENCRYPTION_KEY` throws clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)