### PR TITLE
fix(docker): copy mcp-client package.json into deps stage

### DIFF
--- a/packages/platform-ui/Dockerfile
+++ b/packages/platform-ui/Dockerfile
@@ -11,6 +11,7 @@ COPY packages/platform-infra/package.json packages/platform-infra/
 COPY packages/workflow-engine/package.json packages/workflow-engine/
 COPY packages/agent-runtime/package.json packages/agent-runtime/
 COPY packages/agent-queue/package.json packages/agent-queue/
+COPY packages/mcp-client/package.json packages/mcp-client/
 COPY packages/supply-intelligence/package.json packages/supply-intelligence/
 COPY packages/supply-intelligence-plugins/package.json packages/supply-intelligence-plugins/
 COPY packages/platform-ui/package.json packages/platform-ui/


### PR DESCRIPTION
## Summary

Production and staging Docker builds currently fail on `main` with:

```
../mcp-client/src/mcp-client-manager.ts
Module not found: Can't resolve '@modelcontextprotocol/sdk/client/index.js'
```

Root cause: PR #162 (MCP cowork support) added `packages/mcp-client/` as a new workspace package that platform-ui imports (`"@mediforce/mcp-client": "workspace:*"`), but the Dockerfile's deps stage was not updated to `COPY` its `package.json`. Without that, `pnpm install` in the deps stage doesn't see the package in the workspace graph, so `@modelcontextprotocol/sdk` is never installed, and webpack fails at build time on `mcp-client-manager.ts` subpath imports.

One-line fix: add the missing `COPY` line.

## Why CI didn't catch it

The full Docker build is only exercised during deploy (`deploy-production.yml` / `deploy-staging.yml` SSH into the server and run `scripts/deploy.sh`). CI on PRs does unit tests + typecheck with a locally-installed `node_modules` that has everything, so the missing COPY is invisible until deploy time.

Worth adding a `docker build` smoke to CI to prevent regressions like this — out of scope here.

## Test plan

- [ ] Docker build on the staging server completes the `platform-ui builder` stage without "Module not found" errors
- [ ] `docker compose -f docker-compose.prod.yml ps` shows `platform-ui` as running after deploy
- [ ] App responds on `:80` (smoke check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)