### PR TITLE
fix: gate not-found render on auth readiness to prevent race on cold load

### DIFF
--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -40,7 +40,7 @@ export default function ProcessDefinitionPage() {
     return map;
   }, [activeTasks]);
 
-  const { firebaseUser } = useAuth();
+  const { firebaseUser, loading: authLoading } = useAuth();
   const { namespaces } = useAllUserNamespaces(firebaseUser?.uid);
 
   const [archiving, setArchiving] = React.useState(false);
@@ -68,7 +68,7 @@ export default function ProcessDefinitionPage() {
     (trigger: { type: string }) => trigger.type === 'manual',
   ) ?? false;
 
-  if (versionsLoading) {
+  if (versionsLoading || authLoading) {
     return (
       <div className="p-6 space-y-4 animate-pulse">
         <div className="h-4 w-20 rounded bg-muted" />
@@ -78,7 +78,7 @@ export default function ProcessDefinitionPage() {
     );
   }
 
-  if (!versionsLoading && versions.length === 0) {
+  if (!versionsLoading && !authLoading && versions.length === 0) {
     return (
       <div className="p-6 text-center text-sm text-muted-foreground">
         Workflow &ldquo;{decodedName}&rdquo; not found.{' '}


### PR DESCRIPTION
## Summary

- Gates the loading skeleton and the "not found" branch on `authLoading` from `useAuth()` in addition to `versionsLoading`
- On cold load (direct URL / refresh), Firebase auth initialisation is async; the Firestore subscription could resolve with an empty snapshot before the auth token propagated, immediately rendering the "not found" message
- With the fix, the loading skeleton remains visible until both auth and the versions query are settled — only then does an empty result trigger the "not found" branch

Closes #197

## Files changed

- `packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx`: destructure `loading: authLoading` from `useAuth()`, include it in both the loading guard and the not-found guard