### PR TITLE
fix: workflow editor UX — iteration display, focus loss, step type badge

### DIFF
--- a/packages/platform-ui/src/components/tasks/__tests__/task-utils.test.ts
+++ b/packages/platform-ui/src/components/tasks/__tests__/task-utils.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { buildHumanTask } from '@mediforce/platform-core/testing';
+import { getAgentOutput, getAgentOutputFromSiblings } from '../task-utils';
+
+const SHARED_STEP = 'step-review';
+const SHARED_INSTANCE = 'inst-shared';
+
+describe('getAgentOutputFromSiblings', () => {
+  it('[DATA] returns output from preceding sibling, not first sibling', () => {
+    const agent1 = buildHumanTask({
+      stepId: SHARED_STEP,
+      processInstanceId: SHARED_INSTANCE,
+      completionData: { agentOutput: { presentation: 'v1' } },
+    });
+    const review1 = buildHumanTask({
+      stepId: SHARED_STEP,
+      processInstanceId: SHARED_INSTANCE,
+    });
+    const agent2 = buildHumanTask({
+      stepId: SHARED_STEP,
+      processInstanceId: SHARED_INSTANCE,
+      completionData: { agentOutput: { presentation: 'v2' } },
+    });
+    const review2 = buildHumanTask({
+      stepId: SHARED_STEP,
+      processInstanceId: SHARED_INSTANCE,
+    });
+
+    // Siblings in createdAt-asc order: agent1, review1, agent2, review2
+    const siblings = [agent1, review1, agent2, review2];
+
+    // For review1, the nearest preceding sibling with output is agent1 ("v1")
+    const outputForReview1 = getAgentOutputFromSiblings(review1, siblings);
+    expect(outputForReview1).not.toBeNull();
+    expect(outputForReview1!.presentation).toBe('v1');
+
+    // For review2, the nearest preceding sibling with output is agent2 ("v2")
+    const outputForReview2 = getAgentOutputFromSiblings(review2, siblings);
+    expect(outputForReview2).not.toBeNull();
+    expect(outputForReview2!.presentation).toBe('v2');
+  });
+
+  it('[DATA] returns null when no preceding sibling has output', () => {
+    const review = buildHumanTask({
+      stepId: SHARED_STEP,
+      processInstanceId: SHARED_INSTANCE,
+    });
+    const agent = buildHumanTask({
+      stepId: SHARED_STEP,
+      processInstanceId: SHARED_INSTANCE,
+      completionData: { agentOutput: { presentation: 'later' } },
+    });
+
+    // review is first — no preceding sibling with output
+    const siblings = [review, agent];
+    const output = getAgentOutputFromSiblings(review, siblings);
+    expect(output).toBeNull();
+  });
+});
+
+describe('getAgentOutput', () => {
+  it('[DATA] extracts presentation from task completionData', () => {
+    const task = buildHumanTask({
+      completionData: {
+        agentOutput: {
+          presentation: '<div>some html</div>',
+          confidence: 0.95,
+          reasoning: 'looks good',
+        },
+      },
+    });
+
+    const output = getAgentOutput(task);
+    expect(output).not.toBeNull();
+    expect(output!.presentation).toBe('<div>some html</div>');
+    expect(output!.confidence).toBe(0.95);
+    expect(output!.reasoning).toBe('looks good');
+  });
+});

--- a/packages/platform-ui/src/components/tasks/task-utils.ts
+++ b/packages/platform-ui/src/components/tasks/task-utils.ts
@@ -76,14 +76,20 @@ export function getAgentOutput(task: HumanTask): AgentOutputData | null {
   };
 }
 
