### PR TITLE
feat: add code-review skill, skills router, clean up CLAUDE.md

### DIFF
--- a/.claude/skills/code-review
+++ b/.claude/skills/code-review
@@ -1,0 +1,1 @@
+../../skills/code-review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,19 @@ The `skills/_registry.yml` indexes development skills. Runtime skills have per-a
 - `cp packages/platform-ui/.env.local.example packages/platform-ui/.env.local` and fill Firebase + OpenRouter keys
 - Deploys via Firebase App Hosting (`apphosting.yaml`)
 
+## Skills Router
+
+When a task matches one of these, invoke the skill before starting work:
+
+| Task | Skill |
+|------|-------|
+| Review a PR or code diff | `/code-review` → `skills/code-review/SKILL.md` |
+| Write or run E2E journey tests | `/e2e-test` → `skills/e2e-test/SKILL.md` |
+| Visual UI verification in browser | `/agent-browser` → `skills/agent-browser/SKILL.md` |
+| Review a Renovate dependency PR | `/renovate-review` → `skills/renovate-review/SKILL.md` |
+| Write a Discord community update | `/community` → `skills/community/SKILL.md` |
+| Generate a pitch deck | `/generate-pitch` → `skills/generate-pitch/SKILL.md` |
+
 ## Core Principles
 
 - **Simplicity First**: Make every change as simple as possible. Minimal code impact.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,1 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 @AGENTS.md

--- a/docs/ai-development-process.md
+++ b/docs/ai-development-process.md
@@ -31,18 +31,6 @@ The main AI thread acts as a **Tech Lead** — not an individual contributor. It
 
 In practice: receive task → break it down → dispatch subagents → verify output → report back.
 
-## How We Work: No Spec Theatre
-
-We don't write formal specs for every change. The workflow scales to task size:
-
-| Task size | Approach |
-|-----------|----------|
-| Small fix, single file | Just do it. TypeCheck + test after. |
-| Feature, 3–10 files | Plan briefly in conversation, then execute. |
-| Architecture change | Discuss trade-offs with user, align on approach, then execute with subagents. |
-
-The key question before any non-trivial change: **"Is there a more elegant way to do this?"** If yes, pause and discuss before coding.
-
 ## Skills: Standardized Workflows
 
 Skills are reusable instruction sets invoked on demand via `/skill-name`:

--- a/docs/ai-development-process.md
+++ b/docs/ai-development-process.md
@@ -1,84 +1,81 @@
 # AI-Assisted Development Process
 
-How we use AI coding agents (Claude Code) to build Mediforce — and how the repo is structured to make that reliable.
+How we use AI coding agents to build Mediforce — and how the repo is structured to make that work well.
 
-## Why Structure Matters
+## Why This Matters
 
-AI agents are powerful but context-dependent. Without structure, they guess, skip steps, and produce inconsistent code. With the right instruction files, they behave like a disciplined senior engineer who reads the project conventions before touching anything.
+AI agents are powerful but context-dependent. Without structure, they guess, hallucinate conventions, and produce inconsistent code. With the right files in the right places, they become reliable collaborators that follow your project's actual patterns.
 
-The goal isn't to trust AI blindly — it's to give it clear enough instructions that a human Tech Lead can delegate confidently and review efficiently.
+This isn't about trusting AI blindly — it's about giving it the right instructions so a human Tech Lead can delegate effectively and review confidently.
 
-## The Instruction Hierarchy
+## How It Works
+
+### The Instruction Hierarchy
 
 ```
-CLAUDE.md (root)              ← Auto-loaded. Single line: @AGENTS.md
+CLAUDE.md (root)              ← Auto-loaded. Points to AGENTS.md
 └── AGENTS.md (root)          ← Core rules, architecture, testing, skills router
       └── Skills Router       ← Maps "what am I doing" → "which skill to invoke"
 
 skills/*/SKILL.md             ← On-demand workflows (invoked via /skill-name)
+skills/*/references/          ← Checklists, templates used by skills
 ```
 
