### PR TITLE
fix: cron heartbeat script — avoid crontab % escaping bug

### DIFF
--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -4,6 +4,19 @@ source /opt/mediforce/.env
 
 URL="https://${DOMAIN}/api/cron/heartbeat"
 LOG="/opt/mediforce/logs/heartbeat.log"
+LOG_PREV="/opt/mediforce/logs/heartbeat.last-week.log"
+
+# Weekly log rotation (Monday 00:00–00:14 window, runs every 15 min)
+if [[ "$(date +%u)" == "1" && "$(date +%H)" == "00" && ! -f "$LOG.rotated-this-week" ]]; then
+  mv -f "$LOG_PREV" "$LOG_PREV.tmp" 2>/dev/null || true
+  mv -f "$LOG" "$LOG_PREV" 2>/dev/null || true
+  rm -f "$LOG_PREV.tmp"
+  touch "$LOG.rotated-this-week"
+fi
+# Clear rotation guard after Monday
+if [[ "$(date +%u)" != "1" ]]; then
+  rm -f "$LOG.rotated-this-week"
+fi
 
 HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$URL" \
   -H "X-Api-Key: $PLATFORM_API_KEY" \

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+source /opt/mediforce/.env
+
+URL="https://${DOMAIN}/api/cron/heartbeat"
+LOG="/opt/mediforce/logs/heartbeat.log"
+
+HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "X-Api-Key: $PLATFORM_API_KEY" \
+  -H "Content-Type: application/json" 2>/dev/null) || HTTP_CODE="FAIL"
+
+printf "[%s] %s\n" "$(date -Iseconds)" "$HTTP_CODE" >> "$LOG"

--- a/scripts/setup-cron.py
+++ b/scripts/setup-cron.py
@@ -37,11 +37,12 @@ def install(host: str, interval: int) -> None:
         print("  Run a deploy first so the repo is on the server.")
         sys.exit(1)
 
-    # Verify .env has required vars
-    result = ssh(host, f"grep -qE '^(PLATFORM_API_KEY|DOMAIN)=' {MEDIFORCE_DIR}/.env")
-    if result.returncode != 0:
-        print(f"ERROR: PLATFORM_API_KEY or DOMAIN not found in {MEDIFORCE_DIR}/.env on {host}")
-        sys.exit(1)
+    # Verify .env has both required vars
+    for var in ("PLATFORM_API_KEY", "DOMAIN"):
+        result = ssh(host, f"grep -q '^{var}=' {MEDIFORCE_DIR}/.env")
+        if result.returncode != 0:
+            print(f"ERROR: {var} not found in {MEDIFORCE_DIR}/.env on {host}")
+            sys.exit(1)
 
     cron_line = f"*/{interval} * * * * {HEARTBEAT_SCRIPT} # {CRON_COMMENT}"
 

--- a/scripts/setup-cron.py
+++ b/scripts/setup-cron.py
@@ -17,6 +17,7 @@ import sys
 
 CRON_COMMENT = "mediforce-heartbeat"
 MEDIFORCE_DIR = "/opt/mediforce"
+HEARTBEAT_SCRIPT = f"{MEDIFORCE_DIR}/scripts/heartbeat.sh"
 DEFAULT_INTERVAL = 15
 
 
@@ -29,33 +30,20 @@ def ssh(host: str, command: str) -> subprocess.CompletedProcess:
 
 
 def install(host: str, interval: int) -> None:
-    # Read env vars from server
-    result = ssh(host, f"grep -E '^(PLATFORM_API_KEY|DOMAIN)=' {MEDIFORCE_DIR}/.env")
+    # Verify heartbeat script exists on server
+    result = ssh(host, f"test -x {HEARTBEAT_SCRIPT}")
     if result.returncode != 0:
-        print(f"ERROR: Cannot read .env on {host}: {result.stderr.strip()}")
+        print(f"ERROR: {HEARTBEAT_SCRIPT} not found or not executable on {host}")
+        print("  Run a deploy first so the repo is on the server.")
         sys.exit(1)
 
-    env = {}
-    for line in result.stdout.strip().splitlines():
-        key, _, value = line.partition("=")
-        env[key] = value.strip().strip('"').strip("'")
+    # Verify .env has required vars
+    result = ssh(host, f"grep -qE '^(PLATFORM_API_KEY|DOMAIN)=' {MEDIFORCE_DIR}/.env")
+    if result.returncode != 0:
+        print(f"ERROR: PLATFORM_API_KEY or DOMAIN not found in {MEDIFORCE_DIR}/.env on {host}")
+        sys.exit(1)
 
-    for key in ("PLATFORM_API_KEY", "DOMAIN"):
-        if key not in env:
-            print(f"ERROR: {key} not found in {MEDIFORCE_DIR}/.env on {host}")
-            sys.exit(1)
-
-    url = f"https://{env['DOMAIN']}/api/cron/heartbeat"
-    api_key = env["PLATFORM_API_KEY"]
-
-    cron_line = (
-        f"*/{interval} * * * * "
-        f'curl -sf -X POST "{url}" '
-        f'-H "X-Api-Key: {api_key}" '
-        f'-H "Content-Type: application/json" '
-        f">/dev/null 2>&1 "
-        f"# {CRON_COMMENT}"
-    )
+    cron_line = f"*/{interval} * * * * {HEARTBEAT_SCRIPT} # {CRON_COMMENT}"
 
     # Remove old entry if exists, then append new one
     install_cmd = (
@@ -69,12 +57,23 @@ def install(host: str, interval: int) -> None:
         sys.exit(1)
 
     print(f"Installed on {host}:")
-    print(f"  URL:      {url}")
+    print(f"  Script:   {HEARTBEAT_SCRIPT}")
     print(f"  Interval: every {interval} min")
 
-    # Verify
+    # Verify crontab was written
     result = ssh(host, f"crontab -l | grep '{CRON_COMMENT}'")
     print(f"  Crontab:  {result.stdout.strip()}")
+
+    # Smoke test: run the heartbeat script and check exit code + log output
+    print("\n  Smoke test...")
+    result = ssh(host, f"{HEARTBEAT_SCRIPT} && tail -1 {MEDIFORCE_DIR}/logs/heartbeat.log")
+    if result.returncode != 0:
+        print(f"  WARN: Heartbeat script failed: {result.stderr.strip()}")
+    else:
+        last_line = result.stdout.strip()
+        print(f"  Result:   {last_line}")
+        if "200" not in last_line:
+            print("  WARN: Expected HTTP 200 — check .env DOMAIN and PLATFORM_API_KEY")
 
 
 def remove(host: str) -> None:


### PR DESCRIPTION
## Summary
- Crontab treats `%` as newline — inline curl with `%{http_code}` and `printf %s` was silently broken (command truncated, log redirect never executed)
- Extracted heartbeat curl into `scripts/heartbeat.sh` — crontab now calls the script instead of inline command
- Simplified `setup-cron.py` to install a one-liner crontab + smoke test after install

## What happened
The cron was running every 15 min but the actual command was `printf [` (everything after the first `%` became stdin). The heartbeat endpoint was never called, so scheduled workflows like `daily-reads` never triggered.

## Test plan
- [x] Manually tested heartbeat.sh on staging VPS — returns `[timestamp] 200`
- [x] Verified cron fires and triggers workflows (daily-reads instance created)
- [x] Heartbeat log now shows entries every 15 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)