### PR TITLE
fix: fail-fast on startup when SECRETS_ENCRYPTION_KEY is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
           # of the self-fetch, so validateApiKey passes. Only used locally within
           # the Next.js process — no real secret needed.
           PLATFORM_API_KEY: ci-e2e-test-key
+          # Fake 64-hex-char key to satisfy validateSecretsKey() fail-fast check
+          # in getPlatformServices(). No real workflow secrets are encrypted/decrypted
+          # during E2E runs — this just has to be present and well-formed.
+          SECRETS_ENCRYPTION_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
 
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/packages/platform-infra/src/__tests__/secrets-cipher.test.ts
+++ b/packages/platform-infra/src/__tests__/secrets-cipher.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { validateSecretsKey, encrypt, decrypt } from '../crypto/secrets-cipher.js';
+
+const VALID_KEY = 'a'.repeat(64);
+
+describe('validateSecretsKey', () => {
+  const original = process.env.SECRETS_ENCRYPTION_KEY;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.SECRETS_ENCRYPTION_KEY;
+    } else {
+      process.env.SECRETS_ENCRYPTION_KEY = original;
+    }
+  });
+
+  it('passes for a valid 64-hex-char key', () => {
+    process.env.SECRETS_ENCRYPTION_KEY = VALID_KEY;
+    expect(() => validateSecretsKey()).not.toThrow();
+  });
+
+  it('throws when key is missing, mentioning .env.example and bootstrap-server.py', () => {
+    delete process.env.SECRETS_ENCRYPTION_KEY;
+    expect(() => validateSecretsKey()).toThrow(/SECRETS_ENCRYPTION_KEY/);
+    expect(() => validateSecretsKey()).toThrow(/\.env\.example/);
+    expect(() => validateSecretsKey()).toThrow(/bootstrap-server\.py/);
+  });
+
+  it('throws for a key that is too short', () => {
+    process.env.SECRETS_ENCRYPTION_KEY = 'abc123';
+    expect(() => validateSecretsKey()).toThrow(/64/);
+  });
+
+  it('throws for a key that is too long', () => {
+    process.env.SECRETS_ENCRYPTION_KEY = 'a'.repeat(65);
+    expect(() => validateSecretsKey()).toThrow(/64/);
+  });
+
+  it('throws for a key with non-hex characters', () => {
+    process.env.SECRETS_ENCRYPTION_KEY = 'z'.repeat(64);
+    expect(() => validateSecretsKey()).toThrow(/64/);
+  });
+});
+
+describe('encrypt / decrypt round-trip', () => {
+  beforeEach(() => {
+    process.env.SECRETS_ENCRYPTION_KEY = VALID_KEY;
+  });
+
+  afterEach(() => {
+    delete process.env.SECRETS_ENCRYPTION_KEY;
+  });
+
+  it('round-trips plaintext through encrypt and decrypt', () => {
+    const plaintext = 'super-secret-value';
+    const ciphertext = encrypt(plaintext);
+    expect(decrypt(ciphertext)).toBe(plaintext);
+  });
+});

--- a/packages/platform-infra/src/crypto/secrets-cipher.ts
+++ b/packages/platform-infra/src/crypto/secrets-cipher.ts
@@ -4,6 +4,29 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
 