-**Key principle:** Instructions live close to the code they describe. `AGENTS.md` is the single source of truth for how agents behave in this repo.
+**Key principle:** Instructions live close to the code they describe. The root `AGENTS.md` stays under 300 lines and routes to specific skills for deep workflows.
 
-## The Agent Delegation Model
+### The Agent Delegation Model
 
-The main AI thread acts as a **Tech Lead** — not an individual contributor. It:
+The main AI thread acts as a **Tech Lead** — it delegates execution to subagents and focuses on architecture, coherence, and review.
 
-- Delegates execution to subagents (research, analysis, coding)
-- Parallelizes independent work across multiple agents
-- Reviews subagent output critically — rejects hacks, over-engineering, unnecessary deps
-- Keeps context clean for architectural decisions, not line-by-line implementation
+- **Delegate execution** — spawn subagents for research, analysis, and coding. Parallelize independent work.
+- **Think big picture** — focus on architecture, goals, and coherence, not line-by-line implementation.
+- **Review, don't rubber-stamp** — reject hacks, unnecessary dependencies, over-engineering, and solutions that don't fit the project's direction.
 
 In practice: receive task → break it down → dispatch subagents → verify output → report back.
 
-## Skills: Standardized Workflows
+### Skills (Standardized Workflows)
 
-Skills are reusable instruction sets invoked on demand via `/skill-name`:
+Skills are reusable instruction sets invoked on demand via `/skill-name`. The Skills Router in `AGENTS.md` maps task types to the right skill:
 
-| Skill | When to invoke |
-|-------|---------------|
-| `/code-review` | Reviewing any PR or diff |
-| `/e2e-test` | Writing or running E2E journey tests |
+| Skill | Purpose |
+|-------|---------|
+| `/code-review` | Review PRs and diffs against an 8-section checklist (security, architecture, testing, etc.) |
+| `/e2e-test` | Write, run, and record E2E journey tests with TDD workflow |
 | `/agent-browser` | Visual verification of UI in a live browser |
-| `/renovate-review` | Reviewing Renovate dependency update PRs |
-| `/community` | Writing Discord updates from rough notes |
-| `/generate-pitch` | Generating a Marp pitch deck |
+| `/renovate-review` | Triage and validate Renovate dependency PRs |
+| `/community` | Write Discord updates from rough notes |
+| `/generate-pitch` | Generate a Marp pitch deck from vision docs |
 
-Each skill has a `SKILL.md` with step-by-step workflow and optional `references/` with checklists and templates.
+Each skill has a `SKILL.md` with step-by-step workflow and optional `references/` with templates and checklists.
 
-## Testing Workflow (TDD for UI Features)
+### Testing: TDD with GIF Recordings
 
-UI features follow a tight loop:
+UI features follow a tight TDD loop where the E2E test comes first and the GIF recording is part of the deliverable:
 
-1. **RED** — Write the E2E journey test first (`/e2e-test`)
+1. **RED** — Write the E2E journey test first
 2. **GREEN** — Implement until the test passes
-3. **Record** — `pnpm test:e2e:gif` converts recordings to GIFs in `docs/features/`
+3. **Record** — Convert test recordings to GIFs in `docs/features/`
 4. **Gallery** — Add entry to `docs/features/FEATURES.md`
-5. **Commit** — GIF + feature code + FEATURES.md in the same PR
+5. **Ship** — GIF + feature code + gallery update in the same PR
 
-GIF recordings are part of the deliverable, not an afterthought.
+Quality gates run after every change: typecheck (~5s), affected tests (<1s), full suite (~9s). E2E with Firebase emulators (~60s) before merging UI changes.
 
-## Code Quality Gates
+## Adding New Instructions
 
-After every code change:
+### When to create a new skill
 
