### PR TITLE
chore: skip CI for docs/md/skills-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,24 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'agents/**'
+      - 'skills/**'
+      - '.planning/**'
+      - 'LICENSE'
   push:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'agents/**'
+      - 'skills/**'
+      - '.planning/**'
+      - 'LICENSE'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Add `paths-ignore` to CI workflow for both `pull_request` and `push` triggers
- Skipped paths: `*.md`, `docs/`, `.claude/`, `agents/`, `skills/`, `.planning/`, `LICENSE`

Concurrency (`cancel-in-progress`) was already in place.

## Impact

Based on Marcin's analysis: CI is ~3,200 min/mo with ~460 runs in March. Docs/skills-only PRs (like #104) were triggering full typecheck + unit tests + E2E for no reason. This should cut a meaningful chunk of those runs.

## E2E

No code changes — CI config only.