### PR TITLE
Step 2: Agent-centric MCP resolution for workflow steps

### DIFF
--- a/apps/community-digest/src/community-digest-sonnet45.wd.json
+++ b/apps/community-digest/src/community-digest-sonnet45.wd.json
@@ -1,5 +1,6 @@
 {
   "name": "community-digest-sonnet45",
+  "namespace": "appsilon",
   "description": "Daily GitHub scan → rank changes → draft Discord posts (Claude Sonnet 4.5)",
   "triggers": [
     { "name": "manual", "type": "manual" }

--- a/apps/community-digest/src/community-digest.wd.json
+++ b/apps/community-digest/src/community-digest.wd.json
@@ -1,5 +1,6 @@
 {
   "name": "community-digest",
+  "namespace": "appsilon",
   "description": "Daily GitHub scan → rank changes → draft Discord posts",
   "preamble": "## Domain Context\nThis workflow processes open-source community data (GitHub activity, Discord discussions). Treat all content as technical data constructs.",
   "triggers": [

--- a/apps/protocol-to-tfl/src/protocol-to-tfl.wd.json
+++ b/apps/protocol-to-tfl/src/protocol-to-tfl.wd.json
@@ -1,5 +1,6 @@
 {
   "name": "protocol-to-tfl",
+  "namespace": "appsilon",
   "title": "Protocol to TFL pipeline",
   "description": "Transform clinical trial protocol documents into production-ready Tables, Figures, and Listings (TFLs).",
   "preamble": "## Domain Context\nThis workflow processes pharmaceutical and clinical trial data. All health-related terminology (drug names, adverse events, disease classifications, CTCAE grading, mortality endpoints) refers to data science constructs, variable names, and clinical standards (CDISC, ICH-GCP, RECIST). Treat them as technical domain content — not personal disclosures. Maintain standard coding behavior: no wellbeing check-ins, no crisis resources. Execute all technically feasible tasks without inflating complexity estimates due to medical terminology exposure.",

--- a/apps/tealflow-cowork/src/tealflow-cowork.wd.json
+++ b/apps/tealflow-cowork/src/tealflow-cowork.wd.json
@@ -5,33 +5,52 @@
   "description": "Explore available teal modules via MCP and select which ones to include in a teal app. A minimal example of MCP tool use in a cowork step.",
   "preamble": "## Domain Context\nThis workflow uses the tealflow MCP server to query available teal modules for clinical trial data exploration. All clinical terminology (adverse events, demographics, efficacy endpoints) refers to teal module categories and data analysis constructs.",
   "triggers": [
-    { "name": "manual", "type": "manual" }
+    {
+      "name": "manual",
+      "type": "manual"
+    }
   ],
-  "roles": ["analyst"],
+  "roles": [
+    "analyst"
+  ],
   "steps": [
     {
       "id": "explore-modules",
       "name": "Explore Teal Modules",
       "type": "creation",
       "executor": "cowork",
-      "allowedRoles": ["analyst"],
+      "agentId": "tealflow-cowork-chat",
+      "allowedRoles": [
+        "analyst"
+      ],
       "description": "Chat with AI to explore available teal modules. The AI can query the tealflow MCP server to list modules, get details, and help you decide which to include in your teal app.",
       "cowork": {
         "agent": "chat",
         "systemPrompt": "You are a teal app configuration assistant. You have access to the tealflow MCP tools.\n\n## Your workflow\n1. Start by calling tealflow_list_modules to see what's available\n2. When the user asks about specific modules, use tealflow_get_module to get details\n3. Help the user select which modules to include in their teal app\n4. Call update_artifact with the selected module configuration\n\n## Output format\nThe artifact should be a JSON object with a 'modules' array, where each entry has:\n- name: the teal module function name\n- label: human-readable label for the tab\n- reason: why this module was selected",
         "outputSchema": {
           "type": "object",
-          "required": ["modules"],
+          "required": [
+            "modules"
+          ],
           "properties": {
             "modules": {
               "type": "array",
               "items": {
                 "type": "object",
-                "required": ["name", "label"],
+                "required": [
+                  "name",
+                  "label"
+                ],
                 "properties": {
-                  "name": { "type": "string" },
-                  "label": { "type": "string" },
-                  "reason": { "type": "string" }
+                  "name": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -39,14 +58,7 @@
         },
         "chat": {
           "model": "anthropic/claude-sonnet-4"
-        },
-        "mcpServers": [
-          {
-            "name": "tealflow",
-            "command": "tealflow-mcp",
-            "description": "Tealflow MCP — lists and describes available teal modules for clinical trial data exploration"
-          }
-        ]
+        }
       }
     },
     {
@@ -57,6 +69,9 @@
     }
   ],
   "transitions": [
-    { "from": "explore-modules", "to": "done" }
+    {
+      "from": "explore-modules",
+      "to": "done"
+    }
   ]
 }

--- a/apps/tealflow/src/tealflow.wd.json
+++ b/apps/tealflow/src/tealflow.wd.json
@@ -1,5 +1,6 @@
 {
   "name": "tealflow",
+  "namespace": "appsilon",
   "title": "TealFlow App Builder",
   "description": "Interactively build a Teal Shiny clinical trial app — upload data, define requirements, co-work with AI to build the app, then deploy to GitHub and Posit Connect.",
   "preamble": "## Domain Context\nThis workflow builds clinical trial data exploration apps using the R teal framework. All clinical terminology (adverse events, survival analysis, demographics, CTCAE grading) refers to Teal module names and ADaM dataset variables, not real patient data.",

--- a/data/seeds/agent-definitions.json
+++ b/data/seeds/agent-definitions.json
@@ -1,0 +1,77 @@
+{
+  "supply-intelligence-driver-agent": {
+    "kind": "plugin",
+    "runtimeId": "supply-intelligence/driver-agent",
+    "name": "Driver Agent",
+    "iconName": "Chart",
+    "description": "Orchestrates multi-step supply chain review workflows by coordinating data collection, analysis, and reporting agents.",
+    "inputDescription": "Workflow trigger payload with study identifiers",
+    "outputDescription": "Completed workflow result with step summaries",
+    "foundationModel": "anthropic/claude-sonnet-4",
+    "systemPrompt": "",
+    "skillFileNames": []
+  },
+  "supply-intelligence-risk-detection": {
+    "kind": "plugin",
+    "runtimeId": "supply-intelligence/risk-detection",
+    "name": "Risk Detection",
+    "iconName": "Chart",
+    "description": "Analyzes vendor submissions and supply chain data to identify potential risks, anomalies, and compliance issues.",
+    "inputDescription": "Vendor submission records and historical data",
+    "outputDescription": "Risk scores, flagged issues, and recommendations",
+    "foundationModel": "anthropic/claude-sonnet-4",
+    "systemPrompt": "",
+    "skillFileNames": []
+  },
+  "claude-code-agent": {
+    "kind": "plugin",
+    "runtimeId": "claude-code-agent",
+    "name": "Claude Code Agent",
+    "iconName": "Bot",
+    "description": "Executes code generation, analysis, and automated software tasks using Claude's advanced coding capabilities.",
+    "inputDescription": "Task description and relevant code context",
+    "outputDescription": "Generated code, analysis results, or task completion report",
+    "foundationModel": "anthropic/claude-sonnet-4",
+    "systemPrompt": "",
+    "skillFileNames": []
+  },
+  "opencode-agent": {
+    "kind": "plugin",
+    "runtimeId": "opencode-agent",
+    "name": "OpenCode Agent",
+    "iconName": "Cpu",
+    "description": "Open-source code execution agent powered by DeepSeek for cost-efficient automated development tasks.",
+    "inputDescription": "Code task description and project context",
+    "outputDescription": "Implemented code changes and execution results",
+    "foundationModel": "deepseek/deepseek-chat",
+    "systemPrompt": "",
+    "skillFileNames": []
+  },
+  "script-container": {
+    "kind": "plugin",
+    "runtimeId": "script-container",
+    "name": "Script Container",
+    "iconName": "Terminal",
+    "description": "Sandboxed execution environment for running custom scripts, data transformations, and automation tasks.",
+    "inputDescription": "Script definition and input parameters",
+    "outputDescription": "Script execution output and exit status",
+    "foundationModel": "anthropic/claude-sonnet-4",
+    "systemPrompt": "",
+    "skillFileNames": []
+  },
+  "tealflow-cowork-chat": {
+    "kind": "cowork",
+    "runtimeId": "chat",
+    "name": "Tealflow Cowork Chat",
+    "iconName": "MessageCircle",
+    "description": "Chat cowork agent with the tealflow MCP server attached for teal module exploration.",
+    "inputDescription": "User messages and artifact state",
+    "outputDescription": "Teal module selection artifact",
+    "foundationModel": "anthropic/claude-sonnet-4",
+    "systemPrompt": "",
+    "skillFileNames": [],
+    "mcpServers": {
+      "tealflow": { "type": "stdio", "catalogId": "tealflow-mcp" }
+    }
+  }
+}

--- a/data/seeds/tool-catalog.json
+++ b/data/seeds/tool-catalog.json
@@ -1,0 +1,9 @@
+{
+  "appsilon": [
+    {
+      "id": "tealflow-mcp",
+      "command": "tealflow-mcp",
+      "description": "Tealflow MCP — lists and describes available teal modules for clinical trial data exploration."
+    }
+  ]
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -40,6 +40,7 @@ export type { MissingEnvVar } from './plugins/resolve-env.js';
 // MCP resolution helpers
 export { resolveMcpForStep, AgentDefinitionNotFoundError } from './mcp/resolve-mcp-for-step.js';
 export type { ResolveMcpForStepDeps } from './mcp/resolve-mcp-for-step.js';
+export { flattenResolvedMcpToLegacy } from './mcp/flatten-resolved-mcp.js';
 
 // Testing utilities
 export {

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -37,6 +37,10 @@ export { FallbackHandler } from './runner/fallback-handler.js';
 export { validateWorkflowEnv } from './plugins/resolve-env.js';
 export type { MissingEnvVar } from './plugins/resolve-env.js';
 
+// MCP resolution helpers
+export { resolveMcpForStep, AgentDefinitionNotFoundError } from './mcp/resolve-mcp-for-step.js';
+export type { ResolveMcpForStepDeps } from './mcp/resolve-mcp-for-step.js';
+
 // Testing utilities
 export {
   InMemoryAgentEventLog,

--- a/packages/agent-runtime/src/interfaces/agent-plugin.ts
+++ b/packages/agent-runtime/src/interfaces/agent-plugin.ts
@@ -2,6 +2,7 @@ import type {
   AgentEvent,
   ProcessConfig,
   PluginCapabilityMetadata,
+  ResolvedMcpConfig,
   WorkflowDefinition,
   WorkflowStep,
 } from '@mediforce/platform-core';
@@ -55,6 +56,11 @@ export interface WorkflowAgentContext {
   getPreviousStepOutputs: () => Promise<Record<string, unknown>>;
   /** Pre-fetched workflow secrets for {{TEMPLATE}} resolution */
   workflowSecrets?: Record<string, string>;
+  /** Pre-resolved MCP configuration for this step. Produced by
+   *  resolveMcpForStep at handoff time: AgentDefinition + step
+   *  restrictions + tool catalog collapsed into a flat map of server
+   *  name → launch spec. undefined when step.agentId is unset. */
+  resolvedMcpConfig?: ResolvedMcpConfig;
 }
 
 // EmitFn: platform assigns id and sequence — plugin provides type, payload, timestamp

--- a/packages/agent-runtime/src/mcp/__tests__/flatten-resolved-mcp.test.ts
+++ b/packages/agent-runtime/src/mcp/__tests__/flatten-resolved-mcp.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { McpServerConfigSchema } from '@mediforce/platform-core';
+import { flattenResolvedMcpToLegacy } from '../flatten-resolved-mcp.js';
+
+describe('flattenResolvedMcpToLegacy', () => {
+  it('returns empty array for empty resolved config', () => {
+    expect(flattenResolvedMcpToLegacy({ servers: {} })).toEqual([]);
+  });
+
+  it('emits each entry with map key promoted to name', () => {
+    const result = flattenResolvedMcpToLegacy({
+      servers: {
+        tealflow: { type: 'stdio', command: 'tealflow-mcp' },
+        github: { type: 'stdio', command: 'github-mcp', args: ['--stdio'] },
+      },
+    });
+    expect(result).toHaveLength(2);
+    expect(result.find((s) => s.name === 'tealflow')).toEqual({
+      name: 'tealflow',
+      command: 'tealflow-mcp',
+      args: [],
+    });
+    expect(result.find((s) => s.name === 'github')).toEqual({
+      name: 'github',
+      command: 'github-mcp',
+      args: ['--stdio'],
+    });
+  });
+
+  it('carries allowedTools and env on stdio servers', () => {
+    const [entry] = flattenResolvedMcpToLegacy({
+      servers: {
+        github: {
+          type: 'stdio',
+          command: 'github-mcp',
+          env: { TOKEN: '{{GH}}' },
+          allowedTools: ['search_code'],
+        },
+      },
+    });
+    expect(entry.env).toEqual({ TOKEN: '{{GH}}' });
+    expect(entry.allowedTools).toEqual(['search_code']);
+  });
+
+  it('produces url-only entries for http servers', () => {
+    const [entry] = flattenResolvedMcpToLegacy({
+      servers: {
+        remote: {
+          type: 'http',
+          url: 'https://mcp.example.com/v1',
+          allowedTools: ['search'],
+        },
+      },
+    });
+    expect(entry.name).toBe('remote');
+    expect(entry.url).toBe('https://mcp.example.com/v1');
+    expect(entry.command).toBeUndefined();
+    expect(entry.allowedTools).toEqual(['search']);
+  });
+
+  it('output entries satisfy McpServerConfigSchema', () => {
+    const flattened = flattenResolvedMcpToLegacy({
+      servers: {
+        tealflow: { type: 'stdio', command: 'tealflow-mcp' },
+        remote: { type: 'http', url: 'https://mcp.example.com/v1' },
+      },
+    });
+    for (const entry of flattened) {
+      expect(() => McpServerConfigSchema.parse(entry)).not.toThrow();
+    }
+  });
+});

--- a/packages/agent-runtime/src/mcp/__tests__/resolve-mcp-for-step.test.ts
+++ b/packages/agent-runtime/src/mcp/__tests__/resolve-mcp-for-step.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  AgentDefinitionSchema,
+  CatalogEntryNotFoundError,
+  WorkflowStepSchema,
+  type AgentDefinition,
+  type AgentDefinitionRepository,
+  type CreateAgentDefinitionInput,
+  type UpdateAgentDefinitionInput,
+  type WorkflowStep,
+} from '@mediforce/platform-core';
+import { InMemoryToolCatalogRepository } from '@mediforce/platform-core/testing';
+import {
+  AgentDefinitionNotFoundError,
+  resolveMcpForStep,
+} from '../resolve-mcp-for-step.js';
+
+class InMemoryAgentDefinitionRepository implements AgentDefinitionRepository {
+  private readonly byId = new Map<string, AgentDefinition>();
+
+  async create(_input: CreateAgentDefinitionInput): Promise<AgentDefinition> {
+    throw new Error('create() not needed for this test double');
+  }
+
+  async upsert(id: string, input: CreateAgentDefinitionInput): Promise<AgentDefinition> {
+    const now = new Date().toISOString();
+    const existing = this.byId.get(id);
+    const parsed = AgentDefinitionSchema.parse({
+      ...input,
+      id,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    });
+    this.byId.set(id, parsed);
+    return parsed;
+  }
+
+  async getById(id: string): Promise<AgentDefinition | null> {
+    return this.byId.get(id) ?? null;
+  }
+
+  async list(): Promise<AgentDefinition[]> {
+    return [...this.byId.values()];
+  }
+
+  async update(_id: string, _input: UpdateAgentDefinitionInput): Promise<AgentDefinition> {
+    throw new Error('update() not needed for this test double');
+  }
+
+  async delete(id: string): Promise<void> {
+    this.byId.delete(id);
+  }
+}
+
+function makeStep(overrides: Partial<WorkflowStep> = {}): WorkflowStep {
+  return WorkflowStepSchema.parse({
+    id: 'explore',
+    name: 'Explore',
+    type: 'creation',
+    executor: 'agent',
+    ...overrides,
+  });
+}
+
+const NS = 'appsilon';
+
+describe('resolveMcpForStep', () => {
+  let agentRepo: InMemoryAgentDefinitionRepository;
+  let catalogRepo: InMemoryToolCatalogRepository;
+
+  beforeEach(() => {
+    agentRepo = new InMemoryAgentDefinitionRepository();
+    catalogRepo = new InMemoryToolCatalogRepository();
+  });
+
+  it('returns null when step has no agentId (no MCP resolution runs)', async () => {
+    const step = makeStep();
+    const result = await resolveMcpForStep(step, {
+      agentDefinitionRepo: agentRepo,
+      toolCatalogRepo: catalogRepo,
+      namespace: NS,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('throws AgentDefinitionNotFoundError when agentId is rotten', async () => {
+    const step = makeStep({ agentId: 'missing-agent' });
+    await expect(
+      resolveMcpForStep(step, {
+        agentDefinitionRepo: agentRepo,
+        toolCatalogRepo: catalogRepo,
+        namespace: NS,
+      }),
+    ).rejects.toThrow(AgentDefinitionNotFoundError);
+  });
+
+  it('returns empty servers when agent has no mcpServers', async () => {
+    await agentRepo.upsert('bare-agent', {
+      kind: 'plugin',
+      runtimeId: 'claude-code-agent',
+      name: 'Bare',
+      iconName: 'Bot',
+      description: '',
+      foundationModel: 'sonnet',
+      systemPrompt: '',
+      inputDescription: '',
+      outputDescription: '',
+      skillFileNames: [],
+    });
+    const step = makeStep({ agentId: 'bare-agent' });
+
+    const result = await resolveMcpForStep(step, {
+      agentDefinitionRepo: agentRepo,
+      toolCatalogRepo: catalogRepo,
+      namespace: NS,
+    });
+    expect(result).toEqual({ servers: {} });
+  });
+
+  it('resolves stdio bindings via the catalog', async () => {
+    await catalogRepo.upsert(NS, {
+      id: 'tealflow-mcp',
+      command: 'tealflow-mcp',
+      args: ['--stdio'],
+      description: 'Tealflow MCP',
+    });
+    await agentRepo.upsert('tealflow-chat', {
+      kind: 'cowork',
+      runtimeId: 'chat',
+      name: 'Tealflow Cowork Chat',
+      iconName: 'MessageCircle',
+      description: '',
+      foundationModel: 'sonnet',
+      systemPrompt: '',
+      inputDescription: '',
+      outputDescription: '',
+      skillFileNames: [],
+      mcpServers: {
+        tealflow: { type: 'stdio', catalogId: 'tealflow-mcp' },
+      },
+    });
+    const step = makeStep({ agentId: 'tealflow-chat', executor: 'cowork' });
+
+    const result = await resolveMcpForStep(step, {
+      agentDefinitionRepo: agentRepo,
+      toolCatalogRepo: catalogRepo,
+      namespace: NS,
+    });
+
+    expect(result!.servers.tealflow).toMatchObject({
+      type: 'stdio',
+      command: 'tealflow-mcp',
+      args: ['--stdio'],
+    });
+  });
+
+  it('surfaces CatalogEntryNotFoundError when binding references missing catalogId', async () => {
+    await agentRepo.upsert('tealflow-chat', {
+      kind: 'cowork',
+      runtimeId: 'chat',
+      name: 'Tealflow Cowork Chat',
+      iconName: 'MessageCircle',
+      description: '',
+      foundationModel: 'sonnet',
+      systemPrompt: '',
+      inputDescription: '',
+      outputDescription: '',
+      skillFileNames: [],
+      mcpServers: {
+        tealflow: { type: 'stdio', catalogId: 'never-seeded' },
+      },
+    });
+    const step = makeStep({ agentId: 'tealflow-chat', executor: 'cowork' });
+
+    await expect(
+      resolveMcpForStep(step, {
+        agentDefinitionRepo: agentRepo,
+        toolCatalogRepo: catalogRepo,
+        namespace: NS,
+      }),
+    ).rejects.toThrow(CatalogEntryNotFoundError);
+  });
+
+  it('applies step-level denyTools and disable restrictions', async () => {
+    await catalogRepo.upsert(NS, { id: 'github-mcp', command: 'github-mcp' });
+    await catalogRepo.upsert(NS, { id: 'cdisc-mcp', command: 'cdisc-mcp' });
+    await agentRepo.upsert('analyst', {
+      kind: 'plugin',
+      runtimeId: 'claude-code-agent',
+      name: 'Analyst',
+      iconName: 'Bot',
+      description: '',
+      foundationModel: 'sonnet',
+      systemPrompt: '',
+      inputDescription: '',
+      outputDescription: '',
+      skillFileNames: [],
+      mcpServers: {
+        github: {
+          type: 'stdio',
+          catalogId: 'github-mcp',
+          allowedTools: ['search_code', 'get_file_contents', 'delete_repo'],
+        },
+        cdisc: { type: 'stdio', catalogId: 'cdisc-mcp' },
+      },
+    });
+    const step = makeStep({
+      agentId: 'analyst',
+      mcpRestrictions: {
+        github: { denyTools: ['delete_repo'] },
+        cdisc: { disable: true },
+      },
+    });
+
+    const result = await resolveMcpForStep(step, {
+      agentDefinitionRepo: agentRepo,
+      toolCatalogRepo: catalogRepo,
+      namespace: NS,
+    });
+
+    expect(result!.servers.cdisc).toBeUndefined();
+    expect(result!.servers.github).toBeDefined();
+    expect((result!.servers.github as { allowedTools?: string[] }).allowedTools)
+      .toEqual(['search_code', 'get_file_contents']);
+  });
+
+  it('passes http bindings through without touching the catalog', async () => {
+    await agentRepo.upsert('remote-agent', {
+      kind: 'plugin',
+      runtimeId: 'claude-code-agent',
+      name: 'Remote',
+      iconName: 'Bot',
+      description: '',
+      foundationModel: 'sonnet',
+      systemPrompt: '',
+      inputDescription: '',
+      outputDescription: '',
+      skillFileNames: [],
+      mcpServers: {
+        webmcp: { type: 'http', url: 'https://mcp.example.com/v1' },
+      },
+    });
+    const step = makeStep({ agentId: 'remote-agent' });
+
+    const result = await resolveMcpForStep(step, {
+      agentDefinitionRepo: agentRepo,
+      toolCatalogRepo: catalogRepo,
+      namespace: NS,
+    });
+    expect(result!.servers.webmcp).toMatchObject({
+      type: 'http',
+      url: 'https://mcp.example.com/v1',
+    });
+  });
+});

--- a/packages/agent-runtime/src/mcp/flatten-resolved-mcp.ts
+++ b/packages/agent-runtime/src/mcp/flatten-resolved-mcp.ts
@@ -5,11 +5,6 @@ import type { McpServerConfig, ResolvedMcpConfig } from '@mediforce/platform-cor
  *  still expect. The server name, which is the map key in the resolved
  *  config, becomes the `name` field.
  *
- *  The resolver's `deniedTools` field (2nd-stage post-discovery filter)
- *  has no representation in McpServerConfig and is dropped here. That's
- *  accepted scope for Step 2 — cowork workflows today don't use
- *  denyTools without an explicit allowedTools to subtract from.
- *
  *  Returns an empty array when the resolved config has no servers. */
 export function flattenResolvedMcpToLegacy(
   resolved: ResolvedMcpConfig,

--- a/packages/agent-runtime/src/mcp/flatten-resolved-mcp.ts
+++ b/packages/agent-runtime/src/mcp/flatten-resolved-mcp.ts
@@ -1,0 +1,34 @@
+import type { McpServerConfig, ResolvedMcpConfig } from '@mediforce/platform-core';
+
+/** Flatten a ResolvedMcpConfig into the legacy McpServerConfig[] shape
+ *  that McpClientManager (cowork chat route) and any stray consumers
+ *  still expect. The server name, which is the map key in the resolved
+ *  config, becomes the `name` field.
+ *
+ *  The resolver's `deniedTools` field (2nd-stage post-discovery filter)
+ *  has no representation in McpServerConfig and is dropped here. That's
+ *  accepted scope for Step 2 — cowork workflows today don't use
+ *  denyTools without an explicit allowedTools to subtract from.
+ *
+ *  Returns an empty array when the resolved config has no servers. */
+export function flattenResolvedMcpToLegacy(
+  resolved: ResolvedMcpConfig,
+): McpServerConfig[] {
+  return Object.entries(resolved.servers).map(([name, server]) => {
+    if (server.type === 'stdio') {
+      return {
+        name,
+        command: server.command,
+        args: server.args ?? [],
+        ...(server.env !== undefined ? { env: server.env } : {}),
+        ...(server.allowedTools !== undefined ? { allowedTools: server.allowedTools } : {}),
+      };
+    }
+    return {
+      name,
+      url: server.url,
+      args: [],
+      ...(server.allowedTools !== undefined ? { allowedTools: server.allowedTools } : {}),
+    };
+  });
+}

--- a/packages/agent-runtime/src/mcp/resolve-mcp-for-step.ts
+++ b/packages/agent-runtime/src/mcp/resolve-mcp-for-step.ts
@@ -1,0 +1,75 @@
+import {
+  resolveEffectiveMcp,
+  type AgentDefinitionRepository,
+  type ResolvedMcpConfig,
+  type ToolCatalogEntry,
+  type ToolCatalogRepository,
+  type WorkflowStep,
+} from '@mediforce/platform-core';
+
+/** Raised when a step points at an agentId that is not present in the
+ *  repository. Carries the id and stepId for actionable diagnostics. */
+export class AgentDefinitionNotFoundError extends Error {
+  public readonly agentId: string;
+  public readonly stepId: string;
+
+  constructor(agentId: string, stepId: string) {
+    super(
+      `AgentDefinition '${agentId}' (referenced by step '${stepId}' via agentId) not found in the repository`,
+    );
+    this.name = 'AgentDefinitionNotFoundError';
+    this.agentId = agentId;
+    this.stepId = stepId;
+  }
+}
+
+export interface ResolveMcpForStepDeps {
+  agentDefinitionRepo: Pick<AgentDefinitionRepository, 'getById'>;
+  toolCatalogRepo: Pick<ToolCatalogRepository, 'getById'>;
+  /** Namespace used to scope toolCatalog lookups. */
+  namespace: string;
+}
+
+/** Resolve the effective MCP configuration for a workflow step.
+ *
+ *  Contract:
+ *   - step.agentId unset  → returns null (no MCP resolution runs).
+ *   - step.agentId set but AgentDefinition missing → throws
+ *     AgentDefinitionNotFoundError (rotten reference must surface, not
+ *     silently degrade to no-MCP).
+ *   - AgentDefinition has no mcpServers → returns { servers: {} }.
+ *   - AgentDefinition has stdio bindings → their catalogIds are fetched
+ *     from the namespace-scoped tool catalog; missing entries surface
+ *     as CatalogEntryNotFoundError from resolveEffectiveMcp.
+ *
+ *  Only catalog entries actually referenced by the agent's stdio
+ *  bindings are fetched (O(#stdio bindings), not O(#catalog)). */
+export async function resolveMcpForStep(
+  step: WorkflowStep,
+  deps: ResolveMcpForStepDeps,
+): Promise<ResolvedMcpConfig | null> {
+  if (step.agentId === undefined) return null;
+
+  const agent = await deps.agentDefinitionRepo.getById(step.agentId);
+  if (agent === null) {
+    throw new AgentDefinitionNotFoundError(step.agentId, step.id);
+  }
+
+  const bindings = agent.mcpServers ?? {};
+  const catalogIds = new Set<string>();
+  for (const binding of Object.values(bindings)) {
+    if (binding.type === 'stdio') {
+      catalogIds.add(binding.catalogId);
+    }
+  }
+
+  const catalog = new Map<string, ToolCatalogEntry>();
+  await Promise.all(
+    [...catalogIds].map(async (id) => {
+      const entry = await deps.toolCatalogRepo.getById(deps.namespace, id);
+      if (entry !== null) catalog.set(id, entry);
+    }),
+  );
+
+  return resolveEffectiveMcp(agent, step, catalog);
+}

--- a/packages/agent-runtime/src/plugins/__tests__/mcp-config-integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/mcp-config-integration.test.ts
@@ -57,6 +57,7 @@ function buildMockWorkflowAgentContext(
   const workflowDefinition: WorkflowDefinition = {
     name: 'test-workflow',
     version: 1,
+    namespace: 'test',
     steps: [step],
     transitions: [],
     triggers: [{ type: 'manual', name: 'start' }],

--- a/packages/agent-runtime/src/plugins/__tests__/mcp-config-integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/mcp-config-integration.test.ts
@@ -361,4 +361,181 @@ describe('writeMcpConfig integration', () => {
 
     await cleanup();
   });
+
+  describe('resolver-backed (workflow mode with context.resolvedMcpConfig)', () => {
+    it('[DATA] serializes resolved stdio + http servers in flat shape', async () => {
+      const context = buildMockWorkflowAgentContext({
+        resolvedMcpConfig: {
+          servers: {
+            tealflow: {
+              type: 'stdio',
+              command: 'tealflow-mcp',
+              args: ['--stdio'],
+            },
+            remote: {
+              type: 'http',
+              url: 'https://mcp.example.com/v1',
+              allowedTools: ['search'],
+            },
+          },
+        },
+      });
+      await plugin.initialize(context);
+
+      await (plugin as unknown as WriteMcpConfigTarget).writeMcpConfig(tmpDir);
+
+      const raw = await readFile(join(tmpDir, 'mcp-config.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as {
+        mcpServers: Record<string, Record<string, unknown>>;
+      };
+
+      expect(parsed.mcpServers.tealflow).toMatchObject({
+        command: 'tealflow-mcp',
+        args: ['--stdio'],
+      });
+      expect(parsed.mcpServers.remote).toMatchObject({
+        url: 'https://mcp.example.com/v1',
+        allowedTools: ['search'],
+      });
+      expect(parsed.mcpServers.remote).not.toHaveProperty('command');
+
+      await cleanup();
+    });
+
+    it('[DATA] preserves allowedTools trimmed by step-level denyTools', async () => {
+      const context = buildMockWorkflowAgentContext({
+        resolvedMcpConfig: {
+          servers: {
+            github: {
+              type: 'stdio',
+              command: 'github-mcp',
+              allowedTools: ['search_code', 'get_file_contents'],
+            },
+          },
+        },
+      });
+      await plugin.initialize(context);
+
+      await (plugin as unknown as WriteMcpConfigTarget).writeMcpConfig(tmpDir);
+
+      const raw = await readFile(join(tmpDir, 'mcp-config.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as {
+        mcpServers: Record<string, { allowedTools?: string[] }>;
+      };
+      expect(parsed.mcpServers.github?.allowedTools).toEqual([
+        'search_code',
+        'get_file_contents',
+      ]);
+
+      await cleanup();
+    });
+
+    it('[DATA] writes nothing when resolved config has no servers (all disabled)', async () => {
+      const context = buildMockWorkflowAgentContext({
+        resolvedMcpConfig: { servers: {} },
+      });
+      await plugin.initialize(context);
+
+      await (plugin as unknown as WriteMcpConfigTarget).writeMcpConfig(tmpDir);
+
+      const contents = await readFile(join(tmpDir, 'mcp-config.json'), 'utf-8').catch(
+        () => null,
+      );
+      expect(contents).toBeNull();
+
+      await cleanup();
+    });
+
+    it('[DATA] resolver config wins over legacy step.agent.mcpServers', async () => {
+      // step.agent.mcpServers carries a legacy entry; resolvedMcpConfig carries
+      // the post-refactor binding. The resolver path must take precedence so
+      // that once a workflow migrates to agentId, the legacy field is dead weight.
+      const context = buildMockWorkflowAgentContext({
+        step: {
+          id: 'extract',
+          name: 'Extract Step',
+          type: 'creation',
+          executor: 'agent',
+          plugin: 'claude-code-agent',
+          agent: {
+            skill: 'test-skill',
+            skillsDir: '/plugins/test/skills',
+            image: 'mediforce-agent:test',
+            mcpServers: [
+              { name: 'should-be-ignored', command: 'legacy-inline' },
+            ],
+          },
+        } as unknown as WorkflowStep,
+        resolvedMcpConfig: {
+          servers: {
+            canonical: { type: 'stdio', command: 'resolver-path' },
+          },
+        },
+      });
+      context.workflowDefinition.steps[0] = context.step;
+
+      await plugin.initialize(context);
+
+      await (plugin as unknown as WriteMcpConfigTarget).writeMcpConfig(tmpDir);
+
+      const raw = await readFile(join(tmpDir, 'mcp-config.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as {
+        mcpServers: Record<string, Record<string, unknown>>;
+      };
+      expect(parsed.mcpServers).toHaveProperty('canonical');
+      expect(parsed.mcpServers).not.toHaveProperty('should-be-ignored');
+
+      await cleanup();
+    });
+
+    it('[DATA] resolves {{SECRET}} templates in resolved stdio env', async () => {
+      const context = buildMockWorkflowAgentContext({
+        workflowSecrets: { GITHUB_TOKEN: 'gh-secret-value' },
+        resolvedMcpConfig: {
+          servers: {
+            github: {
+              type: 'stdio',
+              command: 'github-mcp',
+              env: { TOKEN: '{{GITHUB_TOKEN}}' },
+            },
+          },
+        },
+      });
+      await plugin.initialize(context);
+
+      await (plugin as unknown as WriteMcpConfigTarget).writeMcpConfig(tmpDir);
+
+      const raw = await readFile(join(tmpDir, 'mcp-config.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as {
+        mcpServers: Record<string, { env?: Record<string, string> }>;
+      };
+      expect(parsed.mcpServers.github?.env?.TOKEN).toBe('gh-secret-value');
+
+      await cleanup();
+    });
+  });
+
+  describe('legacy path regression (no resolvedMcpConfig)', () => {
+    it('[DATA] legacy process-mode agentConfig.mcpServers still produces mcp-config.json', async () => {
+      // This is the AgentContext (process-mode) path — never has resolvedMcpConfig
+      // and must keep working after Step 2 for non-migrated processConfigs.
+      const context = buildContextWithMcpServers([
+        { name: 'legacy-stdio', command: 'node', args: ['/opt/mcp/legacy.js'] },
+      ]);
+      await plugin.initialize(context);
+
+      await (plugin as unknown as WriteMcpConfigTarget).writeMcpConfig(tmpDir);
+
+      const raw = await readFile(join(tmpDir, 'mcp-config.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as {
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      };
+      expect(parsed.mcpServers['legacy-stdio']).toMatchObject({
+        command: 'node',
+        args: ['/opt/mcp/legacy.js'],
+      });
+
+      await cleanup();
+    });
+  });
 });

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -4,7 +4,7 @@ import { join, dirname, isAbsolute, resolve } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin.js';
-import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata, McpServerConfig } from '@mediforce/platform-core';
+import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata, McpServerConfig, ResolvedMcpConfig } from '@mediforce/platform-core';
 import { resolveStepEnv, resolveValue, type ResolvedEnv } from './resolve-env.js';
 import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy.js';
 import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, resolveRepoToken, normalizeRepoUrls } from './container-plugin.js';
@@ -241,8 +241,88 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
   }
 
   /** Generate mcp-config.json for Claude CLI --mcp-config flag.
-   *  Resolves {{SECRET}} templates in MCP server env vars. */
+   *  Resolves {{SECRET}} templates in MCP server env vars.
+   *
+   *  Two sources, checked in order:
+   *   1. Workflow-mode with a pre-resolved config from resolveMcpForStep
+   *      (context.resolvedMcpConfig). This is the canonical path — bindings
+   *      come from the referenced AgentDefinition + step restrictions.
+   *   2. Legacy inline config on agentConfig.mcpServers (array of
+   *      McpServerConfig). Still used by process-mode steps and
+   *      by workflow steps that predate the migration to agentId. */
   protected async writeMcpConfig(outputDir: string): Promise<void> {
+    const resolved = isWorkflowAgentContext(this.context)
+      ? this.context.resolvedMcpConfig
+      : undefined;
+
+    if (resolved !== undefined) {
+      await this.writeResolvedMcpConfig(outputDir, resolved);
+      return;
+    }
+
+    await this.writeLegacyMcpConfig(outputDir);
+  }
+
+  /** Serialize a resolved MCP config into the flat mcp-config.json shape
+   *  Claude CLI expects. Applies {{SECRET}} template resolution to env
+   *  values on stdio entries at write time. */
+  private async writeResolvedMcpConfig(
+    outputDir: string,
+    resolved: ResolvedMcpConfig,
+  ): Promise<void> {
+    const entries = Object.entries(resolved.servers);
+    if (entries.length === 0) return;
+
+    const workflowSecrets = isWorkflowAgentContext(this.context)
+      ? this.context.workflowSecrets
+      : undefined;
+
+    type StdioEntry = { command: string; args?: string[]; env?: Record<string, string>; allowedTools?: string[] };
+    type HttpEntry = { url: string; allowedTools?: string[] };
+    const mcpConfig: Record<string, StdioEntry | HttpEntry> = {};
+
+    for (const [name, server] of entries) {
+      const allowedToolsPart = server.allowedTools && server.allowedTools.length > 0
+        ? { allowedTools: server.allowedTools }
+        : {};
+
+      if (server.type === 'stdio') {
+        const resolvedEnv: Record<string, string> = {};
+        if (server.env) {
+          for (const [key, value] of Object.entries(server.env)) {
+            resolvedEnv[key] = resolveValue(value, workflowSecrets);
+          }
+        }
+        mcpConfig[name] = {
+          command: server.command,
+          ...(server.args !== undefined && server.args.length > 0 ? { args: server.args } : {}),
+          ...(Object.keys(resolvedEnv).length > 0 ? { env: resolvedEnv } : {}),
+          ...allowedToolsPart,
+        };
+      } else {
+        mcpConfig[name] = {
+          url: server.url,
+          ...allowedToolsPart,
+        };
+      }
+    }
+
+    await writeFile(
+      join(outputDir, 'mcp-config.json'),
+      JSON.stringify({ mcpServers: mcpConfig }, null, 2),
+      'utf-8',
+    );
+
+    agentLog('mcp.config', 'MCP config written (resolver-backed)', {
+      stepId: this.context.stepId,
+      servers: entries.map(([name]) => name),
+    });
+  }
+
+  /** Pre-refactor path: serialize agentConfig.mcpServers (array) directly
+   *  into mcp-config.json. Retained for process-mode steps and any
+   *  workflow step that has not yet migrated to agentId. */
+  private async writeLegacyMcpConfig(outputDir: string): Promise<void> {
     const servers = this.agentConfig.mcpServers;
     if (!servers || servers.length === 0) return;
 
@@ -289,7 +369,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
       'utf-8',
     );
 
-    agentLog('mcp.config', 'MCP config written', {
+    agentLog('mcp.config', 'MCP config written (legacy)', {
       stepId: this.context.stepId,
       servers: servers.map((s) => s.name),
     });

--- a/packages/agent-runtime/vitest.config.ts
+++ b/packages/agent-runtime/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
   resolve: {
     conditions: ['@mediforce/source'],
     alias: {
+      '@mediforce/platform-core/testing': path.resolve(
+        __dirname,
+        '../platform-core/src/testing/index.ts',
+      ),
       '@mediforce/platform-core': path.resolve(
         __dirname,
         '../platform-core/src/index.ts',

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -206,6 +206,7 @@ export {
   resolveEffectiveMcp,
   CatalogEntryNotFoundError,
   UnknownRestrictionTargetError,
+  DenyToolsWithoutAllowedToolsError,
   type ResolvedMcpConfig,
   type ResolvedMcpServer,
   type ResolvedStdioMcpServer,

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -150,7 +150,9 @@ export type {
   UserDirectoryService,
   DirectoryUser,
   AgentRunRepository,
-  CoworkSessionRepository,  CronTriggerStateRepository,
+  CoworkSessionRepository,
+  CronTriggerStateRepository,
+  ToolCatalogRepository,
 } from './interfaces/index.js';
 
 // Agent definition schema + repository interface

--- a/packages/platform-core/src/interfaces/index.ts
+++ b/packages/platform-core/src/interfaces/index.ts
@@ -7,4 +7,6 @@ export type { HandoffRepository } from './handoff-repository.js';
 export type { NotificationService, NotificationEvent, NotificationTarget } from './notification-service.js';
 export type { UserDirectoryService, DirectoryUser } from './user-directory-service.js';
 export type { AgentRunRepository } from './agent-run-repository.js';
-export type { CoworkSessionRepository } from './cowork-session-repository.js';export type { CronTriggerStateRepository } from './cron-trigger-state-repository.js';
+export type { CoworkSessionRepository } from './cowork-session-repository.js';
+export type { CronTriggerStateRepository } from './cron-trigger-state-repository.js';
+export type { ToolCatalogRepository } from './tool-catalog-repository.js';

--- a/packages/platform-core/src/interfaces/tool-catalog-repository.ts
+++ b/packages/platform-core/src/interfaces/tool-catalog-repository.ts
@@ -1,0 +1,19 @@
+import type { ToolCatalogEntry } from '../schemas/agent-mcp-binding.js';
+
+/** Admin-curated catalog of stdio MCP server launch specs, keyed by id
+ *  within a namespace. Entries are referenced by AgentMcpBinding.catalogId;
+ *  keeping command/args only in this store closes the RCE surface that
+ *  step-level inline command fields used to expose.
+ *
+ *  All operations are namespace-scoped: `namespaces/{handle}/toolCatalog/*`. */
+export interface ToolCatalogRepository {
+  /** Return the entry with the given id, or null when absent. */
+  getById(namespace: string, entryId: string): Promise<ToolCatalogEntry | null>;
+  /** Return all entries in the namespace, in no guaranteed order. */
+  list(namespace: string): Promise<ToolCatalogEntry[]>;
+  /** Create or replace an entry. Seed scripts use this to keep catalog
+   *  contents reproducible across environments. */
+  upsert(namespace: string, entry: ToolCatalogEntry): Promise<ToolCatalogEntry>;
+  /** Remove an entry. No-op when id is absent. */
+  delete(namespace: string, entryId: string): Promise<void>;
+}

--- a/packages/platform-core/src/mcp/__tests__/resolve-effective-mcp.test.ts
+++ b/packages/platform-core/src/mcp/__tests__/resolve-effective-mcp.test.ts
@@ -21,6 +21,7 @@ import {
 function makeAgent(mcpServers?: AgentMcpBindingMap): AgentDefinition {
   return {
     id: 'agent-1',
+    kind: 'plugin',
     name: 'Test Agent',
     iconName: 'bot',
     description: '',

--- a/packages/platform-core/src/mcp/__tests__/resolve-effective-mcp.test.ts
+++ b/packages/platform-core/src/mcp/__tests__/resolve-effective-mcp.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   CatalogEntryNotFoundError,
+  DenyToolsWithoutAllowedToolsError,
   UnknownRestrictionTargetError,
   resolveEffectiveMcp,
   type ResolvedMcpServer,
@@ -134,7 +135,6 @@ describe('resolveEffectiveMcp', () => {
       const result = resolveEffectiveMcp(agent, makeStep(), catalog);
       const github = asStdio(result.servers.github);
       expect(github.allowedTools).toEqual(['search_code', 'get_file']);
-      expect(github.deniedTools).toBeUndefined();
     });
   });
 
@@ -177,7 +177,6 @@ describe('resolveEffectiveMcp', () => {
       const result = resolveEffectiveMcp(agent, step, catalog);
       const github = asStdio(result.servers.github);
       expect(github.allowedTools).toEqual(['search_code', 'get_file']);
-      expect(github.deniedTools).toBeUndefined();
     });
 
     it('drops server entirely when denyTools empties the allowlist', () => {
@@ -211,23 +210,6 @@ describe('resolveEffectiveMcp', () => {
       expect(Object.keys(result.servers)).toEqual(['postgres']);
     });
 
-    it('carries denyTools forward as deniedTools when binding has no allowedTools', () => {
-      // Convention: binding.allowedTools=undefined means "all tools from server".
-      // With only denyTools available here, the resolver cannot materialize an
-      // explicit allowlist (doesn't know the full tool set). It emits
-      // allowedTools=undefined and deniedTools=[...] so the runtime layer can
-      // apply a second-stage subtractive filter.
-      const catalog = makeCatalog([{ id: 'gh', command: 'gh-mcp' }]);
-      const agent = makeAgent({
-        github: { type: 'stdio', catalogId: 'gh' },
-      });
-      const step = makeStep({ github: { denyTools: ['delete_repo'] } });
-      const result = resolveEffectiveMcp(agent, step, catalog);
-      const github = asStdio(result.servers.github);
-      expect(github.allowedTools).toBeUndefined();
-      expect(github.deniedTools).toEqual(['delete_repo']);
-    });
-
     it('applies denyTools to http bindings the same way', () => {
       const agent = makeAgent({
         remote: {
@@ -239,6 +221,61 @@ describe('resolveEffectiveMcp', () => {
       const step = makeStep({ remote: { denyTools: ['push'] } });
       const result = resolveEffectiveMcp(agent, step, new Map());
       expect(asHttp(result.servers.remote).allowedTools).toEqual(['fetch']);
+    });
+
+    it('denyTools without binding allowedTools throws DenyToolsWithoutAllowedToolsError', () => {
+      // Binding has no allowedTools → the resolver cannot materialize an
+      // explicit allowlist to subtract from, and the downstream serializers
+      // (mcp-config.json / McpServerConfig) have no way to express the
+      // "all-minus-X" state. Rejecting at resolution time forces the author
+      // to either add allowedTools to the binding or use disable: true.
+      const catalog = makeCatalog([{ id: 'gh', command: 'gh-mcp' }]);
+      const agent = makeAgent({
+        github: { type: 'stdio', catalogId: 'gh' },
+      });
+      const step = makeStep({ github: { denyTools: ['delete_repo'] } });
+      expect(() => resolveEffectiveMcp(agent, step, catalog)).toThrow(
+        DenyToolsWithoutAllowedToolsError,
+      );
+    });
+
+    it('DenyToolsWithoutAllowedToolsError exposes serverName and denyTools', () => {
+      const catalog = makeCatalog([{ id: 'gh', command: 'gh-mcp' }]);
+      const agent = makeAgent({
+        github: { type: 'stdio', catalogId: 'gh' },
+      });
+      const step = makeStep({ github: { denyTools: ['delete_repo', 'admin_purge'] } });
+      try {
+        resolveEffectiveMcp(agent, step, catalog);
+        expect.fail('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(DenyToolsWithoutAllowedToolsError);
+        if (err instanceof DenyToolsWithoutAllowedToolsError) {
+          expect(err.serverName).toBe('github');
+          expect(err.denyTools).toEqual(['delete_repo', 'admin_purge']);
+        }
+      }
+    });
+
+    it('does not throw when denyTools is empty on a binding without allowedTools', () => {
+      // denyTools=[] is a no-op — no authorization gap, nothing to reject.
+      const catalog = makeCatalog([{ id: 'gh', command: 'gh-mcp' }]);
+      const agent = makeAgent({
+        github: { type: 'stdio', catalogId: 'gh' },
+      });
+      const step = makeStep({ github: { denyTools: [] } });
+      expect(() => resolveEffectiveMcp(agent, step, catalog)).not.toThrow();
+    });
+
+    it('does not throw when denyTools accompanies disable:true on a binding without allowedTools', () => {
+      // disable short-circuits the server — denyTools is moot, so no error.
+      const catalog = makeCatalog([{ id: 'gh', command: 'gh-mcp' }]);
+      const agent = makeAgent({
+        github: { type: 'stdio', catalogId: 'gh' },
+      });
+      const step = makeStep({ github: { disable: true, denyTools: ['delete_repo'] } });
+      const result = resolveEffectiveMcp(agent, step, catalog);
+      expect(result.servers.github).toBeUndefined();
     });
   });
 

--- a/packages/platform-core/src/mcp/resolve-effective-mcp.ts
+++ b/packages/platform-core/src/mcp/resolve-effective-mcp.ts
@@ -44,16 +44,36 @@ export class UnknownRestrictionTargetError extends Error {
   }
 }
 
+/** Raised when a step applies `denyTools` to a server whose agent-level
+ *  binding does not carry an explicit `allowedTools`. Such state has no
+ *  serializable representation in either `mcp-config.json` or
+ *  `McpServerConfig` — there's no way to express "all tools minus X" at
+ *  the downstream layer, so the deny list would be silently dropped at
+ *  spawn time, creating an authorization gap. Authors must either add
+ *  `allowedTools` to the binding (so the subtraction can materialize)
+ *  or replace `denyTools` with `disable: true`. */
+export class DenyToolsWithoutAllowedToolsError extends Error {
+  public readonly serverName: string;
+  public readonly denyTools: readonly string[];
+
+  constructor(serverName: string, denyTools: readonly string[]) {
+    super(
+      `Step mcpRestrictions.${serverName}.denyTools is set (${denyTools.join(', ')}), ` +
+      `but the agent's binding for "${serverName}" has no allowedTools to subtract from. ` +
+      `Add allowedTools to the binding (so the deny list can be applied) or use disable: true.`,
+    );
+    this.name = 'DenyToolsWithoutAllowedToolsError';
+    this.serverName = serverName;
+    this.denyTools = denyTools;
+  }
+}
+
 type ResolvedMcpServerShared = {
   /** Explicit allowlist after applying step-level denyTools subtraction.
-   *  undefined means "all tools from the server" (deniedTools may still
-   *  apply a second-stage filter). Never an empty array — servers whose
-   *  allowlist was emptied by denyTools are dropped from the result. */
+   *  undefined means "all tools from the server". Never an empty array —
+   *  servers whose allowlist was emptied by denyTools are dropped from
+   *  the result. */
   allowedTools?: string[];
-  /** Tools denied at step level when binding did not carry an explicit
-   *  allowlist to subtract from. Runtime layer should apply this as a
-   *  subtractive filter after discovering the server's full tool set. */
-  deniedTools?: string[];
 };
 
 export type ResolvedStdioMcpServer = ResolvedMcpServerShared & {
@@ -82,17 +102,11 @@ export type ResolvedMcpConfig = {
  *  servers (disable) or tools (denyTools). Step 2 will feed this result
  *  into writeMcpConfig() at agent spawn time.
  *
- *  Two-phase subtractive model for denyTools:
- *    - If the binding has an explicit allowedTools, denyTools is applied
- *      immediately (set-difference) and the result surfaces as
- *      ResolvedMcpServer.allowedTools. If that difference is empty, the
- *      server is dropped from the output entirely (no point spawning a
- *      subprocess that exposes zero tools).
- *    - If the binding has no allowedTools (meaning "all tools from
- *      server"), the resolver cannot materialize an explicit allowlist
- *      without knowing the server's full tool set. It forwards the deny
- *      list as ResolvedMcpServer.deniedTools; the runtime layer applies
- *      the second-stage filter after tool discovery. */
+ *  denyTools is only meaningful when the agent's binding already carries
+ *  an explicit allowedTools (otherwise the subtraction has no materialized
+ *  list to operate on and would silently lose the deny list at the
+ *  downstream writer). Attempts to use denyTools without binding
+ *  allowedTools throw DenyToolsWithoutAllowedToolsError. */
 export function resolveEffectiveMcp(
   agent: AgentDefinition,
   step: WorkflowStep,
@@ -110,12 +124,26 @@ export function resolveEffectiveMcp(
     }
   }
 
+  // Surface denyTools-without-allowedTools early, before any catalog
+  // lookup: the resolver cannot materialize an explicit allowlist for
+  // such bindings, so letting it through would silently drop the deny
+  // list at serialization time.
+  for (const [name, restriction] of Object.entries(restrictions)) {
+    if (restriction?.disable === true) continue;
+    const denyTools = restriction?.denyTools;
+    if (denyTools === undefined || denyTools.length === 0) continue;
+    const binding = mcpServers[name];
+    if (binding !== undefined && binding.allowedTools === undefined) {
+      throw new DenyToolsWithoutAllowedToolsError(name, denyTools);
+    }
+  }
+
   for (const [name, binding] of Object.entries(mcpServers)) {
     const restriction = restrictions[name];
     if (restriction?.disable === true) continue;
 
     const resolved = resolveBinding(name, binding, catalog);
-    applyDenyTools(resolved, binding, restriction?.denyTools);
+    applyDenyTools(resolved, restriction?.denyTools);
 
     if (resolved.allowedTools !== undefined && resolved.allowedTools.length === 0) {
       continue;
@@ -154,20 +182,17 @@ function resolveBinding(
   };
 }
 
+/** Apply a step-level denyTools subtraction to a resolved server. Safe
+ *  by the time we reach here — resolveEffectiveMcp has already rejected
+ *  bindings that lack allowedTools, so every call here has a materialized
+ *  allowlist to filter. */
 function applyDenyTools(
   resolved: ResolvedMcpServer,
-  binding: AgentMcpBinding,
   denyTools: readonly string[] | undefined,
 ): void {
   if (denyTools === undefined || denyTools.length === 0) return;
-
-  if (binding.allowedTools !== undefined) {
-    const denySet = new Set(denyTools);
-    resolved.allowedTools = (resolved.allowedTools ?? []).filter(
-      tool => denySet.has(tool) === false,
-    );
-    return;
-  }
-
-  resolved.deniedTools = [...denyTools];
+  const denySet = new Set(denyTools);
+  resolved.allowedTools = (resolved.allowedTools ?? []).filter(
+    tool => denySet.has(tool) === false,
+  );
 }

--- a/packages/platform-core/src/repositories/agent-definition-repository.ts
+++ b/packages/platform-core/src/repositories/agent-definition-repository.ts
@@ -8,6 +8,10 @@ export type { CreateAgentDefinitionInput, UpdateAgentDefinitionInput };
 
 export interface AgentDefinitionRepository {
   create(input: CreateAgentDefinitionInput): Promise<AgentDefinition>;
+  /** Create or replace a definition at a caller-specified deterministic
+   *  id. Used by seed scripts and migrators so that references from
+   *  wd.json files (step.agentId) stay stable across environments. */
+  upsert(id: string, input: CreateAgentDefinitionInput): Promise<AgentDefinition>;
   getById(id: string): Promise<AgentDefinition | null>;
   list(): Promise<AgentDefinition[]>;
   update(id: string, input: UpdateAgentDefinitionInput): Promise<AgentDefinition>;

--- a/packages/platform-core/src/schemas/__tests__/agent-mcp-binding.test.ts
+++ b/packages/platform-core/src/schemas/__tests__/agent-mcp-binding.test.ts
@@ -365,6 +365,7 @@ describe('WorkflowDefinitionSchema with step.mcpRestrictions', () => {
     const result = WorkflowDefinitionSchema.safeParse({
       name: 'test-workflow',
       version: 1,
+      namespace: 'test',
       steps: [
         {
           id: 'extract',
@@ -392,6 +393,7 @@ describe('WorkflowDefinitionSchema with step.mcpRestrictions', () => {
     const result = WorkflowDefinitionSchema.safeParse({
       name: 'test-workflow',
       version: 1,
+      namespace: 'test',
       steps: [
         {
           id: 'explore',
@@ -415,6 +417,7 @@ describe('WorkflowDefinitionSchema with step.mcpRestrictions', () => {
     const result = WorkflowDefinitionSchema.safeParse({
       name: 'legacy-workflow',
       version: 1,
+      namespace: 'test',
       steps: [
         {
           id: 'extract',

--- a/packages/platform-core/src/schemas/__tests__/agent-mcp-binding.test.ts
+++ b/packages/platform-core/src/schemas/__tests__/agent-mcp-binding.test.ts
@@ -326,6 +326,38 @@ describe('AgentDefinitionSchema with mcpServers', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('defaults kind to "plugin" when omitted (backcompat)', () => {
+    const result = AgentDefinitionSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.kind).toBe('plugin');
+    }
+  });
+
+  it('parses cowork-kind agent with runtimeId', () => {
+    const result = AgentDefinitionSchema.safeParse({
+      ...base,
+      kind: 'cowork',
+      runtimeId: 'chat',
+      mcpServers: {
+        tealflow: { type: 'stdio', catalogId: 'tealflow-mcp' },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.kind).toBe('cowork');
+      expect(result.data.runtimeId).toBe('chat');
+    }
+  });
+
+  it('rejects unknown kind values', () => {
+    const result = AgentDefinitionSchema.safeParse({
+      ...base,
+      kind: 'daemon',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('WorkflowDefinitionSchema with step.mcpRestrictions', () => {
@@ -353,6 +385,29 @@ describe('WorkflowDefinitionSchema with step.mcpRestrictions', () => {
       const step = result.data.steps[0];
       expect(step.mcpRestrictions?.github?.denyTools).toEqual(['delete_repo']);
       expect(step.mcpRestrictions?.postgres?.disable).toBe(true);
+    }
+  });
+
+  it('parses a step with agentId pointer', () => {
+    const result = WorkflowDefinitionSchema.safeParse({
+      name: 'test-workflow',
+      version: 1,
+      steps: [
+        {
+          id: 'explore',
+          name: 'Explore',
+          type: 'creation',
+          executor: 'cowork',
+          agentId: 'tealflow-cowork-chat',
+          cowork: { agent: 'chat' },
+        },
+      ],
+      transitions: [],
+      triggers: [{ type: 'manual', name: 'Start' }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.steps[0].agentId).toBe('tealflow-cowork-chat');
     }
   });
 

--- a/packages/platform-core/src/schemas/agent-definition.ts
+++ b/packages/platform-core/src/schemas/agent-definition.ts
@@ -3,6 +3,14 @@ import { AgentMcpBindingMapSchema } from './agent-mcp-binding.js';
 
 export const AgentDefinitionSchema = z.object({
   id: z.string(),
+  /** Discriminates runtime dispatch. 'plugin' routes to PluginRegistry
+   *  (container agent). 'cowork' routes to the cowork session runtime
+   *  (chat/voice widget with human-in-the-loop). */
+  kind: z.enum(['plugin', 'cowork']).default('plugin'),
+  /** Runtime implementation identifier. For kind='plugin' this is a
+   *  PluginRegistry key (e.g. 'claude-code-agent'). For kind='cowork'
+   *  this is a cowork runtime key (e.g. 'chat', 'voice-realtime'). */
+  runtimeId: z.string().optional(),
   name: z.string().min(1),
   iconName: z.string(),
   description: z.string(),
@@ -11,7 +19,6 @@ export const AgentDefinitionSchema = z.object({
   inputDescription: z.string(),
   outputDescription: z.string(),
   skillFileNames: z.array(z.string()),
-  pluginId: z.string().optional(),
   /** Canonical MCP server configuration for this agent. Map of server
    *  name → AgentMcpBinding. Step-level restrictions can only narrow
    *  (disable servers or deny tools) — they cannot broaden. */

--- a/packages/platform-core/src/schemas/workflow-definition.ts
+++ b/packages/platform-core/src/schemas/workflow-definition.ts
@@ -83,6 +83,11 @@ export const WorkflowStepSchema = z.object({
   executor: z.enum(['human', 'agent', 'script', 'cowork']),
   autonomyLevel: z.enum(['L0', 'L1', 'L2', 'L3', 'L4']).optional(),
   plugin: z.string().optional(),
+  /** References an AgentDefinition by its deterministic slug (doc id).
+   *  The referenced definition carries canonical MCP server bindings
+   *  and runtime identity. Step-level mcpRestrictions narrow further.
+   *  When unset, no MCP resolution runs for this step. */
+  agentId: z.string().optional(),
   allowedRoles: z.array(z.string()).optional(),
   agent: WorkflowAgentConfigSchema.optional(),
   review: WorkflowReviewConfigSchema.optional(),

--- a/packages/platform-core/src/schemas/workflow-definition.ts
+++ b/packages/platform-core/src/schemas/workflow-definition.ts
@@ -103,7 +103,11 @@ export const WorkflowStepSchema = z.object({
 export const WorkflowDefinitionSchema = z.object({
   name: z.string().min(1),
   version: z.number().int().positive(),
-  namespace: z.string().optional(),
+  /** Workspace namespace that owns this definition. Required because
+   *  MCP resolution, workflow secret lookups, and the namespace-scoped
+   *  tool catalog all key off this field — a workflow without one is
+   *  not a runnable workflow. */
+  namespace: z.string().min(1),
   title: z.string().min(1).optional(),
   description: z.string().optional(),
   preamble: z.string().optional(),

--- a/packages/platform-core/src/testing/__tests__/in-memory-tool-catalog-repository.test.ts
+++ b/packages/platform-core/src/testing/__tests__/in-memory-tool-catalog-repository.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryToolCatalogRepository } from '../in-memory-tool-catalog-repository.js';
+import type { ToolCatalogEntry } from '../../schemas/agent-mcp-binding.js';
+
+function makeEntry(overrides: Partial<ToolCatalogEntry> = {}): ToolCatalogEntry {
+  return {
+    id: 'tealflow-mcp',
+    command: 'tealflow-mcp',
+    args: [],
+    description: 'Tealflow MCP — lists and describes teal modules',
+    ...overrides,
+  };
+}
+
+describe('InMemoryToolCatalogRepository', () => {
+  let repo: InMemoryToolCatalogRepository;
+
+  beforeEach(() => {
+    repo = new InMemoryToolCatalogRepository();
+  });
+
+  it('returns null for missing entry', async () => {
+    const result = await repo.getById('appsilon', 'missing');
+    expect(result).toBeNull();
+  });
+
+  it('upsert then getById returns a clone of the stored entry', async () => {
+    const entry = makeEntry();
+    await repo.upsert('appsilon', entry);
+
+    const retrieved = await repo.getById('appsilon', 'tealflow-mcp');
+    expect(retrieved).toEqual(entry);
+    // Mutating the retrieved copy must not affect storage
+    retrieved!.command = 'hacked';
+    const retrievedAgain = await repo.getById('appsilon', 'tealflow-mcp');
+    expect(retrievedAgain!.command).toBe('tealflow-mcp');
+  });
+
+  it('upsert replaces existing entry with same id', async () => {
+    await repo.upsert('appsilon', makeEntry({ command: 'v1' }));
+    await repo.upsert('appsilon', makeEntry({ command: 'v2' }));
+
+    const retrieved = await repo.getById('appsilon', 'tealflow-mcp');
+    expect(retrieved!.command).toBe('v2');
+  });
+
+  it('isolates entries by namespace', async () => {
+    await repo.upsert('appsilon', makeEntry({ id: 'shared-id', command: 'cmd-a' }));
+    await repo.upsert('other-org', makeEntry({ id: 'shared-id', command: 'cmd-b' }));
+
+    const appsilon = await repo.getById('appsilon', 'shared-id');
+    const otherOrg = await repo.getById('other-org', 'shared-id');
+    expect(appsilon!.command).toBe('cmd-a');
+    expect(otherOrg!.command).toBe('cmd-b');
+  });
+
+  it('list returns only entries in the given namespace', async () => {
+    await repo.upsert('appsilon', makeEntry({ id: 'a' }));
+    await repo.upsert('appsilon', makeEntry({ id: 'b' }));
+    await repo.upsert('other-org', makeEntry({ id: 'c' }));
+
+    const appsilonList = await repo.list('appsilon');
+    expect(appsilonList.map((e) => e.id).sort()).toEqual(['a', 'b']);
+    const otherOrgList = await repo.list('other-org');
+    expect(otherOrgList.map((e) => e.id)).toEqual(['c']);
+  });
+
+  it('delete removes only the target entry', async () => {
+    await repo.upsert('appsilon', makeEntry({ id: 'a' }));
+    await repo.upsert('appsilon', makeEntry({ id: 'b' }));
+    await repo.delete('appsilon', 'a');
+
+    expect(await repo.getById('appsilon', 'a')).toBeNull();
+    expect(await repo.getById('appsilon', 'b')).not.toBeNull();
+  });
+
+  it('delete is a no-op for absent entries', async () => {
+    await expect(repo.delete('appsilon', 'never-existed')).resolves.toBeUndefined();
+  });
+});

--- a/packages/platform-core/src/testing/factories.ts
+++ b/packages/platform-core/src/testing/factories.ts
@@ -293,6 +293,7 @@ export function buildWorkflowDefinition(
   return {
     name: 'test-workflow',
     version: 1,
+    namespace: 'test',
     steps: [
       {
         id: 'intake',

--- a/packages/platform-core/src/testing/in-memory-tool-catalog-repository.ts
+++ b/packages/platform-core/src/testing/in-memory-tool-catalog-repository.ts
@@ -1,0 +1,39 @@
+import type { ToolCatalogEntry } from '../schemas/agent-mcp-binding.js';
+import type { ToolCatalogRepository } from '../interfaces/tool-catalog-repository.js';
+
+/** In-memory double for ToolCatalogRepository. Stores entries keyed by
+ *  `${namespace}/${entryId}` so tests can exercise namespace isolation
+ *  without spinning up Firestore. */
+export class InMemoryToolCatalogRepository implements ToolCatalogRepository {
+  private readonly entries = new Map<string, ToolCatalogEntry>();
+
+  private key(namespace: string, entryId: string): string {
+    return `${namespace}/${entryId}`;
+  }
+
+  async getById(namespace: string, entryId: string): Promise<ToolCatalogEntry | null> {
+    const entry = this.entries.get(this.key(namespace, entryId));
+    return entry ? { ...entry } : null;
+  }
+
+  async list(namespace: string): Promise<ToolCatalogEntry[]> {
+    const prefix = `${namespace}/`;
+    return [...this.entries.entries()]
+      .filter(([k]) => k.startsWith(prefix))
+      .map(([, entry]) => ({ ...entry }));
+  }
+
+  async upsert(namespace: string, entry: ToolCatalogEntry): Promise<ToolCatalogEntry> {
+    this.entries.set(this.key(namespace, entry.id), { ...entry });
+    return { ...entry };
+  }
+
+  async delete(namespace: string, entryId: string): Promise<void> {
+    this.entries.delete(this.key(namespace, entryId));
+  }
+
+  /** Test helper: wipe all entries across namespaces. */
+  clear(): void {
+    this.entries.clear();
+  }
+}

--- a/packages/platform-core/src/testing/index.ts
+++ b/packages/platform-core/src/testing/index.ts
@@ -5,7 +5,9 @@ export { InMemoryProcessInstanceRepository } from './in-memory-process-instance-
 export { InMemoryHumanTaskRepository } from './in-memory-human-task-repository.js';
 export { InMemoryHandoffRepository } from './in-memory-handoff-repository.js';
 export { NoopNotificationService } from './noop-notification-service.js';
-export { InMemoryCoworkSessionRepository } from './in-memory-cowork-session-repository.js';export { InMemoryCronTriggerStateRepository } from './in-memory-cron-trigger-state-repository.js';
+export { InMemoryCoworkSessionRepository } from './in-memory-cowork-session-repository.js';
+export { InMemoryCronTriggerStateRepository } from './in-memory-cron-trigger-state-repository.js';
+export { InMemoryToolCatalogRepository } from './in-memory-tool-catalog-repository.js';
 
 // Test factories
 export {

--- a/packages/platform-infra/src/__tests__/tool-catalog-repository.test.ts
+++ b/packages/platform-infra/src/__tests__/tool-catalog-repository.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Firestore } from 'firebase-admin/firestore';
+import { FirestoreToolCatalogRepository } from '../firestore/tool-catalog-repository.js';
+import type { ToolCatalogEntry } from '@mediforce/platform-core';
+
+// Mock Firestore using the chainable stub pattern used elsewhere in this
+// package. Any call returns `chain` so `.collection().doc().get()` works;
+// terminal calls (get/set/delete) are controllable spies.
+const {
+  mockGet, mockSet, mockDelete, mockDoc, mockCollection,
+} = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(),
+  mockDelete: vi.fn(),
+  mockDoc: vi.fn(),
+  mockCollection: vi.fn(),
+}));
+
+function buildChain() {
+  return {
+    doc: mockDoc,
+    collection: mockCollection,
+    get: mockGet,
+    set: mockSet,
+    delete: mockDelete,
+  };
+}
+
+function resetChainMocks() {
+  vi.resetAllMocks();
+  const chain = buildChain();
+  mockCollection.mockReturnValue(chain);
+  mockDoc.mockReturnValue(chain);
+  mockSet.mockResolvedValue(undefined);
+  mockDelete.mockResolvedValue(undefined);
+}
+
+function makeFakeDb() {
+  return { collection: mockCollection } as unknown as Firestore;
+}
+
+describe('FirestoreToolCatalogRepository', () => {
+  let repo: FirestoreToolCatalogRepository;
+
+  beforeEach(() => {
+    resetChainMocks();
+    repo = new FirestoreToolCatalogRepository(makeFakeDb());
+  });
+
+  it('resolves to namespaces/{handle}/toolCatalog/{id} path on upsert', async () => {
+    const entry: ToolCatalogEntry = {
+      id: 'tealflow-mcp',
+      command: 'tealflow-mcp',
+      description: 'Tealflow MCP',
+    };
+    await repo.upsert('appsilon', entry);
+
+    // collection('namespaces').doc('appsilon').collection('toolCatalog').doc('tealflow-mcp')
+    const collectionCalls = mockCollection.mock.calls.map((c) => c[0]);
+    const docCalls = mockDoc.mock.calls.map((c) => c[0]);
+    expect(collectionCalls).toContain('namespaces');
+    expect(collectionCalls).toContain('toolCatalog');
+    expect(docCalls).toContain('appsilon');
+    expect(docCalls).toContain('tealflow-mcp');
+  });
+
+  it('strips id from payload on upsert (id lives in the doc path)', async () => {
+    const entry: ToolCatalogEntry = {
+      id: 'tealflow-mcp',
+      command: 'tealflow-mcp',
+    };
+    await repo.upsert('appsilon', entry);
+
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    const persisted = mockSet.mock.calls[0][0] as Record<string, unknown>;
+    expect(persisted.id).toBeUndefined();
+    expect(persisted.command).toBe('tealflow-mcp');
+  });
+
+  it('getById returns null when the doc does not exist', async () => {
+    mockGet.mockResolvedValueOnce({ exists: false });
+    const result = await repo.getById('appsilon', 'missing');
+    expect(result).toBeNull();
+  });
+
+  it('getById parses stored data and populates id from the doc path', async () => {
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      id: 'tealflow-mcp',
+      data: () => ({ command: 'tealflow-mcp', description: 'Tealflow MCP' }),
+    });
+    const result = await repo.getById('appsilon', 'tealflow-mcp');
+    expect(result).toEqual({
+      id: 'tealflow-mcp',
+      command: 'tealflow-mcp',
+      description: 'Tealflow MCP',
+    });
+  });
+
+  it('list maps snapshot docs into parsed entries', async () => {
+    mockGet.mockResolvedValueOnce({
+      docs: [
+        { id: 'a', data: () => ({ command: 'cmd-a' }) },
+        { id: 'b', data: () => ({ command: 'cmd-b' }) },
+      ],
+    });
+    const entries = await repo.list('appsilon');
+    expect(entries).toEqual([
+      { id: 'a', command: 'cmd-a' },
+      { id: 'b', command: 'cmd-b' },
+    ]);
+  });
+
+  it('rejects payload that violates catalog entry schema on upsert', async () => {
+    const bogus = { id: 'x', command: '' } as unknown as ToolCatalogEntry;
+    await expect(repo.upsert('appsilon', bogus)).rejects.toThrow();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('delete calls through to Firestore for the right doc', async () => {
+    await repo.delete('appsilon', 'tealflow-mcp');
+    const docCalls = mockDoc.mock.calls.map((c) => c[0]);
+    expect(docCalls).toContain('tealflow-mcp');
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/platform-infra/src/firestore/agent-definition-repository.ts
+++ b/packages/platform-infra/src/firestore/agent-definition-repository.ts
@@ -8,13 +8,21 @@ import {
 } from '@mediforce/platform-core';
 
 function toAgentDefinition(id: string, data: Record<string, unknown>): AgentDefinition {
+  // Legacy rows wrote this field as `pluginId`; new rows write `runtimeId`.
+  // Normalize on read so orphan rows with the old field still parse.
+  const runtimeId =
+    typeof data.runtimeId === 'string'
+      ? data.runtimeId
+      : typeof data.pluginId === 'string'
+        ? data.pluginId
+        : undefined;
   return AgentDefinitionSchema.parse({
     ...data,
     id,
+    runtimeId,
     inputDescription: data.inputDescription ?? '',
     outputDescription: data.outputDescription ?? '',
     skillFileNames: data.skillFileNames ?? [],
-    pluginId: typeof data.pluginId === 'string' ? data.pluginId : undefined,
     createdAt:
       data.createdAt instanceof Timestamp
         ? data.createdAt.toDate().toISOString()

--- a/packages/platform-infra/src/firestore/agent-definition-repository.ts
+++ b/packages/platform-infra/src/firestore/agent-definition-repository.ts
@@ -48,6 +48,16 @@ export class FirestoreAgentDefinitionRepository implements AgentDefinitionReposi
     return toAgentDefinition(ref.id, snap.data() as Record<string, unknown>);
   }
 
+  async upsert(id: string, input: CreateAgentDefinitionInput): Promise<AgentDefinition> {
+    const ref = this.col.doc(id);
+    const now = FieldValue.serverTimestamp();
+    const existing = await ref.get();
+    const createdAt = existing.exists ? (existing.data()?.createdAt ?? now) : now;
+    await ref.set({ ...input, createdAt, updatedAt: now });
+    const snap = await ref.get();
+    return toAgentDefinition(snap.id, snap.data() as Record<string, unknown>);
+  }
+
   async getById(id: string): Promise<AgentDefinition | null> {
     const snap = await this.col.doc(id).get();
     if (!snap.exists) return null;

--- a/packages/platform-infra/src/firestore/tool-catalog-repository.ts
+++ b/packages/platform-infra/src/firestore/tool-catalog-repository.ts
@@ -1,0 +1,42 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import {
+  ToolCatalogEntrySchema,
+  type ToolCatalogEntry,
+  type ToolCatalogRepository,
+} from '@mediforce/platform-core';
+
+/** Firestore-backed ToolCatalogRepository.
+ *
+ *  Path: namespaces/{handle}/toolCatalog/{entryId}
+ *  Doc id IS the entryId (human-readable slug, referenced by AgentMcpBinding.catalogId).
+ *  Writes strip the id from the payload so it doesn't end up duplicated
+ *  inside the document — the id is already the doc path. */
+export class FirestoreToolCatalogRepository implements ToolCatalogRepository {
+  constructor(private readonly db: Firestore) {}
+
+  private col(namespace: string) {
+    return this.db.collection('namespaces').doc(namespace).collection('toolCatalog');
+  }
+
+  async getById(namespace: string, entryId: string): Promise<ToolCatalogEntry | null> {
+    const snap = await this.col(namespace).doc(entryId).get();
+    if (!snap.exists) return null;
+    return ToolCatalogEntrySchema.parse({ ...snap.data(), id: snap.id });
+  }
+
+  async list(namespace: string): Promise<ToolCatalogEntry[]> {
+    const snap = await this.col(namespace).get();
+    return snap.docs.map((d) => ToolCatalogEntrySchema.parse({ ...d.data(), id: d.id }));
+  }
+
+  async upsert(namespace: string, entry: ToolCatalogEntry): Promise<ToolCatalogEntry> {
+    const parsed = ToolCatalogEntrySchema.parse(entry);
+    const { id, ...body } = parsed;
+    await this.col(namespace).doc(id).set(body);
+    return parsed;
+  }
+
+  async delete(namespace: string, entryId: string): Promise<void> {
+    await this.col(namespace).doc(entryId).delete();
+  }
+}

--- a/packages/platform-infra/src/index.ts
+++ b/packages/platform-infra/src/index.ts
@@ -25,6 +25,7 @@ export { FirestoreNamespaceRepository } from './firestore/namespace-repository.j
 export { FirestoreWorkflowSecretsRepository } from './firestore/workflow-secrets-repository.js';
 export { FirestoreCoworkSessionRepository } from './firestore/cowork-session-repository.js';
 export { FirestoreCronTriggerStateRepository } from './firestore/cron-trigger-state-repository.js';
+export { FirestoreToolCatalogRepository } from './firestore/tool-catalog-repository.js';
 export { validateSecretsKey } from './crypto/secrets-cipher.js';
 export { getAdminAuth, getAdminFirestore } from './auth/firebase-admin-init.js';
 export { FirebaseInviteService } from './auth/firebase-invite-service.js';

--- a/packages/platform-ui/e2e/auth-setup.ts
+++ b/packages/platform-ui/e2e/auth-setup.ts
@@ -32,7 +32,6 @@ setup('authenticate and seed data', async ({ page }) => {
   await seedCollection('processDefinitions', data.processDefinitions);
   await seedCollection('processConfigs', data.processConfigs);
   await seedCollection('workflowDefinitions', data.workflowDefinitions);
-  await seedCollection('agentDefinitions', data.agentDefinitions);
   await seedCollection('namespaces', data.namespaces);
   await seedSubcollection('namespaces', TEST_ORG_HANDLE, 'members', data.namespaceMembers);
   await seedSubcollection('processInstances', 'proc-completed-1', 'stepExecutions', data.completedProcessStepExecutions);

--- a/packages/platform-ui/e2e/helpers/seed-data.ts
+++ b/packages/platform-ui/e2e/helpers/seed-data.ts
@@ -735,7 +735,8 @@ export function buildSeedData(testUserId: string) {
   const agentDefinitions: Record<string, Record<string, unknown>> = {
     'agent-def-driver': {
       id: 'agent-def-driver',
-      pluginId: 'supply-intelligence/driver-agent',
+      kind: 'plugin',
+      runtimeId: 'supply-intelligence/driver-agent',
       name: 'Driver Agent',
       iconName: 'Chart',
       description: 'Orchestrates multi-step supply chain review workflows by coordinating data collection, analysis, and reporting agents.',
@@ -749,7 +750,8 @@ export function buildSeedData(testUserId: string) {
     },
     'agent-def-risk-detection': {
       id: 'agent-def-risk-detection',
-      pluginId: 'supply-intelligence/risk-detection',
+      kind: 'plugin',
+      runtimeId: 'supply-intelligence/risk-detection',
       name: 'Risk Detection',
       iconName: 'Chart',
       description: 'Analyzes vendor submissions and supply chain data to identify potential risks, anomalies, and compliance issues.',
@@ -763,7 +765,8 @@ export function buildSeedData(testUserId: string) {
     },
     'agent-def-claude-code': {
       id: 'agent-def-claude-code',
-      pluginId: 'claude-code-agent',
+      kind: 'plugin',
+      runtimeId: 'claude-code-agent',
       name: 'Claude Code Agent',
       iconName: 'Bot',
       description: 'Executes code generation, analysis, and automated software tasks using Claude\'s advanced coding capabilities.',
@@ -777,7 +780,8 @@ export function buildSeedData(testUserId: string) {
     },
     'agent-def-opencode': {
       id: 'agent-def-opencode',
-      pluginId: 'opencode-agent',
+      kind: 'plugin',
+      runtimeId: 'opencode-agent',
       name: 'OpenCode Agent',
       iconName: 'Cpu',
       description: 'Open-source code execution agent powered by DeepSeek for cost-efficient automated development tasks.',
@@ -791,7 +795,8 @@ export function buildSeedData(testUserId: string) {
     },
     'agent-def-script-container': {
       id: 'agent-def-script-container',
-      pluginId: 'script-container',
+      kind: 'plugin',
+      runtimeId: 'script-container',
       name: 'Script Container',
       iconName: 'Terminal',
       description: 'Sandboxed execution environment for running custom scripts, data transformations, and automation tasks.',

--- a/packages/platform-ui/e2e/helpers/seed-data.ts
+++ b/packages/platform-ui/e2e/helpers/seed-data.ts
@@ -732,84 +732,6 @@ export function buildSeedData(testUserId: string) {
     },
   };
 
-  const agentDefinitions: Record<string, Record<string, unknown>> = {
-    'agent-def-driver': {
-      id: 'agent-def-driver',
-      kind: 'plugin',
-      runtimeId: 'supply-intelligence/driver-agent',
-      name: 'Driver Agent',
-      iconName: 'Chart',
-      description: 'Orchestrates multi-step supply chain review workflows by coordinating data collection, analysis, and reporting agents.',
-      inputDescription: 'Workflow trigger payload with study identifiers',
-      outputDescription: 'Completed workflow result with step summaries',
-      foundationModel: 'anthropic/claude-sonnet-4',
-      systemPrompt: '',
-      skillFileNames: [],
-      createdAt: twoDaysAgo,
-      updatedAt: twoDaysAgo,
-    },
-    'agent-def-risk-detection': {
-      id: 'agent-def-risk-detection',
-      kind: 'plugin',
-      runtimeId: 'supply-intelligence/risk-detection',
-      name: 'Risk Detection',
-      iconName: 'Chart',
-      description: 'Analyzes vendor submissions and supply chain data to identify potential risks, anomalies, and compliance issues.',
-      inputDescription: 'Vendor submission records and historical data',
-      outputDescription: 'Risk scores, flagged issues, and recommendations',
-      foundationModel: 'anthropic/claude-sonnet-4',
-      systemPrompt: '',
-      skillFileNames: [],
-      createdAt: twoDaysAgo,
-      updatedAt: twoDaysAgo,
-    },
-    'agent-def-claude-code': {
-      id: 'agent-def-claude-code',
-      kind: 'plugin',
-      runtimeId: 'claude-code-agent',
-      name: 'Claude Code Agent',
-      iconName: 'Bot',
-      description: 'Executes code generation, analysis, and automated software tasks using Claude\'s advanced coding capabilities.',
-      inputDescription: 'Task description and relevant code context',
-      outputDescription: 'Generated code, analysis results, or task completion report',
-      foundationModel: 'anthropic/claude-sonnet-4',
-      systemPrompt: '',
-      skillFileNames: [],
-      createdAt: twoDaysAgo,
-      updatedAt: twoDaysAgo,
-    },
-    'agent-def-opencode': {
-      id: 'agent-def-opencode',
-      kind: 'plugin',
-      runtimeId: 'opencode-agent',
-      name: 'OpenCode Agent',
-      iconName: 'Cpu',
-      description: 'Open-source code execution agent powered by DeepSeek for cost-efficient automated development tasks.',
-      inputDescription: 'Code task description and project context',
-      outputDescription: 'Implemented code changes and execution results',
-      foundationModel: 'deepseek/deepseek-chat',
-      systemPrompt: '',
-      skillFileNames: [],
-      createdAt: twoDaysAgo,
-      updatedAt: twoDaysAgo,
-    },
-    'agent-def-script-container': {
-      id: 'agent-def-script-container',
-      kind: 'plugin',
-      runtimeId: 'script-container',
-      name: 'Script Container',
-      iconName: 'Terminal',
-      description: 'Sandboxed execution environment for running custom scripts, data transformations, and automation tasks.',
-      inputDescription: 'Script definition and input parameters',
-      outputDescription: 'Script execution output and exit status',
-      foundationModel: 'anthropic/claude-sonnet-4',
-      systemPrompt: '',
-      skillFileNames: [],
-      createdAt: twoDaysAgo,
-      updatedAt: twoDaysAgo,
-    },
-  };
-
   const namespaces: Record<string, Record<string, unknown>> = {
     test: {
       id: 'test',
@@ -948,5 +870,5 @@ export function buildSeedData(testUserId: string) {
     createdAt: twoDaysAgo,
   };
 
-  return { users, humanTasks, processInstances, agentRuns, auditEvents, stepExecutions, humanWaitingStepExecutions, retryTestStepExecutions, processDefinitions, completedProcessStepExecutions, completedSupplyChainStepExecutions, processConfigs, workflowDefinitions, agentDefinitions, namespaces, namespaceMembers, coworkSessions };
+  return { users, humanTasks, processInstances, agentRuns, auditEvents, stepExecutions, humanWaitingStepExecutions, retryTestStepExecutions, processDefinitions, completedProcessStepExecutions, completedSupplyChainStepExecutions, processConfigs, workflowDefinitions, namespaces, namespaceMembers, coworkSessions };
 }

--- a/packages/platform-ui/scripts/seed-dev-data.ts
+++ b/packages/platform-ui/scripts/seed-dev-data.ts
@@ -42,7 +42,6 @@ async function main() {
       ['processDefinitions', data.processDefinitions],
       ['processConfigs', data.processConfigs],
       ['workflowDefinitions', data.workflowDefinitions],
-      ['agentDefinitions', data.agentDefinitions],
       ['namespaces', data.namespaces],
       ['coworkSessions', data.coworkSessions],
     ] as const;

--- a/packages/platform-ui/src/app/(app)/[handle]/agents/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/agents/page.tsx
@@ -212,18 +212,22 @@ function AgentCatalog({ handle }: { handle: string }) {
       }),
     ])
       .then(([pluginsData, definitionsData]) => {
-        const definitionEntries = (definitionsData.agents ?? []).map(agentDefinitionToEntry);
-        // Map from runtimeId → definition entry (for dedup and Configure link)
+        // Map from runtimeId → definition entry. Dedups definitions that share a
+        // runtimeId (e.g. an older seeded doc + the builtin-seeded doc) and also
+        // backs the plugin filter below.
         const definitionByRuntimeId = new Map(
-          definitionEntries.map((e) => [e.name, e]),
+          (definitionsData.agents ?? []).map((def) => {
+            const entry = agentDefinitionToEntry(def);
+            return [entry.name, entry] as const;
+          }),
         );
-        // For plugins not covered by a definition, include them as-is
-        // For plugins that have a matching definition, the definition entry (with Configure button) wins
+        // For plugins not covered by a definition, include them as-is.
+        // For plugins that have a matching definition, the definition entry (with Configure button) wins.
         const coveredRuntimeIds = new Set(definitionByRuntimeId.keys());
         const uncoveredPlugins = (pluginsData.plugins ?? []).filter(
           (p) => !coveredRuntimeIds.has(p.name),
         );
-        setAgents([...definitionEntries, ...uncoveredPlugins]);
+        setAgents([...definitionByRuntimeId.values(), ...uncoveredPlugins]);
       })
       .catch((err) => {
         setError(err instanceof Error ? err.message : 'Unknown error');

--- a/packages/platform-ui/src/app/(app)/[handle]/agents/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/agents/page.tsx
@@ -181,7 +181,7 @@ function agentMatchesQuery(agent: AgentEntry, query: string): boolean {
 
 function agentDefinitionToEntry(def: AgentDefinition): AgentEntry {
   return {
-    name: def.pluginId ?? def.id,
+    name: def.runtimeId ?? def.id,
     definitionId: def.id,
     metadata: {
       name: def.name,
@@ -213,15 +213,15 @@ function AgentCatalog({ handle }: { handle: string }) {
     ])
       .then(([pluginsData, definitionsData]) => {
         const definitionEntries = (definitionsData.agents ?? []).map(agentDefinitionToEntry);
-        // Map from pluginId → definition entry (for dedup and Configure link)
-        const definitionByPluginId = new Map(
+        // Map from runtimeId → definition entry (for dedup and Configure link)
+        const definitionByRuntimeId = new Map(
           definitionEntries.map((e) => [e.name, e]),
         );
         // For plugins not covered by a definition, include them as-is
         // For plugins that have a matching definition, the definition entry (with Configure button) wins
-        const coveredPluginIds = new Set(definitionByPluginId.keys());
+        const coveredRuntimeIds = new Set(definitionByRuntimeId.keys());
         const uncoveredPlugins = (pluginsData.plugins ?? []).filter(
-          (p) => !coveredPluginIds.has(p.name),
+          (p) => !coveredRuntimeIds.has(p.name),
         );
         setAgents([...definitionEntries, ...uncoveredPlugins]);
       })

--- a/packages/platform-ui/src/app/api/migrate-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/migrate-definitions/route.ts
@@ -48,9 +48,16 @@ function mergeDefinitionAndConfig(
     };
   });
 
+  // Legacy ProcessDefinitions predate namespacing. The schema may carry
+  // a namespace at the document level in Firestore (seed-data uses
+  // 'test'); prefer that if present, otherwise default to 'appsilon'.
+  const maybeNamespace = (legacyDef as { namespace?: unknown }).namespace;
+  const legacyNamespace = typeof maybeNamespace === 'string' ? maybeNamespace : 'appsilon';
+
   return {
     name: legacyDef.name,
     version,
+    namespace: legacyNamespace,
     description: legacyDef.description,
     repo: legacyDef.repo,
     url: legacyDef.url,

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
@@ -61,6 +61,7 @@ function makeRequest(body?: unknown): NextRequest {
 const workflowDefinition = {
   name: 'community-digest',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'gather-data', name: 'Gather Data', type: 'creation', executor: 'agent', autonomyLevel: 'L2' },
     { id: 'human-review', name: 'Human Review', type: 'creation', executor: 'human', allowedRoles: ['reviewer'] },

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
@@ -42,6 +42,13 @@ vi.mock('@/lib/execute-agent-step', () => ({
   executeAgentStep: (...args: unknown[]) => mockExecuteAgentStep(...args),
 }));
 
+// Pre-flight in the route fetches workflow secrets from Firestore. In unit
+// tests we have no emulator and no project id, so we stub the call to return
+// an empty map — template validation covers secret presence separately.
+vi.mock('@/app/actions/workflow-secrets', () => ({
+  getWorkflowSecretsForRuntime: vi.fn().mockResolvedValue({}),
+}));
+
 import { POST } from '../route';
 
 // ---- Helpers ----

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -58,10 +58,10 @@ export async function POST(
 
     // Pre-flight: validate all env templates are resolvable before executing anything
     {
-      const namespace = workflowDefinition.namespace ?? '';
-      const secrets = namespace
-        ? await getWorkflowSecretsForRuntime(namespace, workflowDefinition.name)
-        : {};
+      const secrets = await getWorkflowSecretsForRuntime(
+        workflowDefinition.namespace,
+        workflowDefinition.name,
+      );
       const missingEnv = validateWorkflowEnv(workflowDefinition, secrets);
       if (missingEnv.length > 0) {
         const names = missingEnv.map((m) => m.secretName);
@@ -179,13 +179,11 @@ export async function POST(
           // Resolve MCP config for the step if it points at an AgentDefinition.
           // Falls back to legacy inline cowork.mcpServers when agentId is unset
           // (workflows not yet migrated).
-          const resolvedMcp = workflowDefinition.namespace
-            ? await resolveMcpForStep(currentStep, {
-                agentDefinitionRepo,
-                toolCatalogRepo,
-                namespace: workflowDefinition.namespace,
-              })
-            : null;
+          const resolvedMcp = await resolveMcpForStep(currentStep, {
+            agentDefinitionRepo,
+            toolCatalogRepo,
+            namespace: workflowDefinition.namespace,
+          });
           const sessionMcpServers = resolvedMcp !== null
             ? flattenResolvedMcpToLegacy(resolvedMcp)
             : (currentStep.cowork?.mcpServers ?? null);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
 import { executeAgentStep } from '@/lib/execute-agent-step';
-import { validateWorkflowEnv } from '@mediforce/agent-runtime';
+import { flattenResolvedMcpToLegacy, resolveMcpForStep, validateWorkflowEnv } from '@mediforce/agent-runtime';
 import { getWorkflowSecretsForRuntime } from '@/app/actions/workflow-secrets';
 import { isStuckLoop, createLoopTracker, MAX_SAME_STEP_ITERATIONS } from '@/lib/loop-guard';
 
@@ -156,7 +156,7 @@ export async function POST(
 
         if (currentStep.executor === 'cowork') {
           // Guard: skip if an active cowork session already exists for this step
-          const { coworkSessionRepo } = getPlatformServices();
+          const { coworkSessionRepo, agentDefinitionRepo, toolCatalogRepo } = getPlatformServices();
           const existingSessions = await coworkSessionRepo.getByInstanceId(instanceId);
           const hasActiveSession = existingSessions.some(
             (s) => s.stepId === instance.currentStepId && s.status === 'active',
@@ -175,6 +175,20 @@ export async function POST(
 
           const now = new Date().toISOString();
           const sessionId = crypto.randomUUID();
+
+          // Resolve MCP config for the step if it points at an AgentDefinition.
+          // Falls back to legacy inline cowork.mcpServers when agentId is unset
+          // (workflows not yet migrated).
+          const resolvedMcp = workflowDefinition.namespace
+            ? await resolveMcpForStep(currentStep, {
+                agentDefinitionRepo,
+                toolCatalogRepo,
+                namespace: workflowDefinition.namespace,
+              })
+            : null;
+          const sessionMcpServers = resolvedMcp !== null
+            ? flattenResolvedMcpToLegacy(resolvedMcp)
+            : (currentStep.cowork?.mcpServers ?? null);
 
           const agentType = currentStep.cowork?.agent ?? 'chat';
           const model = agentType === 'voice-realtime'
@@ -202,7 +216,7 @@ export async function POST(
             outputSchema: currentStep.cowork?.outputSchema ?? null,
             voiceConfig,
             artifact: null,
-            mcpServers: currentStep.cowork?.mcpServers ?? null,
+            mcpServers: sessionMcpServers,
             turns: [],
             createdAt: now,
             updatedAt: now,

--- a/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
@@ -77,6 +77,13 @@ vi.mock('@/lib/platform-services', () => ({
   }),
 }));
 
+// executeAgentStep pre-fetches workflow secrets from Firestore. In unit tests
+// there's no emulator and no project id, so stub the call to return an empty
+// map — template resolution covers secret presence separately.
+vi.mock('@/app/actions/workflow-secrets', () => ({
+  getWorkflowSecretsForRuntime: vi.fn().mockResolvedValue({}),
+}));
+
 // Import after mock setup
 import { executeAgentStep } from '../execute-agent-step';
 

--- a/packages/platform-ui/src/lib/__tests__/resolve-definition-steps.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/resolve-definition-steps.test.ts
@@ -13,6 +13,7 @@ const makeLegacy = (version: string, stepIds: string[]) => ({
 const makeWorkflow = (version: number, stepIds: string[]): WorkflowDefinition => ({
   name: 'test',
   version,
+  namespace: 'test',
   steps: stepIds.map(workflowStep),
   transitions: [],
   triggers: [{ type: 'manual', name: 'start' }],

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -85,20 +85,19 @@ export async function executeAgentStep(
   });
 
   // Pre-fetch workflow secrets for {{TEMPLATE}} resolution
-  const workflowSecrets = workflowDefinition.namespace
-    ? await getWorkflowSecretsForRuntime(workflowDefinition.namespace, workflowDefinition.name)
-    : {};
+  const workflowSecrets = await getWorkflowSecretsForRuntime(
+    workflowDefinition.namespace,
+    workflowDefinition.name,
+  );
 
   // Pre-resolve MCP configuration from the agent definition + step restrictions
   // + tool catalog. undefined when step.agentId is unset. Namespace-scoped
   // catalog lookups use the workflow's namespace.
-  const resolvedMcpConfig = workflowDefinition.namespace
-    ? (await resolveMcpForStep(workflowStep, {
-        agentDefinitionRepo,
-        toolCatalogRepo,
-        namespace: workflowDefinition.namespace,
-      })) ?? undefined
-    : undefined;
+  const resolvedMcpConfig = (await resolveMcpForStep(workflowStep, {
+    agentDefinitionRepo,
+    toolCatalogRepo,
+    namespace: workflowDefinition.namespace,
+  })) ?? undefined;
 
   const workflowAgentContext: WorkflowAgentContext = {
     stepId,

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -6,7 +6,7 @@
 // Called by the auto-runner loop when the instance was created via fireWorkflow (no configName).
 
 import { getPlatformServices } from './platform-services';
-import type { WorkflowAgentContext } from '@mediforce/agent-runtime';
+import { resolveMcpForStep, type WorkflowAgentContext } from '@mediforce/agent-runtime';
 import type { WorkflowDefinition, WorkflowStep } from '@mediforce/platform-core';
 import { getWorkflowSecretsForRuntime } from '../app/actions/workflow-secrets';
 
@@ -31,7 +31,7 @@ export async function executeAgentStep(
   triggeredBy: string,
   stepExecutionId?: string,
 ): Promise<WorkflowAgentStepResult> {
-  const { engine, agentRunner, pluginRegistry, instanceRepo, processRepo, auditRepo, humanTaskRepo, llmClient } =
+  const { engine, agentRunner, pluginRegistry, instanceRepo, processRepo, auditRepo, humanTaskRepo, llmClient, agentDefinitionRepo, toolCatalogRepo } =
     getPlatformServices();
 
   const instance = await instanceRepo.getById(instanceId);
@@ -89,6 +89,17 @@ export async function executeAgentStep(
     ? await getWorkflowSecretsForRuntime(workflowDefinition.namespace, workflowDefinition.name)
     : {};
 
+  // Pre-resolve MCP configuration from the agent definition + step restrictions
+  // + tool catalog. undefined when step.agentId is unset. Namespace-scoped
+  // catalog lookups use the workflow's namespace.
+  const resolvedMcpConfig = workflowDefinition.namespace
+    ? (await resolveMcpForStep(workflowStep, {
+        agentDefinitionRepo,
+        toolCatalogRepo,
+        namespace: workflowDefinition.namespace,
+      })) ?? undefined
+    : undefined;
+
   const workflowAgentContext: WorkflowAgentContext = {
     stepId,
     processInstanceId: instanceId,
@@ -99,6 +110,7 @@ export async function executeAgentStep(
     step: workflowStep,
     llm: llmClient,
     workflowSecrets,
+    resolvedMcpConfig,
     getPreviousStepOutputs: async () => {
       const executions = await instanceRepo.getStepExecutions(instanceId);
       const result: Record<string, unknown> = {};

--- a/packages/platform-ui/src/lib/platform-services.ts
+++ b/packages/platform-ui/src/lib/platform-services.ts
@@ -8,6 +8,7 @@ import {
   FirestoreAgentDefinitionRepository,
   FirestoreCoworkSessionRepository,
   FirestoreCronTriggerStateRepository,
+  FirestoreToolCatalogRepository,
   getAdminFirestore,
   validateSecretsKey,
 } from '@mediforce/platform-infra';
@@ -47,6 +48,7 @@ export interface PlatformServices {
   agentDefinitionRepo: FirestoreAgentDefinitionRepository;
   coworkSessionRepo: FirestoreCoworkSessionRepository;
   cronTriggerStateRepo: CronTriggerStateRepository;
+  toolCatalogRepo: FirestoreToolCatalogRepository;
 }
 
 export function getPlatformServices(): PlatformServices {
@@ -66,6 +68,7 @@ export function getPlatformServices(): PlatformServices {
   const agentDefinitionRepo = new FirestoreAgentDefinitionRepository(db);
   const coworkSessionRepo = new FirestoreCoworkSessionRepository(db);
   const cronTriggerStateRepo = new FirestoreCronTriggerStateRepository(db);
+  const toolCatalogRepo = new FirestoreToolCatalogRepository(db);
   const eventLog = new FirestoreAgentEventLog(db);
 
   const pluginRegistry = new PluginRegistry();
@@ -128,6 +131,7 @@ export function getPlatformServices(): PlatformServices {
     agentDefinitionRepo,
     coworkSessionRepo,
     cronTriggerStateRepo,
+    toolCatalogRepo,
   };
 
   if (!seedingStarted) {

--- a/packages/platform-ui/src/lib/platform-services.ts
+++ b/packages/platform-ui/src/lib/platform-services.ts
@@ -30,6 +30,7 @@ import {
 } from '@mediforce/agent-runtime';
 import { registerSupplyIntelligencePlugins } from '@mediforce/supply-intelligence-plugins';
 import { seedBuiltinAgentDefinitions } from './seed-agent-definitions.js';
+import { seedBuiltinToolCatalog } from './seed-tool-catalog.js';
 
 let services: PlatformServices | null = null;
 let seedingStarted = false;
@@ -138,6 +139,9 @@ export function getPlatformServices(): PlatformServices {
     seedingStarted = true;
     seedBuiltinAgentDefinitions(agentDefinitionRepo).catch((err) => {
       console.error('[platform-services] Failed to seed built-in agent definitions:', err);
+    });
+    seedBuiltinToolCatalog(toolCatalogRepo).catch((err) => {
+      console.error('[platform-services] Failed to seed built-in tool catalog:', err);
     });
   }
 

--- a/packages/platform-ui/src/lib/seed-agent-definitions.ts
+++ b/packages/platform-ui/src/lib/seed-agent-definitions.ts
@@ -1,100 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { FirestoreAgentDefinitionRepository } from '@mediforce/platform-infra';
 import type { CreateAgentDefinitionInput } from '@mediforce/platform-core';
+import { CreateAgentDefinitionInputSchema } from '@mediforce/platform-core';
 
 /** Deterministic slug → AgentDefinition body. Slug doubles as Firestore
  *  doc id so wd.json files can reference it via step.agentId without
- *  fear of IDs shifting between environments. */
-const BUILTIN_AGENTS: Record<string, CreateAgentDefinitionInput> = {
-  'supply-intelligence-driver-agent': {
-    kind: 'plugin',
-    runtimeId: 'supply-intelligence/driver-agent',
-    name: 'Driver Agent',
-    iconName: 'Chart',
-    description:
-      'Orchestrates multi-step supply chain review workflows by coordinating data collection, analysis, and reporting agents.',
-    inputDescription: 'Workflow trigger payload with study identifiers',
-    outputDescription: 'Completed workflow result with step summaries',
-    foundationModel: 'anthropic/claude-sonnet-4',
-    systemPrompt: '',
-    skillFileNames: [],
-  },
-  'supply-intelligence-risk-detection': {
-    kind: 'plugin',
-    runtimeId: 'supply-intelligence/risk-detection',
-    name: 'Risk Detection',
-    iconName: 'Chart',
-    description:
-      'Analyzes vendor submissions and supply chain data to identify potential risks, anomalies, and compliance issues.',
-    inputDescription: 'Vendor submission records and historical data',
-    outputDescription: 'Risk scores, flagged issues, and recommendations',
-    foundationModel: 'anthropic/claude-sonnet-4',
-    systemPrompt: '',
-    skillFileNames: [],
-  },
-  'claude-code-agent': {
-    kind: 'plugin',
-    runtimeId: 'claude-code-agent',
-    name: 'Claude Code Agent',
-    iconName: 'Bot',
-    description:
-      "Executes code generation, analysis, and automated software tasks using Claude's advanced coding capabilities.",
-    inputDescription: 'Task description and relevant code context',
-    outputDescription: 'Generated code, analysis results, or task completion report',
-    foundationModel: 'anthropic/claude-sonnet-4',
-    systemPrompt: '',
-    skillFileNames: [],
-  },
-  'opencode-agent': {
-    kind: 'plugin',
-    runtimeId: 'opencode-agent',
-    name: 'OpenCode Agent',
-    iconName: 'Cpu',
-    description:
-      'Open-source code execution agent powered by DeepSeek for cost-efficient automated development tasks.',
-    inputDescription: 'Code task description and project context',
-    outputDescription: 'Implemented code changes and execution results',
-    foundationModel: 'deepseek/deepseek-chat',
-    systemPrompt: '',
-    skillFileNames: [],
-  },
-  'script-container': {
-    kind: 'plugin',
-    runtimeId: 'script-container',
-    name: 'Script Container',
-    iconName: 'Terminal',
-    description:
-      'Sandboxed execution environment for running custom scripts, data transformations, and automation tasks.',
-    inputDescription: 'Script definition and input parameters',
-    outputDescription: 'Script execution output and exit status',
-    foundationModel: 'anthropic/claude-sonnet-4',
-    systemPrompt: '',
-    skillFileNames: [],
-  },
-  // Per-workflow AgentDefinition referenced by tealflow-cowork.wd.json via
-  // step.agentId. Sits in the same seed file for Step 2 scope; Step 3+ will
-  // move per-workflow definitions into sibling files next to their wd.json.
-  'tealflow-cowork-chat': {
-    kind: 'cowork',
-    runtimeId: 'chat',
-    name: 'Tealflow Cowork Chat',
-    iconName: 'MessageCircle',
-    description:
-      'Chat cowork agent with the tealflow MCP server attached for teal module exploration.',
-    inputDescription: 'User messages and artifact state',
-    outputDescription: 'Teal module selection artifact',
-    foundationModel: 'anthropic/claude-sonnet-4',
-    systemPrompt: '',
-    skillFileNames: [],
-    mcpServers: {
-      tealflow: { type: 'stdio', catalogId: 'tealflow-mcp' },
-    },
-  },
-};
+ *  fear of IDs shifting between environments.
+ *
+ *  Authoritative data lives in data/seeds/agent-definitions.json (shared
+ *  with scripts/seed_agent_definitions.py). Validated on load so schema
+ *  drift in the JSON surfaces at startup, not at the first call site.
+ *
+ *  Idempotent: only writes when the doc is missing — user edits via the
+ *  Agents UI are preserved across restarts. */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// packages/platform-ui/src/lib -> repo root (4 levels up)
+const SEED_PATH = resolve(__dirname, '../../../../data/seeds/agent-definitions.json');
+
+function loadBuiltinAgents(): Record<string, CreateAgentDefinitionInput> {
+  const raw = JSON.parse(readFileSync(SEED_PATH, 'utf-8')) as Record<string, unknown>;
+  const result: Record<string, CreateAgentDefinitionInput> = {};
+  for (const [id, body] of Object.entries(raw)) {
+    result[id] = CreateAgentDefinitionInputSchema.parse(body);
+  }
+  return result;
+}
+
+const BUILTIN_AGENTS = loadBuiltinAgents();
 
 export async function seedBuiltinAgentDefinitions(
   repo: FirestoreAgentDefinitionRepository,
 ): Promise<void> {
   await Promise.all(
-    Object.entries(BUILTIN_AGENTS).map(([id, body]) => repo.upsert(id, body)),
+    Object.entries(BUILTIN_AGENTS).map(async ([id, body]) => {
+      const existing = await repo.getById(id);
+      if (existing === null) {
+        await repo.upsert(id, body);
+      }
+    }),
   );
 }

--- a/packages/platform-ui/src/lib/seed-agent-definitions.ts
+++ b/packages/platform-ui/src/lib/seed-agent-definitions.ts
@@ -1,8 +1,12 @@
 import type { FirestoreAgentDefinitionRepository } from '@mediforce/platform-infra';
+import type { CreateAgentDefinitionInput } from '@mediforce/platform-core';
 
-const BUILTIN_AGENTS = [
-  {
-    kind: 'plugin' as const,
+/** Deterministic slug → AgentDefinition body. Slug doubles as Firestore
+ *  doc id so wd.json files can reference it via step.agentId without
+ *  fear of IDs shifting between environments. */
+const BUILTIN_AGENTS: Record<string, CreateAgentDefinitionInput> = {
+  'supply-intelligence-driver-agent': {
+    kind: 'plugin',
     runtimeId: 'supply-intelligence/driver-agent',
     name: 'Driver Agent',
     iconName: 'Chart',
@@ -12,10 +16,10 @@ const BUILTIN_AGENTS = [
     outputDescription: 'Completed workflow result with step summaries',
     foundationModel: 'anthropic/claude-sonnet-4',
     systemPrompt: '',
-    skillFileNames: [] as string[],
+    skillFileNames: [],
   },
-  {
-    kind: 'plugin' as const,
+  'supply-intelligence-risk-detection': {
+    kind: 'plugin',
     runtimeId: 'supply-intelligence/risk-detection',
     name: 'Risk Detection',
     iconName: 'Chart',
@@ -25,10 +29,10 @@ const BUILTIN_AGENTS = [
     outputDescription: 'Risk scores, flagged issues, and recommendations',
     foundationModel: 'anthropic/claude-sonnet-4',
     systemPrompt: '',
-    skillFileNames: [] as string[],
+    skillFileNames: [],
   },
-  {
-    kind: 'plugin' as const,
+  'claude-code-agent': {
+    kind: 'plugin',
     runtimeId: 'claude-code-agent',
     name: 'Claude Code Agent',
     iconName: 'Bot',
@@ -38,10 +42,10 @@ const BUILTIN_AGENTS = [
     outputDescription: 'Generated code, analysis results, or task completion report',
     foundationModel: 'anthropic/claude-sonnet-4',
     systemPrompt: '',
-    skillFileNames: [] as string[],
+    skillFileNames: [],
   },
-  {
-    kind: 'plugin' as const,
+  'opencode-agent': {
+    kind: 'plugin',
     runtimeId: 'opencode-agent',
     name: 'OpenCode Agent',
     iconName: 'Cpu',
@@ -51,10 +55,10 @@ const BUILTIN_AGENTS = [
     outputDescription: 'Implemented code changes and execution results',
     foundationModel: 'deepseek/deepseek-chat',
     systemPrompt: '',
-    skillFileNames: [] as string[],
+    skillFileNames: [],
   },
-  {
-    kind: 'plugin' as const,
+  'script-container': {
+    kind: 'plugin',
     runtimeId: 'script-container',
     name: 'Script Container',
     iconName: 'Terminal',
@@ -64,24 +68,14 @@ const BUILTIN_AGENTS = [
     outputDescription: 'Script execution output and exit status',
     foundationModel: 'anthropic/claude-sonnet-4',
     systemPrompt: '',
-    skillFileNames: [] as string[],
+    skillFileNames: [],
   },
-];
+};
 
 export async function seedBuiltinAgentDefinitions(
   repo: FirestoreAgentDefinitionRepository,
 ): Promise<void> {
-  const existing = await repo.list();
-  const existingByRuntimeId = new Map(
-    existing.filter((a) => a.runtimeId !== undefined).map((a) => [a.runtimeId!, a]),
-  );
-
   await Promise.all(
-    BUILTIN_AGENTS.map(async (agent) => {
-      const existingAgent = existingByRuntimeId.get(agent.runtimeId);
-      if (existingAgent === undefined) {
-        await repo.create(agent);
-      }
-    }),
+    Object.entries(BUILTIN_AGENTS).map(([id, body]) => repo.upsert(id, body)),
   );
 }

--- a/packages/platform-ui/src/lib/seed-agent-definitions.ts
+++ b/packages/platform-ui/src/lib/seed-agent-definitions.ts
@@ -70,6 +70,25 @@ const BUILTIN_AGENTS: Record<string, CreateAgentDefinitionInput> = {
     systemPrompt: '',
     skillFileNames: [],
   },
+  // Per-workflow AgentDefinition referenced by tealflow-cowork.wd.json via
+  // step.agentId. Sits in the same seed file for Step 2 scope; Step 3+ will
+  // move per-workflow definitions into sibling files next to their wd.json.
+  'tealflow-cowork-chat': {
+    kind: 'cowork',
+    runtimeId: 'chat',
+    name: 'Tealflow Cowork Chat',
+    iconName: 'MessageCircle',
+    description:
+      'Chat cowork agent with the tealflow MCP server attached for teal module exploration.',
+    inputDescription: 'User messages and artifact state',
+    outputDescription: 'Teal module selection artifact',
+    foundationModel: 'anthropic/claude-sonnet-4',
+    systemPrompt: '',
+    skillFileNames: [],
+    mcpServers: {
+      tealflow: { type: 'stdio', catalogId: 'tealflow-mcp' },
+    },
+  },
 };
 
 export async function seedBuiltinAgentDefinitions(

--- a/packages/platform-ui/src/lib/seed-agent-definitions.ts
+++ b/packages/platform-ui/src/lib/seed-agent-definitions.ts
@@ -2,7 +2,8 @@ import type { FirestoreAgentDefinitionRepository } from '@mediforce/platform-inf
 
 const BUILTIN_AGENTS = [
   {
-    pluginId: 'supply-intelligence/driver-agent',
+    kind: 'plugin' as const,
+    runtimeId: 'supply-intelligence/driver-agent',
     name: 'Driver Agent',
     iconName: 'Chart',
     description:
@@ -14,7 +15,8 @@ const BUILTIN_AGENTS = [
     skillFileNames: [] as string[],
   },
   {
-    pluginId: 'supply-intelligence/risk-detection',
+    kind: 'plugin' as const,
+    runtimeId: 'supply-intelligence/risk-detection',
     name: 'Risk Detection',
     iconName: 'Chart',
     description:
@@ -26,7 +28,8 @@ const BUILTIN_AGENTS = [
     skillFileNames: [] as string[],
   },
   {
-    pluginId: 'claude-code-agent',
+    kind: 'plugin' as const,
+    runtimeId: 'claude-code-agent',
     name: 'Claude Code Agent',
     iconName: 'Bot',
     description:
@@ -38,7 +41,8 @@ const BUILTIN_AGENTS = [
     skillFileNames: [] as string[],
   },
   {
-    pluginId: 'opencode-agent',
+    kind: 'plugin' as const,
+    runtimeId: 'opencode-agent',
     name: 'OpenCode Agent',
     iconName: 'Cpu',
     description:
@@ -50,7 +54,8 @@ const BUILTIN_AGENTS = [
     skillFileNames: [] as string[],
   },
   {
-    pluginId: 'script-container',
+    kind: 'plugin' as const,
+    runtimeId: 'script-container',
     name: 'Script Container',
     iconName: 'Terminal',
     description:
@@ -67,13 +72,13 @@ export async function seedBuiltinAgentDefinitions(
   repo: FirestoreAgentDefinitionRepository,
 ): Promise<void> {
   const existing = await repo.list();
-  const existingByPluginId = new Map(
-    existing.filter((a) => a.pluginId !== undefined).map((a) => [a.pluginId!, a]),
+  const existingByRuntimeId = new Map(
+    existing.filter((a) => a.runtimeId !== undefined).map((a) => [a.runtimeId!, a]),
   );
 
   await Promise.all(
     BUILTIN_AGENTS.map(async (agent) => {
-      const existingAgent = existingByPluginId.get(agent.pluginId);
+      const existingAgent = existingByRuntimeId.get(agent.runtimeId);
       if (existingAgent === undefined) {
         await repo.create(agent);
       }

--- a/packages/platform-ui/src/lib/seed-tool-catalog.ts
+++ b/packages/platform-ui/src/lib/seed-tool-catalog.ts
@@ -1,0 +1,29 @@
+import type { FirestoreToolCatalogRepository } from '@mediforce/platform-infra';
+import type { ToolCatalogEntry } from '@mediforce/platform-core';
+
+/** Namespace → catalog entries to upsert at startup. Entries here are the
+ *  ones required by checked-in workflow definitions; bespoke
+ *  admin-configured entries will live in Firestore only. Keep this list
+ *  small — it's not a catalog of all known MCP servers. */
+const BUILTIN_CATALOG: Record<string, ToolCatalogEntry[]> = {
+  appsilon: [
+    {
+      id: 'tealflow-mcp',
+      command: 'tealflow-mcp',
+      description:
+        'Tealflow MCP — lists and describes available teal modules for clinical trial data exploration.',
+    },
+  ],
+};
+
+export async function seedBuiltinToolCatalog(
+  repo: FirestoreToolCatalogRepository,
+): Promise<void> {
+  const tasks: Promise<unknown>[] = [];
+  for (const [namespace, entries] of Object.entries(BUILTIN_CATALOG)) {
+    for (const entry of entries) {
+      tasks.push(repo.upsert(namespace, entry));
+    }
+  }
+  await Promise.all(tasks);
+}

--- a/packages/platform-ui/src/lib/seed-tool-catalog.ts
+++ b/packages/platform-ui/src/lib/seed-tool-catalog.ts
@@ -1,20 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { FirestoreToolCatalogRepository } from '@mediforce/platform-infra';
 import type { ToolCatalogEntry } from '@mediforce/platform-core';
+import { ToolCatalogEntrySchema } from '@mediforce/platform-core';
 
-/** Namespace → catalog entries to upsert at startup. Entries here are the
- *  ones required by checked-in workflow definitions; bespoke
+/** Namespace → catalog entries to upsert at startup. Entries here are
+ *  the ones required by checked-in workflow definitions; bespoke
  *  admin-configured entries will live in Firestore only. Keep this list
- *  small — it's not a catalog of all known MCP servers. */
-const BUILTIN_CATALOG: Record<string, ToolCatalogEntry[]> = {
-  appsilon: [
-    {
-      id: 'tealflow-mcp',
-      command: 'tealflow-mcp',
-      description:
-        'Tealflow MCP — lists and describes available teal modules for clinical trial data exploration.',
-    },
-  ],
-};
+ *  small — it's not a catalog of all known MCP servers.
+ *
+ *  Authoritative data lives in data/seeds/tool-catalog.json (shared with
+ *  scripts/seed_tool_catalog.py). Validated on load so schema drift in
+ *  the JSON surfaces at startup, not at the first call site. */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// packages/platform-ui/src/lib -> repo root (4 levels up)
+const SEED_PATH = resolve(__dirname, '../../../../data/seeds/tool-catalog.json');
+
+function loadBuiltinCatalog(): Record<string, ToolCatalogEntry[]> {
+  const raw = JSON.parse(readFileSync(SEED_PATH, 'utf-8')) as Record<string, unknown[]>;
+  const result: Record<string, ToolCatalogEntry[]> = {};
+  for (const [namespace, entries] of Object.entries(raw)) {
+    result[namespace] = entries.map(entry => ToolCatalogEntrySchema.parse(entry));
+  }
+  return result;
+}
+
+const BUILTIN_CATALOG = loadBuiltinCatalog();
 
 export async function seedBuiltinToolCatalog(
   repo: FirestoreToolCatalogRepository,

--- a/packages/workflow-engine/src/__tests__/cowork-engine.test.ts
+++ b/packages/workflow-engine/src/__tests__/cowork-engine.test.ts
@@ -18,6 +18,7 @@ import type { StepActor } from '../index.js';
 const coworkDef: WorkflowDefinition = {
   name: 'cowork-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'intake', name: 'Intake', type: 'creation', executor: 'human' },
     {
@@ -45,6 +46,7 @@ const coworkDef: WorkflowDefinition = {
 const coworkFirstDef: WorkflowDefinition = {
   name: 'cowork-first',
   version: 1,
+  namespace: 'test',
   steps: [
     {
       id: 'brainstorm',

--- a/packages/workflow-engine/src/__tests__/cowork-lifecycle.test.ts
+++ b/packages/workflow-engine/src/__tests__/cowork-lifecycle.test.ts
@@ -21,6 +21,7 @@ import { WorkflowEngine } from '../index.js';
 const coworkDesignerDef: WorkflowDefinition = {
   name: 'cowork-designer-test',
   version: 1,
+  namespace: 'test',
   steps: [
     {
       id: 'intake',

--- a/packages/workflow-engine/src/__tests__/manual-trigger.test.ts
+++ b/packages/workflow-engine/src/__tests__/manual-trigger.test.ts
@@ -14,6 +14,7 @@ import type { WorkflowTriggerContext } from '../index.js';
 const linearDef: WorkflowDefinition = {
   name: 'linear-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'start', name: 'Start', type: 'creation', executor: 'agent' },
     { id: 'process', name: 'Process', type: 'creation', executor: 'human' },

--- a/packages/workflow-engine/src/__tests__/rbac.test.ts
+++ b/packages/workflow-engine/src/__tests__/rbac.test.ts
@@ -16,6 +16,7 @@ import type { StepActor } from '../index.js';
 const simpleDefinition: WorkflowDefinition = {
   name: 'rbac-test-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'start', name: 'Start', type: 'creation', executor: 'human', allowedRoles: ['approver'] },
     { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },
@@ -28,6 +29,7 @@ const simpleDefinition: WorkflowDefinition = {
 const noRolesDefinition: WorkflowDefinition = {
   name: 'rbac-no-roles',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'start', name: 'Start', type: 'creation', executor: 'human' },
     { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },

--- a/packages/workflow-engine/src/__tests__/retry-step.test.ts
+++ b/packages/workflow-engine/src/__tests__/retry-step.test.ts
@@ -11,6 +11,7 @@ import type { StepActor } from '../index.js';
 const def: WorkflowDefinition = {
   name: 'retry-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'upload', name: 'Upload', type: 'creation', executor: 'human' },
     { id: 'deploy', name: 'Deploy', type: 'creation', executor: 'agent' },

--- a/packages/workflow-engine/src/__tests__/webhook-trigger.test.ts
+++ b/packages/workflow-engine/src/__tests__/webhook-trigger.test.ts
@@ -16,6 +16,7 @@ import type { WorkflowTriggerContext } from '../index.js';
 const webhookDef: WorkflowDefinition = {
   name: 'webhook-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'start', name: 'Start', type: 'creation', executor: 'agent' },
     { id: 'process', name: 'Process', type: 'creation', executor: 'human' },

--- a/packages/workflow-engine/src/__tests__/workflow-engine.test.ts
+++ b/packages/workflow-engine/src/__tests__/workflow-engine.test.ts
@@ -21,6 +21,7 @@ import type { StepActor } from '../index.js';
 const linearDef: WorkflowDefinition = {
   name: 'linear-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'start', name: 'Start', type: 'creation', executor: 'agent' },
     { id: 'process', name: 'Process', type: 'creation', executor: 'human' },
@@ -36,6 +37,7 @@ const linearDef: WorkflowDefinition = {
 const branchingDef: WorkflowDefinition = {
   name: 'branching-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'start', name: 'Start', type: 'creation', executor: 'agent' },
     { id: 'path-a', name: 'Path A', type: 'creation', executor: 'agent' },
@@ -54,6 +56,7 @@ const branchingDef: WorkflowDefinition = {
 const reviewDef: WorkflowDefinition = {
   name: 'review-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'draft', name: 'Draft', type: 'creation', executor: 'agent' },
     {
@@ -574,6 +577,7 @@ describe('WorkflowEngine', () => {
       const defWithRoles = {
         name: 'linear-process-with-roles',
         version: 1,
+        namespace: 'test',
         steps: [
           { id: 'start', name: 'Start', type: 'creation' as const, executor: 'agent' as const },
           { id: 'process', name: 'Process', type: 'creation' as const, executor: 'human' as const, allowedRoles: ['reviewer'] },
@@ -620,6 +624,7 @@ describe('WorkflowEngine', () => {
       const defWithRoles = {
         name: 'linear-process-analyst',
         version: 1,
+        namespace: 'test',
         steps: [
           { id: 'start', name: 'Start', type: 'creation' as const, executor: 'agent' as const },
           { id: 'process', name: 'Process', type: 'creation' as const, executor: 'human' as const, allowedRoles: ['supply-analyst'] },
@@ -652,6 +657,7 @@ describe('WorkflowEngine', () => {
     const selectionDef: WorkflowDefinition = {
       name: 'selection-process',
       version: 1,
+      namespace: 'test',
       steps: [
         { id: 'generate', name: 'Generate Options', type: 'creation', executor: 'agent' },
         {
@@ -759,6 +765,7 @@ describe('WorkflowEngine', () => {
 const linearWorkflowDef: WorkflowDefinition = {
   name: 'linear-workflow',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'start', name: 'Start', type: 'creation', executor: 'agent' },
     { id: 'process', name: 'Process', type: 'creation', executor: 'human', allowedRoles: ['operator'] },
@@ -775,6 +782,7 @@ const linearWorkflowDef: WorkflowDefinition = {
 const reviewWorkflowDef: WorkflowDefinition = {
   name: 'review-workflow',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'draft', name: 'Draft', type: 'creation', executor: 'agent' },
     {
@@ -1039,6 +1047,7 @@ describe('WorkflowEngine — WorkflowDefinition (unified schema)', () => {
   const autonomyTestDef: WorkflowDefinition = {
     name: 'autonomy-test',
     version: 1,
+    namespace: 'test',
     steps: [
       { id: 'agent-step', name: 'Agent Step', type: 'creation', executor: 'agent', autonomyLevel: 'L2' },
       { id: 'human-step', name: 'Human Review', type: 'creation', executor: 'human', allowedRoles: ['reviewer'] },
@@ -1079,6 +1088,7 @@ describe('WorkflowEngine — WorkflowDefinition (unified schema)', () => {
     const directTerminalDef: WorkflowDefinition = {
       name: 'direct-terminal',
       version: 1,
+      namespace: 'test',
       steps: [
         { id: 'agent-step', name: 'Agent Step', type: 'creation', executor: 'agent', autonomyLevel: 'L2' },
         { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },
@@ -1103,6 +1113,7 @@ describe('WorkflowEngine — WorkflowDefinition (unified schema)', () => {
     const chainedAgentDef: WorkflowDefinition = {
       name: 'chained-agents',
       version: 1,
+      namespace: 'test',
       steps: [
         { id: 'step-1', name: 'Step 1', type: 'creation', executor: 'agent', autonomyLevel: 'L2' },
         { id: 'step-2', name: 'Step 2', type: 'creation', executor: 'agent', autonomyLevel: 'L4' },

--- a/packages/workflow-engine/src/engine/__tests__/escalation.test.ts
+++ b/packages/workflow-engine/src/engine/__tests__/escalation.test.ts
@@ -35,6 +35,7 @@ class InMemoryUserDirectoryService implements UserDirectoryService {
 const agentProcessDef: WorkflowDefinition = {
   name: 'agent-process',
   version: 1,
+  namespace: 'test',
   steps: [
     { id: 'agent-step', name: 'Agent Step', type: 'creation', executor: 'agent' },
     { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },

--- a/scripts/migrate_tealflow_cowork_mcp.py
+++ b/scripts/migrate_tealflow_cowork_mcp.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Migrate apps/tealflow-cowork/src/tealflow-cowork.wd.json from legacy
+step-level cowork.mcpServers to the Step-2 agent-centric model.
+
+Before:
+    cowork: {
+      agent: 'chat',
+      mcpServers: [{ name: 'tealflow', command: 'tealflow-mcp', ... }]
+    }
+
+After:
+    agentId: 'tealflow-cowork-chat'
+    cowork: {
+      agent: 'chat'
+    }
+
+The AgentDefinition with id 'tealflow-cowork-chat' and the ToolCatalog
+entry 'tealflow-mcp' are seeded by companion scripts:
+    scripts/seed_tool_catalog.py
+    scripts/seed_agent_definitions.py
+
+Idempotent: running twice is safe. If the step already carries agentId
+and has no cowork.mcpServers, the file is left untouched.
+
+Usage:
+    python3 scripts/migrate_tealflow_cowork_mcp.py
+
+Exits 0 on success (migrated or already-migrated), 1 on any error.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).parent.parent
+WD_PATH = REPO_ROOT / "apps" / "tealflow-cowork" / "src" / "tealflow-cowork.wd.json"
+AGENT_ID = "tealflow-cowork-chat"
+EXPECTED_MCP_SERVER_NAME = "tealflow"
+EXPECTED_COMMAND = "tealflow-mcp"
+
+
+def migrate_step(step: dict[str, Any]) -> bool:
+    """Return True if the step was modified, False if no-op."""
+    if step.get("executor") != "cowork":
+        return False
+
+    cowork = step.get("cowork")
+    if not isinstance(cowork, dict):
+        return False
+
+    legacy_servers = cowork.get("mcpServers")
+    already_has_agent_id = "agentId" in step
+
+    # Already migrated and legacy field cleaned: nothing to do.
+    if already_has_agent_id and legacy_servers is None:
+        return False
+
+    # Safety: verify the legacy payload is the shape we expect before touching it.
+    if legacy_servers is not None:
+        if not isinstance(legacy_servers, list) or len(legacy_servers) != 1:
+            raise RuntimeError(
+                f"Step {step.get('id')!r}: expected exactly one entry in "
+                f"cowork.mcpServers, got {legacy_servers!r}"
+            )
+        server = legacy_servers[0]
+        if server.get("name") != EXPECTED_MCP_SERVER_NAME or server.get("command") != EXPECTED_COMMAND:
+            raise RuntimeError(
+                f"Step {step.get('id')!r}: legacy cowork.mcpServers does not "
+                f"match the expected tealflow-mcp entry, refusing to migrate: {server!r}"
+            )
+        del cowork["mcpServers"]
+
+    if not already_has_agent_id:
+        # Insert agentId near the top of the step for readability — after id/name/type/executor.
+        ordered: dict[str, Any] = {}
+        for key in ("id", "name", "type", "executor"):
+            if key in step:
+                ordered[key] = step[key]
+        ordered["agentId"] = AGENT_ID
+        for key, value in step.items():
+            if key not in ordered:
+                ordered[key] = value
+        step.clear()
+        step.update(ordered)
+
+    return True
+
+
+def main() -> int:
+    if not WD_PATH.exists():
+        print(f"Error: workflow definition not found at {WD_PATH}", file=sys.stderr)
+        return 1
+
+    with WD_PATH.open("r", encoding="utf-8") as f:
+        wd = json.load(f)
+
+    steps = wd.get("steps")
+    if not isinstance(steps, list):
+        print("Error: wd.json has no steps array", file=sys.stderr)
+        return 1
+
+    changed_ids: list[str] = []
+    for step in steps:
+        if migrate_step(step):
+            changed_ids.append(step.get("id", "<unknown>"))
+
+    if not changed_ids:
+        print(f"No changes: {WD_PATH.name} already matches Step 2 shape.")
+        return 0
+
+    with WD_PATH.open("w", encoding="utf-8") as f:
+        json.dump(wd, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"Migrated steps in {WD_PATH.name}: {', '.join(changed_ids)}")
+    print(
+        f"Remember to seed AgentDefinition '{AGENT_ID}' and "
+        f"ToolCatalog entry '{EXPECTED_COMMAND}' in the target namespace."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_agent_definitions.py
+++ b/scripts/seed_agent_definitions.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Seed Step-2 AgentDefinitions into the Firestore emulator.
+
+Writes to agentDefinitions/{id} at deterministic slugs so
+WorkflowStep.agentId references stay stable across environments.
+Re-runnable: each PATCH replaces the doc by id.
+
+Dev-only: targets the Firestore emulator via its REST API (no auth).
+For non-emulator environments, rely on platform-ui's startup seed
+(seedBuiltinAgentDefinitions in platform-services.ts).
+
+Usage:
+    FIRESTORE_EMULATOR_HOST=localhost:8080 \\
+    python3 scripts/seed_agent_definitions.py
+
+    python3 scripts/seed_agent_definitions.py --emulator-host localhost:8080
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+DEFAULT_PROJECT_ID = "demo-mediforce"
+
+# Keep these entries in sync with
+# packages/platform-ui/src/lib/seed-agent-definitions.ts.
+# The TS seed is authoritative for non-emulator environments; this
+# script primes the emulator so a fresh dev box can be readied before
+# platform-ui starts.
+AGENT_DEFINITIONS: dict[str, dict[str, Any]] = {
+    "claude-code-agent": {
+        "kind": "plugin",
+        "runtimeId": "claude-code-agent",
+        "name": "Claude Code Agent",
+        "iconName": "Bot",
+        "description": (
+            "Executes code generation, analysis, and automated software "
+            "tasks using Claude's advanced coding capabilities."
+        ),
+        "inputDescription": "Task description and relevant code context",
+        "outputDescription": "Generated code, analysis results, or task completion report",
+        "foundationModel": "anthropic/claude-sonnet-4",
+        "systemPrompt": "",
+        "skillFileNames": [],
+    },
+    "opencode-agent": {
+        "kind": "plugin",
+        "runtimeId": "opencode-agent",
+        "name": "OpenCode Agent",
+        "iconName": "Cpu",
+        "description": (
+            "Open-source code execution agent powered by DeepSeek for "
+            "cost-efficient automated development tasks."
+        ),
+        "inputDescription": "Code task description and project context",
+        "outputDescription": "Implemented code changes and execution results",
+        "foundationModel": "deepseek/deepseek-chat",
+        "systemPrompt": "",
+        "skillFileNames": [],
+    },
+    "script-container": {
+        "kind": "plugin",
+        "runtimeId": "script-container",
+        "name": "Script Container",
+        "iconName": "Terminal",
+        "description": (
+            "Sandboxed execution environment for running custom scripts, "
+            "data transformations, and automation tasks."
+        ),
+        "inputDescription": "Script definition and input parameters",
+        "outputDescription": "Script execution output and exit status",
+        "foundationModel": "anthropic/claude-sonnet-4",
+        "systemPrompt": "",
+        "skillFileNames": [],
+    },
+    "supply-intelligence-driver-agent": {
+        "kind": "plugin",
+        "runtimeId": "supply-intelligence/driver-agent",
+        "name": "Driver Agent",
+        "iconName": "Chart",
+        "description": (
+            "Orchestrates multi-step supply chain review workflows by "
+            "coordinating data collection, analysis, and reporting agents."
+        ),
+        "inputDescription": "Workflow trigger payload with study identifiers",
+        "outputDescription": "Completed workflow result with step summaries",
+        "foundationModel": "anthropic/claude-sonnet-4",
+        "systemPrompt": "",
+        "skillFileNames": [],
+    },
+    "supply-intelligence-risk-detection": {
+        "kind": "plugin",
+        "runtimeId": "supply-intelligence/risk-detection",
+        "name": "Risk Detection",
+        "iconName": "Chart",
+        "description": (
+            "Analyzes vendor submissions and supply chain data to identify "
+            "potential risks, anomalies, and compliance issues."
+        ),
+        "inputDescription": "Vendor submission records and historical data",
+        "outputDescription": "Risk scores, flagged issues, and recommendations",
+        "foundationModel": "anthropic/claude-sonnet-4",
+        "systemPrompt": "",
+        "skillFileNames": [],
+    },
+    # Per-workflow AgentDefinition referenced by tealflow-cowork.wd.json.
+    "tealflow-cowork-chat": {
+        "kind": "cowork",
+        "runtimeId": "chat",
+        "name": "Tealflow Cowork Chat",
+        "iconName": "MessageCircle",
+        "description": (
+            "Chat cowork agent with the tealflow MCP server attached for "
+            "teal module exploration."
+        ),
+        "inputDescription": "User messages and artifact state",
+        "outputDescription": "Teal module selection artifact",
+        "foundationModel": "anthropic/claude-sonnet-4",
+        "systemPrompt": "",
+        "skillFileNames": [],
+        "mcpServers": {
+            "tealflow": {"type": "stdio", "catalogId": "tealflow-mcp"},
+        },
+    },
+}
+
+
+def _typed_value(value: Any) -> dict[str, Any]:
+    """Encode a Python value as a Firestore REST `fields` entry."""
+    if value is None:
+        return {"nullValue": None}
+    if isinstance(value, bool):
+        return {"booleanValue": value}
+    if isinstance(value, int):
+        return {"integerValue": str(value)}
+    if isinstance(value, float):
+        return {"doubleValue": value}
+    if isinstance(value, str):
+        return {"stringValue": value}
+    if isinstance(value, list):
+        return {"arrayValue": {"values": [_typed_value(v) for v in value]}}
+    if isinstance(value, dict):
+        return {"mapValue": {"fields": {k: _typed_value(v) for k, v in value.items()}}}
+    raise TypeError(f"Unsupported value type for Firestore encode: {type(value)}")
+
+
+def _encode_fields(entry: dict[str, Any]) -> dict[str, Any]:
+    return {"fields": {k: _typed_value(v) for k, v in entry.items()}}
+
+
+def _upsert(
+    emulator_host: str,
+    project_id: str,
+    doc_id: str,
+    entry: dict[str, Any],
+) -> None:
+    url = (
+        f"http://{emulator_host}/v1/projects/{project_id}/databases/(default)/documents/"
+        f"agentDefinitions/{doc_id}"
+    )
+    now_iso = datetime.now(tz=timezone.utc).isoformat()
+    payload = {**entry, "createdAt": now_iso, "updatedAt": now_iso}
+    req = Request(
+        url,
+        data=json.dumps(_encode_fields(payload)).encode(),
+        method="PATCH",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urlopen(req) as resp:
+            resp.read()
+    except HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        print(f"Error upserting agentDefinitions/{doc_id}: HTTP {e.code} — {detail}", file=sys.stderr)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--emulator-host",
+        default=os.environ.get("FIRESTORE_EMULATOR_HOST", "localhost:8080"),
+        help="Firestore emulator host (default: $FIRESTORE_EMULATOR_HOST or localhost:8080)",
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("GOOGLE_CLOUD_PROJECT", DEFAULT_PROJECT_ID),
+        help=f"Firebase project id (default: $GOOGLE_CLOUD_PROJECT or {DEFAULT_PROJECT_ID})",
+    )
+    args = parser.parse_args()
+
+    for doc_id, entry in AGENT_DEFINITIONS.items():
+        _upsert(args.emulator_host, args.project_id, doc_id, entry)
+        print(f"Upserted agentDefinitions/{doc_id}")
+    print(f"Done: {len(AGENT_DEFINITIONS)} agent definitions seeded.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_agent_definitions.py
+++ b/scripts/seed_agent_definitions.py
@@ -10,6 +10,9 @@ Dev-only: targets the Firestore emulator via its REST API (no auth).
 For non-emulator environments, rely on platform-ui's startup seed
 (seedBuiltinAgentDefinitions in platform-services.ts).
 
+Source data: data/seeds/agent-definitions.json (shared with the TS seed
+in packages/platform-ui/src/lib/seed-agent-definitions.ts).
+
 Usage:
     FIRESTORE_EMULATOR_HOST=localhost:8080 \\
     python3 scripts/seed_agent_definitions.py
@@ -24,113 +27,20 @@ import json
 import os
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 DEFAULT_PROJECT_ID = "demo-mediforce"
 
-# Keep these entries in sync with
-# packages/platform-ui/src/lib/seed-agent-definitions.ts.
-# The TS seed is authoritative for non-emulator environments; this
-# script primes the emulator so a fresh dev box can be readied before
-# platform-ui starts.
-AGENT_DEFINITIONS: dict[str, dict[str, Any]] = {
-    "claude-code-agent": {
-        "kind": "plugin",
-        "runtimeId": "claude-code-agent",
-        "name": "Claude Code Agent",
-        "iconName": "Bot",
-        "description": (
-            "Executes code generation, analysis, and automated software "
-            "tasks using Claude's advanced coding capabilities."
-        ),
-        "inputDescription": "Task description and relevant code context",
-        "outputDescription": "Generated code, analysis results, or task completion report",
-        "foundationModel": "anthropic/claude-sonnet-4",
-        "systemPrompt": "",
-        "skillFileNames": [],
-    },
-    "opencode-agent": {
-        "kind": "plugin",
-        "runtimeId": "opencode-agent",
-        "name": "OpenCode Agent",
-        "iconName": "Cpu",
-        "description": (
-            "Open-source code execution agent powered by DeepSeek for "
-            "cost-efficient automated development tasks."
-        ),
-        "inputDescription": "Code task description and project context",
-        "outputDescription": "Implemented code changes and execution results",
-        "foundationModel": "deepseek/deepseek-chat",
-        "systemPrompt": "",
-        "skillFileNames": [],
-    },
-    "script-container": {
-        "kind": "plugin",
-        "runtimeId": "script-container",
-        "name": "Script Container",
-        "iconName": "Terminal",
-        "description": (
-            "Sandboxed execution environment for running custom scripts, "
-            "data transformations, and automation tasks."
-        ),
-        "inputDescription": "Script definition and input parameters",
-        "outputDescription": "Script execution output and exit status",
-        "foundationModel": "anthropic/claude-sonnet-4",
-        "systemPrompt": "",
-        "skillFileNames": [],
-    },
-    "supply-intelligence-driver-agent": {
-        "kind": "plugin",
-        "runtimeId": "supply-intelligence/driver-agent",
-        "name": "Driver Agent",
-        "iconName": "Chart",
-        "description": (
-            "Orchestrates multi-step supply chain review workflows by "
-            "coordinating data collection, analysis, and reporting agents."
-        ),
-        "inputDescription": "Workflow trigger payload with study identifiers",
-        "outputDescription": "Completed workflow result with step summaries",
-        "foundationModel": "anthropic/claude-sonnet-4",
-        "systemPrompt": "",
-        "skillFileNames": [],
-    },
-    "supply-intelligence-risk-detection": {
-        "kind": "plugin",
-        "runtimeId": "supply-intelligence/risk-detection",
-        "name": "Risk Detection",
-        "iconName": "Chart",
-        "description": (
-            "Analyzes vendor submissions and supply chain data to identify "
-            "potential risks, anomalies, and compliance issues."
-        ),
-        "inputDescription": "Vendor submission records and historical data",
-        "outputDescription": "Risk scores, flagged issues, and recommendations",
-        "foundationModel": "anthropic/claude-sonnet-4",
-        "systemPrompt": "",
-        "skillFileNames": [],
-    },
-    # Per-workflow AgentDefinition referenced by tealflow-cowork.wd.json.
-    "tealflow-cowork-chat": {
-        "kind": "cowork",
-        "runtimeId": "chat",
-        "name": "Tealflow Cowork Chat",
-        "iconName": "MessageCircle",
-        "description": (
-            "Chat cowork agent with the tealflow MCP server attached for "
-            "teal module exploration."
-        ),
-        "inputDescription": "User messages and artifact state",
-        "outputDescription": "Teal module selection artifact",
-        "foundationModel": "anthropic/claude-sonnet-4",
-        "systemPrompt": "",
-        "skillFileNames": [],
-        "mcpServers": {
-            "tealflow": {"type": "stdio", "catalogId": "tealflow-mcp"},
-        },
-    },
-}
+REPO_ROOT = Path(__file__).parent.parent
+SEED_PATH = REPO_ROOT / "data" / "seeds" / "agent-definitions.json"
+
+
+def _load_agent_definitions() -> dict[str, dict[str, Any]]:
+    with SEED_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def _typed_value(value: Any) -> dict[str, Any]:
@@ -197,10 +107,11 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    for doc_id, entry in AGENT_DEFINITIONS.items():
+    agent_definitions = _load_agent_definitions()
+    for doc_id, entry in agent_definitions.items():
         _upsert(args.emulator_host, args.project_id, doc_id, entry)
         print(f"Upserted agentDefinitions/{doc_id}")
-    print(f"Done: {len(AGENT_DEFINITIONS)} agent definitions seeded.")
+    print(f"Done: {len(agent_definitions)} agent definitions seeded.")
     return 0
 
 

--- a/scripts/seed_tool_catalog.py
+++ b/scripts/seed_tool_catalog.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Seed the Step-2 MCP tool catalog into the Firestore emulator.
+
+Writes to namespaces/{handle}/toolCatalog/{id}. Re-runnable: each PATCH
+replaces the doc by id (no duplicates).
+
+Dev-only: targets the Firestore emulator via its REST API (no auth).
+For non-emulator environments, wait for platform-ui startup — it
+auto-seeds via seedBuiltinToolCatalog in platform-services.ts.
+
+Usage:
+    # With emulators running (firebase emulators:start)
+    FIRESTORE_EMULATOR_HOST=localhost:8080 \\
+    python3 scripts/seed_tool_catalog.py
+
+    # Or pass host via flag
+    python3 scripts/seed_tool_catalog.py --emulator-host localhost:8080
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+DEFAULT_PROJECT_ID = "demo-mediforce"
+
+# Each entry mirrors ToolCatalogEntry and is keyed by the namespace it
+# belongs to. Keep this in sync with
+# packages/platform-ui/src/lib/seed-tool-catalog.ts (single source of
+# truth per Step 2 — duplication reviewed via PR).
+CATALOG: dict[str, list[dict[str, Any]]] = {
+    "appsilon": [
+        {
+            "id": "tealflow-mcp",
+            "command": "tealflow-mcp",
+            "description": (
+                "Tealflow MCP — lists and describes available teal modules "
+                "for clinical trial data exploration."
+            ),
+        },
+    ],
+}
+
+
+def _typed_value(value: Any) -> dict[str, Any]:
+    """Encode a Python value as a Firestore REST `fields` entry.
+    Supports the subset needed by ToolCatalogEntry: string, list[string],
+    dict[string, string]. Extend cautiously — keep the surface small. """
+    if isinstance(value, str):
+        return {"stringValue": value}
+    if isinstance(value, list):
+        return {"arrayValue": {"values": [_typed_value(v) for v in value]}}
+    if isinstance(value, dict):
+        return {
+            "mapValue": {
+                "fields": {k: _typed_value(v) for k, v in value.items()},
+            },
+        }
+    raise TypeError(f"Unsupported value type for Firestore encode: {type(value)}")
+
+
+def _encode_fields(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "fields": {k: _typed_value(v) for k, v in entry.items() if k != "id"},
+    }
+
+
+def _upsert(
+    emulator_host: str,
+    project_id: str,
+    namespace: str,
+    entry: dict[str, Any],
+) -> None:
+    entry_id = entry["id"]
+    url = (
+        f"http://{emulator_host}/v1/projects/{project_id}/databases/(default)/documents/"
+        f"namespaces/{namespace}/toolCatalog/{entry_id}"
+    )
+    payload = json.dumps(_encode_fields(entry)).encode()
+    req = Request(url, data=payload, method="PATCH", headers={"Content-Type": "application/json"})
+    try:
+        with urlopen(req) as resp:
+            resp.read()
+    except HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        print(f"Error upserting {namespace}/{entry_id}: HTTP {e.code} — {detail}", file=sys.stderr)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--emulator-host",
+        default=os.environ.get("FIRESTORE_EMULATOR_HOST", "localhost:8080"),
+        help="Firestore emulator host (default: $FIRESTORE_EMULATOR_HOST or localhost:8080)",
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("GOOGLE_CLOUD_PROJECT", DEFAULT_PROJECT_ID),
+        help=f"Firebase project id (default: $GOOGLE_CLOUD_PROJECT or {DEFAULT_PROJECT_ID})",
+    )
+    args = parser.parse_args()
+
+    total = 0
+    for namespace, entries in CATALOG.items():
+        for entry in entries:
+            _upsert(args.emulator_host, args.project_id, namespace, entry)
+            print(f"Upserted namespaces/{namespace}/toolCatalog/{entry['id']}")
+            total += 1
+    print(f"Done: {total} catalog entries seeded.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_tool_catalog.py
+++ b/scripts/seed_tool_catalog.py
@@ -9,6 +9,9 @@ Dev-only: targets the Firestore emulator via its REST API (no auth).
 For non-emulator environments, wait for platform-ui startup — it
 auto-seeds via seedBuiltinToolCatalog in platform-services.ts.
 
+Source data: data/seeds/tool-catalog.json (shared with the TS seed in
+packages/platform-ui/src/lib/seed-tool-catalog.ts).
+
 Usage:
     # With emulators running (firebase emulators:start)
     FIRESTORE_EMULATOR_HOST=localhost:8080 \\
@@ -24,28 +27,20 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 DEFAULT_PROJECT_ID = "demo-mediforce"
 
-# Each entry mirrors ToolCatalogEntry and is keyed by the namespace it
-# belongs to. Keep this in sync with
-# packages/platform-ui/src/lib/seed-tool-catalog.ts (single source of
-# truth per Step 2 — duplication reviewed via PR).
-CATALOG: dict[str, list[dict[str, Any]]] = {
-    "appsilon": [
-        {
-            "id": "tealflow-mcp",
-            "command": "tealflow-mcp",
-            "description": (
-                "Tealflow MCP — lists and describes available teal modules "
-                "for clinical trial data exploration."
-            ),
-        },
-    ],
-}
+REPO_ROOT = Path(__file__).parent.parent
+SEED_PATH = REPO_ROOT / "data" / "seeds" / "tool-catalog.json"
+
+
+def _load_catalog() -> dict[str, list[dict[str, Any]]]:
+    with SEED_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def _typed_value(value: Any) -> dict[str, Any]:
@@ -107,8 +102,9 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    catalog = _load_catalog()
     total = 0
-    for namespace, entries in CATALOG.items():
+    for namespace, entries in catalog.items():
         for entry in entries:
             _upsert(args.emulator_host, args.project_id, namespace, entry)
             print(f"Upserted namespaces/{namespace}/toolCatalog/{entry['id']}")


### PR DESCRIPTION
## Summary

Implement Step 2 of the MCP binding refactor: move MCP server configuration from step-level inline definitions to agent-centric definitions, with step-level restrictions applied at resolution time. This enables reusable agent definitions with MCP servers while maintaining per-step control via `mcpRestrictions`.

## Key Changes

### Core Resolution Logic
- **`resolveMcpForStep()`**: New function that resolves effective MCP configuration for a workflow step by:
  - Looking up the referenced `AgentDefinition` by `step.agentId`
  - Fetching stdio server specs from the namespace-scoped `ToolCatalogRepository`
  - Applying step-level `mcpRestrictions` (denyTools, disable) via `resolveEffectiveMcp()`
  - Returning `null` when step has no agentId (no MCP resolution needed)
  - Throwing `AgentDefinitionNotFoundError` for rotten agentId references

- **`flattenResolvedMcpToLegacy()`**: Convert resolved config back to legacy `McpServerConfig[]` array shape for consumers (cowork chat route) that still expect it

### Data Layer
- **`ToolCatalogRepository`**: New interface for namespace-scoped MCP server launch specs
  - `FirestoreToolCatalogRepository`: Firestore implementation at `namespaces/{handle}/toolCatalog/{id}`
  - `InMemoryToolCatalogRepository`: Test double with namespace isolation
  - Entries keyed by human-readable slug (e.g., `tealflow-mcp`) to avoid RCE surface of inline commands

### Schema & Model Updates
- **`AgentDefinition`**: Add `kind` field ('plugin' | 'cowork') to discriminate runtime dispatch; add `mcpServers` map for stdio bindings
- **`WorkflowStep`**: Add `agentId` field to reference agent definitions; add `mcpRestrictions` map for step-level tool filtering
- **`ToolCatalogEntry`**: New schema for stdio server specs (command, args, description)

### Plugin Integration
- **`BaseContainerAgentPlugin.writeMcpConfig()`**: Dual-path implementation:
  1. Workflow mode: Use pre-resolved `context.resolvedMcpConfig` from `resolveMcpForStep()`
  2. Legacy mode: Fall back to inline `agentConfig.mcpServers` for process-mode steps
  - Resolved config takes precedence so migrated workflows don't carry dead legacy fields

### Seeding & Migration
- **Python scripts** for dev environment setup:
  - `seed_tool_catalog.py`: Populate Firestore emulator with builtin MCP server specs
  - `seed_agent_definitions.py`: Populate Firestore emulator with builtin agent definitions (including `tealflow-cowork-chat` with tealflow MCP binding)
  - `migrate_tealflow_cowork_mcp.py`: Idempotent migration of tealflow-cowork workflow from legacy step-level mcpServers to agentId model

- **TypeScript seed functions**: `seedBuiltinToolCatalog()` and updated `seedBuiltinAgentDefinitions()` for non-emulator environments

### Test Coverage
- `resolveMcpForStep.test.ts`: 255 lines covering null/missing agent/empty servers/stdio resolution/catalog errors/step restrictions
- `flatten-resolved-mcp.test.ts`: Conversion back to legacy array shape
- `tool-catalog-repository.test.ts`: Firestore and in-memory implementations
- `in-memory-tool-catalog-repository.test.ts`: Namespace isolation and clone semantics
- `mcp-config-integration.test.ts`: Plugin integration with resolved config (stdio/http serialization, allowedTools preservation, secret template resolution)

### Workflow Updates
- **tealflow-cowork.wd.json**: Migrated to agentId model with `tealflow-cowork-chat` agent reference; removed legacy inline mcpServers

## Notable Implementation Details

- **Namespace scoping**:

https://claude.ai/code/session_01QezAAQkz2gnKzgUQ435u9y