-```bash
-pnpm typecheck          # ~5s — catches type errors
-pnpm test:affected      # <1s — tests for changed files only
-pnpm test               # ~9s — full unit + integration suite
+When you find yourself giving the same multi-step instructions repeatedly. A skill standardizes the workflow so every invocation is consistent. Add the skill to `skills/`, register it in `_registry.yml`, symlink it into `.claude/skills/`, and add a row to the Skills Router in `AGENTS.md`.
+
+### Writing style for instruction files
+
+`AGENTS.md` and skill files are **instructions**, not documentation:
+
+```markdown
+# Wrong
+The module provides CRUD operations for managing processes.
+
+# Right
+Use `makeCrudRoute` for all CRUD endpoints. MUST export `openApi` from every route.
 ```
 
-Before merging UI changes:
-```bash
-cd packages/platform-ui && pnpm test:e2e:auth   # ~60s — full E2E with emulators
-```
-
-## File Reference
-
-| File | Purpose | When to modify |
-|------|---------|----------------|
-| `CLAUDE.md` | Entry point | Never — it's one line |
-| `AGENTS.md` | Core rules, architecture, testing, skills router | When adding packages, changing conventions, or adding skills |
-| `skills/*/SKILL.md` | Workflow instructions | When improving a repeatable workflow |
-| `skills/*/references/*` | Checklists and templates | When improving quality gates |
-| `skills/_registry.yml` | Skills index | When adding a new skill |
+Every sentence tells the agent what to DO, what to REUSE, or what rules to FOLLOW.

--- a/docs/ai-development-process.md
+++ b/docs/ai-development-process.md
@@ -1,0 +1,96 @@
+# AI-Assisted Development Process
+
+How we use AI coding agents (Claude Code) to build Mediforce — and how the repo is structured to make that reliable.
+
+## Why Structure Matters
+
+AI agents are powerful but context-dependent. Without structure, they guess, skip steps, and produce inconsistent code. With the right instruction files, they behave like a disciplined senior engineer who reads the project conventions before touching anything.
+
+The goal isn't to trust AI blindly — it's to give it clear enough instructions that a human Tech Lead can delegate confidently and review efficiently.
+
+## The Instruction Hierarchy
+
+```
+CLAUDE.md (root)              ← Auto-loaded. Single line: @AGENTS.md
+└── AGENTS.md (root)          ← Core rules, architecture, testing, skills router
+      └── Skills Router       ← Maps "what am I doing" → "which skill to invoke"
+
+skills/*/SKILL.md             ← On-demand workflows (invoked via /skill-name)
+```
+
+**Key principle:** Instructions live close to the code they describe. `AGENTS.md` is the single source of truth for how agents behave in this repo.
+
+## The Agent Delegation Model
+
+The main AI thread acts as a **Tech Lead** — not an individual contributor. It:
+
+- Delegates execution to subagents (research, analysis, coding)
+- Parallelizes independent work across multiple agents
+- Reviews subagent output critically — rejects hacks, over-engineering, unnecessary deps
+- Keeps context clean for architectural decisions, not line-by-line implementation
+
+In practice: receive task → break it down → dispatch subagents → verify output → report back.
+
+## How We Work: No Spec Theatre
+
+We don't write formal specs for every change. The workflow scales to task size:
+
+| Task size | Approach |
+|-----------|----------|
+| Small fix, single file | Just do it. TypeCheck + test after. |
+| Feature, 3–10 files | Plan briefly in conversation, then execute. |
+| Architecture change | Discuss trade-offs with user, align on approach, then execute with subagents. |
+
+The key question before any non-trivial change: **"Is there a more elegant way to do this?"** If yes, pause and discuss before coding.
+
+## Skills: Standardized Workflows
+
+Skills are reusable instruction sets invoked on demand via `/skill-name`:
+
+| Skill | When to invoke |
+|-------|---------------|
+| `/code-review` | Reviewing any PR or diff |
+| `/e2e-test` | Writing or running E2E journey tests |
+| `/agent-browser` | Visual verification of UI in a live browser |
+| `/renovate-review` | Reviewing Renovate dependency update PRs |
+| `/community` | Writing Discord updates from rough notes |
+| `/generate-pitch` | Generating a Marp pitch deck |
+
+Each skill has a `SKILL.md` with step-by-step workflow and optional `references/` with checklists and templates.
+
+## Testing Workflow (TDD for UI Features)
+
+UI features follow a tight loop:
+
+1. **RED** — Write the E2E journey test first (`/e2e-test`)
+2. **GREEN** — Implement until the test passes
+3. **Record** — `pnpm test:e2e:gif` converts recordings to GIFs in `docs/features/`
+4. **Gallery** — Add entry to `docs/features/FEATURES.md`
+5. **Commit** — GIF + feature code + FEATURES.md in the same PR
+
+GIF recordings are part of the deliverable, not an afterthought.
+
+## Code Quality Gates
+
+After every code change:
+
+```bash
+pnpm typecheck          # ~5s — catches type errors
+pnpm test:affected      # <1s — tests for changed files only
+pnpm test               # ~9s — full unit + integration suite
+```
+
+Before merging UI changes:
+```bash
+cd packages/platform-ui && pnpm test:e2e:auth   # ~60s — full E2E with emulators
+```
+
+## File Reference
+
+| File | Purpose | When to modify |
+|------|---------|----------------|
+| `CLAUDE.md` | Entry point | Never — it's one line |
+| `AGENTS.md` | Core rules, architecture, testing, skills router | When adding packages, changing conventions, or adding skills |
+| `skills/*/SKILL.md` | Workflow instructions | When improving a repeatable workflow |
+| `skills/*/references/*` | Checklists and templates | When improving quality gates |
+| `skills/_registry.yml` | Skills index | When adding a new skill |

--- a/skills/_registry.yml
+++ b/skills/_registry.yml
@@ -1,7 +1,7 @@
 version: "1.0"
 generated: "2026-03-25"
 standard: "agentskills.io/specification"
-total_skills: 5
+total_skills: 6
 
 # Runtime skills have their own per-app registries:
 #   apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/_registry.yml
@@ -32,6 +32,11 @@ domains:
         complexity: intermediate
         language: multi
         description: Write, run, and record E2E journey tests with TDD workflow
+      - id: code-review
+        path: skills/code-review/SKILL.md
+        complexity: intermediate
+        language: multi
+        description: Review PRs and code changes for architecture, security, and quality
       - id: renovate-review
         path: skills/renovate-review/SKILL.md
         complexity: basic

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: code-review
+description: Review pull requests and code changes for architecture, security, conventions, and quality. Use when asked to review a PR, diff, or specific files.
+allowed-tools: Bash, Read, Glob, Grep
+metadata:
+  version: "1.0"
+  domain: development
+  complexity: intermediate
+  tags: review, quality, security, architecture
+---
+
+# Code Review
+
+## Usage
+
+```
+/code-review          # review current branch changes vs main
+/code-review 42       # review PR #42
+```
+
+## Workflow
+
+1. **Get the diff** — `gh pr diff <number>` or `git diff main...HEAD`
+2. **Classify files** — group by layer: API routes, UI components, data/schemas, config, tests
+3. **Apply checklist** — go through `references/review-checklist.md` section by section
+4. **Check test coverage** — verify behavioral changes have tests
+5. **Output findings** — structured report with severity levels
+
+## Output Format
+
+```markdown
+## Summary
+[1-2 sentences on overall quality and readiness]
+
+## Findings
+
+### Critical (blocks merge)
+- `file:line` — description
+
+### High (should fix before merge)
+- `file:line` — description
+
+### Medium (improve if possible)
+- `file:line` — description
+
+### Low (suggestions)
+- `file:line` — description
+
+## Verdict
+APPROVE / REQUEST CHANGES / NEEDS DISCUSSION
+```
+
+## Rules
+
+- MUST check every changed file against the checklist
+- MUST flag known project conventions from `AGENTS.md` (no `any`, explicit booleans, Python scripts, etc.)
+- MUST NOT rubber-stamp — flag real issues, not just style preferences
+- MUST include file:line references for all findings
+- If no issues found in a category, omit it from the report

--- a/skills/code-review/references/review-checklist.md
+++ b/skills/code-review/references/review-checklist.md
@@ -1,0 +1,65 @@
+# Code Review Checklist
+
+## 1. Architecture & Module Boundaries
+
+- [ ] Dependencies flow in the right direction (see package graph in `AGENTS.md`)
+- [ ] No cross-package imports via internal paths — use package-level exports only
+- [ ] New files are in the correct location per project conventions
+- [ ] No unnecessary coupling; shared code lives in shared packages
+
+## 2. Security
+
+- [ ] All user inputs validated with Zod schemas
+- [ ] No SQL injection, XSS, or command injection vectors
+- [ ] Secrets not hardcoded or logged — use env vars
+- [ ] Auth checks on all protected API routes
+- [ ] Error messages don't leak internal details to clients
+
+## 3. Data Integrity
+
+- [ ] Firestore queries are tenant-scoped where applicable
+- [ ] Nullable fields handled defensively
+- [ ] No unbounded reads (missing `.limit()`)
+
+## 4. API Design
+
+- [ ] RESTful conventions followed
+- [ ] Consistent error response shape
+- [ ] Pagination for list endpoints
+
+## 5. Code Quality
+
+- [ ] No `any` types — use Zod + `z.infer<typeof Schema>`
+- [ ] No `console.log` in production code
+- [ ] No commented-out code
+- [ ] No one-letter variable names
+- [ ] Explicit boolean comparisons (`=== true`, not just truthy)
+- [ ] Scripts are Python, not bash
+
+## 6. Testing
+
+- [ ] New behavior has unit tests (colocated `__tests__/` or `*.test.ts`)
+- [ ] UI features have E2E journey tests in `packages/platform-ui/e2e/journeys/`
+- [ ] Tests cover happy path + key error paths
+- [ ] No flaky timing dependencies
+
+## 7. Error Handling
+
+- [ ] No empty catch blocks (swallowed errors)
+- [ ] Async errors propagated correctly
+- [ ] User-facing error messages are helpful
+
+## 8. Performance
+
+- [ ] No N+1 query patterns
+- [ ] No unbounded data fetches
+- [ ] Heavy operations are async/background where appropriate
+
+## Anti-Pattern Quick Scan
+
+```bash
+# Run in repo root before approving
+grep -rn ": any" --include="*.ts" --include="*.tsx" packages/
+grep -rn "console\.log" --include="*.ts" --include="*.tsx" packages/
+grep -rn "TODO\|FIXME\|HACK" --include="*.ts" packages/
+```


### PR DESCRIPTION
## Summary

- **`skills/code-review/`** — new skill with 8-section review checklist (architecture, security, data integrity, API, code quality, testing, error handling, performance), adapted to our stack (Zod, Firestore, Playwright, Python scripts)
- **`AGENTS.md`** — added Skills Router table mapping task types to skills (`/code-review`, `/e2e-test`, `/agent-browser`, `/renovate-review`, `/community`, `/generate-pitch`)
- **`CLAUDE.md`** — simplified to 1 line (`@AGENTS.md`)
- **`docs/ai-development-process.md`** — rewritten: no spec theatre, focused on delegation model, TDD+GIF workflow, skills system, quality gates

Cherry-picked the valuable parts from PR #2 (now closed). Spec-driven workflow excluded.

## E2E

No UI changes — no E2E tests needed.