### PR TITLE
fix: pass SECRETS_ENCRYPTION_KEY to staging container

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -26,6 +26,7 @@ services:
   platform-ui:
     environment:
       - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
+      - SECRETS_ENCRYPTION_KEY=${SECRETS_ENCRYPTION_KEY}
 
   agent-worker:
     environment:


### PR DESCRIPTION
## Summary
- Forward `SECRETS_ENCRYPTION_KEY` from `.env` to `platform-ui` container in staging docker-compose overlay
- Fixes: `Error: SECRETS_ENCRYPTION_KEY env var is not set` when running workflows on staging

## What was done
- Added env var to `docker-compose.staging.yml` → `platform-ui.environment`
- Added the key to `.env` on the staging VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)