### PR TITLE
Add SECRETS_ENCRYPTION_KEY to E2E test environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
           # of the self-fetch, so validateApiKey passes. Only used locally within
           # the Next.js process — no real secret needed.
           PLATFORM_API_KEY: ci-e2e-test-key
+          # Fake 64-hex-char key to satisfy validateSecretsKey() fail-fast check
+          # in getPlatformServices(). No real workflow secrets are encrypted/decrypted
+          # during E2E runs — this just has to be present and well-formed.
+          SECRETS_ENCRYPTION_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
 
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/packages/platform-ui/scripts/bootstrap_e2e.py
+++ b/packages/platform-ui/scripts/bootstrap_e2e.py
@@ -69,6 +69,9 @@ def ensure_env_local() -> bool:
         "NEXT_PUBLIC_FIREBASE_APP_ID=1:000000000000:web:0000000000000000\n"
         "OPENROUTER_API_KEY=fake-openrouter-key\n"
         "PLATFORM_API_KEY=test-api-key\n"
+        # 64 hex chars — satisfies validateSecretsKey() fail-fast check.
+        # No real secrets are encrypted/decrypted during E2E runs.
+        "SECRETS_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000\n"
     )
     log(f"Created {ENV_LOCAL} with demo credentials")
     return True


### PR DESCRIPTION
## Summary
Add the `SECRETS_ENCRYPTION_KEY` environment variable to both CI and local E2E test configurations to satisfy the `validateSecretsKey()` validation check in `getPlatformServices()`.

## Changes
- **CI workflow** (`ci.yml`): Added `SECRETS_ENCRYPTION_KEY` with a fake 64-character hex string to the E2E test job environment
- **Local bootstrap script** (`bootstrap_e2e.py`): Added `SECRETS_ENCRYPTION_KEY` to the generated `.env.local` file for local E2E testing

## Implementation Details
- The key is a 64-character hexadecimal string (`0000000000000000...`) that satisfies the format validation without being a real secret
- This is a fail-fast check requirement — no actual encryption/decryption of workflow secrets occurs during E2E runs
- The variable must be present and well-formed, but the specific value is not used for cryptographic operations in test environments

https://claude.ai/code/session_015yqMmmGchHpBKsQ9PcjhPF