### PR TITLE
fix: deploy staging from explicit SHA instead of current branch

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,4 +16,4 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key deploy@${{ secrets.STAGING_SERVER_IP }} "/opt/mediforce/scripts/deploy-staging.sh"
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key deploy@${{ secrets.STAGING_SERVER_IP }} "/opt/mediforce/scripts/deploy-staging.sh ${{ github.sha }}"

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+DEPLOY_SHA="${1:?Usage: deploy-staging.sh <commit-sha>}"
+
 cd /opt/mediforce
 COMPOSE="docker compose -f docker-compose.prod.yml -f docker-compose.staging.yml"
 
 echo "==> Pulling latest code"
 git fetch origin
-git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)
+git checkout "$DEPLOY_SHA"
 
 echo "==> Pruning Docker build cache"
 docker builder prune -af --filter "until=72h" 2>/dev/null || true
@@ -15,7 +17,7 @@ docker image prune -af --filter "until=72h" 2>/dev/null || true
 export NEXT_PUBLIC_GIT_SHA=$(git rev-parse --short HEAD)
 echo "==> Building (SHA: $NEXT_PUBLIC_GIT_SHA)"
 
-if [ "${1:-}" = "--no-cache" ]; then
+if [ "${2:-}" = "--no-cache" ]; then
   $COMPOSE build --no-cache platform-ui
 else
   $COMPOSE build


### PR DESCRIPTION
## Summary
- Deploy script used `git reset --hard origin/$(current branch)` — if anyone checked out a different branch on the server, all deploys would build from that branch instead of main
- Staging has been stuck on commit `b9c39b3` (branch `feat/lazy-docker-image-build`) since April 1st — no code has actually deployed in 2 weeks
- Now the workflow passes `${{ github.sha }}` to the script, which does `git checkout <sha>` — deploy always matches the commit that triggered it

## Changes
- `.github/workflows/deploy-staging.yml` — pass `github.sha` as argument
- `scripts/deploy-staging.sh` — require SHA as `$1`, use `git checkout "$DEPLOY_SHA"` instead of `git reset --hard origin/<branch>`