### PR TITLE
fix(infra): cap Docker builder cache + pnpm store cache mount

### DIFF
--- a/packages/agent-queue/Dockerfile.worker
+++ b/packages/agent-queue/Dockerfile.worker
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 FROM node:24-slim
 
 # Install Docker CLI so the worker can spawn containers
@@ -5,6 +6,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends docker.io git o
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
 
 WORKDIR /app
 
@@ -13,8 +16,11 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
 COPY packages/agent-queue/package.json packages/agent-queue/
 COPY packages/platform-core/package.json packages/platform-core/
 
-# Install dependencies
-RUN pnpm install --frozen-lockfile || pnpm install
+# Install dependencies — pnpm store persisted via BuildKit cache mount
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && \
+    pnpm config set package-import-method copy && \
+    (pnpm install --frozen-lockfile || pnpm install)
 
 # Copy source
 COPY packages/agent-queue/ packages/agent-queue/

--- a/packages/platform-ui/Dockerfile
+++ b/packages/platform-ui/Dockerfile
@@ -1,5 +1,8 @@
+# syntax=docker/dockerfile:1.6
 FROM node:24-slim AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
 
 # --- Dependencies ---
 FROM base AS deps
@@ -19,7 +22,10 @@ COPY apps/community-digest/package.json apps/community-digest/
 COPY apps/protocol-to-tfl/package.json apps/protocol-to-tfl/
 COPY apps/supply-intelligence/package.json apps/supply-intelligence/
 
-RUN pnpm install --frozen-lockfile || pnpm install
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm config set store-dir /pnpm/store && \
+    pnpm config set package-import-method copy && \
+    (pnpm install --frozen-lockfile || pnpm install)
 
 # --- Builder ---
 FROM base AS builder

--- a/scripts/bootstrap-server.py
+++ b/scripts/bootstrap-server.py
@@ -26,6 +26,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import base64
 import getpass
 import json
 import os
