### PR TITLE
feat: lazy Docker image build + skill loading from workflow git repo

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,6 +78,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
+      - ${DEPLOY_KEY_PATH:-/home/deploy/.ssh/deploy_key}:/root/.ssh/deploy_key:ro
     depends_on:
       redis:
         condition: service_healthy

--- a/packages/agent-queue/Dockerfile.worker
+++ b/packages/agent-queue/Dockerfile.worker
@@ -1,7 +1,7 @@
 FROM node:24-slim
 
 # Install Docker CLI so the worker can spawn containers
-RUN apt-get update && apt-get install -y --no-install-recommends docker.io git openssh-client && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends docker.io git openssh-client ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/packages/agent-queue/Dockerfile.worker
+++ b/packages/agent-queue/Dockerfile.worker
@@ -1,7 +1,7 @@
 FROM node:24-slim
 
 # Install Docker CLI so the worker can spawn containers
-RUN apt-get update && apt-get install -y --no-install-recommends docker.io && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends docker.io git openssh-client && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/packages/agent-queue/src/docker-image-builder.ts
+++ b/packages/agent-queue/src/docker-image-builder.ts
@@ -1,0 +1,99 @@
+/**
+ * Lazy Docker image builder for the BullMQ worker.
+ *
+ * Lightweight copy of agent-runtime/plugins/docker-image-builder.ts.
+ * Duplicated to avoid pulling agent-runtime (and Firebase) into agent-queue.
+ */
+import { execSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+
+const BUILD_COMMIT_LABEL = 'mediforce.build.commit';
+
+function getGitSshCommand(): string {
+  const deployKeyPath = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
+  return `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no`;
+}
+
+export async function imageExistsLocally(image: string): Promise<boolean> {
+  try {
+    execSync(`docker image inspect "${image}"`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getImageBuildCommit(image: string): Promise<string | null> {
+  try {
+    const output = execSync(
+      `docker inspect --format '{{index .Config.Labels "${BUILD_COMMIT_LABEL}"}}' "${image}"`,
+      { stdio: 'pipe' },
+    ).toString().trim();
+    return output.length > 0 ? output : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function buildImageFromRepo(options: {
+  image: string;
+  repoUrl: string;
+  commit: string;
+  dockerfile?: string;
+}): Promise<void> {
+  const { image, repoUrl, commit, dockerfile = 'Dockerfile' } = options;
+  const buildDir = await mkdtemp(join(tmpdir(), 'mediforce-build-'));
+
+  try {
+    const execOpts = {
+      stdio: 'pipe' as const,
+      env: { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() },
+    };
+
+    execSync(`git init "${buildDir}"`, execOpts);
+    execSync(`git -C "${buildDir}" remote add origin "${repoUrl}"`, execOpts);
+    execSync(`git -C "${buildDir}" fetch origin ${commit} --depth 1`, execOpts);
+    execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
+
+    const dockerfilePath = join(buildDir, dockerfile);
+    console.log(`[docker-image-builder] Building image "${image}" from ${repoUrl}@${commit.slice(0, 8)}`);
+    execSync(
+      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildDir}"`,
+      { stdio: 'pipe' },
+    );
+    console.log(`[docker-image-builder] Image "${image}" built successfully`);
+  } finally {
+    await rm(buildDir, { recursive: true, force: true });
+  }
+}
+
+export async function ensureImage(options: {
+  image: string;
+  repoUrl?: string;
+  commit?: string;
+  dockerfile?: string;
+}): Promise<void> {
+  const { image, repoUrl, commit, dockerfile } = options;
+
+  if (!repoUrl || !commit) {
+    const exists = await imageExistsLocally(image);
+    if (exists) return;
+    throw new Error(
+      `Docker image "${image}" not found locally and no repo+commit configured for auto-build.`,
+    );
+  }
+
+  const exists = await imageExistsLocally(image);
+  if (exists) {
+    const currentCommit = await getImageBuildCommit(image);
+    if (currentCommit === commit) {
+      console.log(`[docker-image-builder] Image "${image}" up-to-date (commit ${commit.slice(0, 8)})`);
+      return;
+    }
+    console.log(`[docker-image-builder] Image "${image}" stale (${currentCommit?.slice(0, 8)} → ${commit.slice(0, 8)}), rebuilding`);
+  }
+
+  await buildImageFromRepo({ image, repoUrl, commit, dockerfile });
+}

--- a/packages/agent-queue/src/docker-image-builder.ts
+++ b/packages/agent-queue/src/docker-image-builder.ts
@@ -64,14 +64,14 @@ export async function buildImageFromRepo(options: {
 
     execSync(`git init "${buildDir}"`, execOpts);
     execSync(`git -C "${buildDir}" remote add origin "${cloneUrl}"`, execOpts);
-    execSync(`git -C "${buildDir}" fetch origin ${commit} --depth 1`, execOpts);
+    execSync(`git -C "${buildDir}" fetch origin "${commit}" --depth 1`, execOpts);
     execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
 
     const dockerfilePath = join(buildDir, dockerfile);
     const buildContext = dirname(dockerfilePath);
     console.log(`[docker-image-builder] Building image "${image}" from ${repoUrl}@${commit.slice(0, 8)}`);
     execSync(
-      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildContext}"`,
+      `docker build -t "${image}" --label "${BUILD_COMMIT_LABEL}=${commit}" -f "${dockerfilePath}" "${buildContext}"`,
       { stdio: 'pipe' },
     );
     console.log(`[docker-image-builder] Image "${image}" built successfully`);

--- a/packages/agent-queue/src/docker-image-builder.ts
+++ b/packages/agent-queue/src/docker-image-builder.ts
@@ -6,7 +6,7 @@
  */
 import { execSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 
 const BUILD_COMMIT_LABEL = 'mediforce.build.commit';
@@ -68,9 +68,10 @@ export async function buildImageFromRepo(options: {
     execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
 
     const dockerfilePath = join(buildDir, dockerfile);
+    const buildContext = dirname(dockerfilePath);
     console.log(`[docker-image-builder] Building image "${image}" from ${repoUrl}@${commit.slice(0, 8)}`);
     execSync(
-      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildDir}"`,
+      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildContext}"`,
       { stdio: 'pipe' },
     );
     console.log(`[docker-image-builder] Image "${image}" built successfully`);

--- a/packages/agent-queue/src/docker-image-builder.ts
+++ b/packages/agent-queue/src/docker-image-builder.ts
@@ -37,23 +37,33 @@ export async function getImageBuildCommit(image: string): Promise<string | null>
   }
 }
 
+function toHttpsWithToken(sshUrl: string, token: string): string {
+  const match = sshUrl.match(/git@github\.com:(.+?)(?:\.git)?$/);
+  if (match) {
+    return `https://x-access-token:${token}@github.com/${match[1]}.git`;
+  }
+  return sshUrl.replace('https://', `https://x-access-token:${token}@`);
+}
+
 export async function buildImageFromRepo(options: {
   image: string;
   repoUrl: string;
   commit: string;
   dockerfile?: string;
+  repoToken?: string;
 }): Promise<void> {
-  const { image, repoUrl, commit, dockerfile = 'Dockerfile' } = options;
+  const { image, repoUrl, commit, dockerfile = 'Dockerfile', repoToken } = options;
   const buildDir = await mkdtemp(join(tmpdir(), 'mediforce-build-'));
 
   try {
+    const cloneUrl = repoToken ? toHttpsWithToken(repoUrl, repoToken) : repoUrl;
     const execOpts = {
       stdio: 'pipe' as const,
       env: { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() },
     };
 
     execSync(`git init "${buildDir}"`, execOpts);
-    execSync(`git -C "${buildDir}" remote add origin "${repoUrl}"`, execOpts);
+    execSync(`git -C "${buildDir}" remote add origin "${cloneUrl}"`, execOpts);
     execSync(`git -C "${buildDir}" fetch origin ${commit} --depth 1`, execOpts);
     execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
 
@@ -74,8 +84,9 @@ export async function ensureImage(options: {
   repoUrl?: string;
   commit?: string;
   dockerfile?: string;
+  repoToken?: string;
 }): Promise<void> {
-  const { image, repoUrl, commit, dockerfile } = options;
+  const { image, repoUrl, commit, dockerfile, repoToken } = options;
 
   if (!repoUrl || !commit) {
     const exists = await imageExistsLocally(image);
@@ -95,5 +106,5 @@ export async function ensureImage(options: {
     console.log(`[docker-image-builder] Image "${image}" stale (${currentCommit?.slice(0, 8)} → ${commit.slice(0, 8)}), rebuilding`);
   }
 
-  await buildImageFromRepo({ image, repoUrl, commit, dockerfile });
+  await buildImageFromRepo({ image, repoUrl, commit, dockerfile, repoToken });
 }

--- a/packages/agent-queue/src/schemas.ts
+++ b/packages/agent-queue/src/schemas.ts
@@ -29,6 +29,13 @@ export const DockerJobDataSchema = z.object({
   /** Files from outputDir, keyed by filename. Sent through Redis when caller
    *  and worker don't share a filesystem (e.g. Vercel → VPS). */
   inputFiles: z.record(z.string(), z.string()).optional(),
+  /** Image build metadata — when present, worker ensures image exists before docker run. */
+  imageBuild: z.object({
+    image: z.string(),
+    repoUrl: z.string(),
+    commit: z.string(),
+    dockerfile: z.string().optional(),
+  }).optional(),
 });
 
 export type DockerJobData = z.infer<typeof DockerJobDataSchema>;

--- a/packages/agent-queue/src/schemas.ts
+++ b/packages/agent-queue/src/schemas.ts
@@ -35,6 +35,7 @@ export const DockerJobDataSchema = z.object({
     repoUrl: z.string(),
     commit: z.string(),
     dockerfile: z.string().optional(),
+    repoToken: z.string().optional(),
   }).optional(),
 });
 

--- a/packages/agent-queue/src/worker-entry.ts
+++ b/packages/agent-queue/src/worker-entry.ts
@@ -11,6 +11,7 @@ import { dirname, join } from 'node:path';
 import { getRedisConnection } from './connection.js';
 import { QUEUE_NAME, DockerJobDataSchema } from './schemas.js';
 import type { DockerJobResult } from './schemas.js';
+import { ensureImage } from './docker-image-builder.js';
 
 /**
  * If inputFiles are provided (remote caller), create a local temp dir,
@@ -60,10 +61,15 @@ async function collectOutputFiles(outputDir: string): Promise<Record<string, str
   return files;
 }
 
-function processDockerJob(rawData: unknown): Promise<DockerJobResult> {
+async function processDockerJob(rawData: unknown): Promise<DockerJobResult> {
   const data = DockerJobDataSchema.parse(rawData);
   const logFile = data.logFile;
   const hasInputFiles = data.inputFiles && Object.keys(data.inputFiles).length > 0;
+
+  // Lazy image build: ensure Docker image exists before running container
+  if (data.imageBuild) {
+    await ensureImage(data.imageBuild);
+  }
 
   return prepareLocalOutputDir(data).then(({ localOutputDir, patchedArgs }) => new Promise<DockerJobResult>((resolve, reject) => {
     const child = spawn('docker', patchedArgs, {

--- a/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Integration tests for docker-image-builder.
+ * Requires Docker daemon running. Skipped if Docker is not available.
+ * Uses local bare git repos — no network required.
+ */
+import { execSync } from 'node:child_process';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  imageExistsLocally,
+  getImageBuildCommit,
+  buildImageFromRepo,
+  ensureImage,
+} from '../docker-image-builder.js';
+import { createTestRepo, addCommitToTestRepo, type TestRepo } from './helpers/create-test-repo.js';
+
+function dockerAvailable(): boolean {
+  try {
+    execSync('docker info', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const testImagePrefix = `mediforce-test-${Date.now()}`;
+const imagesToCleanup: string[] = [];
+
+function testImageName(suffix: string): string {
+  const name = `${testImagePrefix}-${suffix}`;
+  imagesToCleanup.push(name);
+  return name;
+}
+
+afterAll(() => {
+  for (const image of imagesToCleanup) {
+    try {
+      execSync(`docker rmi -f "${image}"`, { stdio: 'pipe' });
+    } catch {
+      // Image may not have been created in a failed test
+    }
+  }
+});
+
+describe.skipIf(!dockerAvailable())('docker-image-builder integration', () => {
+  let repo: TestRepo;
+
+  beforeAll(() => {
+    repo = createTestRepo();
+  });
+
+  afterAll(() => {
+    repo.cleanup();
+  });
+
+  it('builds image from local bare repo', async () => {
+    const image = testImageName('fresh-build');
+
+    await buildImageFromRepo({
+      image,
+      repoUrl: repo.repoPath,
+      commit: repo.commitSha,
+    });
+
+    const exists = await imageExistsLocally(image);
+    expect(exists).toBe(true);
+
+    const buildCommit = await getImageBuildCommit(image);
+    expect(buildCommit).toBe(repo.commitSha);
+  }, 60_000);
+
+  it('ensureImage skips rebuild when commit matches', async () => {
+    const image = testImageName('cache-reuse');
+
+    // First build
+    await ensureImage({
+      image,
+      repoUrl: repo.repoPath,
+      commit: repo.commitSha,
+    });
+
+    // Get image ID
+    const idBefore = execSync(`docker inspect --format '{{.Id}}' "${image}"`, { stdio: 'pipe' })
+      .toString().trim();
+
+    // Second call — should skip
+    await ensureImage({
+      image,
+      repoUrl: repo.repoPath,
+      commit: repo.commitSha,
+    });
+
+    const idAfter = execSync(`docker inspect --format '{{.Id}}' "${image}"`, { stdio: 'pipe' })
+      .toString().trim();
+
+    expect(idAfter).toBe(idBefore);
+  }, 60_000);
+
+  it('rebuilds when commit changes (stale detection)', async () => {
+    const image = testImageName('stale-rebuild');
+
+    // Build with initial commit
+    await ensureImage({
+      image,
+      repoUrl: repo.repoPath,
+      commit: repo.commitSha,
+    });
+
+    const idBefore = execSync(`docker inspect --format '{{.Id}}' "${image}"`, { stdio: 'pipe' })
+      .toString().trim();
+
+    // Add new commit with different content
+    const newCommit = addCommitToTestRepo(repo.repoPath, {
+      'run.sh': '#!/bin/sh\necho \'{"status":"updated"}\' > /output/result.json\n',
+    });
+
+    // Rebuild with new commit
+    await ensureImage({
+      image,
+      repoUrl: repo.repoPath,
+      commit: newCommit,
+    });
+
+    const idAfter = execSync(`docker inspect --format '{{.Id}}' "${image}"`, { stdio: 'pipe' })
+      .toString().trim();
+    const buildCommit = await getImageBuildCommit(image);
+
+    expect(idAfter).not.toBe(idBefore);
+    expect(buildCommit).toBe(newCommit);
+  }, 60_000);
+
+  it('fails clearly when Dockerfile is missing', async () => {
+    const repoNoDockerfile = createTestRepo({
+      dockerfile: 'Dockerfile',
+    });
+
+    // Remove Dockerfile by creating a new commit without it
+    const emptyCommit = addCommitToTestRepo(repoNoDockerfile.repoPath, {
+      'Dockerfile': '', // empty — docker build will fail
+      'run.sh': '#!/bin/sh\necho ok',
+    });
+
+    // Replace with a repo that has no Dockerfile at the expected path
+    const repoWrongPath = createTestRepo();
+    const image = testImageName('missing-dockerfile');
+
+    try {
+      await expect(
+        buildImageFromRepo({
+          image,
+          repoUrl: repoWrongPath.repoPath,
+          commit: repoWrongPath.commitSha,
+          dockerfile: 'nonexistent/Dockerfile',
+        }),
+      ).rejects.toThrow();
+    } finally {
+      repoNoDockerfile.cleanup();
+      repoWrongPath.cleanup();
+    }
+  }, 60_000);
+
+  it('uses custom dockerfile path', async () => {
+    const repoCustomPath = createTestRepo({
+      dockerfilePath: 'container/Dockerfile',
+    });
+
+    const image = testImageName('custom-path');
+
+    try {
+      await buildImageFromRepo({
+        image,
+        repoUrl: repoCustomPath.repoPath,
+        commit: repoCustomPath.commitSha,
+        dockerfile: 'container/Dockerfile',
+      });
+
+      const exists = await imageExistsLocally(image);
+      expect(exists).toBe(true);
+    } finally {
+      repoCustomPath.cleanup();
+    }
+  }, 60_000);
+
+  it('throws when image missing and no repo+commit', async () => {
+    await expect(
+      ensureImage({ image: 'mediforce-nonexistent-image-xyz' }),
+    ).rejects.toThrow(/not found locally.*no repo\+commit/i);
+  });
+});

--- a/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.test.ts
@@ -87,7 +87,7 @@ describe('buildImageFromRepo', () => {
     // Should init, add remote, fetch commit, checkout (uses git -C <dir> syntax)
     expect(calls.some((cmd) => cmd.includes('git init'))).toBe(true);
     expect(calls.some((cmd) => cmd.includes('remote add origin'))).toBe(true);
-    expect(calls.some((cmd) => cmd.includes('fetch origin abc123'))).toBe(true);
+    expect(calls.some((cmd) => cmd.includes('fetch origin "abc123"'))).toBe(true);
     expect(calls.some((cmd) => cmd.includes('checkout FETCH_HEAD'))).toBe(true);
 
     // Should docker build with label

--- a/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  mkdtemp: vi.fn(),
+  rm: vi.fn(),
+}));
+
+import { execSync, spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import {
+  imageExistsLocally,
+  getImageBuildCommit,
+  buildImageFromRepo,
+  ensureImage,
+} from '../docker-image-builder.js';
+
+const execSyncMock = vi.mocked(execSync);
+const mkdtempMock = vi.mocked(mkdtemp);
+const rmMock = vi.mocked(rm);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mkdtempMock.mockResolvedValue('/tmp/mediforce-build-abc');
+  rmMock.mockResolvedValue(undefined);
+});
+
+describe('imageExistsLocally', () => {
+  it('returns true when docker image inspect succeeds', async () => {
+    execSyncMock.mockReturnValueOnce(Buffer.from(''));
+    const result = await imageExistsLocally('my-image:latest');
+    expect(result).toBe(true);
+    expect(execSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('docker image inspect'),
+      expect.anything(),
+    );
+  });
+
+  it('returns false when docker image inspect fails', async () => {
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error('No such image');
+    });
+    const result = await imageExistsLocally('missing-image');
+    expect(result).toBe(false);
+  });
+});
+
+describe('getImageBuildCommit', () => {
+  it('returns commit SHA from image label', async () => {
+    execSyncMock.mockReturnValueOnce(Buffer.from('abc123def456\n'));
+    const result = await getImageBuildCommit('my-image');
+    expect(result).toBe('abc123def456');
+  });
+
+  it('returns null when image has no build label', async () => {
+    execSyncMock.mockReturnValueOnce(Buffer.from('\n'));
+    const result = await getImageBuildCommit('my-image');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when docker inspect fails', async () => {
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error('No such image');
+    });
+    const result = await getImageBuildCommit('missing-image');
+    expect(result).toBeNull();
+  });
+});
+
+describe('buildImageFromRepo', () => {
+  it('clones repo at specific commit and runs docker build', async () => {
+    // All execSync calls succeed
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await buildImageFromRepo({
+      image: 'test-image',
+      repoUrl: '/tmp/test-repo.git',
+      commit: 'abc123',
+    });
+
+    const calls = execSyncMock.mock.calls.map(([cmd]) => String(cmd));
+
+    // Should init, add remote, fetch commit, checkout (uses git -C <dir> syntax)
+    expect(calls.some((cmd) => cmd.includes('git init'))).toBe(true);
+    expect(calls.some((cmd) => cmd.includes('remote add origin'))).toBe(true);
+    expect(calls.some((cmd) => cmd.includes('fetch origin abc123'))).toBe(true);
+    expect(calls.some((cmd) => cmd.includes('checkout FETCH_HEAD'))).toBe(true);
+
+    // Should docker build with label
+    expect(calls.some((cmd) =>
+      cmd.includes('docker build') &&
+      cmd.includes('test-image') &&
+      cmd.includes('mediforce.build.commit=abc123'),
+    )).toBe(true);
+
+    // Should cleanup temp dir
+    expect(rmMock).toHaveBeenCalledWith('/tmp/mediforce-build-abc', { recursive: true, force: true });
+  });
+
+  it('uses custom dockerfile path when provided', async () => {
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await buildImageFromRepo({
+      image: 'test-image',
+      repoUrl: '/tmp/test-repo.git',
+      commit: 'abc123',
+      dockerfile: 'container/Dockerfile',
+    });
+
+    const calls = execSyncMock.mock.calls.map(([cmd]) => String(cmd));
+    expect(calls.some((cmd) =>
+      cmd.includes('docker build') && cmd.includes('container/Dockerfile'),
+    )).toBe(true);
+  });
+
+  it('defaults to Dockerfile in repo root', async () => {
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await buildImageFromRepo({
+      image: 'test-image',
+      repoUrl: '/tmp/test-repo.git',
+      commit: 'abc123',
+    });
+
+    const calls = execSyncMock.mock.calls.map(([cmd]) => String(cmd));
+    const buildCmd = calls.find((cmd) => cmd.includes('docker build'));
+    expect(buildCmd).toBeDefined();
+    // Should use Dockerfile (default) — the -f flag should reference repo root Dockerfile
+    expect(buildCmd).toMatch(/-f\s+\S*Dockerfile/);
+  });
+
+  it('cleans up temp dir even on build failure', async () => {
+    let callCount = 0;
+    execSyncMock.mockImplementation(() => {
+      callCount++;
+      // Fail on docker build (after git commands succeed)
+      if (callCount >= 5) throw new Error('docker build failed');
+      return Buffer.from('');
+    });
+
+    await expect(
+      buildImageFromRepo({
+        image: 'test-image',
+        repoUrl: '/tmp/test-repo.git',
+        commit: 'abc123',
+      }),
+    ).rejects.toThrow('docker build failed');
+
+    expect(rmMock).toHaveBeenCalledWith('/tmp/mediforce-build-abc', { recursive: true, force: true });
+  });
+});
+
+describe('ensureImage', () => {
+  it('skips build when image exists with same commit', async () => {
+    // imageExistsLocally → true
+    execSyncMock.mockReturnValueOnce(Buffer.from(''));
+    // getImageBuildCommit → same commit
+    execSyncMock.mockReturnValueOnce(Buffer.from('abc123\n'));
+
+    await ensureImage({
+      image: 'test-image',
+      repoUrl: '/tmp/repo.git',
+      commit: 'abc123',
+    });
+
+    // No git or docker build commands should follow
+    expect(execSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebuilds when image exists with different commit', async () => {
+    // imageExistsLocally → true
+    execSyncMock.mockReturnValueOnce(Buffer.from(''));
+    // getImageBuildCommit → different commit
+    execSyncMock.mockReturnValueOnce(Buffer.from('old-commit\n'));
+    // buildImageFromRepo calls
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await ensureImage({
+      image: 'test-image',
+      repoUrl: '/tmp/repo.git',
+      commit: 'new-commit',
+    });
+
+    const calls = execSyncMock.mock.calls.map(([cmd]) => String(cmd));
+    expect(calls.some((cmd) => cmd.includes('docker build'))).toBe(true);
+  });
+
+  it('builds when image does not exist and repo+commit provided', async () => {
+    // imageExistsLocally → false
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error('No such image');
+    });
+    // buildImageFromRepo calls
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await ensureImage({
+      image: 'test-image',
+      repoUrl: '/tmp/repo.git',
+      commit: 'abc123',
+    });
+
+    const calls = execSyncMock.mock.calls.map(([cmd]) => String(cmd));
+    expect(calls.some((cmd) => cmd.includes('docker build'))).toBe(true);
+  });
+
+  it('throws when image missing and no repo+commit', async () => {
+    // imageExistsLocally → false
+    execSyncMock.mockImplementationOnce(() => {
+      throw new Error('No such image');
+    });
+
+    await expect(
+      ensureImage({ image: 'test-image' }),
+    ).rejects.toThrow(/not found locally.*no repo.*commit/i);
+  });
+
+  it('succeeds when image exists and no repo+commit (no stale check possible)', async () => {
+    // imageExistsLocally → true
+    execSyncMock.mockReturnValueOnce(Buffer.from(''));
+
+    await ensureImage({ image: 'test-image' });
+
+    // Only the one inspect call
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent-runtime/src/plugins/__tests__/helpers/create-test-repo.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/helpers/create-test-repo.ts
@@ -1,0 +1,127 @@
+/**
+ * Creates a local bare git repo for testing docker-image-builder.
+ * No network required — everything is local filesystem.
+ */
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export interface TestRepo {
+  /** Path to the bare git repo (use as repoUrl) */
+  repoPath: string;
+  /** SHA of the initial commit */
+  commitSha: string;
+  /** Clean up all temp directories */
+  cleanup: () => void;
+}
+
+export interface CreateTestRepoOptions {
+  /** Dockerfile content. Defaults to a minimal alpine image that runs /app/run.sh */
+  dockerfile?: string;
+  /** Script content written to run.sh. Defaults to writing {"status":"ok"} to /output/result.json */
+  script?: string;
+  /** Path for the Dockerfile relative to repo root. Defaults to 'Dockerfile' */
+  dockerfilePath?: string;
+}
+
+const DEFAULT_DOCKERFILE = `FROM alpine:3.21
+COPY run.sh /app/run.sh
+RUN chmod +x /app/run.sh
+CMD ["/bin/sh", "/app/run.sh"]
+`;
+
+const DEFAULT_SCRIPT = `#!/bin/sh
+echo '{"status":"ok"}' > /output/result.json
+`;
+
+export function createTestRepo(options: CreateTestRepoOptions = {}): TestRepo {
+  const dockerfile = options.dockerfile ?? DEFAULT_DOCKERFILE;
+  const script = options.script ?? DEFAULT_SCRIPT;
+  const dockerfilePath = options.dockerfilePath ?? 'Dockerfile';
+
+  const bareDir = mkdtempSync(join(tmpdir(), 'mediforce-test-bare-'));
+  const workDir = mkdtempSync(join(tmpdir(), 'mediforce-test-work-'));
+
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'test',
+    GIT_AUTHOR_EMAIL: 'test@test.com',
+    GIT_COMMITTER_NAME: 'test',
+    GIT_COMMITTER_EMAIL: 'test@test.com',
+  };
+  const execOpts = { env: gitEnv, stdio: 'pipe' as const };
+
+  // Create bare repo
+  execSync(`git init --bare "${bareDir}"`, execOpts);
+
+  // Clone to worktree
+  execSync(`git clone "${bareDir}" "${workDir}"`, execOpts);
+
+  // Write Dockerfile (may be nested like container/Dockerfile)
+  const dockerfileFullPath = join(workDir, dockerfilePath);
+  const dockerfileDir = join(dockerfileFullPath, '..');
+  mkdirSync(dockerfileDir, { recursive: true });
+  writeFileSync(dockerfileFullPath, dockerfile);
+
+  // Write script
+  writeFileSync(join(workDir, 'run.sh'), script);
+
+  // Commit and push
+  execSync('git add -A', { ...execOpts, cwd: workDir });
+  execSync('git commit -m "initial"', { ...execOpts, cwd: workDir });
+  execSync('git push origin HEAD', { ...execOpts, cwd: workDir });
+
+  const commitSha = execSync('git rev-parse HEAD', { ...execOpts, cwd: workDir })
+    .toString()
+    .trim();
+
+  return {
+    repoPath: bareDir,
+    commitSha,
+    cleanup: () => {
+      rmSync(bareDir, { recursive: true, force: true });
+      rmSync(workDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Add a new commit to an existing test repo.
+ * Returns the new commit SHA.
+ */
+export function addCommitToTestRepo(
+  repoPath: string,
+  files: Record<string, string>,
+  message = 'update',
+): string {
+  const workDir = mkdtempSync(join(tmpdir(), 'mediforce-test-update-'));
+
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'test',
+    GIT_AUTHOR_EMAIL: 'test@test.com',
+    GIT_COMMITTER_NAME: 'test',
+    GIT_COMMITTER_EMAIL: 'test@test.com',
+  };
+  const execOpts = { env: gitEnv, stdio: 'pipe' as const };
+
+  execSync(`git clone "${repoPath}" "${workDir}"`, execOpts);
+
+  for (const [filePath, content] of Object.entries(files)) {
+    const fullPath = join(workDir, filePath);
+    mkdirSync(join(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+
+  execSync('git add -A', { ...execOpts, cwd: workDir });
+  execSync(`git commit -m "${message}"`, { ...execOpts, cwd: workDir });
+  execSync('git push origin HEAD', { ...execOpts, cwd: workDir });
+
+  const commitSha = execSync('git rev-parse HEAD', { ...execOpts, cwd: workDir })
+    .toString()
+    .trim();
+
+  rmSync(workDir, { recursive: true, force: true });
+  return commitSha;
+}

--- a/packages/agent-runtime/src/plugins/__tests__/helpers/create-test-repo.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/helpers/create-test-repo.ts
@@ -65,8 +65,7 @@ export function createTestRepo(options: CreateTestRepoOptions = {}): TestRepo {
   writeFileSync(dockerfileFullPath, dockerfile);
 
   // Write script next to the Dockerfile (build context = Dockerfile's directory)
-  const dockerfileDir2 = join(workDir, dockerfilePath, '..');
-  writeFileSync(join(dockerfileDir2, 'run.sh'), script);
+  writeFileSync(join(dockerfileDir, 'run.sh'), script);
 
   // Commit and push
   execSync('git add -A', { ...execOpts, cwd: workDir });

--- a/packages/agent-runtime/src/plugins/__tests__/helpers/create-test-repo.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/helpers/create-test-repo.ts
@@ -64,8 +64,9 @@ export function createTestRepo(options: CreateTestRepoOptions = {}): TestRepo {
   mkdirSync(dockerfileDir, { recursive: true });
   writeFileSync(dockerfileFullPath, dockerfile);
 
-  // Write script
-  writeFileSync(join(workDir, 'run.sh'), script);
+  // Write script next to the Dockerfile (build context = Dockerfile's directory)
+  const dockerfileDir2 = join(workDir, dockerfilePath, '..');
+  writeFileSync(join(dockerfileDir2, 'run.sh'), script);
 
   // Commit and push
   execSync('git add -A', { ...execOpts, cwd: workDir });

--- a/packages/agent-runtime/src/plugins/__tests__/lazy-build-local.integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/lazy-build-local.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tier 3: Full E2E test with LocalDockerSpawnStrategy.
+ * Verifies the complete flow: missing image → auto-build → docker run → output.
+ * Requires Docker daemon. Uses local bare git repo.
+ */
+import { execSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { LocalDockerSpawnStrategy } from '../docker-spawn-strategy.js';
+import { createTestRepo, type TestRepo } from './helpers/create-test-repo.js';
+
+function dockerAvailable(): boolean {
+  try {
+    execSync('docker info', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const testImagePrefix = `mediforce-e2e-${Date.now()}`;
+const imagesToCleanup: string[] = [];
+
+function testImageName(suffix: string): string {
+  const name = `${testImagePrefix}-${suffix}`;
+  imagesToCleanup.push(name);
+  return name;
+}
+
+afterAll(() => {
+  for (const image of imagesToCleanup) {
+    try {
+      execSync(`docker rmi -f "${image}"`, { stdio: 'pipe' });
+    } catch {
+      // Ignore
+    }
+  }
+});
+
+describe.skipIf(!dockerAvailable())('LocalDockerSpawnStrategy with lazy image build', () => {
+  let repo: TestRepo;
+  const strategy = new LocalDockerSpawnStrategy();
+
+  beforeAll(() => {
+    repo = createTestRepo({
+      script: '#!/bin/sh\necho \'{"status":"ok","source":"lazy-build-test"}\' > /output/result.json\n',
+    });
+  });
+
+  afterAll(() => {
+    repo.cleanup();
+  });
+
+  it('auto-builds missing image, runs container, and produces output', async () => {
+    const image = testImageName('local-e2e');
+    const outputDir = await mkdtemp(join(tmpdir(), 'mediforce-e2e-output-'));
+
+    try {
+      const result = await strategy.spawn({
+        dockerArgs: [
+          'run', '--rm',
+          '-v', `${outputDir}:/output`,
+          image,
+        ],
+        stdinPayload: null,
+        timeoutMs: 60_000,
+        containerName: `mediforce-e2e-test-${Date.now()}`,
+        processInstanceId: 'test-process',
+        stepId: 'test-step',
+        outputDir,
+        logFile: null,
+        imageBuild: {
+          image,
+          repoUrl: repo.repoPath,
+          commit: repo.commitSha,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify the container wrote expected output
+      const resultJson = await readFile(join(outputDir, 'result.json'), 'utf-8');
+      const parsed = JSON.parse(resultJson);
+      expect(parsed).toEqual({ status: 'ok', source: 'lazy-build-test' });
+    } finally {
+      await rm(outputDir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
 import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata } from '@mediforce/platform-core';
 import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
-import { getDockerSpawnStrategy } from './docker-spawn-strategy.js';
+import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy.js';
 
 function isWorkflowAgentContext(ctx: AgentContext | WorkflowAgentContext): ctx is WorkflowAgentContext {
   return 'step' in ctx && 'workflowDefinition' in ctx;
@@ -1108,6 +1108,35 @@ export abstract class BaseContainerAgentPlugin implements AgentPlugin {
       throw new Error(`agentConfig.image is required for Docker container execution`);
     }
 
+    // Resolve image build metadata for lazy Docker image building.
+    // A step opts in to lazy build when it has:
+    //   a) step-level repo + commit (explicit — always enables lazy build), OR
+    //   b) step-level dockerfile + workflow-level repo with commit (fallback)
+    // Steps without repo/commit/dockerfile are left alone (image must exist).
+    let imageBuild: ImageBuildMeta | undefined;
+    {
+      const dockerfile = this.agentConfig.dockerfile;
+      let buildRepoUrl: string | undefined;
+      let buildCommit: string | undefined;
+
+      if (repo && commit) {
+        // Step explicitly declares its own repo + commit
+        buildRepoUrl = normalizeRepoUrls(repo).gitUrl;
+        buildCommit = commit;
+      } else if (dockerfile && isWorkflowAgentContext(this.context)) {
+        // Step has dockerfile but no repo — fall back to workflow-level repo
+        const wfRepo = this.context.workflowDefinition.repo;
+        if (wfRepo?.url && wfRepo?.commit) {
+          buildRepoUrl = repo ? normalizeRepoUrls(repo).gitUrl : normalizeRepoUrls(wfRepo.url).gitUrl;
+          buildCommit = commit ?? wfRepo.commit;
+        }
+      }
+
+      if (buildRepoUrl && buildCommit) {
+        imageBuild = { image, repoUrl: buildRepoUrl, commit: buildCommit, dockerfile };
+      }
+    }
+
     // Merge config-driven env vars with plugin-internal env vars
     const internalVars = this.getInternalEnvVars();
     const envVars = { ...this.resolvedEnv.vars, ...internalVars };
@@ -1233,6 +1262,7 @@ export abstract class BaseContainerAgentPlugin implements AgentPlugin {
       stepId,
       outputDir,
       logFile,
+      imageBuild,
     });
 
     // Process stdout lines for activity logging (batch mode — lines arrive after completion

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -9,9 +9,6 @@ import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
 import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy.js';
 import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, resolveRepoToken, normalizeRepoUrls } from './container-plugin.js';
 
-// Re-export for backward compatibility (other files import from here)
-export { normalizeRepoUrls };
-
 const __filename_base = fileURLToPath(import.meta.url);
 const __dirname_base = dirname(__filename_base);
 

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -3,14 +3,14 @@ import { readFile, readdir, mkdtemp, writeFile, rm, mkdir, appendFile, realpath,
 import { join, dirname, isAbsolute, resolve } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
 import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata } from '@mediforce/platform-core';
 import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
 import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy.js';
+import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, normalizeRepoUrls } from './container-plugin.js';
 
-function isWorkflowAgentContext(ctx: AgentContext | WorkflowAgentContext): ctx is WorkflowAgentContext {
-  return 'step' in ctx && 'workflowDefinition' in ctx;
-}
+// Re-export for backward compatibility (other files import from here)
+export { normalizeRepoUrls };
 
 const __filename_base = fileURLToPath(import.meta.url);
 const __dirname_base = dirname(__filename_base);
@@ -100,30 +100,6 @@ export interface AgentCommandSpec {
   promptDelivery: 'stdin' | 'file';
 }
 
-/** Normalize a repo reference to SSH clone URL and HTTPS browsable URL.
- *  Supports: "org/repo", "git@github.com:org/repo.git", "https://github.com/org/repo", "/path/to/bare.git" */
-export function normalizeRepoUrls(repo: string): { gitUrl: string; httpsUrl: string } {
-  // File path (local bare repo)
-  if (repo.startsWith('/') || repo.startsWith('.')) {
-    return { gitUrl: repo, httpsUrl: '' };
-  }
-  // Already an SSH URL
-  if (repo.startsWith('git@')) {
-    const match = repo.match(/git@github\.com:(.+?)(?:\.git)?$/);
-    const orgRepo = match ? match[1] : repo;
-    return { gitUrl: repo, httpsUrl: `https://github.com/${orgRepo}` };
-  }
-  // Already an HTTPS URL
-  if (repo.startsWith('https://')) {
-    const clean = repo.replace(/\.git$/, '');
-    return { gitUrl: `${clean}.git`, httpsUrl: clean };
-  }
-  // Short form: "org/repo"
-  return {
-    gitUrl: `git@github.com:${repo}.git`,
-    httpsUrl: `https://github.com/${repo}`,
-  };
-}
 
 function hasFiles(input: Record<string, unknown>): input is Record<string, unknown> & { files: FileEntry[] } {
   return Array.isArray(input.files) &&
@@ -175,17 +151,11 @@ export async function cleanupTempDir(tempDir: string | null): Promise<void> {
  * prompt assembly, output extraction, file downloads, mock mode.
  * Subclasses implement agent-specific CLI invocation, env vars, and output parsing.
  */
-export abstract class BaseContainerAgentPlugin implements AgentPlugin {
-  abstract readonly metadata: PluginCapabilityMetadata;
-
-  protected context!: AgentContext | WorkflowAgentContext;
+export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
   protected agentConfig!: AgentConfig;
 
   /** Human-readable agent name for log/status messages (e.g. "Claude Code", "OpenCode"). */
   abstract readonly agentName: string;
-
-  /** Resolved env vars from config — set during run(), used by spawnDockerContainer */
-  protected resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [] };
 
   /** Return plugin-internal env vars needed by the container (e.g. config paths).
    *  NOT for API keys — those come from the step config's `env` field.
@@ -1108,34 +1078,7 @@ export abstract class BaseContainerAgentPlugin implements AgentPlugin {
       throw new Error(`agentConfig.image is required for Docker container execution`);
     }
 
-    // Resolve image build metadata for lazy Docker image building.
-    // A step opts in to lazy build when it has:
-    //   a) step-level repo + commit (explicit — always enables lazy build), OR
-    //   b) step-level dockerfile + workflow-level repo with commit (fallback)
-    // Steps without repo/commit/dockerfile are left alone (image must exist).
-    let imageBuild: ImageBuildMeta | undefined;
-    {
-      const dockerfile = this.agentConfig.dockerfile;
-      let buildRepoUrl: string | undefined;
-      let buildCommit: string | undefined;
-
-      if (repo && commit) {
-        // Step explicitly declares its own repo + commit
-        buildRepoUrl = normalizeRepoUrls(repo).gitUrl;
-        buildCommit = commit;
-      } else if (dockerfile && isWorkflowAgentContext(this.context)) {
-        // Step has dockerfile but no repo — fall back to workflow-level repo
-        const wfRepo = this.context.workflowDefinition.repo;
-        if (wfRepo?.url && wfRepo?.commit) {
-          buildRepoUrl = repo ? normalizeRepoUrls(repo).gitUrl : normalizeRepoUrls(wfRepo.url).gitUrl;
-          buildCommit = commit ?? wfRepo.commit;
-        }
-      }
-
-      if (buildRepoUrl && buildCommit) {
-        imageBuild = { image, repoUrl: buildRepoUrl, commit: buildCommit, dockerfile };
-      }
-    }
+    const imageBuild = resolveImageBuild(image, this.agentConfig, this.context);
 
     // Merge config-driven env vars with plugin-internal env vars
     const internalVars = this.getInternalEnvVars();

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -1078,7 +1078,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
       throw new Error(`agentConfig.image is required for Docker container execution`);
     }
 
-    const imageBuild = resolveImageBuild(image, this.agentConfig, this.context);
+    const imageBuild = resolveImageBuild(image, this.agentConfig, this.context, this.resolvedEnv.vars);
 
     // Merge config-driven env vars with plugin-internal env vars
     const internalVars = this.getInternalEnvVars();

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -7,7 +7,7 @@ import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/a
 import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata } from '@mediforce/platform-core';
 import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
 import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy.js';
-import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, normalizeRepoUrls } from './container-plugin.js';
+import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, resolveRepoToken, normalizeRepoUrls } from './container-plugin.js';
 
 // Re-export for backward compatibility (other files import from here)
 export { normalizeRepoUrls };
@@ -247,7 +247,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
    *  Returns null if skillsDir is not set. */
   protected getMockFixturesDir(): string | null {
     if (!this.agentConfig.skillsDir) return null;
-    return join(resolveProjectPath(this.agentConfig.skillsDir), '..', 'mock-fixtures');
+    return join(this.resolveSkillsDir(this.agentConfig.skillsDir, resolveProjectPath), '..', 'mock-fixtures');
   }
 
   /** Resolve the host path to the mock data directory from _config.json.
@@ -431,10 +431,24 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         workingDirForPrompt = '/workspace';
       }
 
+      // Fetch skills from workflow repo if configured
+      if (this.agentConfig.skillsDir && isWorkflowAgentContext(this.context)) {
+        const wfRepo = this.context.workflowDefinition.repo;
+        if (wfRepo?.url && wfRepo?.commit) {
+          const repoToken = resolveRepoToken(this.agentConfig, this.context, this.resolvedEnv.vars);
+          await this.fetchSkillsFromRepo(
+            this.agentConfig.skillsDir,
+            normalizeRepoUrls(wfRepo.url).gitUrl,
+            wfRepo.commit,
+            repoToken,
+          );
+        }
+      }
+
       agentLog('run.buildPrompt', 'building prompt', {
         stepId,
         skillsDir: this.agentConfig.skillsDir ?? null,
-        resolvedSkillsDir: this.agentConfig.skillsDir ? resolveProjectPath(this.agentConfig.skillsDir) : null,
+        resolvedSkillsDir: this.agentConfig.skillsDir ? this.resolveSkillsDir(this.agentConfig.skillsDir, resolveProjectPath) : null,
       });
 
       const prompt = await this.buildPrompt(updatedInput, timeoutMs, outputDirForPrompt, dockerOutputDir, workingDirForPrompt);
@@ -453,7 +467,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
 
       // Mount skill directory so reference files are available inside the container
       if (this.agentConfig.skill && this.agentConfig.skillsDir) {
-        options.skillDir = join(resolveProjectPath(this.agentConfig.skillsDir), this.agentConfig.skill);
+        options.skillDir = join(this.resolveSkillsDir(this.agentConfig.skillsDir, resolveProjectPath), this.agentConfig.skill);
       }
 
       // Create activity log file for observability
@@ -679,7 +693,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
     // 1. Skill prompt from SKILL.md
     if (this.agentConfig.skill && this.agentConfig.skillsDir) {
       const skillContent = await this.readSkillFile(
-        resolveProjectPath(this.agentConfig.skillsDir),
+        this.resolveSkillsDir(this.agentConfig.skillsDir, resolveProjectPath),
         this.agentConfig.skill,
       );
       parts.push(skillContent);

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -4,6 +4,12 @@
  * Shared logic: image build metadata resolution, env var resolution, context storage.
  * Subclasses: BaseContainerAgentPlugin (LLM agents), ScriptContainerPlugin (deterministic scripts).
  */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, cpSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
 import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
 import type { AgentConfig, PluginCapabilityMetadata } from '@mediforce/platform-core';
 import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
@@ -49,7 +55,7 @@ export function isWorkflowAgentContext(ctx: AgentContext | WorkflowAgentContext)
  * Resolve the repo auth token from the step or workflow-level config.
  * `repoAuth` is the name of a key in resolvedEnv (sourced from workflow secrets).
  */
-function resolveRepoToken(
+export function resolveRepoToken(
   agentConfig: AgentConfig,
   context: AgentContext | WorkflowAgentContext,
   resolvedEnv?: Record<string, string>,
@@ -95,12 +101,25 @@ export function resolveImageBuild(
   return undefined;
 }
 
+const SKILLS_CACHE_DIR = join(tmpdir(), 'mediforce-skills-cache');
+
+/** Convert SSH git URL to HTTPS with token for authenticated clone. */
+function toHttpsWithToken(sshUrl: string, token: string): string {
+  const match = sshUrl.match(/git@github\.com:(.+?)(?:\.git)?$/);
+  if (match) {
+    return `https://x-access-token:${token}@github.com/${match[1]}.git`;
+  }
+  return sshUrl.replace('https://', `https://x-access-token:${token}@`);
+}
+
 export abstract class ContainerPlugin implements AgentPlugin {
   abstract readonly metadata: PluginCapabilityMetadata;
 
   protected context!: AgentContext | WorkflowAgentContext;
   protected resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [] };
   protected imageBuild: ImageBuildMeta | undefined;
+  /** Cached skills dir path fetched from git repo. */
+  protected repoSkillsDir: string | null = null;
 
   abstract initialize(context: AgentContext | WorkflowAgentContext): Promise<void>;
   abstract run(emit: EmitFn): Promise<void>;
@@ -114,5 +133,71 @@ export abstract class ContainerPlugin implements AgentPlugin {
     workflowSecrets?: Record<string, string>,
   ): void {
     this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv, workflowSecrets);
+  }
+
+  /**
+   * Fetch skills from a git repo into a deterministic cache directory.
+   * Cache key: sha256(repoUrl + commit + skillsDir).
+   * Returns the path to the cached skills directory.
+   */
+  protected async fetchSkillsFromRepo(
+    skillsDir: string,
+    repoUrl: string,
+    commit: string,
+    repoToken?: string,
+  ): Promise<string> {
+    const hash = createHash('sha256').update(`${repoUrl}\0${commit}\0${skillsDir}`).digest('hex').slice(0, 16);
+    const cacheDir = join(SKILLS_CACHE_DIR, hash);
+
+    // Cache hit
+    if (existsSync(cacheDir)) {
+      console.log(`[container-plugin] Skills cache hit for ${skillsDir} (${hash})`);
+      this.repoSkillsDir = cacheDir;
+      return cacheDir;
+    }
+
+    // Cache miss — clone, copy, delete clone
+    console.log(`[container-plugin] Fetching skills from ${repoUrl}@${commit.slice(0, 8)} path=${skillsDir}`);
+    const cloneDir = mkdtempSync(join(tmpdir(), 'mediforce-skills-clone-'));
+
+    try {
+      const cloneUrl = repoToken ? toHttpsWithToken(repoUrl, repoToken) : repoUrl;
+      const deployKeyPath = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
+      const execOpts = {
+        stdio: 'pipe' as const,
+        env: { ...process.env, GIT_SSH_COMMAND: `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no` },
+      };
+
+      execSync(`git init "${cloneDir}"`, execOpts);
+      execSync(`git -C "${cloneDir}" remote add origin "${cloneUrl}"`, execOpts);
+      execSync(`git -C "${cloneDir}" fetch origin ${commit} --depth 1`, execOpts);
+      execSync(`git -C "${cloneDir}" checkout FETCH_HEAD`, execOpts);
+
+      const sourceDir = join(cloneDir, skillsDir);
+      if (!existsSync(sourceDir)) {
+        throw new Error(
+          `Skills directory "${skillsDir}" not found in repo ${repoUrl}@${commit.slice(0, 8)}`,
+        );
+      }
+
+      mkdirSync(SKILLS_CACHE_DIR, { recursive: true });
+      cpSync(sourceDir, cacheDir, { recursive: true });
+      console.log(`[container-plugin] Skills cached at ${cacheDir}`);
+    } finally {
+      rmSync(cloneDir, { recursive: true, force: true });
+    }
+
+    this.repoSkillsDir = cacheDir;
+    return cacheDir;
+  }
+
+  /**
+   * Resolve skillsDir — uses repo cache if available, otherwise resolveProjectPath.
+   */
+  protected resolveSkillsDir(skillsDir: string, resolveProjectPath: (p: string) => string): string {
+    if (this.repoSkillsDir) {
+      return this.repoSkillsDir;
+    }
+    return resolveProjectPath(skillsDir);
   }
 }

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -170,7 +170,7 @@ export abstract class ContainerPlugin implements AgentPlugin {
 
       execSync(`git init "${cloneDir}"`, execOpts);
       execSync(`git -C "${cloneDir}" remote add origin "${cloneUrl}"`, execOpts);
-      execSync(`git -C "${cloneDir}" fetch origin ${commit} --depth 1`, execOpts);
+      execSync(`git -C "${cloneDir}" fetch origin "${commit}" --depth 1`, execOpts);
       execSync(`git -C "${cloneDir}" checkout FETCH_HEAD`, execOpts);
 
       const sourceDir = join(cloneDir, skillsDir);

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -1,0 +1,97 @@
+/**
+ * Abstract base class for plugins that run Docker containers.
+ *
+ * Shared logic: image build metadata resolution, env var resolution, context storage.
+ * Subclasses: BaseContainerAgentPlugin (LLM agents), ScriptContainerPlugin (deterministic scripts).
+ */
+import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
+import type { AgentConfig, PluginCapabilityMetadata } from '@mediforce/platform-core';
+import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
+import type { ImageBuildMeta } from './docker-spawn-strategy.js';
+
+/** Normalize a repo reference to SSH clone URL and HTTPS browsable URL.
+ *  Supports: "org/repo", "git@github.com:org/repo.git", "https://github.com/org/repo", "/path/to/bare.git" */
+export function normalizeRepoUrls(repo: string): { gitUrl: string; httpsUrl: string } {
+  if (repo.startsWith('/') || repo.startsWith('.')) {
+    return { gitUrl: repo, httpsUrl: '' };
+  }
+  if (repo.startsWith('git@')) {
+    const match = repo.match(/git@github\.com:(.+?)(?:\.git)?$/);
+    const orgRepo = match ? match[1] : repo;
+    return { gitUrl: repo, httpsUrl: `https://github.com/${orgRepo}` };
+  }
+  if (repo.startsWith('https://')) {
+    const clean = repo.replace(/\.git$/, '');
+    return { gitUrl: `${clean}.git`, httpsUrl: clean };
+  }
+  return {
+    gitUrl: `git@github.com:${repo}.git`,
+    httpsUrl: `https://github.com/${repo}`,
+  };
+}
+
+export function isWorkflowAgentContext(ctx: AgentContext | WorkflowAgentContext): ctx is WorkflowAgentContext {
+  return 'step' in ctx && 'workflowDefinition' in ctx;
+}
+
+/**
+ * Resolve image build metadata for lazy Docker image building.
+ *
+ * A step opts in to lazy build when it has:
+ *   a) step-level repo + commit (explicit — always enables lazy build), OR
+ *   b) step-level dockerfile + workflow-level repo with commit (fallback)
+ *
+ * Steps without repo/commit/dockerfile are left alone (image must already exist).
+ */
+export function resolveImageBuild(
+  image: string,
+  agentConfig: AgentConfig,
+  context: AgentContext | WorkflowAgentContext,
+): ImageBuildMeta | undefined {
+  const { dockerfile, repo, commit } = agentConfig;
+
+  if (repo && commit) {
+    return {
+      image,
+      repoUrl: normalizeRepoUrls(repo).gitUrl,
+      commit,
+      dockerfile,
+    };
+  }
+
+  if (dockerfile && isWorkflowAgentContext(context)) {
+    const wfRepo = context.workflowDefinition.repo;
+    if (wfRepo?.url && wfRepo?.commit) {
+      return {
+        image,
+        repoUrl: repo ? normalizeRepoUrls(repo).gitUrl : normalizeRepoUrls(wfRepo.url).gitUrl,
+        commit: commit ?? wfRepo.commit,
+        dockerfile,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export abstract class ContainerPlugin implements AgentPlugin {
+  abstract readonly metadata: PluginCapabilityMetadata;
+
+  protected context!: AgentContext | WorkflowAgentContext;
+  protected resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [] };
+  protected imageBuild: ImageBuildMeta | undefined;
+
+  abstract initialize(context: AgentContext | WorkflowAgentContext): Promise<void>;
+  abstract run(emit: EmitFn): Promise<void>;
+
+  /**
+   * Resolve environment variables from definition-level + step-level env + workflow secrets.
+   */
+  protected resolveEnvironment(
+    definitionEnv?: Record<string, string>,
+    stepEnv?: Record<string, string>,
+    workflowSecrets?: Record<string, string>,
+  ): void {
+    this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv, workflowSecrets);
+  }
+}

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -45,10 +45,27 @@ export function isWorkflowAgentContext(ctx: AgentContext | WorkflowAgentContext)
  *
  * Steps without repo/commit/dockerfile are left alone (image must already exist).
  */
+/**
+ * Resolve the repo auth token from the step or workflow-level config.
+ * `repoAuth` is the name of a key in resolvedEnv (sourced from workflow secrets).
+ */
+function resolveRepoToken(
+  agentConfig: AgentConfig,
+  context: AgentContext | WorkflowAgentContext,
+  resolvedEnv?: Record<string, string>,
+): string | undefined {
+  // Step-level repoAuth takes priority
+  const authKey = agentConfig.repoAuth
+    ?? (isWorkflowAgentContext(context) ? context.workflowDefinition.repo?.auth : undefined);
+  if (!authKey || !resolvedEnv) return undefined;
+  return resolvedEnv[authKey];
+}
+
 export function resolveImageBuild(
   image: string,
   agentConfig: AgentConfig,
   context: AgentContext | WorkflowAgentContext,
+  resolvedEnv?: Record<string, string>,
 ): ImageBuildMeta | undefined {
   const { dockerfile, repo, commit } = agentConfig;
 
@@ -58,6 +75,7 @@ export function resolveImageBuild(
       repoUrl: normalizeRepoUrls(repo).gitUrl,
       commit,
       dockerfile,
+      repoToken: resolveRepoToken(agentConfig, context, resolvedEnv),
     };
   }
 
@@ -69,6 +87,7 @@ export function resolveImageBuild(
         repoUrl: repo ? normalizeRepoUrls(repo).gitUrl : normalizeRepoUrls(wfRepo.url).gitUrl,
         commit: commit ?? wfRepo.commit,
         dockerfile,
+        repoToken: resolveRepoToken(agentConfig, context, resolvedEnv),
       };
     }
   }

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -22,7 +22,9 @@ export function normalizeRepoUrls(repo: string): { gitUrl: string; httpsUrl: str
   }
   if (repo.startsWith('https://')) {
     const clean = repo.replace(/\.git$/, '');
-    return { gitUrl: `${clean}.git`, httpsUrl: clean };
+    const match = clean.match(/https:\/\/github\.com\/(.+)/);
+    const sshUrl = match ? `git@github.com:${match[1]}.git` : `${clean}.git`;
+    return { gitUrl: sshUrl, httpsUrl: clean };
   }
   return {
     gitUrl: `git@github.com:${repo}.git`,

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -104,7 +104,7 @@ export function resolveImageBuild(
 const SKILLS_CACHE_DIR = join(tmpdir(), 'mediforce-skills-cache');
 
 /** Convert SSH git URL to HTTPS with token for authenticated clone. */
-function toHttpsWithToken(sshUrl: string, token: string): string {
+export function toHttpsWithToken(sshUrl: string, token: string): string {
   const match = sshUrl.match(/git@github\.com:(.+?)(?:\.git)?$/);
   if (match) {
     return `https://x-access-token:${token}@github.com/${match[1]}.git`;

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -80,7 +80,7 @@ export async function buildImageFromRepo(options: BuildImageOptions): Promise<vo
     // Clone repo at specific commit (sparse — fetch only what we need)
     execSync(`git init "${buildDir}"`, execOpts);
     execSync(`git -C "${buildDir}" remote add origin "${cloneUrl}"`, execOpts);
-    execSync(`git -C "${buildDir}" fetch origin ${commit} --depth 1`, execOpts);
+    execSync(`git -C "${buildDir}" fetch origin "${commit}" --depth 1`, execOpts);
     execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
 
     // Build image — use the Dockerfile's directory as build context so COPY paths work naturally
@@ -88,7 +88,7 @@ export async function buildImageFromRepo(options: BuildImageOptions): Promise<vo
     const buildContext = dirname(dockerfilePath);
     console.log(`[docker-image-builder] Building image "${image}" from ${repoUrl}@${commit.slice(0, 8)}`);
     execSync(
-      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildContext}"`,
+      `docker build -t "${image}" --label "${BUILD_COMMIT_LABEL}=${commit}" -f "${dockerfilePath}" "${buildContext}"`,
       { stdio: 'pipe' },
     );
     console.log(`[docker-image-builder] Image "${image}" built successfully`);

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -15,6 +15,7 @@ export interface BuildImageOptions {
   repoUrl: string;
   commit: string;
   dockerfile?: string;
+  repoToken?: string;
 }
 
 export interface EnsureImageOptions {
@@ -22,6 +23,7 @@ export interface EnsureImageOptions {
   repoUrl?: string;
   commit?: string;
   dockerfile?: string;
+  repoToken?: string;
 }
 
 const BUILD_COMMIT_LABEL = 'mediforce.build.commit';
@@ -55,11 +57,21 @@ export async function getImageBuildCommit(image: string): Promise<string | null>
   }
 }
 
+/** Convert SSH git URL to HTTPS with token for authenticated clone. */
+function toHttpsWithToken(sshUrl: string, token: string): string {
+  const match = sshUrl.match(/git@github\.com:(.+?)(?:\.git)?$/);
+  if (match) {
+    return `https://x-access-token:${token}@github.com/${match[1]}.git`;
+  }
+  return sshUrl.replace('https://', `https://x-access-token:${token}@`);
+}
+
 export async function buildImageFromRepo(options: BuildImageOptions): Promise<void> {
-  const { image, repoUrl, commit, dockerfile = 'Dockerfile' } = options;
+  const { image, repoUrl, commit, dockerfile = 'Dockerfile', repoToken } = options;
   const buildDir = await mkdtemp(join(tmpdir(), 'mediforce-build-'));
 
   try {
+    const cloneUrl = repoToken ? toHttpsWithToken(repoUrl, repoToken) : repoUrl;
     const execOpts = {
       stdio: 'pipe' as const,
       env: { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() },
@@ -67,7 +79,7 @@ export async function buildImageFromRepo(options: BuildImageOptions): Promise<vo
 
     // Clone repo at specific commit (sparse — fetch only what we need)
     execSync(`git init "${buildDir}"`, execOpts);
-    execSync(`git -C "${buildDir}" remote add origin "${repoUrl}"`, execOpts);
+    execSync(`git -C "${buildDir}" remote add origin "${cloneUrl}"`, execOpts);
     execSync(`git -C "${buildDir}" fetch origin ${commit} --depth 1`, execOpts);
     execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
 
@@ -85,7 +97,7 @@ export async function buildImageFromRepo(options: BuildImageOptions): Promise<vo
 }
 
 export async function ensureImage(options: EnsureImageOptions): Promise<void> {
-  const { image, repoUrl, commit, dockerfile } = options;
+  const { image, repoUrl, commit, dockerfile, repoToken } = options;
 
   // If repo+commit not provided, just check existence
   if (!repoUrl || !commit) {
@@ -116,7 +128,7 @@ export async function ensureImage(options: EnsureImageOptions): Promise<void> {
         console.log(`[docker-image-builder] Image "${image}" stale (${currentCommit?.slice(0, 8)} → ${commit.slice(0, 8)}), rebuilding`);
       }
 
-      await buildImageFromRepo({ image, repoUrl, commit, dockerfile });
+      await buildImageFromRepo({ image, repoUrl, commit, dockerfile, repoToken });
     } finally {
       buildLocks.delete(image);
     }

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -9,6 +9,7 @@ import { execSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
+import { toHttpsWithToken } from './container-plugin.js';
 
 export interface BuildImageOptions {
   image: string;
@@ -55,15 +56,6 @@ export async function getImageBuildCommit(image: string): Promise<string | null>
   } catch {
     return null;
   }
-}
-
-/** Convert SSH git URL to HTTPS with token for authenticated clone. */
-function toHttpsWithToken(sshUrl: string, token: string): string {
-  const match = sshUrl.match(/git@github\.com:(.+?)(?:\.git)?$/);
-  if (match) {
-    return `https://x-access-token:${token}@github.com/${match[1]}.git`;
-  }
-  return sshUrl.replace('https://', `https://x-access-token:${token}@`);
 }
 
 export async function buildImageFromRepo(options: BuildImageOptions): Promise<void> {

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -1,0 +1,127 @@
+/**
+ * Lazy Docker image builder.
+ *
+ * Checks whether a Docker image exists locally and, if not, builds it from
+ * a git repo at a specific commit. Labels the image with the commit SHA so
+ * subsequent runs can detect staleness and rebuild when the commit changes.
+ */
+import { execSync } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+
+export interface BuildImageOptions {
+  image: string;
+  repoUrl: string;
+  commit: string;
+  dockerfile?: string;
+}
+
+export interface EnsureImageOptions {
+  image: string;
+  repoUrl?: string;
+  commit?: string;
+  dockerfile?: string;
+}
+
+const BUILD_COMMIT_LABEL = 'mediforce.build.commit';
+
+/** In-process mutex to avoid concurrent builds of the same image. */
+const buildLocks = new Map<string, Promise<void>>();
+
+function getGitSshCommand(): string {
+  const deployKeyPath = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
+  return `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no`;
+}
+
+export async function imageExistsLocally(image: string): Promise<boolean> {
+  try {
+    execSync(`docker image inspect "${image}"`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getImageBuildCommit(image: string): Promise<string | null> {
+  try {
+    const output = execSync(
+      `docker inspect --format '{{index .Config.Labels "${BUILD_COMMIT_LABEL}"}}' "${image}"`,
+      { stdio: 'pipe' },
+    ).toString().trim();
+    return output.length > 0 ? output : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function buildImageFromRepo(options: BuildImageOptions): Promise<void> {
+  const { image, repoUrl, commit, dockerfile = 'Dockerfile' } = options;
+  const buildDir = await mkdtemp(join(tmpdir(), 'mediforce-build-'));
+
+  try {
+    const execOpts = {
+      stdio: 'pipe' as const,
+      env: { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() },
+    };
+
+    // Clone repo at specific commit (sparse — fetch only what we need)
+    execSync(`git init "${buildDir}"`, execOpts);
+    execSync(`git -C "${buildDir}" remote add origin "${repoUrl}"`, execOpts);
+    execSync(`git -C "${buildDir}" fetch origin ${commit} --depth 1`, execOpts);
+    execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
+
+    // Build image with commit label for stale detection
+    const dockerfilePath = join(buildDir, dockerfile);
+    console.log(`[docker-image-builder] Building image "${image}" from ${repoUrl}@${commit.slice(0, 8)}`);
+    execSync(
+      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildDir}"`,
+      { stdio: 'pipe' },
+    );
+    console.log(`[docker-image-builder] Image "${image}" built successfully`);
+  } finally {
+    await rm(buildDir, { recursive: true, force: true });
+  }
+}
+
+export async function ensureImage(options: EnsureImageOptions): Promise<void> {
+  const { image, repoUrl, commit, dockerfile } = options;
+
+  // If repo+commit not provided, just check existence
+  if (!repoUrl || !commit) {
+    const exists = await imageExistsLocally(image);
+    if (exists) return;
+    throw new Error(
+      `Docker image "${image}" not found locally and no repo+commit configured for auto-build. ` +
+      'Either pull/build the image manually, or set repo and commit in the workflow step agent config.',
+    );
+  }
+
+  // Check if existing lock for this image
+  const existingLock = buildLocks.get(image);
+  if (existingLock) {
+    await existingLock;
+    return;
+  }
+
+  const buildPromise = (async () => {
+    try {
+      const exists = await imageExistsLocally(image);
+      if (exists) {
+        const currentCommit = await getImageBuildCommit(image);
+        if (currentCommit === commit) {
+          console.log(`[docker-image-builder] Image "${image}" up-to-date (commit ${commit.slice(0, 8)})`);
+          return;
+        }
+        console.log(`[docker-image-builder] Image "${image}" stale (${currentCommit?.slice(0, 8)} → ${commit.slice(0, 8)}), rebuilding`);
+      }
+
+      await buildImageFromRepo({ image, repoUrl, commit, dockerfile });
+    } finally {
+      buildLocks.delete(image);
+    }
+  })();
+
+  buildLocks.set(image, buildPromise);
+  await buildPromise;
+}

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -7,7 +7,7 @@
  */
 import { execSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 
 export interface BuildImageOptions {
@@ -83,11 +83,12 @@ export async function buildImageFromRepo(options: BuildImageOptions): Promise<vo
     execSync(`git -C "${buildDir}" fetch origin ${commit} --depth 1`, execOpts);
     execSync(`git -C "${buildDir}" checkout FETCH_HEAD`, execOpts);
 
-    // Build image with commit label for stale detection
+    // Build image — use the Dockerfile's directory as build context so COPY paths work naturally
     const dockerfilePath = join(buildDir, dockerfile);
+    const buildContext = dirname(dockerfilePath);
     console.log(`[docker-image-builder] Building image "${image}" from ${repoUrl}@${commit.slice(0, 8)}`);
     execSync(
-      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildDir}"`,
+      `docker build -t "${image}" --label ${BUILD_COMMIT_LABEL}=${commit} -f "${dockerfilePath}" "${buildContext}"`,
       { stdio: 'pipe' },
     );
     console.log(`[docker-image-builder] Image "${image}" built successfully`);

--- a/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
+++ b/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
@@ -17,6 +17,8 @@ export interface ImageBuildMeta {
   repoUrl: string;
   commit: string;
   dockerfile?: string;
+  /** Resolved token for authenticated HTTPS clone. When absent, falls back to SSH deploy key. */
+  repoToken?: string;
 }
 
 export interface DockerSpawnRequest {

--- a/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
+++ b/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
@@ -10,6 +10,14 @@
 import { spawn } from 'node:child_process';
 import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { ensureImage } from './docker-image-builder.js';
+
+export interface ImageBuildMeta {
+  image: string;
+  repoUrl: string;
+  commit: string;
+  dockerfile?: string;
+}
 
 export interface DockerSpawnRequest {
   dockerArgs: string[];
@@ -20,6 +28,8 @@ export interface DockerSpawnRequest {
   stepId: string;
   outputDir: string;
   logFile: string | null;
+  /** When present, strategy ensures the image exists (lazy build) before docker run. */
+  imageBuild?: ImageBuildMeta;
 }
 
 export interface DockerSpawnResult {
@@ -38,7 +48,11 @@ export interface DockerSpawnStrategy {
  * This is the current behavior — extracted into a strategy for swapability.
  */
 export class LocalDockerSpawnStrategy implements DockerSpawnStrategy {
-  spawn(request: DockerSpawnRequest): Promise<DockerSpawnResult> {
+  async spawn(request: DockerSpawnRequest): Promise<DockerSpawnResult> {
+    if (request.imageBuild) {
+      await ensureImage(request.imageBuild);
+    }
+
     return new Promise<DockerSpawnResult>((resolve, reject) => {
       const child = spawn('docker', request.dockerArgs, {
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -139,6 +153,7 @@ export class QueuedDockerSpawnStrategy implements DockerSpawnStrategy {
       outputDir: request.outputDir,
       logFile: request.logFile,
       inputFiles,
+      imageBuild: request.imageBuild,
     });
 
     // Write output files from worker back to caller's outputDir

--- a/packages/agent-runtime/src/plugins/script-container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/script-container-plugin.ts
@@ -1,15 +1,10 @@
 import { readFile, mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
 import type { AgentConfig, StepConfig, PluginCapabilityMetadata } from '@mediforce/platform-core';
-import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
-import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy.js';
-import { normalizeRepoUrls } from './base-container-agent-plugin.js';
-
-function isWorkflowAgentContext(ctx: AgentContext | WorkflowAgentContext): ctx is WorkflowAgentContext {
-  return 'step' in ctx && 'workflowDefinition' in ctx;
-}
+import { getDockerSpawnStrategy } from './docker-spawn-strategy.js';
+import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild } from './container-plugin.js';
 
 const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 
@@ -38,7 +33,7 @@ const RUNTIME_CONFIG: Record<string, { image: string; ext: string; cmd: (path: s
  *   3. Runs the script using the runtime's command in an auto-resolved Docker image
  *   4. Reads /output/result.json from the container
  */
-export class ScriptContainerPlugin implements AgentPlugin {
+export class ScriptContainerPlugin extends ContainerPlugin {
   readonly metadata: PluginCapabilityMetadata = {
     name: 'Script Container',
     description: 'Runs a deterministic script or inline code inside a Docker container — no LLM involved.',
@@ -47,14 +42,11 @@ export class ScriptContainerPlugin implements AgentPlugin {
     roles: ['executor'],
   };
 
-  private context!: AgentContext | WorkflowAgentContext;
   private image!: string;
   private commandArgs!: string[];
   private commandDisplay!: string;
   private inlineScript: string | null = null;
   private runtime: string | null = null;
-  private resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [] };
-  private imageBuild: ImageBuildMeta | undefined;
 
   async initialize(context: AgentContext | WorkflowAgentContext): Promise<void> {
     this.context = context;
@@ -130,31 +122,8 @@ export class ScriptContainerPlugin implements AgentPlugin {
 
     // Resolve env vars from definition-level + step-level env + workflow secrets
     const workflowSecrets = isWorkflowAgentContext(context) ? context.workflowSecrets : undefined;
-    this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv, workflowSecrets);
-
-    // Resolve image build metadata for lazy Docker image building.
-    const dockerfile = agentConfig.dockerfile;
-    const repo = agentConfig.repo;
-    const commit = agentConfig.commit;
-
-    if (repo && commit) {
-      this.imageBuild = {
-        image: this.image,
-        repoUrl: normalizeRepoUrls(repo).gitUrl,
-        commit,
-        dockerfile,
-      };
-    } else if (dockerfile && isWorkflowAgentContext(context)) {
-      const wfRepo = context.workflowDefinition.repo;
-      if (wfRepo?.url && wfRepo?.commit) {
-        this.imageBuild = {
-          image: this.image,
-          repoUrl: repo ? normalizeRepoUrls(repo).gitUrl : normalizeRepoUrls(wfRepo.url).gitUrl,
-          commit: commit ?? wfRepo.commit,
-          dockerfile,
-        };
-      }
-    }
+    this.resolveEnvironment(definitionEnv, stepEnv, workflowSecrets);
+    this.imageBuild = resolveImageBuild(this.image, agentConfig, context);
   }
 
   async run(emit: EmitFn): Promise<void> {

--- a/packages/agent-runtime/src/plugins/script-container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/script-container-plugin.ts
@@ -4,7 +4,8 @@ import { tmpdir } from 'node:os';
 import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
 import type { AgentConfig, StepConfig, PluginCapabilityMetadata } from '@mediforce/platform-core';
 import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
-import { getDockerSpawnStrategy } from './docker-spawn-strategy.js';
+import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy.js';
+import { normalizeRepoUrls } from './base-container-agent-plugin.js';
 
 function isWorkflowAgentContext(ctx: AgentContext | WorkflowAgentContext): ctx is WorkflowAgentContext {
   return 'step' in ctx && 'workflowDefinition' in ctx;
@@ -53,6 +54,7 @@ export class ScriptContainerPlugin implements AgentPlugin {
   private inlineScript: string | null = null;
   private runtime: string | null = null;
   private resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [] };
+  private imageBuild: ImageBuildMeta | undefined;
 
   async initialize(context: AgentContext | WorkflowAgentContext): Promise<void> {
     this.context = context;
@@ -129,6 +131,30 @@ export class ScriptContainerPlugin implements AgentPlugin {
     // Resolve env vars from definition-level + step-level env + workflow secrets
     const workflowSecrets = isWorkflowAgentContext(context) ? context.workflowSecrets : undefined;
     this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv, workflowSecrets);
+
+    // Resolve image build metadata for lazy Docker image building.
+    const dockerfile = agentConfig.dockerfile;
+    const repo = agentConfig.repo;
+    const commit = agentConfig.commit;
+
+    if (repo && commit) {
+      this.imageBuild = {
+        image: this.image,
+        repoUrl: normalizeRepoUrls(repo).gitUrl,
+        commit,
+        dockerfile,
+      };
+    } else if (dockerfile && isWorkflowAgentContext(context)) {
+      const wfRepo = context.workflowDefinition.repo;
+      if (wfRepo?.url && wfRepo?.commit) {
+        this.imageBuild = {
+          image: this.image,
+          repoUrl: repo ? normalizeRepoUrls(repo).gitUrl : normalizeRepoUrls(wfRepo.url).gitUrl,
+          commit: commit ?? wfRepo.commit,
+          dockerfile,
+        };
+      }
+    }
   }
 
   async run(emit: EmitFn): Promise<void> {
@@ -190,6 +216,7 @@ export class ScriptContainerPlugin implements AgentPlugin {
         stepId: this.context.stepId,
         outputDir,
         logFile: null,
+        imageBuild: this.imageBuild,
       });
 
       // Emit stdout/stderr lines as activity events (batch mode after completion)

--- a/packages/agent-runtime/src/plugins/script-container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/script-container-plugin.ts
@@ -123,7 +123,7 @@ export class ScriptContainerPlugin extends ContainerPlugin {
     // Resolve env vars from definition-level + step-level env + workflow secrets
     const workflowSecrets = isWorkflowAgentContext(context) ? context.workflowSecrets : undefined;
     this.resolveEnvironment(definitionEnv, stepEnv, workflowSecrets);
-    this.imageBuild = resolveImageBuild(this.image, agentConfig, context);
+    this.imageBuild = resolveImageBuild(this.image, agentConfig, context, this.resolvedEnv.vars);
   }
 
   async run(emit: EmitFn): Promise<void> {

--- a/packages/platform-core/src/schemas/process-config.ts
+++ b/packages/platform-core/src/schemas/process-config.ts
@@ -21,6 +21,7 @@ export const AgentConfigSchema = z.object({
   runtime: z.enum(['javascript', 'python', 'r', 'bash']).optional(),
   // Container image — when omitted, inline scripts auto-resolve the image from the runtime
   image: z.string().optional(),
+  dockerfile: z.string().optional(),
   repo: z.string().optional(),
   commit: z.string().optional(),
 });

--- a/packages/platform-core/src/schemas/process-config.ts
+++ b/packages/platform-core/src/schemas/process-config.ts
@@ -23,7 +23,7 @@ export const AgentConfigSchema = z.object({
   image: z.string().optional(),
   dockerfile: z.string().optional(),
   repo: z.string().optional(),
-  commit: z.string().optional(),
+  commit: z.string().regex(/^[a-f0-9]{7,40}$/, 'commit must be a hex SHA (7-40 chars)').optional(),
   repoAuth: z.string().optional(),
 });
 

--- a/packages/platform-core/src/schemas/process-config.ts
+++ b/packages/platform-core/src/schemas/process-config.ts
@@ -24,6 +24,7 @@ export const AgentConfigSchema = z.object({
   dockerfile: z.string().optional(),
   repo: z.string().optional(),
   commit: z.string().optional(),
+  repoAuth: z.string().optional(),
 });
 
 export const StepConfigSchema = z.object({

--- a/packages/platform-core/src/schemas/process-definition.ts
+++ b/packages/platform-core/src/schemas/process-definition.ts
@@ -58,7 +58,7 @@ export const RepoSchema = z.object({
   url: z.string().url(),
   branch: z.string().optional(),
   directory: z.string().optional(),
-  commit: z.string().optional(),
+  commit: z.string().regex(/^[a-f0-9]{7,40}$/, 'commit must be a hex SHA (7-40 chars)').optional(),
   /** Name of a workflow secret containing a token for repo access (e.g. "GITHUB_TOKEN"). */
   auth: z.string().optional(),
 });

--- a/packages/platform-core/src/schemas/process-definition.ts
+++ b/packages/platform-core/src/schemas/process-definition.ts
@@ -59,6 +59,8 @@ export const RepoSchema = z.object({
   branch: z.string().optional(),
   directory: z.string().optional(),
   commit: z.string().optional(),
+  /** Name of a workflow secret containing a token for repo access (e.g. "GITHUB_TOKEN"). */
+  auth: z.string().optional(),
 });
 
 export const ProcessDefinitionSchema = z.object({

--- a/packages/platform-core/src/schemas/process-definition.ts
+++ b/packages/platform-core/src/schemas/process-definition.ts
@@ -58,6 +58,7 @@ export const RepoSchema = z.object({
   url: z.string().url(),
   branch: z.string().optional(),
   directory: z.string().optional(),
+  commit: z.string().optional(),
 });
 
 export const ProcessDefinitionSchema = z.object({

--- a/packages/platform-core/src/schemas/workflow-definition.ts
+++ b/packages/platform-core/src/schemas/workflow-definition.ts
@@ -21,6 +21,7 @@ export const WorkflowAgentConfigSchema = z.object({
   inlineScript: z.string().optional(),
   runtime: z.enum(['javascript', 'python', 'r', 'bash']).optional(),
   image: z.string().optional(),
+  dockerfile: z.string().optional(),
   repo: z.string().optional(),
   commit: z.string().optional(),
   confidenceThreshold: z.number().min(0).max(1).optional(),

--- a/packages/platform-core/src/schemas/workflow-definition.ts
+++ b/packages/platform-core/src/schemas/workflow-definition.ts
@@ -24,6 +24,8 @@ export const WorkflowAgentConfigSchema = z.object({
   dockerfile: z.string().optional(),
   repo: z.string().optional(),
   commit: z.string().optional(),
+  /** Name of a workflow secret containing a token for repo access. */
+  repoAuth: z.string().optional(),
   confidenceThreshold: z.number().min(0).max(1).optional(),
   fallbackBehavior: z.enum(['escalate_to_human', 'continue_with_flag', 'pause']).optional(),
 });

--- a/packages/platform-core/src/schemas/workflow-definition.ts
+++ b/packages/platform-core/src/schemas/workflow-definition.ts
@@ -23,7 +23,7 @@ export const WorkflowAgentConfigSchema = z.object({
   image: z.string().optional(),
   dockerfile: z.string().optional(),
   repo: z.string().optional(),
-  commit: z.string().optional(),
+  commit: z.string().regex(/^[a-f0-9]{7,40}$/, 'commit must be a hex SHA (7-40 chars)').optional(),
   /** Name of a workflow secret containing a token for repo access. */
   repoAuth: z.string().optional(),
   confidenceThreshold: z.number().min(0).max(1).optional(),

--- a/packages/platform-ui/Dockerfile
+++ b/packages/platform-ui/Dockerfile
@@ -41,6 +41,10 @@ RUN pnpm --filter @mediforce/platform-ui build
 
 # --- Runner ---
 FROM node:24-slim AS runner
+
+# Git needed for cloning workflow repos (skill loading, lazy image build)
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary

- **Lazy Docker image build**: When a workflow step references a Docker image that doesn't exist locally, the runtime clones the source repo at a specific commit and builds it automatically. Stale detection via Docker labels rebuilds when commit changes.
- **Skill loading from git repo**: When a workflow has `repo` configured, `skillsDir` resolves from a shallow clone of that repo (cached deterministically) instead of requiring files on the host filesystem.
- **Repo auth via workflow secrets**: New `auth` field on `RepoSchema` and `repoAuth` on agent config — references a workflow secret name for authenticated HTTPS clone. Different steps can use different repos with different tokens.
- **ContainerPlugin abstract base class**: Extracted shared Docker logic (image build resolution, env resolution, skill fetching) from `BaseContainerAgentPlugin` and `ScriptContainerPlugin` into a common parent.

## Schema changes

- `RepoSchema`: added `commit`, `auth` fields
- `AgentConfigSchema` / `WorkflowAgentConfigSchema`: added `dockerfile`, `repoAuth` fields
- `DockerJobDataSchema`: added `imageBuild` with `repoToken` for worker-side builds

## New files

- `packages/agent-runtime/src/plugins/container-plugin.ts` — abstract base class
- `packages/agent-runtime/src/plugins/docker-image-builder.ts` — build/cache logic
- `packages/agent-queue/src/docker-image-builder.ts` — worker-side copy

## Test plan

- [x] 14 unit tests (mocked child_process) — decision logic for image builds
- [x] 6 integration tests (real Docker + local bare git repo) — fresh build, cache reuse, stale rebuild, missing Dockerfile, custom path
- [x] 1 E2E test (LocalDockerSpawnStrategy) — full flow: missing image → auto-build → docker run → verify output
- [x] Tested end-to-end on staging with `daily-reads` workflow (private repo, GITHUB_TOKEN auth, skill loading)
- [ ] Queued strategy (BullMQ worker) integration test — follow-up in #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)