### PR TITLE
Run report API endpoint (JSON/Markdown/HTML) for any run status

### DIFF
--- a/packages/platform-ui/src/app/api/processes/[instanceId]/report/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/report/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPlatformServices, validateApiKey } from '@/lib/platform-services';
+import { assembleReport } from '@/lib/report/assemble-report';
+import { renderMarkdown } from '@/lib/report/render-markdown';
+import { renderHtml } from '@/lib/report/render-html';
+
+/**
+ * GET /api/processes/:instanceId/report
+ *
+ * Returns a full run report. Works for any run status (running, paused, failed, completed).
+ *
+ * Query params:
+ *   format=json (default) — structured report data
+ *   format=markdown       — human-readable markdown
+ *   format=html           — standalone HTML file (self-contained, no external deps)
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ instanceId: string }> },
+): Promise<NextResponse> {
+  if (!validateApiKey(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { instanceId } = await params;
+    const format = req.nextUrl.searchParams.get('format') ?? 'json';
+    const services = getPlatformServices();
+    const report = await assembleReport(instanceId, services);
+
+    if (format === 'markdown') {
+      const md = renderMarkdown(report);
+      return new NextResponse(md, {
+        headers: {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          'Content-Disposition': `inline; filename="${report.definitionName}-report.md"`,
+        },
+      });
+    }
+
+    if (format === 'html') {
+      const html = renderHtml(report);
+      return new NextResponse(html, {
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Content-Disposition': `inline; filename="${report.definitionName}-report.html"`,
+        },
+      });
+    }
+
+    // Default: JSON
+    return NextResponse.json(report);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    const status = message.includes('not found') ? 404 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/packages/platform-ui/src/lib/report/assemble-report.ts
+++ b/packages/platform-ui/src/lib/report/assemble-report.ts
@@ -1,0 +1,231 @@
+import type {
+  ProcessInstance,
+  StepExecution,
+  AuditEvent,
+  Step,
+  WorkflowDefinition,
+} from '@mediforce/platform-core';
+import type { PlatformServices } from '../platform-services.js';
+import {
+  formatDuration,
+  computeWallClockDuration,
+  computeActiveProcessingTime,
+} from '../format.js';
+
+export interface ReportStep {
+  stepId: string;
+  name: string;
+  type: string;
+  status: 'completed' | 'running' | 'pending' | 'failed' | 'escalated' | 'paused';
+  executorType: 'human' | 'agent' | 'script' | 'unknown';
+  startedAt: string | null;
+  completedAt: string | null;
+  durationMs: number | null;
+  input: Record<string, unknown>;
+  output: Record<string, unknown> | null;
+  error: string | null;
+  agentOutput: StepExecution['agentOutput'] | null;
+  reviewVerdicts: StepExecution['reviewVerdicts'];
+  auditEvents: Array<AuditEvent & { id: string }>;
+}
+
+export interface ReportSummary {
+  status: string;
+  wallClockDuration: string | null;
+  wallClockDurationMs: number | null;
+  activeProcessingTime: string;
+  activeProcessingTimeMs: number;
+  completedSteps: number;
+  totalSteps: number;
+  currentStepId: string | null;
+  createdAt: string;
+  createdBy: string;
+  triggerType: string;
+}
+
+export interface RunReportData {
+  instance: ProcessInstance;
+  definitionName: string;
+  definitionVersion: string;
+  summary: ReportSummary;
+  steps: ReportStep[];
+  auditEvents: Array<AuditEvent & { id: string }>;
+}
+
+/**
+ * Resolve definition steps from either workflow definitions or legacy process definitions.
+ * Server-side equivalent of resolve-definition-steps.ts (which needs client hooks).
+ */
+async function resolveSteps(
+  instance: ProcessInstance,
+  processRepo: PlatformServices['processRepo'],
+): Promise<Step[]> {
+  const defVersion = instance.definitionVersion;
+  const isNewStyle = /^\d+$/.test(defVersion);
+
+  if (isNewStyle) {
+    const versionNum = parseInt(defVersion, 10);
+    const workflow = await processRepo.getWorkflowDefinition(
+      instance.definitionName,
+      versionNum,
+    );
+    if (workflow?.steps?.length) return workflow.steps;
+  }
+
+  // Fallback to legacy
+  const legacy = await processRepo.getProcessDefinition(
+    instance.definitionName,
+    defVersion,
+  );
+  if (legacy?.steps?.length) return legacy.steps;
+
+  return [];
+}
+
+export async function assembleReport(
+  instanceId: string,
+  services: PlatformServices,
+): Promise<RunReportData> {
+  const { instanceRepo, processRepo, auditRepo } = services;
+
+  const instance = await instanceRepo.getById(instanceId);
+  if (!instance) {
+    throw new Error(`Instance not found: ${instanceId}`);
+  }
+
+  const [stepExecutions, allAuditEvents, definitionSteps] = await Promise.all([
+    instanceRepo.getStepExecutions(instanceId),
+    auditRepo.getByProcess(instanceId),
+    resolveSteps(instance, processRepo),
+  ]);
+
+  // Index audit events by id (Firestore returns them with id)
+  const auditWithIds = allAuditEvents.map((event, index) => ({
+    ...event,
+    id: `audit-${index}`,
+  }));
+
+  // Index executions by stepId (latest per step)
+  const executionsByStep = new Map<string, StepExecution>();
+  for (const exec of stepExecutions) {
+    const existing = executionsByStep.get(exec.stepId);
+    if (!existing || exec.startedAt > existing.startedAt) {
+      executionsByStep.set(exec.stepId, exec);
+    }
+  }
+
+  // Determine step configs for executor type
+  let stepConfigs: Array<{ stepId: string; executorType?: string }> = [];
+  const isNewStyle = /^\d+$/.test(instance.definitionVersion);
+  if (!isNewStyle) {
+    const config = await processRepo.getProcessConfig(
+      instance.definitionName,
+      instance.configName ?? '',
+      instance.configVersion ?? '',
+    );
+    stepConfigs = config?.stepConfigs ?? [];
+  }
+
+  // Build report steps
+  const currentStepId = instance.currentStepId;
+  let pastCurrentStep = false;
+  const reportSteps: ReportStep[] = [];
+
+  for (const step of definitionSteps) {
+    if (step.type === 'terminal') continue;
+
+    const execution = executionsByStep.get(step.id) ?? null;
+
+    // Determine executor type — new-style has it on the step, legacy on config
+    let executorType: ReportStep['executorType'] = 'unknown';
+    if ('executor' in step && step.executor) {
+      executorType = step.executor as ReportStep['executorType'];
+    } else {
+      const stepConfig = stepConfigs.find((sc) => sc.stepId === step.id);
+      executorType = (stepConfig?.executorType as ReportStep['executorType']) ?? 'unknown';
+    }
+
+    // Determine status
+    let status: ReportStep['status'];
+    if (execution?.status === 'failed') {
+      status = 'failed';
+    } else if (execution?.status === 'escalated') {
+      status = 'escalated';
+    } else if (execution?.status === 'paused') {
+      status = 'paused';
+    } else if (pastCurrentStep) {
+      status = 'pending';
+    } else if (step.id === currentStepId) {
+      status = instance.status === 'completed' ? 'completed' : 'running';
+      pastCurrentStep = true;
+    } else if (instance.status === 'completed' && currentStepId === null) {
+      status = execution?.output !== null ? 'completed' : 'pending';
+    } else {
+      const hasOutput = execution?.output !== null;
+      status = hasOutput ? 'completed' : 'pending';
+    }
+
+    // Duration
+    let durationMs: number | null = null;
+    if (execution?.completedAt !== null && execution?.startedAt) {
+      durationMs =
+        new Date(execution.completedAt).getTime() -
+        new Date(execution.startedAt).getTime();
+    }
+
+    // Audit events for this step
+    const stepAudit = auditWithIds
+      .filter((e) => e.stepId === step.id)
+      .sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      );
+
+    reportSteps.push({
+      stepId: step.id,
+      name: step.name,
+      type: step.type,
+      status,
+      executorType,
+      startedAt: execution?.startedAt ?? null,
+      completedAt: execution?.completedAt ?? null,
+      durationMs,
+      input: execution?.input ?? {},
+      output: execution?.output ?? null,
+      error: execution?.error ?? null,
+      agentOutput: execution?.agentOutput ?? null,
+      reviewVerdicts: execution?.reviewVerdicts,
+      auditEvents: stepAudit,
+    });
+  }
+
+  // Summary
+  const wallClockMs = computeWallClockDuration(
+    instance.createdAt,
+    stepExecutions,
+  );
+  const activeMs = computeActiveProcessingTime(stepExecutions);
+
+  const summary: ReportSummary = {
+    status: instance.status,
+    wallClockDuration: wallClockMs !== null ? formatDuration(wallClockMs) : null,
+    wallClockDurationMs: wallClockMs,
+    activeProcessingTime: formatDuration(activeMs),
+    activeProcessingTimeMs: activeMs,
+    completedSteps: reportSteps.filter((s) => s.status === 'completed').length,
+    totalSteps: reportSteps.length,
+    currentStepId,
+    createdAt: instance.createdAt,
+    createdBy: instance.createdBy,
+    triggerType: instance.triggerType,
+  };
+
+  return {
+    instance,
+    definitionName: instance.definitionName,
+    definitionVersion: instance.definitionVersion,
+    summary,
+    steps: reportSteps,
+    auditEvents: auditWithIds,
+  };
+}

