### PR TITLE
fix(docker-build): copy deploy key to 0600 tmp before git fetch

### DIFF
--- a/packages/agent-queue/src/docker-image-builder.ts
+++ b/packages/agent-queue/src/docker-image-builder.ts
@@ -14,6 +14,11 @@ const BUILD_COMMIT_LABEL = 'mediforce.build.commit';
 
 let preparedDeployKeyPath: string | null = null;
 
+/**
+ * NOTE: Keep in sync with the exported copy in
+ * `packages/agent-runtime/src/plugins/container-plugin.ts`.
+ * Duplicated so agent-queue stays free of agent-runtime (and Firebase) deps.
+ */
 function prepareDeployKeyPath(): string {
   const source = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
   if (!existsSync(source)) return source;

--- a/packages/agent-queue/src/docker-image-builder.ts
+++ b/packages/agent-queue/src/docker-image-builder.ts
@@ -6,14 +6,28 @@
  */
 import { execSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
+import { chmodSync, copyFileSync, existsSync, mkdtempSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 
 const BUILD_COMMIT_LABEL = 'mediforce.build.commit';
 
+let preparedDeployKeyPath: string | null = null;
+
+function prepareDeployKeyPath(): string {
+  const source = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
+  if (!existsSync(source)) return source;
+  if (preparedDeployKeyPath && existsSync(preparedDeployKeyPath)) return preparedDeployKeyPath;
+  const dir = mkdtempSync(join(tmpdir(), 'mediforce-ssh-'));
+  const dest = join(dir, 'deploy_key');
+  copyFileSync(source, dest);
+  chmodSync(dest, 0o600);
+  preparedDeployKeyPath = dest;
+  return dest;
+}
+
 function getGitSshCommand(): string {
-  const deployKeyPath = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
-  return `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no`;
+  return `ssh -i ${prepareDeployKeyPath()} -o StrictHostKeyChecking=no -o IdentitiesOnly=yes`;
 }
 
 export async function imageExistsLocally(image: string): Promise<boolean> {

--- a/packages/agent-runtime/src/plugins/__tests__/prepare-deploy-key-path.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/prepare-deploy-key-path.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'prepare-deploy-key-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function importFresh() {
+  vi.resetModules();
+  return import('../container-plugin.js');
+}
+
+beforeEach(() => {
+  delete process.env.DEPLOY_KEY_PATH;
+});
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('prepareDeployKeyPath', () => {
+  it('returns source path unchanged when source does not exist', async () => {
+    const missing = join(makeTmpDir(), 'does-not-exist');
+    process.env.DEPLOY_KEY_PATH = missing;
+
+    const { prepareDeployKeyPath } = await importFresh();
+    const result = prepareDeployKeyPath();
+
+    expect(result).toBe(missing);
+    expect(existsSync(result)).toBe(false);
+  });
+
+  it('copies key to a fresh tmp file with 0600 perms when source exists', async () => {
+    const sourceDir = makeTmpDir();
+    const source = join(sourceDir, 'deploy_key');
+    writeFileSync(source, 'PRIVATE-KEY-CONTENTS', { mode: 0o644 });
+    process.env.DEPLOY_KEY_PATH = source;
+
+    const { prepareDeployKeyPath } = await importFresh();
+    const result = prepareDeployKeyPath();
+    tmpDirs.push(result);
+
+    expect(result).not.toBe(source);
+    expect(existsSync(result)).toBe(true);
+    expect(readFileSync(result, 'utf8')).toBe('PRIVATE-KEY-CONTENTS');
+    // Mask to permission bits — statSync returns full mode incl. file type.
+    expect(statSync(result).mode & 0o777).toBe(0o600);
+  });
+
+  it('caches the prepared path across calls (does not re-copy)', async () => {
+    const sourceDir = makeTmpDir();
+    const source = join(sourceDir, 'deploy_key');
+    writeFileSync(source, 'KEY', { mode: 0o644 });
+    process.env.DEPLOY_KEY_PATH = source;
+
+    const { prepareDeployKeyPath } = await importFresh();
+    const first = prepareDeployKeyPath();
+    const second = prepareDeployKeyPath();
+
+    expect(second).toBe(first);
+  });
+});

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -361,6 +361,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         image: stepAgent.image,
         repo: stepAgent.repo,
         commit: stepAgent.commit,
+        dockerfile: stepAgent.dockerfile,
         mcpServers: stepAgent.mcpServers,
       };
     } else {

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -5,7 +5,7 @@
  * Subclasses: BaseContainerAgentPlugin (LLM agents), ScriptContainerPlugin (deterministic scripts).
  */
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, cpSync } from 'node:fs';
+import { existsSync, mkdirSync, cpSync, chmodSync, copyFileSync } from 'node:fs';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
@@ -14,6 +14,24 @@ import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '..
 import type { AgentConfig, PluginCapabilityMetadata } from '@mediforce/platform-core';
 import { resolveStepEnv, type ResolvedEnv } from './resolve-env.js';
 import type { ImageBuildMeta } from './docker-spawn-strategy.js';
+
+let preparedDeployKeyPath: string | null = null;
+
+/**
+ * Returns a deploy-key path that ssh will accept — copies the configured key
+ * to a private tmp file with 0600 perms so host-side mount modes can't break us.
+ */
+export function prepareDeployKeyPath(): string {
+  const source = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
+  if (!existsSync(source)) return source;
+  if (preparedDeployKeyPath && existsSync(preparedDeployKeyPath)) return preparedDeployKeyPath;
+  const dir = mkdtempSync(join(tmpdir(), 'mediforce-ssh-'));
+  const dest = join(dir, 'deploy_key');
+  copyFileSync(source, dest);
+  chmodSync(dest, 0o600);
+  preparedDeployKeyPath = dest;
+  return dest;
+}
 
 /** Normalize a repo reference to SSH clone URL and HTTPS browsable URL.
  *  Supports: "org/repo", "git@github.com:org/repo.git", "https://github.com/org/repo", "/path/to/bare.git" */
@@ -162,10 +180,10 @@ export abstract class ContainerPlugin implements AgentPlugin {
 
     try {
       const cloneUrl = repoToken ? toHttpsWithToken(repoUrl, repoToken) : repoUrl;
-      const deployKeyPath = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
+      const deployKeyPath = prepareDeployKeyPath();
       const execOpts = {
         stdio: 'pipe' as const,
-        env: { ...process.env, GIT_SSH_COMMAND: `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no` },
+        env: { ...process.env, GIT_SSH_COMMAND: `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no -o IdentitiesOnly=yes` },
       };
 
       execSync(`git init "${cloneDir}"`, execOpts);

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -20,6 +20,10 @@ let preparedDeployKeyPath: string | null = null;
 /**
  * Returns a deploy-key path that ssh will accept — copies the configured key
  * to a private tmp file with 0600 perms so host-side mount modes can't break us.
+ *
+ * NOTE: Keep in sync with the duplicated copy in
+ * `packages/agent-queue/src/docker-image-builder.ts` — agent-queue cannot
+ * import from agent-runtime without dragging in Firebase deps.
  */
 export function prepareDeployKeyPath(): string {
   const source = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -7,9 +7,9 @@
  */
 import { execSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
-import { tmpdir, homedir } from 'node:os';
-import { toHttpsWithToken } from './container-plugin.js';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { prepareDeployKeyPath, toHttpsWithToken } from './container-plugin.js';
 
 export interface BuildImageOptions {
   image: string;
@@ -33,8 +33,7 @@ const BUILD_COMMIT_LABEL = 'mediforce.build.commit';
 const buildLocks = new Map<string, Promise<void>>();
 
 function getGitSshCommand(): string {
-  const deployKeyPath = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
-  return `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no`;
+  return `ssh -i ${prepareDeployKeyPath()} -o StrictHostKeyChecking=no -o IdentitiesOnly=yes`;
 }
 
 export async function imageExistsLocally(image: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Lazy Docker image build on staging fails with `Permissions 0755 for '/root/.ssh/deploy_key' are too open` because the host-mounted deploy key keeps 0755 and ssh refuses it.
- Before invoking `git fetch`, copy the configured deploy key to a private tmpdir with `chmod 0600` and point `GIT_SSH_COMMAND` at that copy. Apply the same fix in all three sites (agent-runtime image builder, agent-runtime skills fetcher, agent-queue worker image builder).
- Pass `IdentitiesOnly=yes` so ssh does not try unrelated agent keys and surface misleading errors.

Unblocks any workflow using `repo`+`commit` lazy-build from a private fork — not just tealflow.

## Why not just `chmod 600` on the host?
The key is managed by the bootstrap flow; a host-side chmod would regress the next time the key is re-provisioned. Doing it in-process makes the runtime robust to whatever perms the host ends up with.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 1062 passed, no regressions
- [ ] Deploy to staging, re-trigger `tealflow` deploy step, confirm lazy build succeeds (image rebuilds, no SSH perm error)
- [ ] Confirm protocol-to-tfl lazy builds still work (same code path)

## E2E
Not applicable — infra code, no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)