@@ -36,6 +37,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import time
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -246,13 +248,22 @@ def _ssh_base_opts(ctx: "Context") -> list[str]:
     about to configure — trust-on-first-use, prints the host key once, then
     pins it in ~/.ssh/known_hosts for later runs.
     """
+    # ControlPath must stay under the UNIX-domain-socket limit (~104 chars on
+    # macOS). `%C` hashes user+host+port to a 16-char digest, keeping the path
+    # well below the limit regardless of tempdir. `~/.ssh/cm-%C` resolves to a
+    # short, stable location that works on both macOS and Linux.
+    #
+    # `-i` is treated as a hint (preferred key) but we do NOT set
+    # IdentitiesOnly=yes — on operator machines the private key often lives in
+    # an ssh-agent (e.g. 1Password) while the `--ssh-key` path is just the
+    # public-key placeholder. Restricting to the file alone drops to password
+    # auth, which fails against servers that disable root password login.
     return [
         "-i", str(ctx.ssh_key_path),
-        "-o", "IdentitiesOnly=yes",
         "-o", "StrictHostKeyChecking=accept-new",
         "-o", "ConnectTimeout=10",
         "-o", "ControlMaster=auto",
-        "-o", f"ControlPath={tempfile.gettempdir()}/mediforce-ssh-%r@%h:%p",
+        "-o", "ControlPath=~/.ssh/cm-%C",
         "-o", "ControlPersist=60",
     ]
 
@@ -594,6 +605,67 @@ systemctl enable --now docker
     verify = ssh(ctx, "docker --version && docker compose version", check=True)
     for line in verify.stdout.strip().splitlines():
         ok(line)
+
+
+def step_docker_gc(ctx: Context) -> None:
+    """Cap BuildKit cache so it cannot fill the Docker data volume.
+
+    Without this cap, the builder keeps cache indefinitely (we've seen 85GB+
+    build cache pile up in under a week, filling the 98GB Hetzner volume and
+    breaking deploys with ENOSPC). A 20GB cap is plenty for one working set
+    and leaves headroom for images + containers on typical volumes.
+    """
+    if ctx.dry_run:
+        info("[dry-run] would write /etc/docker/daemon.json and restart docker")
+        return
+    info("Configuring Docker builder GC (cap cache at 20GB)")
+
+    # Remote python script — checks for existing config, writes + restarts
+    # docker only if needed. Base64-encoded so we pass it as a single argv
+    # token with no escaping landmines (heredoc, quotes, backslashes).
+    remote_py = textwrap.dedent('''
+        import json, os, sys
+        path = "/etc/docker/daemon.json"
+        try:
+            with open(path) as f:
+                cfg = json.load(f)
+        except (FileNotFoundError, ValueError):
+            cfg = {}
+        if cfg.get("builder", {}).get("gc", {}).get("defaultKeepStorage"):
+            print("ALREADY_CONFIGURED")
+            sys.exit(0)
+        cfg.setdefault("builder", {}).setdefault("gc", {}).update({
+            "enabled": True,
+            "defaultKeepStorage": "20GB",
+            "policy": [{"keepStorage": "20GB", "all": True}],
+        })
+        os.makedirs("/etc/docker", exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(cfg, f, indent=2)
+        print("WROTE")
+    ''').strip()
+    b64 = base64.b64encode(remote_py.encode()).decode()
+
+    sudo = "" if ctx.user == "root" else "sudo "
+    # Single ssh call — one password prompt instead of N. bash -lc runs remote
+    # commands; the result of the python invocation drives whether we bounce
+    # the docker daemon (only when config actually changed).
+    remote_cmd = (
+        f"set -eu; "
+        f"result=$(echo {b64} | base64 -d | {sudo}python3 -); "
+        f'echo "$result"; '
+        f'if [ "$result" = "WROTE" ]; then {sudo}systemctl restart docker; echo RESTARTED; fi'
+    )
+    result = ssh(ctx, remote_cmd, capture=True)
+    if result.rc != 0:
+        raise RuntimeError(f"docker GC config failed (rc={result.rc}): {result.stderr}")
+    out = result.stdout.strip()
+    if "ALREADY_CONFIGURED" in out:
+        ok("docker builder GC already configured")
+    elif "RESTARTED" in out:
+        ok("docker builder GC: 20GB cap set, daemon restarted")
+    else:
+        raise RuntimeError(f"unexpected output from docker GC step: {out!r}")
 
 
 def step_deploy_user(ctx: Context) -> None:
@@ -1504,6 +1576,7 @@ STEPS: list[tuple[str, str, Callable[[Context], None]]] = [
     ("target_server",    "Target server + SSH access",           step_target_server),
     ("system_packages",  "System packages (apt)",                step_system_packages),
     ("docker",           "Docker CE + compose plugin",           step_docker),
+    ("docker_gc",        "Docker builder GC cap (20GB)",         step_docker_gc),
     ("deploy_user",      "deploy user",                          step_deploy_user),
     ("github_access",    "GitHub deploy key",                    step_github_access),
     ("clone_repo",       "Clone repo to /opt/mediforce",         step_clone_repo),
@@ -1530,6 +1603,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--repo", help=f"GitHub repo to deploy, e.g. Org/Name (default: {DEFAULT_REPO}).")
     p.add_argument("--branch", help=f"Branch to deploy (default: {DEFAULT_BRANCH}).")
     p.add_argument("--from-step", type=int, help="Skip to step number N (1-based).")
+    p.add_argument("--only-step", help="Run a single step by name (e.g. docker_gc) and exit.")
     p.add_argument("--resume", action="store_true", help="Force resume prompt even if state looks fresh.")
     p.add_argument("--dry-run", action="store_true", help="Describe actions without making changes.")
     return p.parse_args()
@@ -1623,6 +1697,17 @@ def main() -> int:
         state=state,
         dry_run=args.dry_run,
     )
+
+    if args.only_step:
+        matches = [(i, n, t, f) for i, (n, t, f) in enumerate(STEPS, 1) if n == args.only_step]
+        if not matches:
+            available = ", ".join(n for n, _, _ in STEPS)
+            raise SystemExit(f"--only-step {args.only_step!r} not found. Available: {available}")
+        idx, name, title, fn = matches[0]
+        section(f"{idx}. {title} (only-step)")
+        fn(ctx)
+        state.mark(name)
+        return 0
 
     start = resolve_start_index(args, state)
     try:

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -10,9 +10,18 @@ echo "==> Pulling latest code"
 git fetch origin
 git checkout "$DEPLOY_SHA"
 
-echo "==> Pruning Docker build cache"
-docker builder prune -af --filter "until=72h" 2>/dev/null || true
-docker image prune -af --filter "until=72h" 2>/dev/null || true
+echo "==> Pruning Docker build cache + unused images"
+# Unconditional prune — daemon-level builder GC cap (see /etc/docker/daemon.json)
+# provides the steady-state guarantee; this keeps each deploy's working set lean.
+docker builder prune -af 2>/dev/null || true
+docker image prune -af 2>/dev/null || true
+
+# Early warning if the Docker data volume is filling up
+DOCKER_ROOT=$(docker info -f '{{.DockerRootDir}}' 2>/dev/null || echo /var/lib/docker)
+USE_PCT=$(df --output=pcent "$DOCKER_ROOT" | tail -1 | tr -dc '0-9')
+if [ -n "$USE_PCT" ] && [ "$USE_PCT" -gt 80 ]; then
+  echo "WARN: docker volume at ${USE_PCT}% (${DOCKER_ROOT}) — GC cap may need lowering" >&2
+fi
 
 export NEXT_PUBLIC_GIT_SHA=$(git rev-parse --short HEAD)
 echo "==> Building (SHA: $NEXT_PUBLIC_GIT_SHA)"


### PR DESCRIPTION
## Summary

Staging deploy broke with `ENOSPC` — 98 GB Hetzner volume filled with 85 GB of Docker build cache, dropping every `pnpm install` inside the builder.

- **Root cause:** no cap on BuildKit cache, no persistent pnpm store, and `deploy-staging.sh` only pruned artifacts older than 72h — so renovate-bot merges piled cache faster than the filter released it.
- **Immediate action:** pruned staging manually (`docker builder prune -af` → 92.8 GB freed) and applied the new `daemon.json` via `bootstrap-server.py --only-step docker_gc`. Volume now at 2.1 G / 98 G; all 5 services healthy.

## Changes

**1. Daemon-level cap (`scripts/bootstrap-server.py`)**
- New `step_docker_gc` writes `/etc/docker/daemon.json` with `defaultKeepStorage=20GB`. Docker auto-GCs the cache beyond the cap — no cron, no manual intervention.
- `--only-step NAME` flag for running/testing a single step without touching others.
- `ControlPath=~/.ssh/cm-%C` (16-char hash) — fixes "Unix domain socket too long" on macOS.
- Dropped `IdentitiesOnly=yes` so ssh-agent keys (1Password) authenticate when the on-disk key file is a placeholder.

**2. pnpm cache mounts (`packages/platform-ui/Dockerfile`, `packages/agent-queue/Dockerfile.worker`)**
- `RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm install …`
- `package-import-method=copy` so `node_modules` stays hardlink-free and survives `COPY --from=deps`.
- `# syntax=docker/dockerfile:1.6` directive to guarantee BuildKit cache-mount support.
- Before: every dep change duplicated 235 packages into a new layer. After: cache persists between builds, layers stay small.

**3. Deploy script (`scripts/deploy-staging.sh`)**
- Unconditional prune (dropped `--filter "until=72h"`) — keeps each deploy's working set lean; the daemon-level cap handles steady-state.
- Early warning when the Docker data volume exceeds 80% usage.

## Why three layers

- (1) is the fundamental guarantee: the daemon itself enforces the budget.
- (2) reduces cache growth rate so (1) rarely has to GC.
- (3) is belt-and-suspenders and gives us a warning signal before the next ENOSPC.

## Test plan

- [x] `docker_gc` step runs on staging, writes daemon.json, restarts daemon.
- [x] Step is idempotent — rerun prints `ALREADY_CONFIGURED`.
- [x] All services (`caddy`, `platform-ui`, `agent-worker`, `stunnel`, `redis`) up after daemon restart.
- [x] `--only-step` dry-run works (`--dry-run`).
- [ ] Next staging deploy (triggered by merge) completes successfully with Dockerfile cache mounts.
- [ ] Build cache stays under 20 GB after several deploys (monitor `docker system df` on staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)