### PR TITLE
fix(vercel): extract tickets rate limiter so Next.js accepts route exports

### DIFF
--- a/packages/platform-ui/src/app/api/tickets/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/tickets/__tests__/route.test.ts
@@ -10,7 +10,8 @@ vi.mock('@mediforce/platform-infra', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-import { POST, __resetRateLimitsForTests } from '../route';
+import { POST } from '../route';
+import { __resetRateLimitsForTests } from '../rate-limit';
 
 function makePostRequest(body: unknown, headers: Record<string, string> = {}): NextRequest {
   return new Request('http://localhost/api/tickets', {

--- a/packages/platform-ui/src/app/api/tickets/rate-limit.ts
+++ b/packages/platform-ui/src/app/api/tickets/rate-limit.ts
@@ -1,0 +1,29 @@
+export const DAILY_LIMIT = 50;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type RateLimitBucket = { count: number; windowStart: number };
+
+// Per-instance in-memory limiter. On multi-instance deployments the effective
+// cap is DAILY_LIMIT × instances — acceptable for an anti-spam ceiling; move to
+// Firestore if stricter enforcement becomes necessary.
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+
+export function __resetRateLimitsForTests(): void {
+  rateLimitBuckets.clear();
+}
+
+export type RateLimitResult = { ok: true } | { ok: false; retryAfterSeconds: number };
+
+export function consumeRateLimit(uid: string, now: number): RateLimitResult {
+  const bucket = rateLimitBuckets.get(uid);
+  if (bucket === undefined || now - bucket.windowStart >= DAY_MS) {
+    rateLimitBuckets.set(uid, { count: 1, windowStart: now });
+    return { ok: true };
+  }
+  if (bucket.count >= DAILY_LIMIT) {
+    const retryAfterSeconds = Math.ceil((bucket.windowStart + DAY_MS - now) / 1000);
+    return { ok: false, retryAfterSeconds: Math.max(retryAfterSeconds, 1) };
+  }
+  bucket.count += 1;
+  return { ok: true };
+}

--- a/packages/platform-ui/src/app/api/tickets/route.ts
+++ b/packages/platform-ui/src/app/api/tickets/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getAdminAuth } from '@mediforce/platform-infra';
+import { consumeRateLimit, DAILY_LIMIT } from './rate-limit';
 
 const TICKET_TYPES = ['bug', 'idea', 'question'] as const;
 type TicketType = (typeof TICKET_TYPES)[number];
@@ -20,36 +21,6 @@ const TicketBodySchema = z.object({
     .max(10)
     .default([]),
 });
-
-const DAILY_LIMIT = 50;
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-type RateLimitBucket = { count: number; windowStart: number };
-
-// Per-instance in-memory limiter. On multi-instance deployments the effective
-// cap is DAILY_LIMIT × instances — acceptable for an anti-spam ceiling; move to
-// Firestore if stricter enforcement becomes necessary.
-const rateLimitBuckets = new Map<string, RateLimitBucket>();
-
-export function __resetRateLimitsForTests(): void {
-  rateLimitBuckets.clear();
-}
-
-type RateLimitResult = { ok: true } | { ok: false; retryAfterSeconds: number };
-
-function consumeRateLimit(uid: string, now: number): RateLimitResult {
-  const bucket = rateLimitBuckets.get(uid);
-  if (bucket === undefined || now - bucket.windowStart >= DAY_MS) {
-    rateLimitBuckets.set(uid, { count: 1, windowStart: now });
-    return { ok: true };
-  }
-  if (bucket.count >= DAILY_LIMIT) {
-    const retryAfterSeconds = Math.ceil((bucket.windowStart + DAY_MS - now) / 1000);
-    return { ok: false, retryAfterSeconds: Math.max(retryAfterSeconds, 1) };
-  }
-  bucket.count += 1;
-  return { ok: true };
-}
 
 function buildIssueBody(params: {
   description: string;


### PR DESCRIPTION
## Problem

Vercel preview deployments fail for every open PR branched off main after #228. Root cause:

```
src/app/api/tickets/route.ts
Type error: Route "src/app/api/tickets/route.ts" does not match the required
types of a Next.js Route.
  "__resetRateLimitsForTests" is not a valid Route export field.
```

Next.js 16 strictly validates API route exports against a closed allowlist (GET/POST/PUT/DELETE/PATCH + `runtime`, `dynamic`, `revalidate`, etc.). The tickets route exposed a test-only helper `__resetRateLimitsForTests` for vitest; Next.js rejects the whole build because of it.

Timeline:
- #228 (command palette) introduced the test-only export in commit `3008ab8`. Its CI checks (`typecheck`, `unit-tests`) passed because `tsc --noEmit` and `vitest` don't run `next build`. Its Vercel check actually **failed**, but the PR was merged anyway.
- Every PR branched off main since then inherits the broken tickets route and fails Vercel.
- #213 passes because it branched before #228 landed.

`validateSecretsKey()` / Admin SDK are called lazily inside `getPlatformServices()`, so they never run during `next build` — red herring.

## Fix

Move rate-limit state (`rateLimitBuckets` map, `consumeRateLimit`, `DAILY_LIMIT`, `__resetRateLimitsForTests`) into a sibling `rate-limit.ts`. `route.ts` imports only what it uses; the test imports `__resetRateLimitsForTests` directly from `rate-limit`. Route module now has only `POST` — Next.js happy. No behaviour change.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm vitest run src/app/api/tickets` — 15/15 pass
- [x] `pnpm build` in `packages/platform-ui` — passes the tickets-route type check
- [x] Vercel preview on this PR — pass