--- a/packages/platform-ui/src/lib/report/render-html.ts
+++ b/packages/platform-ui/src/lib/report/render-html.ts
@@ -1,0 +1,278 @@
+/**
+ * Converts markdown report to a standalone HTML file.
+ * Zero external dependencies — uses a simple markdown-to-HTML converter
+ * and inline CSS. The output is a single self-contained file.
+ */
+
+import type { RunReportData } from './assemble-report.js';
+import { renderMarkdown } from './render-markdown.js';
+
+// Minimal markdown to HTML converter — handles the subset we generate
+function markdownToHtml(md: string): string {
+  let html = md;
+
+  // Escape HTML entities in non-code blocks (we'll handle code blocks separately)
+  const codeBlocks: string[] = [];
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_match, lang, code) => {
+    const index = codeBlocks.length;
+    const escaped = code
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    codeBlocks.push(
+      `<pre class="code-block"><code class="language-${lang || 'text'}">${escaped}</code></pre>`,
+    );
+    return `__CODE_BLOCK_${index}__`;
+  });
+
+  // Details/summary (pass through as-is — already HTML)
+  // No transformation needed
+
+  // Headers
+  html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+  html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+  html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+  // Blockquotes
+  html = html.replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>');
+  // Merge adjacent blockquotes
+  html = html.replace(/<\/blockquote>\n<blockquote>/g, '<br>');
+
+  // Tables
+  html = html.replace(
+    /(?:^\|.+\|$\n)+/gm,
+    (tableBlock) => {
+      const rows = tableBlock.trim().split('\n');
+      if (rows.length < 2) return tableBlock;
+
+      let tableHtml = '<table>';
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        // Skip separator row (|---|---|)
+        if (/^\|[\s-:|]+\|$/.test(row)) continue;
+
+        const cells = row
+          .split('|')
+          .slice(1, -1)
+          .map((c) => c.trim());
+        const tag = i === 0 ? 'th' : 'td';
+        const rowClass = i === 0 ? ' class="table-header"' : '';
+        tableHtml += `<tr${rowClass}>${cells.map((c) => `<${tag}>${c}</${tag}>`).join('')}</tr>`;
+      }
+      tableHtml += '</table>';
+      return tableHtml;
+    },
+  );
+
+  // Bold
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+
+  // Italic
+  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+  // Inline code
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+  // Links
+  html = html.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noopener">$1</a>',
+  );
+
+  // Unordered lists
+  html = html.replace(/(?:^- .+$\n?)+/gm, (listBlock) => {
+    const items = listBlock
+      .trim()
+      .split('\n')
+      .map((line) => {
+        // Handle nested items (indented with spaces)
+        const indent = line.match(/^(\s*)-/);
+        const content = line.replace(/^\s*- /, '');
+        if (indent && indent[1].length >= 2) {
+          return `<li class="nested">${content}</li>`;
+        }
+        return `<li>${content}</li>`;
+      });
+    return `<ul>${items.join('')}</ul>`;
+  });
+
+  // Horizontal rule
+  html = html.replace(/^---$/gm, '<hr>');
+
+  // Paragraphs — wrap remaining text lines
+  html = html.replace(/^(?!<[a-z/]|__CODE)(.+)$/gm, '<p>$1</p>');
+
+  // Restore code blocks
+  for (let i = 0; i < codeBlocks.length; i++) {
+    html = html.replace(`__CODE_BLOCK_${i}__`, codeBlocks[i]);
+  }
+
+  // Clean up empty paragraphs
+  html = html.replace(/<p><\/p>/g, '');
+  html = html.replace(/\n{3,}/g, '\n\n');
+
+  return html;
+}
+
+const CSS = `
+  :root {
+    --bg: #ffffff;
+    --bg-card: #f8f9fa;
+    --bg-code: #f1f3f5;
+    --text: #212529;
+    --text-muted: #868e96;
+    --border: #dee2e6;
+    --primary: #228be6;
+    --green: #40c057;
+    --red: #fa5252;
+    --amber: #fab005;
+    --blue: #339af0;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #1a1b1e;
+      --bg-card: #25262b;
+      --bg-code: #2c2e33;
+      --text: #c1c2c5;
+      --text-muted: #909296;
+      --border: #373a40;
+      --primary: #4dabf7;
+      --green: #51cf66;
+      --red: #ff6b6b;
+      --amber: #fcc419;
+      --blue: #74c0fc;
+    }
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+  }
+
+  h1 { font-size: 1.75rem; margin-bottom: 1rem; }
+  h2 { font-size: 1.35rem; margin: 2rem 0 0.75rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+  h3 { font-size: 1.1rem; margin: 1.5rem 0 0.5rem; }
+
+  p { margin: 0.25rem 0; }
+
+  a { color: var(--primary); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+
+  blockquote {
+    border-left: 4px solid var(--amber);
+    background: var(--bg-card);
+    padding: 0.75rem 1rem;
+    margin: 0.75rem 0;
+    border-radius: 0 6px 6px 0;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5rem 0;
+    font-size: 0.9rem;
+  }
+
+  th, td {
+    text-align: left;
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  th { font-weight: 600; }
+
+  .table-header th {
+    background: var(--bg-card);
+  }
+
+  code {
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.85em;
+    background: var(--bg-code);
+    padding: 0.15em 0.4em;
+    border-radius: 3px;
+  }
+
+  .code-block {
+    background: var(--bg-code);
+    border-radius: 6px;
+    padding: 1rem;
+    overflow-x: auto;
+    margin: 0.5rem 0;
+    font-size: 0.8rem;
+    line-height: 1.5;
+  }
+
+  .code-block code {
+    background: none;
+    padding: 0;
+  }
+
+  ul { padding-left: 1.5rem; margin: 0.25rem 0; }
+  li { margin: 0.15rem 0; }
+  li.nested { margin-left: 1rem; }
+
+  details {
+    margin: 0.5rem 0;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+
+  summary {
+    cursor: pointer;
+    padding: 0.5rem 0.75rem;
+    background: var(--bg-card);
+    font-weight: 500;
+    font-size: 0.9rem;
+  }
+
+  details > :not(summary) {
+    padding: 0 0.75rem 0.75rem;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 2rem 0;
+  }
+
+  strong { font-weight: 600; }
+  em { font-style: italic; color: var(--text-muted); }
+
+  @media print {
+    body { max-width: 100%; padding: 1rem; }
+    details { border: none; }
+    details[open] summary { display: none; }
+    details > * { padding: 0 !important; }
+    a { color: var(--text); }
+    a::after { content: " (" attr(href) ")"; font-size: 0.8em; color: var(--text-muted); }
+  }
+`;
+
+export function renderHtml(report: RunReportData): string {
+  const md = renderMarkdown(report);
+  const bodyHtml = markdownToHtml(md);
+  const title = `${report.definitionName} \u2014 Run Report`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title}</title>
+  <style>${CSS}</style>
+</head>
+<body>
+${bodyHtml}
+</body>
+</html>`;
+}

--- a/packages/platform-ui/src/lib/report/render-markdown.ts
+++ b/packages/platform-ui/src/lib/report/render-markdown.ts
@@ -1,0 +1,247 @@
+import type { RunReportData, ReportStep } from './assemble-report.js';
+
+function escapeMarkdown(text: string): string {
+  return text.replace(/[|]/g, '\\|');
+}
+
+function statusEmoji(status: string): string {
+  const map: Record<string, string> = {
+    completed: '\u2705',
+    running: '\u23f3',
+    pending: '\u26aa',
+    failed: '\u274c',
+    escalated: '\u26a0\ufe0f',
+    paused: '\u23f8\ufe0f',
+  };
+  return map[status] ?? '\u2753';
+}
+
+function instanceStatusLabel(status: string): string {
+  const map: Record<string, string> = {
+    created: '\ud83d\udfe1 Created',
+    running: '\ud83d\udfe2 Running',
+    paused: '\ud83d\udfe1 Paused',
+    completed: '\u2705 Completed',
+    failed: '\ud83d\udd34 Failed',
+  };
+  return map[status] ?? status;
+}
+
+function executorLabel(type: string): string {
+  const map: Record<string, string> = {
+    human: '\ud83d\udc64 Human',
+    agent: '\ud83e\udd16 AI Agent',
+    script: '\u2699\ufe0f Script',
+    cowork: '\ud83e\udd1d Cowork',
+  };
+  return map[type] ?? type;
+}
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  return date.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, ' UTC');
+}
+
+function truncateJson(value: unknown, maxLines: number): string {
+  const full = JSON.stringify(value, null, 2);
+  const lines = full.split('\n');
+  if (lines.length <= maxLines) return full;
+  return lines.slice(0, maxLines).join('\n') + '\n...';
+}
+
+function renderStepSection(step: ReportStep, index: number): string {
+  const lines: string[] = [];
+
+  const durationStr = step.durationMs !== null
+    ? ` (${formatDurationCompact(step.durationMs)})`
+    : '';
+
+  lines.push(
+    `### ${index + 1}. ${statusEmoji(step.status)} ${step.name}${durationStr}`,
+  );
+  lines.push('');
+
+  // Metadata line
+  const meta: string[] = [];
+  meta.push(`**Status:** ${step.status}`);
+  meta.push(`**Executor:** ${executorLabel(step.executorType)}`);
+  if (step.agentOutput?.model && step.agentOutput.model !== 'script') {
+    meta.push(`**Model:** \`${step.agentOutput.model}\``);
+  }
+  if (
+    step.agentOutput?.confidence !== undefined &&
+    step.agentOutput?.confidence !== null &&
+    step.agentOutput?.model !== 'script'
+  ) {
+    const pct = Math.round(step.agentOutput.confidence * 100);
+    meta.push(`**Confidence:** ${pct}%`);
+    if (step.agentOutput.confidence_rationale) {
+      meta.push(`*${step.agentOutput.confidence_rationale}*`);
+    }
+  }
+  lines.push(meta.join(' | '));
+  lines.push('');
+
+  // Timing
+  if (step.startedAt) {
+    lines.push(
+      `> Started: ${formatTimestamp(step.startedAt)}` +
+        (step.completedAt ? ` \u2192 Completed: ${formatTimestamp(step.completedAt)}` : ''),
+    );
+    lines.push('');
+  }
+
+  // Error
+  if (step.error) {
+    lines.push('**Error:**');
+    lines.push('```');
+    lines.push(step.error);
+    lines.push('```');
+    lines.push('');
+  }
+
+  // Review verdicts
+  if (step.reviewVerdicts && step.reviewVerdicts.length > 0) {
+    lines.push('**Review Verdicts:**');
+    for (const verdict of step.reviewVerdicts) {
+      const comment = verdict.comment ? ` \u2014 ${verdict.comment}` : '';
+      lines.push(
+        `- **${verdict.verdict}** by ${verdict.reviewerId} (${verdict.reviewerRole})${comment}`,
+      );
+    }
+    lines.push('');
+  }
+
+  // Input
+  if (Object.keys(step.input).length > 0) {
+    lines.push('<details><summary>Input</summary>');
+    lines.push('');
+    lines.push('```json');
+    lines.push(truncateJson(step.input, 30));
+    lines.push('```');
+    lines.push('</details>');
+    lines.push('');
+  }
+
+  // Output
+  if (step.output !== null && Object.keys(step.output).length > 0) {
+    lines.push('<details><summary>Output</summary>');
+    lines.push('');
+    lines.push('```json');
+    lines.push(truncateJson(step.output, 30));
+    lines.push('```');
+    lines.push('</details>');
+    lines.push('');
+  }
+
+  // Git metadata
+  const git = step.agentOutput?.gitMetadata;
+  if (git) {
+    lines.push('**Git:**');
+    lines.push(`- Branch: \`${git.branch}\``);
+    lines.push(`- Commit: [\`${git.commitSha.slice(0, 7)}\`](${git.repoUrl}/commit/${git.commitSha})`);
+    if (git.changedFiles.length > 0) {
+      lines.push(`- Changed files (${git.changedFiles.length}):`);
+      for (const file of git.changedFiles) {
+        lines.push(`  - \`${file}\``);
+      }
+    }
+    lines.push('');
+  }
+
+  // Audit trail for this step
+  if (step.auditEvents.length > 0) {
+    lines.push('<details><summary>Audit Trail</summary>');
+    lines.push('');
+    lines.push('| Time | Action | Description |');
+    lines.push('|------|--------|-------------|');
+    for (const event of step.auditEvents.slice(0, 10)) {
+      const time = formatTimestamp(event.timestamp).split(' ')[1] ?? '';
+      lines.push(
+        `| ${time} | ${escapeMarkdown(event.action)} | ${escapeMarkdown(event.description)} |`,
+      );
+    }
+    if (step.auditEvents.length > 10) {
+      lines.push(`| ... | *${step.auditEvents.length - 10} more events* | |`);
+    }
+    lines.push('</details>');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function formatDurationCompact(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+}
+
+export function renderMarkdown(report: RunReportData): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`# ${report.definitionName} \u2014 Run Report`);
+  lines.push('');
+
+  // Status banner for non-completed runs
+  if (report.summary.status !== 'completed') {
+    lines.push(
+      `> **${instanceStatusLabel(report.summary.status)}** \u2014 This report reflects the current state of the run.`,
+    );
+    if (report.instance.pauseReason) {
+      lines.push(`> Pause reason: ${report.instance.pauseReason}`);
+    }
+    if (report.instance.error) {
+      lines.push(`> Error: ${report.instance.error}`);
+    }
+    lines.push('');
+  }
+
+  // Summary table
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`| | |`);
+  lines.push(`|---|---|`);
+  lines.push(`| **Status** | ${instanceStatusLabel(report.summary.status)} |`);
+  lines.push(`| **Started** | ${formatTimestamp(report.summary.createdAt)} |`);
+  lines.push(`| **Triggered by** | ${report.summary.triggerType} |`);
+  lines.push(`| **Created by** | ${report.summary.createdBy} |`);
+  lines.push(
+    `| **Progress** | ${report.summary.completedSteps}/${report.summary.totalSteps} steps |`,
+  );
+  if (report.summary.wallClockDuration) {
+    lines.push(
+      `| **Wall-clock** | ${report.summary.wallClockDuration} |`,
+    );
+  }
+  if (report.summary.activeProcessingTimeMs > 0) {
+    lines.push(
+      `| **Active processing** | ${report.summary.activeProcessingTime} |`,
+    );
+  }
+  lines.push(
+    `| **Definition version** | ${report.definitionVersion} |`,
+  );
+  lines.push('');
+
+  // Step timeline
+  lines.push('## Step Timeline');
+  lines.push('');
+
+  for (let i = 0; i < report.steps.length; i++) {
+    lines.push(renderStepSection(report.steps[i], i));
+  }
+
+  // Footer
+  lines.push('---');
+  lines.push(
+    `*Generated by Mediforce \u2014 ${new Date().toISOString().split('T')[0]}*`,
+  );
+  lines.push('');
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- New `GET /api/processes/:instanceId/report` endpoint that works for **any** run status, not just completed runs
- Three output formats via `?format=` query param: `json` (default), `markdown`, `html`
- Standalone HTML output (inline CSS, dark mode, print-friendly) — self-contained single file, suitable for emailing/archiving

