### PR TITLE
fix(agent-review): don't stall L3 runs when review.type='agent'

### DIFF
--- a/packages/agent-runtime/src/runner/agent-runner.ts
+++ b/packages/agent-runtime/src/runner/agent-runner.ts
@@ -365,12 +365,19 @@ export class AgentRunner {
       case 'L2':
         return { status: 'completed', envelope, appliedToWorkflow: false, fallbackReason: null };
 
-      case 'L3':
+      case 'L3': {
+        // review.type='agent' means the agent's verdict is authoritative for this
+        // step — no human approval needed. Behave like L4 (apply to workflow).
+        // Low-confidence or timeout still routes through the fallback handler above.
+        if (context.step.review?.type === 'agent') {
+          return { status: 'completed', envelope, appliedToWorkflow: true, fallbackReason: null };
+        }
         await this.instanceRepository.update(context.processInstanceId, {
           status: 'paused',
           pauseReason: 'awaiting_agent_approval',
         });
         return { status: 'paused', envelope, appliedToWorkflow: false, fallbackReason: null };
+      }
 
       case 'L4':
         return { status: 'completed', envelope, appliedToWorkflow: true, fallbackReason: null };

--- a/packages/agent-runtime/src/runner/agent-runner.ts
+++ b/packages/agent-runtime/src/runner/agent-runner.ts
@@ -366,8 +366,10 @@ export class AgentRunner {
         return { status: 'completed', envelope, appliedToWorkflow: false, fallbackReason: null };
 
       case 'L3': {
-        // review.type='agent' means the agent's verdict is authoritative for this
-        // step — no human approval needed. Behave like L4 (apply to workflow).
+        // review.type='agent' means the agent is the authoritative decider — do
+        // not pause for human approval. The executor inspects step.type to pick
+        // the right engine path: submitReviewVerdict (iteration loop with
+        // maxIterations enforcement) for review steps, or advanceStep for others.
         // Low-confidence or timeout still routes through the fallback handler above.
         if (context.step.review?.type === 'agent') {
           return { status: 'completed', envelope, appliedToWorkflow: true, fallbackReason: null };

--- a/packages/platform-ui/src/components/tasks/__tests__/agent-output-review-panel.test.tsx
+++ b/packages/platform-ui/src/components/tasks/__tests__/agent-output-review-panel.test.tsx
@@ -13,6 +13,7 @@ function buildAgentOutput(overrides: Partial<AgentOutputData> = {}): AgentOutput
     duration_ms: null,
     gitMetadata: null,
     presentation: null,
+    escalationReason: null,
     ...overrides,
   };
 }
@@ -106,6 +107,30 @@ describe('AgentOutputReviewPanel', () => {
 
     const srcdoc = document.querySelector('iframe')!.getAttribute('srcdoc')!;
     expect(srcdoc).toContain('@tailwindcss/browser@4');
+  });
+
+  it('renders escalation badge when escalationReason is set', () => {
+    const agentOutput = buildAgentOutput({
+      result: { verdict: 'approve' },
+      confidence: 0.72,
+      escalationReason: 'low_confidence',
+    });
+
+    render(<AgentOutputReviewPanel agentOutput={agentOutput} />);
+
+    expect(screen.getByText(/escalated: low confidence/i)).toBeInTheDocument();
+  });
+
+  it('omits escalation badge when escalationReason is null', () => {
+    const agentOutput = buildAgentOutput({
+      result: { verdict: 'approve' },
+      confidence: 0.9,
+      escalationReason: null,
+    });
+
+    render(<AgentOutputReviewPanel agentOutput={agentOutput} />);
+
+    expect(screen.queryByText(/escalated/i)).not.toBeInTheDocument();
   });
 
   it('escapes closing script tags in result data', () => {

--- a/packages/platform-ui/src/components/tasks/__tests__/agent-output-review-panel.test.tsx
+++ b/packages/platform-ui/src/components/tasks/__tests__/agent-output-review-panel.test.tsx
@@ -133,6 +133,17 @@ describe('AgentOutputReviewPanel', () => {
     expect(screen.queryByText(/escalated/i)).not.toBeInTheDocument();
   });
 
+  it('renders iterations_limit escalation badge', () => {
+    const agentOutput = buildAgentOutput({
+      result: { verdict: 'revise' },
+      escalationReason: 'iterations_limit',
+    });
+
+    render(<AgentOutputReviewPanel agentOutput={agentOutput} />);
+
+    expect(screen.getByText(/escalated: iterations limit reached/i)).toBeInTheDocument();
+  });
+
   it('escapes closing script tags in result data', () => {
     const result = { html: '</script><script>alert(1)</script>' };
     const agentOutput = buildAgentOutput({

--- a/packages/platform-ui/src/components/tasks/agent-output-review-panel.tsx
+++ b/packages/platform-ui/src/components/tasks/agent-output-review-panel.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
 import { useTheme } from 'next-themes';
-import { Bot, Code, ExternalLink, FileText, Gauge, GitBranch, Loader2, MonitorPlay } from 'lucide-react';
+import { AlertTriangle, Bot, Code, ExternalLink, FileText, Gauge, GitBranch, Loader2, MonitorPlay } from 'lucide-react';
 import type { AgentOutputData } from './task-utils';
 import { formatStepName } from './task-utils';
 import { cn } from '@/lib/utils';
@@ -178,6 +178,16 @@ export function AgentOutputReviewPanel({
           {stepId && (
             <span className="text-xs font-medium text-foreground">
               — {formatStepName(stepId)}
+            </span>
+          )}
+          {agentOutput.escalationReason !== null && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full border border-amber-500/50 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+              title={`Agent escalated to human because of ${agentOutput.escalationReason.replace(/_/g, ' ')}. Review the recommendation and approve or request revision.`}
+            >
+              <AlertTriangle className="h-3 w-3" />
+              Escalated: {formatEscalationReason(agentOutput.escalationReason)}
+              {agentOutput.escalationReason === 'low_confidence' && confidencePct !== null && ` (${confidencePct}%)`}
             </span>
           )}
         </div>
@@ -599,6 +609,14 @@ function formatKey(key: string): string {
     .replace(/_/g, ' ')
     .replace(/([a-z])([A-Z])/g, '$1 $2')
     .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatEscalationReason(reason: 'low_confidence' | 'timeout' | 'error'): string {
+  switch (reason) {
+    case 'low_confidence': return 'low confidence';
+    case 'timeout': return 'timeout';
+    case 'error': return 'error';
+  }
 }
 
 function formatDuration(ms: number): string {

--- a/packages/platform-ui/src/components/tasks/agent-output-review-panel.tsx
+++ b/packages/platform-ui/src/components/tasks/agent-output-review-panel.tsx
@@ -611,11 +611,12 @@ function formatKey(key: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-function formatEscalationReason(reason: 'low_confidence' | 'timeout' | 'error'): string {
+function formatEscalationReason(reason: 'low_confidence' | 'timeout' | 'error' | 'iterations_limit'): string {
   switch (reason) {
     case 'low_confidence': return 'low confidence';
     case 'timeout': return 'timeout';
     case 'error': return 'error';
+    case 'iterations_limit': return 'iterations limit reached';
   }
 }
 

--- a/packages/platform-ui/src/components/tasks/task-utils.ts
+++ b/packages/platform-ui/src/components/tasks/task-utils.ts
@@ -66,7 +66,10 @@ export function getAgentOutput(task: HumanTask): AgentOutputData | null {
 
   const escalationReason = agentOutput.escalationReason;
   const normalizedEscalation: EscalationReason =
-    escalationReason === 'low_confidence' || escalationReason === 'timeout' || escalationReason === 'error'
+    escalationReason === 'low_confidence' ||
+    escalationReason === 'timeout' ||
+    escalationReason === 'error' ||
+    escalationReason === 'iterations_limit'
       ? escalationReason
       : null;
 
@@ -111,7 +114,7 @@ export interface GitMetadataData {
   repoUrl: string;
 }
 
-export type EscalationReason = 'low_confidence' | 'timeout' | 'error' | null;
+export type EscalationReason = 'low_confidence' | 'timeout' | 'error' | 'iterations_limit' | null;
 
 export interface AgentOutputData {
   confidence: number | null;

--- a/packages/platform-ui/src/components/tasks/task-utils.ts
+++ b/packages/platform-ui/src/components/tasks/task-utils.ts
@@ -64,6 +64,12 @@ export function getAgentOutput(task: HumanTask): AgentOutputData | null {
         }
       : null;
 
+  const escalationReason = agentOutput.escalationReason;
+  const normalizedEscalation: EscalationReason =
+    escalationReason === 'low_confidence' || escalationReason === 'timeout' || escalationReason === 'error'
+      ? escalationReason
+      : null;
+
   return {
     confidence: typeof agentOutput.confidence === 'number' ? agentOutput.confidence : null,
     confidence_rationale: typeof agentOutput.confidence_rationale === 'string' ? agentOutput.confidence_rationale : null,
@@ -73,6 +79,7 @@ export function getAgentOutput(task: HumanTask): AgentOutputData | null {
     duration_ms: typeof agentOutput.duration_ms === 'number' ? agentOutput.duration_ms : null,
     gitMetadata,
     presentation: typeof agentOutput.presentation === 'string' ? agentOutput.presentation : null,
+    escalationReason: normalizedEscalation,
   };
 }
 
@@ -104,6 +111,8 @@ export interface GitMetadataData {
   repoUrl: string;
 }
 
+export type EscalationReason = 'low_confidence' | 'timeout' | 'error' | null;
+
 export interface AgentOutputData {
   confidence: number | null;
   confidence_rationale: string | null;
@@ -113,4 +122,5 @@ export interface AgentOutputData {
   duration_ms: number | null;
   gitMetadata: GitMetadataData | null;
   presentation: string | null;
+  escalationReason: EscalationReason;
 }

--- a/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
@@ -391,6 +391,85 @@ describe('executeAgentStep', () => {
 
       expect(mockHumanTaskRepo.create).toHaveBeenCalled();
     });
+
+    it('[DATA] L3 with review.type=agent + escalated (low_confidence) still creates HumanTask with escalationReason', async () => {
+      const l3AgentReview: WorkflowStep = { ...l3Step, review: { type: 'agent' } };
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+        status: 'escalated',
+        envelope: defaultEnvelope,
+        appliedToWorkflow: false,
+        fallbackReason: 'low_confidence',
+      });
+
+      await executeAgentStep('inst-wf-001', 'gather-data', l3AgentReview, {}, 'user-1');
+
+      expect(mockHumanTaskRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          creationReason: 'agent_review_l3',
+          completionData: expect.objectContaining({
+            agentOutput: expect.objectContaining({
+              escalationReason: 'low_confidence',
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('[DATA] L3 with review.type=agent + paused (no escalation) does NOT create HumanTask', async () => {
+      const l3AgentReview: WorkflowStep = { ...l3Step, review: { type: 'agent' } };
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+        status: 'paused',
+        envelope: defaultEnvelope,
+        appliedToWorkflow: false,
+        fallbackReason: null,
+      });
+
+      await executeAgentStep('inst-wf-001', 'gather-data', l3AgentReview, {}, 'user-1');
+
+      expect(mockHumanTaskRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('[DATA] L3 escalated saves step execution as completed (not failed) when envelope is valid', async () => {
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+        status: 'escalated',
+        envelope: defaultEnvelope,
+        appliedToWorkflow: false,
+        fallbackReason: 'low_confidence',
+      });
+
+      await executeAgentStep('inst-wf-001', 'gather-data', l3Step, {}, 'user-1', 'exec-1');
+
+      expect(mockInstanceRepo.updateStepExecution).toHaveBeenCalledWith(
+        'inst-wf-001',
+        'exec-1',
+        expect.objectContaining({ status: 'completed' }),
+      );
+    });
+
+    it('[DATA] L3 + review.type=agent + completed + appliedToWorkflow=true calls advanceStep (agent verdict is authoritative)', async () => {
+      const l3AgentReview: WorkflowStep = { ...l3Step, review: { type: 'agent' } };
+      const reviewEnvelope = buildAgentOutputEnvelope({
+        result: { verdict: 'approve', summary: 'LGTM' },
+      });
+      const runResult = {
+        status: 'completed' as const,
+        envelope: reviewEnvelope,
+        appliedToWorkflow: true,
+        fallbackReason: null,
+      };
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue(runResult);
+
+      await executeAgentStep('inst-wf-001', 'gather-data', l3AgentReview, {}, 'user-1');
+
+      expect(mockHumanTaskRepo.create).not.toHaveBeenCalled();
+      expect(mockEngine.advanceStep).toHaveBeenCalledWith(
+        'inst-wf-001',
+        { verdict: 'approve', summary: 'LGTM' },
+        { id: 'user-1', role: 'agent' },
+        undefined,
+        runResult,
+      );
+    });
   });
 
   // ---- Escalation/Pause (non-L3) ----

--- a/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
@@ -49,6 +49,7 @@ const mockAuditRepo = {
 };
 const mockEngine = {
   advanceStep: vi.fn(),
+  submitReviewVerdict: vi.fn(),
 };
 const mockHumanTaskRepo = {
   create: vi.fn(),
@@ -446,7 +447,9 @@ describe('executeAgentStep', () => {
       );
     });
 
-    it('[DATA] L3 + review.type=agent + completed + appliedToWorkflow=true calls advanceStep (agent verdict is authoritative)', async () => {
+    it('[DATA] L3 + review.type=agent + non-review step + completed + appliedToWorkflow=true calls advanceStep', async () => {
+      // Non-review step (type=creation) with review.type=agent falls through to
+      // advanceStep — there's no verdict to submit on a creation step.
       const l3AgentReview: WorkflowStep = { ...l3Step, review: { type: 'agent' } };
       const reviewEnvelope = buildAgentOutputEnvelope({
         result: { verdict: 'approve', summary: 'LGTM' },
@@ -462,6 +465,7 @@ describe('executeAgentStep', () => {
       await executeAgentStep('inst-wf-001', 'gather-data', l3AgentReview, {}, 'user-1');
 
       expect(mockHumanTaskRepo.create).not.toHaveBeenCalled();
+      expect(mockEngine.submitReviewVerdict).not.toHaveBeenCalled();
       expect(mockEngine.advanceStep).toHaveBeenCalledWith(
         'inst-wf-001',
         { verdict: 'approve', summary: 'LGTM' },
@@ -469,6 +473,142 @@ describe('executeAgentStep', () => {
         undefined,
         runResult,
       );
+    });
+
+    // ---- L3 + review.type=agent on a REVIEW step: iteration loop via submitReviewVerdict ----
+
+    const l3ReviewAgentStep: WorkflowStep = {
+      id: 'review-pr',
+      name: 'Review PR',
+      type: 'review',
+      executor: 'agent',
+      autonomyLevel: 'L3',
+      allowedRoles: ['senior-reviewer'],
+      review: { type: 'agent', maxIterations: 3 },
+    };
+
+    it('[DATA] L3 + review.type=agent + review step + verdict=approve calls submitReviewVerdict', async () => {
+      const reviewEnvelope = buildAgentOutputEnvelope({
+        result: { verdict: 'approve', comment: 'LGTM' },
+      });
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+        status: 'completed',
+        envelope: reviewEnvelope,
+        appliedToWorkflow: true,
+        fallbackReason: null,
+      });
+      const updatedInstance = buildProcessInstance({
+        id: 'inst-wf-001',
+        status: 'running',
+        currentStepId: 'done',
+      });
+      mockEngine.submitReviewVerdict.mockResolvedValue(updatedInstance);
+
+      const result = await executeAgentStep('inst-wf-001', 'review-pr', l3ReviewAgentStep, {}, 'user-1');
+
+      expect(mockHumanTaskRepo.create).not.toHaveBeenCalled();
+      expect(mockEngine.advanceStep).not.toHaveBeenCalled();
+      expect(mockEngine.submitReviewVerdict).toHaveBeenCalledWith(
+        'inst-wf-001',
+        'review-pr',
+        expect.objectContaining({
+          reviewerId: 'agent:review-pr',
+          reviewerRole: 'agent',
+          verdict: 'approve',
+          comment: 'LGTM',
+        }),
+        { id: 'agent:review-pr', role: 'agent' },
+      );
+      expect(result.currentStepId).toBe('done');
+      expect(result.agentRunStatus).toBe('completed');
+    });
+
+    it('[DATA] L3 + review.type=agent + review step + verdict=revise calls submitReviewVerdict (engine loops back)', async () => {
+      const reviewEnvelope = buildAgentOutputEnvelope({
+        result: { verdict: 'revise', comment: 'Please add tests' },
+      });
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+        status: 'completed',
+        envelope: reviewEnvelope,
+        appliedToWorkflow: true,
+        fallbackReason: null,
+      });
+      const loopedInstance = buildProcessInstance({
+        id: 'inst-wf-001',
+        status: 'running',
+        currentStepId: 'gather-data', // looped back to creation step
+      });
+      mockEngine.submitReviewVerdict.mockResolvedValue(loopedInstance);
+
+      const result = await executeAgentStep('inst-wf-001', 'review-pr', l3ReviewAgentStep, {}, 'user-1');
+
+      expect(mockHumanTaskRepo.create).not.toHaveBeenCalled();
+      expect(mockEngine.submitReviewVerdict).toHaveBeenCalledWith(
+        'inst-wf-001',
+        'review-pr',
+        expect.objectContaining({ verdict: 'revise', comment: 'Please add tests' }),
+        expect.any(Object),
+      );
+      expect(result.currentStepId).toBe('gather-data');
+    });
+
+    it('[DATA] L3 + review.type=agent + review step + missing verdict creates HumanTask with escalationReason=error', async () => {
+      const reviewEnvelope = buildAgentOutputEnvelope({
+        result: { summary: 'looks ok' }, // no verdict field
+      });
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+        status: 'completed',
+        envelope: reviewEnvelope,
+        appliedToWorkflow: true,
+        fallbackReason: null,
+      });
+
+      const result = await executeAgentStep('inst-wf-001', 'review-pr', l3ReviewAgentStep, {}, 'user-1');
+
+      expect(mockEngine.submitReviewVerdict).not.toHaveBeenCalled();
+      expect(mockHumanTaskRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          creationReason: 'agent_review_l3',
+          completionData: expect.objectContaining({
+            agentOutput: expect.objectContaining({ escalationReason: 'error' }),
+          }),
+        }),
+      );
+      expect(result.status).toBe('paused');
+      expect(result.agentRunStatus).toBe('escalated');
+    });
+
+    it('[DATA] L3 + review.type=agent + review step + max_iterations_exceeded creates HumanTask with escalationReason=iterations_limit', async () => {
+      const reviewEnvelope = buildAgentOutputEnvelope({
+        result: { verdict: 'revise', comment: 'still missing tests' },
+      });
+      mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+        status: 'completed',
+        envelope: reviewEnvelope,
+        appliedToWorkflow: true,
+        fallbackReason: null,
+      });
+      const exhaustedInstance = buildProcessInstance({
+        id: 'inst-wf-001',
+        status: 'paused',
+        pauseReason: 'max_iterations_exceeded',
+        currentStepId: 'review-pr',
+      });
+      mockEngine.submitReviewVerdict.mockResolvedValue(exhaustedInstance);
+
+      const result = await executeAgentStep('inst-wf-001', 'review-pr', l3ReviewAgentStep, {}, 'user-1');
+
+      expect(mockEngine.submitReviewVerdict).toHaveBeenCalled();
+      expect(mockHumanTaskRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          creationReason: 'agent_review_l3',
+          completionData: expect.objectContaining({
+            agentOutput: expect.objectContaining({ escalationReason: 'iterations_limit' }),
+          }),
+        }),
+      );
+      expect(result.status).toBe('paused');
+      expect(result.agentRunStatus).toBe('escalated');
     });
   });
 

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -152,6 +152,72 @@ export async function executeAgentStep(
     }
   }
 
+  // Create a human review task for an L3 step, append audit, pause instance.
+  // Used for: (a) paused/escalated agent run, (b) agent reviewer returned no
+  // verdict, (c) agent reviewer exhausted the iteration limit.
+  const createAgentReviewHumanTask = async (
+    escalationReason: 'low_confidence' | 'timeout' | 'error' | 'iterations_limit' | null,
+    auditBasis: string,
+  ): Promise<void> => {
+    const reviewTaskId = crypto.randomUUID();
+    const reviewTaskNow = new Date().toISOString();
+    const assignedRole = workflowStep.allowedRoles?.[0] ?? 'reviewer';
+
+    await humanTaskRepo.create({
+      id: reviewTaskId,
+      processInstanceId: instanceId,
+      stepId,
+      assignedRole,
+      assignedUserId: null,
+      status: 'pending',
+      deadline: null,
+      createdAt: reviewTaskNow,
+      updatedAt: reviewTaskNow,
+      completedAt: null,
+      completionData: {
+        reviewType: 'agent_output_review',
+        agentOutput: {
+          confidence: envelope?.confidence ?? null,
+          reasoning: envelope?.reasoning_summary ?? null,
+          result: envelope?.result ?? null,
+          model: envelope?.model ?? null,
+          annotations: envelope?.annotations ?? null,
+          duration_ms: envelope?.duration_ms ?? null,
+          gitMetadata: envelope?.gitMetadata ?? null,
+          presentation: envelope?.presentation ?? null,
+          escalationReason,
+        },
+        iterationNumber: 0,
+      },
+      creationReason: 'agent_review_l3',
+    });
+
+    await auditRepo.append({
+      actorId: `agent:${pluginId}`,
+      actorType: 'agent',
+      actorRole: autonomyLevel,
+      action: 'task.created',
+      description: `Human task created for workflow step '${stepId}' (reason: agent_review_l3)`,
+      timestamp: reviewTaskNow,
+      inputSnapshot: { taskId: reviewTaskId, stepId, reason: 'agent_review_l3', assignedRole },
+      outputSnapshot: {},
+      basis: auditBasis,
+      entityType: 'humanTask',
+      entityId: reviewTaskId,
+      processInstanceId: instanceId,
+      stepId,
+      processDefinitionVersion: instance.definitionVersion,
+      executorType: 'agent',
+      reviewerType: 'human',
+    });
+
+    await instanceRepo.update(instanceId, {
+      status: 'paused',
+      pauseReason: 'waiting_for_human',
+      updatedAt: new Date().toISOString(),
+    });
+  };
+
   // ---- L3 Review Routing (skip when agent errored — nothing to review) ----
   // Escalation from fallback handler (status='escalated') always needs a human,
   // even when review.type='agent' — the whole point of escalate_to_human is that
@@ -161,64 +227,10 @@ export async function executeAgentStep(
     const isEscalation = runResult.status === 'escalated';
 
     if (reviewerType === 'human' || reviewerType === 'none' || isEscalation) {
-      const reviewTaskId = crypto.randomUUID();
-      const reviewTaskNow = new Date().toISOString();
-
-      await humanTaskRepo.create({
-        id: reviewTaskId,
-        processInstanceId: instanceId,
-        stepId,
-        assignedRole: workflowStep.allowedRoles?.[0] ?? 'reviewer',
-        assignedUserId: null,
-        status: 'pending',
-        deadline: null,
-        createdAt: reviewTaskNow,
-        updatedAt: reviewTaskNow,
-        completedAt: null,
-        completionData: {
-          reviewType: 'agent_output_review',
-          agentOutput: {
-            confidence: runResult.envelope?.confidence ?? null,
-            reasoning: runResult.envelope?.reasoning_summary ?? null,
-            result: runResult.envelope?.result ?? null,
-            model: runResult.envelope?.model ?? null,
-            annotations: runResult.envelope?.annotations ?? null,
-            duration_ms: runResult.envelope?.duration_ms ?? null,
-            gitMetadata: runResult.envelope?.gitMetadata ?? null,
-            presentation: runResult.envelope?.presentation ?? null,
-            escalationReason: isEscalation ? runResult.fallbackReason : null,
-          },
-          iterationNumber: 0,
-        },
-        creationReason: 'agent_review_l3',
-      });
-
-      await auditRepo.append({
-        actorId: `agent:${pluginId}`,
-        actorType: 'agent',
-        actorRole: autonomyLevel,
-        action: 'task.created',
-        description: `Human task created for workflow step '${stepId}' (reason: agent_review_l3)`,
-        timestamp: reviewTaskNow,
-        inputSnapshot: { taskId: reviewTaskId, stepId, reason: 'agent_review_l3', assignedRole: workflowStep.allowedRoles?.[0] ?? 'reviewer' },
-        outputSnapshot: {},
-        basis: 'L3 workflow agent step paused — human reviewer task created',
-        entityType: 'humanTask',
-        entityId: reviewTaskId,
-        processInstanceId: instanceId,
-        stepId,
-        processDefinitionVersion: instance.definitionVersion,
-        executorType: 'agent',
-        reviewerType: 'human',
-      });
-
-      // Pause instance so resolve-task can resume it after human approval
-      await instanceRepo.update(instanceId, {
-        status: 'paused',
-        pauseReason: 'waiting_for_human',
-        updatedAt: new Date().toISOString(),
-      });
-
+      await createAgentReviewHumanTask(
+        isEscalation ? runResult.fallbackReason : null,
+        'L3 workflow agent step paused — human reviewer task created',
+      );
       return {
         instanceId,
         status: 'paused',
@@ -226,6 +238,73 @@ export async function executeAgentStep(
         agentRunStatus: runResult.status,
       };
     }
+  }
+
+  // ---- L3 Agent-as-Reviewer: submit verdict via engine.submitReviewVerdict ----
+  // review.type='agent' on a review step: the agent's verdict flows through
+  // ReviewTracker so iteration counting and maxIterations enforcement fire.
+  // On verdict='revise' the step routes back to a prior creation step; when
+  // iterations are exhausted, the engine pauses with max_iterations_exceeded
+  // and we create a human escalation task so the process stays actionable.
+  if (
+    autonomyLevel === 'L3' &&
+    workflowStep.review?.type === 'agent' &&
+    workflowStep.type === 'review' &&
+    runResult.status === 'completed' &&
+    runResult.appliedToWorkflow
+  ) {
+    const resultObj =
+      envelope?.result && typeof envelope.result === 'object' ? (envelope.result as Record<string, unknown>) : null;
+    const verdictValue = typeof resultObj?.verdict === 'string' ? resultObj.verdict : null;
+
+    if (verdictValue === null || verdictValue.length === 0) {
+      await createAgentReviewHumanTask(
+        'error',
+        `Agent reviewer for step '${stepId}' returned envelope without a verdict`,
+      );
+      return {
+        instanceId,
+        status: 'paused',
+        currentStepId: stepId,
+        agentRunStatus: 'escalated',
+      };
+    }
+
+    const commentValue = typeof resultObj?.comment === 'string' ? resultObj.comment : null;
+    const reviewerId = `agent:${pluginId}`;
+
+    const updated = await engine.submitReviewVerdict(
+      instanceId,
+      stepId,
+      {
+        reviewerId,
+        reviewerRole: 'agent',
+        verdict: verdictValue,
+        comment: commentValue,
+        timestamp: new Date().toISOString(),
+      },
+      { id: reviewerId, role: 'agent' },
+    );
+
+    if (updated.status === 'paused' && updated.pauseReason === 'max_iterations_exceeded') {
+      await createAgentReviewHumanTask(
+        'iterations_limit',
+        `Agent reviewer for step '${stepId}' exhausted iteration limit`,
+      );
+      return {
+        instanceId,
+        status: 'paused',
+        currentStepId: stepId,
+        agentRunStatus: 'escalated',
+      };
+    }
+
+    return {
+      instanceId,
+      status: updated.status,
+      currentStepId: updated.currentStepId,
+      agentRunStatus: 'completed',
+    };
   }
 
   // ---- Escalation/Pause (non-L3) ----

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -117,9 +117,12 @@ export async function executeAgentStep(
   const envelope = runResult.envelope;
   if (stepExecutionId) {
     const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
+    // L3 + escalated (non-error) routes to human review below, so the execution
+    // is not a failure — the run produced a usable envelope, just flagged for review.
+    const isEscalatedToL3Review = autonomyLevel === 'L3' && runResult.status === 'escalated' && !isFailed;
     await instanceRepo.updateStepExecution(instanceId, stepExecutionId, {
       output: envelope?.result ?? null,
-      status: !isFailed && (runResult.status === 'completed' || runResult.status === 'paused') ? 'completed' : 'failed',
+      status: !isFailed && (runResult.status === 'completed' || runResult.status === 'paused' || isEscalatedToL3Review) ? 'completed' : 'failed',
       completedAt: new Date().toISOString(),
       ...(isFailed && runResult.errorMessage ? { error: runResult.errorMessage } : {}),
       agentOutput: envelope
@@ -150,10 +153,14 @@ export async function executeAgentStep(
   }
 
   // ---- L3 Review Routing (skip when agent errored — nothing to review) ----
+  // Escalation from fallback handler (status='escalated') always needs a human,
+  // even when review.type='agent' — the whole point of escalate_to_human is that
+  // the agent couldn't self-resolve.
   if ((runResult.status === 'paused' || runResult.status === 'escalated') && autonomyLevel === 'L3' && runResult.fallbackReason !== 'error') {
     const reviewerType = workflowStep.review?.type ?? 'human';
+    const isEscalation = runResult.status === 'escalated';
 
-    if (reviewerType === 'human' || reviewerType === 'none') {
+    if (reviewerType === 'human' || reviewerType === 'none' || isEscalation) {
       const reviewTaskId = crypto.randomUUID();
       const reviewTaskNow = new Date().toISOString();
 
@@ -179,6 +186,7 @@ export async function executeAgentStep(
             duration_ms: runResult.envelope?.duration_ms ?? null,
             gitMetadata: runResult.envelope?.gitMetadata ?? null,
             presentation: runResult.envelope?.presentation ?? null,
+            escalationReason: isEscalation ? runResult.fallbackReason : null,
           },
           iterationNumber: 0,
         },


### PR DESCRIPTION
## Summary

Fixes two L3 agent-review stalls and adds a proper iteration loop for agent-as-reviewer with `maxIterations` enforcement.

### The original stalls (PR #209 regression)

1. **High confidence → stalled with no task.** L3 + `review.type='agent'` + valid envelope paused the instance with `appliedToWorkflow=false` but no human task (because `reviewer.type='agent'`) and no verdict applied. The workflow sat indefinitely. Now the agent's verdict is routed through the engine.
2. **Low confidence → escalated to nowhere.** Fallback-handler `escalate_to_human` only created a human task when `reviewer.type ∈ {'human','none'}`. With `review.type='agent'` the escalation had nowhere to route. Now `runResult.status === 'escalated'` always creates a human task regardless of `review.type`, with `escalationReason` surfaced as a badge.

### The iteration loop (new)

When the agent is the reviewer on a `type='review'` step, its verdict flows through `engine.submitReviewVerdict` (not `advanceStep`) so `ReviewTracker` iteration counting + `maxIterations` enforcement fire the same way they do for human reviewers.

- `verdict: 'approve'` → verdict routing advances via `step.verdicts.approve.target`.
- `verdict: 'revise'` (or any looping verdict) → routes back to the creation step; `ReviewTracker` increments when the routed step precedes the review step.
- **`maxIterations` exhausted** → engine pauses with `pauseReason='max_iterations_exceeded'`; executor creates a human task tagged `escalationReason='iterations_limit'` ("Iterations limit reached" badge) so the stuck process is actionable.
- **Agent returned no `verdict` in the envelope** → human task with `escalationReason='error'` instead of silently stalling.

The creation step is re-fired by the existing auto-runner polling loop; no new polling plumbing needed.

## Resulting semantics

| Scenario | Behavior |
|---|---|
| L3 + `review.type='human'` + paused | Human task (approve/revise) — unchanged |
| L3 + `review.type='agent'` + review step + verdict=approve | Engine advances via `submitReviewVerdict` |
| L3 + `review.type='agent'` + review step + verdict=revise | Loops back to creation step; iteration +1 |
| L3 + `review.type='agent'` + review step + `maxIterations` exhausted | **Human task** with "Iterations limit reached" badge |
| L3 + `review.type='agent'` + review step + verdict missing | **Human task** with "Error" badge |
| L3 + `review.type='agent'` + escalated (low confidence / timeout) | Human task with "Escalated: low confidence / timeout" badge |
| L3 + `review.type='agent'` + non-review step | `advanceStep` — unchanged (no verdict to submit) |

## Changes

- `packages/agent-runtime/src/runner/agent-runner.ts` — for L3 + `review.type='agent'` returns `{completed, appliedToWorkflow=true}`; comment clarifies the executor picks the engine path based on `step.type`.
- `packages/platform-ui/src/lib/execute-agent-step.ts`:
  - Extracted `createAgentReviewHumanTask` helper (used by existing paused/escalated path and the two new escalation cases).
  - New branch for L3 + `review.type='agent'` + `step.type='review'` + completed: extracts `verdict` + `comment` from envelope, calls `engine.submitReviewVerdict` with actor `{id: 'agent:<plugin>', role: 'agent'}`, handles missing verdict and `max_iterations_exceeded`.
  - L3 + escalated step executions persisted as `completed` (not `failed`) when envelope is valid.
- `packages/platform-ui/src/components/tasks/task-utils.ts` — `EscalationReason` now includes `'iterations_limit'`; runtime normalizer accepts it.
- `packages/platform-ui/src/components/tasks/agent-output-review-panel.tsx` — amber "Escalated: …" badge; new `'iterations_limit'` → "iterations limit reached"; confidence shown in parentheses for `low_confidence`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1121 passed, 1 skipped
- [x] New unit tests (all passing):
  - L3 + `review.type='agent'` + review step + verdict=approve → `submitReviewVerdict`, no advanceStep, no human task
  - L3 + `review.type='agent'` + review step + verdict=revise → `submitReviewVerdict`, engine loops back
  - L3 + `review.type='agent'` + review step + missing verdict → human task with `escalationReason='error'`
  - L3 + `review.type='agent'` + review step + `max_iterations_exceeded` → human task with `escalationReason='iterations_limit'`
  - L3 + `review.type='agent'` + **non**-review step + verdict → `advanceStep` (preserved)
  - L3 + `review.type='agent'` + escalated → human task with `escalationReason='low_confidence'` (preserved)
  - L3 paused/escalated (review.type=human|none) → human task (preserved)
  - L3 escalated saves step execution as `completed` (not `failed`) when envelope is valid
  - UI: "Escalated: iterations limit reached" badge renders
- [ ] Manual: run `mediforce-fullstack` end-to-end to verify the loop — `review-pr` either auto-advances on approve, loops on revise (up to `maxIterations`), or routes to a human task with the "Iterations limit reached" badge

## E2E

Not covered by automated E2E. The fix is unit-tested end-to-end at the `executeAgentStep` level (agent-runner contract + `submitReviewVerdict` routing + human-task creation + `advanceStep` fall-through). A journey-level test would need a mock agent plugin and an L3 review workflow with verdicts, which is scoped out here.

Context for iteration-counting: `ReviewTracker` is in-memory per `WorkflowEngine` instance (pre-existing behavior, not new in this PR). Survives between auto-runner polls because `getPlatformServices()` returns a singleton engine. Does **not** survive a server restart — that applies equally to human and agent reviewers and is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)