+/**
+ * Validate SECRETS_ENCRYPTION_KEY at startup. Throws with a clear message pointing
+ * to .env.example and bootstrap-server.py if the key is missing or malformed.
+ * Call this once during service initialisation so the process fails fast.
+ */
+export function validateSecretsKey(): void {
+  const raw = process.env.SECRETS_ENCRYPTION_KEY;
+  if (!raw) {
+    throw new Error(
+      'SECRETS_ENCRYPTION_KEY is not set. ' +
+        'Set it to a 64-character hex string in your .env file (see .env.example). ' +
+        'For a fresh install, run scripts/bootstrap-server.py to generate a key.',
+    );
+  }
+  if (!/^[0-9a-fA-F]{64}$/.test(raw)) {
+    throw new Error(
+      `SECRETS_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes). ` +
+        `Got ${raw.length} character(s). ` +
+        'See .env.example or run scripts/bootstrap-server.py to generate a valid key.',
+    );
+  }
+}
+
 function getKey(): Buffer {
   const raw = process.env.SECRETS_ENCRYPTION_KEY;
   if (!raw) {

--- a/packages/platform-infra/src/index.ts
+++ b/packages/platform-infra/src/index.ts
@@ -23,7 +23,9 @@ export { WebhookNotificationService } from './notifications/webhook-notification
 export { FirestoreAgentDefinitionRepository } from './firestore/agent-definition-repository.js';
 export { FirestoreNamespaceRepository } from './firestore/namespace-repository.js';
 export { FirestoreWorkflowSecretsRepository } from './firestore/workflow-secrets-repository.js';
-export { FirestoreCoworkSessionRepository } from './firestore/cowork-session-repository.js';export { FirestoreCronTriggerStateRepository } from './firestore/cron-trigger-state-repository.js';
+export { FirestoreCoworkSessionRepository } from './firestore/cowork-session-repository.js';
+export { FirestoreCronTriggerStateRepository } from './firestore/cron-trigger-state-repository.js';
+export { validateSecretsKey } from './crypto/secrets-cipher.js';
 export { getAdminAuth, getAdminFirestore } from './auth/firebase-admin-init.js';
 export { FirebaseInviteService } from './auth/firebase-invite-service.js';
 

--- a/packages/platform-ui/scripts/bootstrap_e2e.py
+++ b/packages/platform-ui/scripts/bootstrap_e2e.py
@@ -69,6 +69,9 @@ def ensure_env_local() -> bool:
         "NEXT_PUBLIC_FIREBASE_APP_ID=1:000000000000:web:0000000000000000\n"
         "OPENROUTER_API_KEY=fake-openrouter-key\n"
         "PLATFORM_API_KEY=test-api-key\n"
+        # 64 hex chars — satisfies validateSecretsKey() fail-fast check.
+        # No real secrets are encrypted/decrypted during E2E runs.
+        "SECRETS_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000\n"
     )
     log(f"Created {ENV_LOCAL} with demo credentials")
     return True

--- a/packages/platform-ui/src/lib/platform-services.ts
+++ b/packages/platform-ui/src/lib/platform-services.ts
@@ -10,6 +10,7 @@ import {
   FirestoreCronTriggerStateRepository,
   initializeFirebase,
   getFirestoreDb,
+  validateSecretsKey,
 } from '@mediforce/platform-infra';
 import { connectFirestoreEmulator } from 'firebase/firestore';
 import type { CronTriggerStateRepository } from '@mediforce/platform-core';
@@ -52,6 +53,10 @@ export interface PlatformServices {
 
 export function getPlatformServices(): PlatformServices {
   if (services) return services;
+
+  // Fail fast if the encryption key is missing or malformed — better to crash here
+  // than to boot successfully and fail opaquely mid-workflow.
+  validateSecretsKey();
 
   // Initialize platform Firebase project (env vars set in platform-ui)
   initializeFirebase({


### PR DESCRIPTION
## Summary

Closes #196

- Added `validateSecretsKey()` to `packages/platform-infra/src/crypto/secrets-cipher.ts` that validates `SECRETS_ENCRYPTION_KEY` is present and exactly 64 hex characters. The error message explicitly names the variable, points to `.env.example`, and mentions `scripts/bootstrap-server.py` for fresh installs.
- Exported `validateSecretsKey` from the `@mediforce/platform-infra` package index.
- Wired the check into `getPlatformServices()` in `packages/platform-ui/src/lib/platform-services.ts` — the service singleton now validates the key before any other initialisation, so the platform process crashes immediately with a clear error instead of failing opaquely mid-workflow.
- Added unit tests in `packages/platform-infra/src/__tests__/secrets-cipher.test.ts` covering: valid key passes, missing key throws with message referencing `.env.example` and `bootstrap-server.py`, too-short key throws, non-hex key throws, too-long key throws, and encrypt/decrypt round-trip.

## Test plan

- [ ] Run `pnpm test` in `packages/platform-infra` — all `secrets-cipher` tests should pass.
- [ ] Start the platform without `SECRETS_ENCRYPTION_KEY` set — process should exit immediately with a message mentioning `.env.example` and `scripts/bootstrap-server.py`.
- [ ] Start with a malformed key (e.g. `abc`) — same fail-fast behaviour.
- [ ] Start with a valid 64-hex-char key — platform boots normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)