## Motivation
The existing `run-report.tsx` is gated behind `instance.status === 'completed'` and is web-only. This PR exposes report generation via API so reports can be fetched for in-progress/paused/failed runs and exported as markdown or a single-file HTML that can be sent to stakeholders.

## What's in it

### New files
- `lib/report/assemble-report.ts` — aggregates `ProcessInstance`, `StepExecution[]`, `AuditEvent[]`, and resolved definition steps into one `RunReportData` structure. Resolves from both new `WorkflowDefinition` and legacy `ProcessDefinition` schemas.
- `lib/report/render-markdown.ts` — converts `RunReportData` to readable markdown with status banner, summary table, and per-step timeline (collapsible input/output).
- `lib/report/render-html.ts` — minimal markdown→HTML converter + inline CSS template. Zero external dependencies, single self-contained file output.
- `app/api/processes/[instanceId]/report/route.ts` — the endpoint.

### Example usage
```bash
# JSON dump
curl -H "X-Api-Key: \$MEDIFORCE_API_KEY" \
  "http://localhost:9003/api/processes/abc123/report"

# Markdown
curl -H "X-Api-Key: \$MEDIFORCE_API_KEY" \
  "http://localhost:9003/api/processes/abc123/report?format=markdown" > report.md

# Standalone HTML to email
curl -H "X-Api-Key: \$MEDIFORCE_API_KEY" \
  "http://localhost:9003/api/processes/abc123/report?format=html" > report.html
```

## Not in scope (follow-ups)
- **`AgentEvent` timeline in the report** — requires a new `AgentEventRepository` (`platform-core` interface + `platform-infra` Firestore impl), since today there is no read-side repo for agent events. Will be a separate PR.
- **Unblocking the existing web view** (`run-report.tsx` currently blocks non-completed runs) — trivial follow-up, kept separate so this PR stays focused on the API surface.
- **Unit tests** for the assembler/renderers — TODO before marking ready for review.

## Test plan
- [ ] Unit tests for `assembleReport` (with in-memory repos from `platform-core/testing`)
- [ ] Unit tests for markdown renderer (snapshot)
- [ ] Unit tests for HTML renderer (snapshot)
- [ ] Manual: fetch JSON/markdown/HTML for a running, paused, failed, and completed run against emulators
- [ ] Visual: open HTML output in browser (dark mode + print preview)
- [ ] `pnpm typecheck` clean for new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)