-/** Find agent output from sibling tasks for the same step. */
+/** Find agent output from the closest preceding sibling task for the same step.
+ *  Siblings are expected in createdAt-asc order. We walk backwards from the
+ *  current task's position to find the agent run that produced output for
+ *  this specific iteration (not just the first match). */
 export function getAgentOutputFromSiblings(
   task: HumanTask,
   siblingTasks: HumanTask[],
 ): AgentOutputData | null {
-  // Look for a sibling task with the same stepId that has agent output
-  for (const sibling of siblingTasks) {
-    if (sibling.id === task.id) continue;
+  const taskIndex = siblingTasks.findIndex((s) => s.id === task.id);
+
+  // Walk backwards from the current task to find the nearest preceding sibling
+  // with agent output on the same step — this is the agent run for this iteration.
+  for (let i = (taskIndex === -1 ? siblingTasks.length : taskIndex) - 1; i >= 0; i--) {
+    const sibling = siblingTasks[i];
     if (sibling.stepId !== task.stepId) continue;
     const output = getAgentOutput(sibling);
     if (output) return output;

--- a/packages/platform-ui/src/components/workflows/__tests__/step-editor.test.tsx
+++ b/packages/platform-ui/src/components/workflows/__tests__/step-editor.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { WorkflowStep } from '@mediforce/platform-core';
+
+// ---- Mocks (must be before component import) ----
+
+vi.mock('@/hooks/use-plugins', () => ({
+  usePlugins: () => ({ plugins: [] }),
+}));
+
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({ firebaseUser: null }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ handle: 'test' }),
+}));
+
+vi.mock('@/app/actions/workflow-secrets', () => ({
+  getWorkflowSecretKeys: () => Promise.resolve([]),
+}));
+
+import { StepEditor } from '../workflow-editor/step-editor';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
+  return {
+    id: 'step-1',
+    name: 'Test Step',
+    type: 'creation',
+    executor: 'human',
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('StepEditor', () => {
+  it('[RENDER] step type badge visible without expanding details', () => {
+    render(
+      <StepEditor
+        step={buildStep({ type: 'creation' })}
+        allSteps={[buildStep({ type: 'creation' })]}
+        onChange={noop}
+      />,
+    );
+
+    expect(screen.getByText('Creation')).toBeInTheDocument();
+  });
+
+  it('[RENDER] step type label shows Creation not Input', () => {
+    render(
+      <StepEditor
+        step={buildStep({ type: 'creation' })}
+        allSteps={[buildStep({ type: 'creation' })]}
+        onChange={noop}
+      />,
+    );
+
+    // The badge should say "Creation", not "Input"
+    expect(screen.getByText('Creation')).toBeInTheDocument();
+    // "Input" should not appear as a step type label
+    expect(screen.queryByText('Input')).not.toBeInTheDocument();
+  });
+
+  it('[RENDER] no step type change buttons exist', () => {
+    render(
+      <StepEditor
+        step={buildStep({ type: 'creation' })}
+        allSteps={[buildStep({ type: 'creation' })]}
+        onChange={noop}
+      />,
+    );
+
+    // There should be no buttons that allow changing the step type
+    // (these would be buttons labeled with type names like Creation/Review/Decision/End)
+    const allButtons = screen.getAllByRole('button');
+    const typeChangeLabels = ['Creation', 'Review', 'Decision', 'End'];
+    for (const label of typeChangeLabels) {
+      const matchingButtons = allButtons.filter(
+        (btn) => btn.textContent?.trim() === label,
+      );
+      expect(matchingButtons).toHaveLength(0);
+    }
+  });
+
+  it('[RENDER] terminal step type shows End label', () => {
+    render(
+      <StepEditor
+        step={buildStep({ type: 'terminal', name: 'Complete' })}
+        allSteps={[buildStep({ type: 'terminal', name: 'Complete' })]}
+        onChange={noop}
+      />,
+    );
+
+    expect(screen.getByText('End')).toBeInTheDocument();
+  });
+
+  it('[RENDER] lock icon present on step type badge', () => {
+    render(
+      <StepEditor
+        step={buildStep({ type: 'creation' })}
+        allSteps={[buildStep({ type: 'creation' })]}
+        onChange={noop}
+      />,
+    );
+
+    // The badge has a title attribute explaining step type is locked
+    const badge = screen.getByTitle(
+      'Step type is set at creation. To change, remove this step and add a new one.',
+    );
+    expect(badge).toBeInTheDocument();
+  });
+});

--- a/packages/platform-ui/src/components/workflows/__tests__/workflow-diagram.test.tsx
+++ b/packages/platform-ui/src/components/workflows/__tests__/workflow-diagram.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// Mock @xyflow/react so StepNode renders as plain HTML without canvas deps.
+vi.mock('@xyflow/react', () => {
+  const Position = { Top: 'top', Bottom: 'bottom', Left: 'left', Right: 'right' };
+  const MarkerType = { ArrowClosed: 'arrowclosed' };
+  return {
+    ReactFlow: ({ nodes, nodeTypes }: { nodes: Array<{ id: string; type: string; data: Record<string, unknown>; selected?: boolean }>; nodeTypes: Record<string, React.ComponentType<unknown>> }) => (
+      <div data-testid="reactflow">
+        {nodes.map((node) => {
+          const Component = nodeTypes[node.type];
+          if (!Component) return null;
+          return <Component key={node.id} id={node.id} data={node.data} selected={node.selected ?? false} />;
+        })}
+      </div>
+    ),
+    ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    BaseEdge: () => null,
+    EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    getSmoothStepPath: () => ['', 0, 0],
+    Handle: () => null,
+    Position,
+    MarkerType,
+  };
+});
+
+import { WorkflowDiagram } from '../workflow-diagram';
+import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+
+describe('StepNode (via WorkflowDiagram)', () => {
+  it('[RENDER] autonomy level shown on agent step nodes', () => {
+    const definition = buildWorkflowDefinition({
+      steps: [
+        { id: 'analyze', name: 'Analyze', type: 'creation', executor: 'agent', autonomyLevel: 'L2' },
+        { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },
+      ],
+      transitions: [{ from: 'analyze', to: 'done' }],
+    });
+
+    render(<WorkflowDiagram definition={definition} />);
+
+    expect(screen.getByText('L2')).toBeInTheDocument();
+  });
+
+  it('[RENDER] autonomy level not shown on script step nodes', () => {
+    const definition = buildWorkflowDefinition({
+      steps: [
+        { id: 'run-script', name: 'Run Script', type: 'creation', executor: 'script', autonomyLevel: 'L4' },
+        { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },
+      ],
+      transitions: [{ from: 'run-script', to: 'done' }],
+    });
+
+    render(<WorkflowDiagram definition={definition} />);
+
+    expect(screen.queryByText('L4')).not.toBeInTheDocument();
+  });
+});

--- a/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
@@ -196,7 +196,7 @@ function StepNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
               <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
                 {{ human: 'Human', agent: 'Agent', script: 'Script', cowork: 'Cowork' }[data.executor] ?? data.executor}
               </span>
-              {data.autonomyLevel && (
+              {data.autonomyLevel && data.executor === 'agent' && (
                 <span className="text-[10px] font-mono text-muted-foreground/70">
                   {data.autonomyLevel}
                 </span>

--- a/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
@@ -59,7 +59,7 @@ const STEP_STYLES: Record<string, { bg: string; border: string; activeBorder: st
 };
 
 const STEP_TYPE_CONFIG: Record<string, { icon: typeof PenLine; label: string; color: string }> = {
-  creation: { icon: PenLine,    label: 'Input',    color: 'text-blue-500 dark:text-blue-400' },
+  creation: { icon: PenLine,    label: 'Creation', color: 'text-blue-500 dark:text-blue-400' },
   review:   { icon: Search,     label: 'Review',   color: 'text-amber-500 dark:text-amber-400' },
   decision: { icon: GitBranch,  label: 'Decision', color: 'text-purple-500 dark:text-purple-400' },
   terminal: { icon: Flag,       label: 'End',      color: 'text-emerald-500 dark:text-emerald-400' },

--- a/packages/platform-ui/src/components/workflows/workflow-editor/constants.ts
+++ b/packages/platform-ui/src/components/workflows/workflow-editor/constants.ts
@@ -6,8 +6,7 @@ export const AUTONOMY_LEVELS = [
   { value: 'L4', label: 'L4 — Full autonomy' },
 ] as const;
 
-export const STEP_TYPES = ['creation', 'review', 'decision', 'terminal'] as const;
-export const STEP_TYPE_LABELS: Record<string, string> = { creation: 'Input', review: 'Review', decision: 'Decision', terminal: 'End' };
+export const STEP_TYPE_LABELS: Record<string, string> = { creation: 'Creation', review: 'Review', decision: 'Decision', terminal: 'End' };
 
 export const FALLBACK_OPTIONS = [
   { value: '', label: 'Default' },

--- a/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { User, Bot, Terminal, Users } from 'lucide-react';
+import { User, Bot, Terminal, Users, Lock } from 'lucide-react';
 import { useParams } from 'next/navigation';
 import { usePlugins } from '@/hooks/use-plugins';
 import { useAuth } from '@/contexts/auth-context';
@@ -10,7 +10,6 @@ import { cn } from '@/lib/utils';
 import type { WorkflowStep } from '@mediforce/platform-core';
 import {
   AUTONOMY_LEVELS,
-  STEP_TYPES,
   STEP_TYPE_LABELS,
   FALLBACK_OPTIONS,
   KNOWN_MODELS,
@@ -183,6 +182,15 @@ export function StepEditor({
           rows={2}
           className={cn(inlineInput, 'mt-2 text-sm text-muted-foreground resize-y leading-relaxed placeholder:italic')}
         />
+      </div>
+
+      {/* Step type (read-only) */}
+      <div
+        className="inline-flex items-center gap-1.5 rounded-md border border-muted px-2 py-1 text-[11px] font-medium text-muted-foreground cursor-default"
+        title="Step type is set at creation. To change, remove this step and add a new one."
+      >
+        <Lock className="h-3 w-3 text-muted-foreground/50" />
+        {STEP_TYPE_LABELS[step.type] ?? step.type}
       </div>
 
       {/* Executor toggle */}
@@ -539,8 +547,8 @@ export function StepEditor({
       {/* Environment variables */}
       {step.type !== 'terminal' && (
         <Section title="Environment">
-          {Object.entries(step.env ?? {}).map(([key, val]) => (
-            <div key={key} className="flex items-baseline gap-1.5">
+          {Object.entries(step.env ?? {}).map(([key, val], idx) => (
+            <div key={idx} className="flex items-baseline gap-1.5">
               <input
                 value={key}
                 onChange={(e) => {
@@ -597,31 +605,6 @@ export function StepEditor({
           </button>
         </Section>
       )}
-
-      {/* Step definition (collapsed) */}
-      <details className="group">
-        <summary className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/40 cursor-pointer hover:text-muted-foreground transition-colors select-none">
-          Step definition
-        </summary>
-        <div className="mt-2 space-y-2.5">
-          <div className="flex gap-1">
-            {STEP_TYPES.map((t) => (
-              <button
-                key={t}
-                onClick={() => onChange({ type: t })}
-                className={cn(
-                  'flex-1 rounded-md py-1 text-[11px] font-medium transition-all border',
-                  step.type === t
-                    ? 'border-primary bg-primary/5 text-primary'
-                    : 'border-transparent bg-muted/50 text-muted-foreground hover:text-foreground',
-                )}
-              >
-                {STEP_TYPE_LABELS[t] ?? t}
-              </button>
-            ))}
-          </div>
-        </div>
-      </details>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Fix 1**: Task detail showed wrong presentation when switching iterations — `getAgentOutputFromSiblings` now walks backward to find the correct preceding agent output
- **Fix 2**: Env var key input lost focus on every keystroke — switched from `key={key}` to `key={idx}` 
- **Fix 3**: Autonomy level badge (L0-L4) no longer shown on script/human/cowork step nodes in the diagram
- **Fix 4+5**: Removed step type changer — type is now a read-only locked badge with tooltip ("Step type is set at creation. To change, remove this step and add a new one."). Also renamed "Input" label to "Creation"

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 1040 tests pass (10 new)
- [ ] E2E: existing `workflow-editor.journey.ts` covers editor basics — no new E2E needed for these fixes

### New unit/component tests
- `task-utils.test.ts` — backward walk iteration logic (3 tests)
- `workflow-diagram.test.tsx` — autonomy badge visibility per executor type (2 tests)
- `step-editor.test.tsx` — locked badge, Creation label, no type change buttons (5 tests)