### PR TITLE
docs: knowledge base (LLM Wiki pattern) + initial ingest of 38 pages

### DIFF
--- a/.claude/skills/knowledge-base
+++ b/.claude/skills/knowledge-base
@@ -1,0 +1,1 @@
+../../skills/knowledge-base

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ minutes/*.html
 # claude
 .claude/settings.local.json
 memory/
+CLAUDE.local.md
 
 # env
 .env.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,18 +143,19 @@ Testing strategies:
 1. `pnpm typecheck`
 2. `pnpm test:affected` — tests for changed files only
 3. `pnpm test` — all unit tests
+4. **Knowledge base** — if the change matches a wiki trigger (architectural change, gotcha discovered, decision made, multi-source synthesis), update `docs/knowledge-base/wiki/` via `/knowledge-base`. See the [Knowledge Base section](#knowledge-base) for full triggers.
 
 **Before pushing (if UI or E2E tests changed):**
-4. Check if any `packages/platform-ui/src/` or `e2e/journeys/` files changed:
+5. Check if any `packages/platform-ui/src/` or `e2e/journeys/` files changed:
    ```bash
    git diff --name-only origin/main...HEAD | grep -qE 'platform-ui/src/|e2e/journeys/' && echo "E2E needed"
    ```
-5. **Bootstrap the E2E environment** (idempotent — safe to run every time):
+6. **Bootstrap the E2E environment** (idempotent — safe to run every time):
    ```bash
    python3 packages/platform-ui/scripts/bootstrap_e2e.py
    ```
    This creates `.env.local` with demo credentials, starts Firebase emulators, installs Playwright browsers, and installs ffmpeg. See [Remote E2E setup](#remote-e2e-setup) for details.
-6. `cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth` — all E2E journey + smoke tests (60s)
+7. `cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth` — all E2E journey + smoke tests (60s)
 
 **When adding/modifying UI features (TDD):**
 1. **RED** — Write the journey test first in `e2e/journeys/<feature>.journey.ts`. Use `showStep`/`showResult` from `helpers/recording.ts` at key moments for pacing during recordings.
@@ -274,6 +275,31 @@ The `skills/_registry.yml` indexes development skills. Runtime skills have per-a
 - `cp packages/platform-ui/.env.local.example packages/platform-ui/.env.local` and fill Firebase + OpenRouter keys
 - Deploys via Firebase App Hosting (`apphosting.yaml`)
 
+## Knowledge Base
+
+The repo maintains an LLM-compiled wiki at `docs/knowledge-base/wiki/` following the [LLM Wiki pattern](docs/knowledge-base/LLM-WIKI.md) (Karpathy, April 2026). The Mediforce-specific schema — raw-source locations, page types, frontmatter, ingest/query/lint flows — lives in [`docs/knowledge-base/SCHEMA.md`](docs/knowledge-base/SCHEMA.md). **Read `SCHEMA.md` before touching the wiki.**
+
+The wiki is an architectural artifact, not notes. Treat it like production code: every claim has a citation, every cross-reference is checked, every page has frontmatter.
+
+**Agents MUST update the wiki after:**
+- A non-trivial architectural change (new plugin, package, moved boundary) → update the entity page.
+- Discovering a gotcha (>15 min chasing something non-obvious) → add `wiki/gotchas/<slug>.md`.
+- A lasting decision (library pick, pattern change, "we chose not to do X") → add `wiki/decisions/YYYY-MM-DD-<slug>.md`.
+- A synthesis answer pulled from ≥2 sources → file under `wiki/syntheses/` (file-back rule).
+
+**Agents MUST consult the wiki before:**
+- Answering "how does X work / why did we choose Y" questions — read `wiki/index.md` first.
+- Starting work in an unfamiliar package — check `wiki/entities/packages/<pkg>.md`.
+- Making a decision that echoes a previous one — grep `wiki/decisions/`.
+
+If the wiki has nothing on the topic, that's a signal to file new knowledge once the work is done.
+
+**Lint the wiki:**
+- Before pushing any PR that touches `docs/knowledge-base/wiki/` pages — run `/knowledge-base lint`.
+- Weekly (at minimum) on the whole wiki.
+
+Use the [`knowledge-base` skill](skills/knowledge-base/SKILL.md) for all wiki operations: `/knowledge-base ingest <src>`, `/knowledge-base query <q>`, `/knowledge-base file <topic>`, `/knowledge-base lint`.
+
 ## Skills Router
 
 When a task matches one of these, invoke the skill before starting work:
@@ -286,6 +312,7 @@ When a task matches one of these, invoke the skill before starting work:
 | Review a Renovate dependency PR | `/renovate-review` → `skills/renovate-review/SKILL.md` |
 | Write a Discord community update | `/community` → `skills/community/SKILL.md` |
 | Generate a pitch deck | `/generate-pitch` → `skills/generate-pitch/SKILL.md` |
+| Ingest/query/lint the knowledge base | `/knowledge-base` → `skills/knowledge-base/SKILL.md` |
 
 ## Core Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,19 +143,18 @@ Testing strategies:
 1. `pnpm typecheck`
 2. `pnpm test:affected` — tests for changed files only
 3. `pnpm test` — all unit tests
-4. **Knowledge base** — if the change matches a wiki trigger (architectural change, gotcha discovered, decision made, multi-source synthesis), update `docs/knowledge-base/wiki/` via `/knowledge-base`. See the [Knowledge Base section](#knowledge-base) for full triggers.
 
 **Before pushing (if UI or E2E tests changed):**
-5. Check if any `packages/platform-ui/src/` or `e2e/journeys/` files changed:
+4. Check if any `packages/platform-ui/src/` or `e2e/journeys/` files changed:
    ```bash
    git diff --name-only origin/main...HEAD | grep -qE 'platform-ui/src/|e2e/journeys/' && echo "E2E needed"
    ```
-6. **Bootstrap the E2E environment** (idempotent — safe to run every time):
+5. **Bootstrap the E2E environment** (idempotent — safe to run every time):
    ```bash
    python3 packages/platform-ui/scripts/bootstrap_e2e.py
    ```
    This creates `.env.local` with demo credentials, starts Firebase emulators, installs Playwright browsers, and installs ffmpeg. See [Remote E2E setup](#remote-e2e-setup) for details.
-7. `cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth` — all E2E journey + smoke tests (60s)
+6. `cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth` — all E2E journey + smoke tests (60s)
 
 **When adding/modifying UI features (TDD):**
 1. **RED** — Write the journey test first in `e2e/journeys/<feature>.journey.ts`. Use `showStep`/`showResult` from `helpers/recording.ts` at key moments for pacing during recordings.
@@ -275,31 +274,6 @@ The `skills/_registry.yml` indexes development skills. Runtime skills have per-a
 - `cp packages/platform-ui/.env.local.example packages/platform-ui/.env.local` and fill Firebase + OpenRouter keys
 - Deploys via Firebase App Hosting (`apphosting.yaml`)
 
-## Knowledge Base
-
-The repo maintains an LLM-compiled wiki at `docs/knowledge-base/wiki/` following the [LLM Wiki pattern](docs/knowledge-base/LLM-WIKI.md) (Karpathy, April 2026). The Mediforce-specific schema — raw-source locations, page types, frontmatter, ingest/query/lint flows — lives in [`docs/knowledge-base/SCHEMA.md`](docs/knowledge-base/SCHEMA.md). **Read `SCHEMA.md` before touching the wiki.**
-
-The wiki is an architectural artifact, not notes. Treat it like production code: every claim has a citation, every cross-reference is checked, every page has frontmatter.
-
-**Agents MUST update the wiki after:**
-- A non-trivial architectural change (new plugin, package, moved boundary) → update the entity page.
-- Discovering a gotcha (>15 min chasing something non-obvious) → add `wiki/gotchas/<slug>.md`.
-- A lasting decision (library pick, pattern change, "we chose not to do X") → add `wiki/decisions/YYYY-MM-DD-<slug>.md`.
-- A synthesis answer pulled from ≥2 sources → file under `wiki/syntheses/` (file-back rule).
-
-**Agents MUST consult the wiki before:**
-- Answering "how does X work / why did we choose Y" questions — read `wiki/index.md` first.
-- Starting work in an unfamiliar package — check `wiki/entities/packages/<pkg>.md`.
-- Making a decision that echoes a previous one — grep `wiki/decisions/`.
-
-If the wiki has nothing on the topic, that's a signal to file new knowledge once the work is done.
-
-**Lint the wiki:**
-- Before pushing any PR that touches `docs/knowledge-base/wiki/` pages — run `/knowledge-base lint`.
-- Weekly (at minimum) on the whole wiki.
-
-Use the [`knowledge-base` skill](skills/knowledge-base/SKILL.md) for all wiki operations: `/knowledge-base ingest <src>`, `/knowledge-base query <q>`, `/knowledge-base file <topic>`, `/knowledge-base lint`.
-
 ## Skills Router
 
 When a task matches one of these, invoke the skill before starting work:
@@ -312,7 +286,6 @@ When a task matches one of these, invoke the skill before starting work:
 | Review a Renovate dependency PR | `/renovate-review` → `skills/renovate-review/SKILL.md` |
 | Write a Discord community update | `/community` → `skills/community/SKILL.md` |
 | Generate a pitch deck | `/generate-pitch` → `skills/generate-pitch/SKILL.md` |
-| Ingest/query/lint the knowledge base | `/knowledge-base` → `skills/knowledge-base/SKILL.md` |
 
 ## Core Principles
 

--- a/docs/knowledge-base/LLM-WIKI.md
+++ b/docs/knowledge-base/LLM-WIKI.md
@@ -1,0 +1,77 @@
+# LLM Wiki
+
+> **Source**: Andrej Karpathy's [llm-wiki.md gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) (April 2026, improved version). Included verbatim. This is the abstract pattern. For the Mediforce-specific instantiation (raw-source locations, page types, conventions, ingest/query/lint workflows for this repo), see [`SCHEMA.md`](./SCHEMA.md).
+
+A pattern for building personal knowledge bases using LLMs.
+
+This is an idea file, it is designed to be copy pasted to your own LLM Agent (e.g. OpenAI Codex, Claude Code, OpenCode / Pi, or etc.). Its goal is to communicate the high level idea, but your agent will build out the specifics in collaboration with you.
+
+## The core idea
+
+Most people's experience with LLMs and documents looks like RAG: you upload a collection of files, the LLM retrieves relevant chunks at query time, and generates an answer. This works, but the LLM is rediscovering knowledge from scratch on every question. There's no accumulation. Ask a subtle question that requires synthesizing five documents, and the LLM has to find and piece together the relevant fragments every time. Nothing is built up. NotebookLM, ChatGPT file uploads, and most RAG systems work this way.
+
+The idea here is different. Instead of just retrieving from raw documents at query time, the LLM **incrementally builds and maintains a persistent wiki** — a structured, interlinked collection of markdown files that sits between you and the raw sources. When you add a new source, the LLM doesn't just index it for later retrieval. It reads it, extracts the key information, and integrates it into the existing wiki — updating entity pages, revising topic summaries, noting where new data contradicts old claims, strengthening or challenging the evolving synthesis. The knowledge is compiled once and then *kept current*, not re-derived on every query.
+
+This is the key difference: **the wiki is a persistent, compounding artifact.** The cross-references are already there. The contradictions have already been flagged. The synthesis already reflects everything you've read. The wiki keeps getting richer with every source you add and every question you ask.
+
+You never (or rarely) write the wiki yourself — the LLM writes and maintains all of it. You're in charge of sourcing, exploration, and asking the right questions. The LLM does all the grunt work — the summarizing, cross-referencing, filing, and bookkeeping that makes a knowledge base actually useful over time. In practice, I have the LLM agent open on one side and Obsidian open on the other. The LLM makes edits based on our conversation, and I browse the results in real time — following links, checking the graph view, reading the updated pages. Obsidian is the IDE; the LLM is the programmer; the wiki is the codebase.
+
+This can apply to a lot of different contexts. A few examples:
+
+- **Personal**: tracking your own goals, health, psychology, self-improvement — filing journal entries, articles, podcast notes, and building up a structured picture of yourself over time.
+- **Research**: going deep on a topic over weeks or months — reading papers, articles, reports, and incrementally building a comprehensive wiki with an evolving thesis.
+- **Reading a book**: filing each chapter as you go, building out pages for characters, themes, plot threads, and how they connect. By the end you have a rich companion wiki. Think of fan wikis like [Tolkien Gateway](https://tolkiengateway.net/wiki/Main_Page) — thousands of interlinked pages covering characters, places, events, languages, built by a community of volunteers over years. You could build something like that personally as you read, with the LLM doing all the cross-referencing and maintenance.
+- **Business/team**: an internal wiki maintained by LLMs, fed by Slack threads, meeting transcripts, project documents, customer calls. Possibly with humans in the loop reviewing updates. The wiki stays current because the LLM does the maintenance that no one on the team wants to do.
+- **Competitive analysis, due diligence, trip planning, course notes, hobby deep-dives** — anything where you're accumulating knowledge over time and want it organized rather than scattered.
+
+## Architecture
+
+There are three layers:
+
+**Raw sources** — your curated collection of source documents. Articles, papers, images, data files. These are immutable — the LLM reads from them but never modifies them. This is your source of truth.
+
+**The wiki** — a directory of LLM-generated markdown files. Summaries, entity pages, concept pages, comparisons, an overview, a synthesis. The LLM owns this layer entirely. It creates pages, updates them when new sources arrive, maintains cross-references, and keeps everything consistent. You read it; the LLM writes it.
+
+**The schema** — a document (e.g. CLAUDE.md for Claude Code or AGENTS.md for Codex) that tells the LLM how the wiki is structured, what the conventions are, and what workflows to follow when ingesting sources, answering questions, or maintaining the wiki. This is the key configuration file — it's what makes the LLM a disciplined wiki maintainer rather than a generic chatbot. You and the LLM co-evolve this over time as you figure out what works for your domain.
+
+## Operations
+
+**Ingest.** You drop a new source into the raw collection and tell the LLM to process it. An example flow: the LLM reads the source, discusses key takeaways with you, writes a summary page in the wiki, updates the index, updates relevant entity and concept pages across the wiki, and appends an entry to the log. A single source might touch 10-15 wiki pages. Personally I prefer to ingest sources one at a time and stay involved — I read the summaries, check the updates, and guide the LLM on what to emphasize. But you could also batch-ingest many sources at once with less supervision. It's up to you to develop the workflow that fits your style and document it in the schema for future sessions.
+
+**Query.** You ask questions against the wiki. The LLM searches for relevant pages, reads them, and synthesizes an answer with citations. Answers can take different forms depending on the question — a markdown page, a comparison table, a slide deck (Marp), a chart (matplotlib), a canvas. The important insight: **good answers can be filed back into the wiki as new pages.** A comparison you asked for, an analysis, a connection you discovered — these are valuable and shouldn't disappear into chat history. This way your explorations compound in the knowledge base just like ingested sources do.
+
+**Lint.** Periodically, ask the LLM to health-check the wiki. Look for: contradictions between pages, stale claims that newer sources have superseded, orphan pages with no inbound links, important concepts mentioned but lacking their own page, missing cross-references, data gaps that could be filled with a web search. The LLM is good at suggesting new questions to investigate and new sources to look for. This keeps the wiki healthy as it grows.
+
+## Indexing and logging
+
+Two special files help the LLM (and you) navigate the wiki as it grows. They serve different purposes:
+
+**index.md** is content-oriented. It's a catalog of everything in the wiki — each page listed with a link, a one-line summary, and optionally metadata like date or source count. Organized by category (entities, concepts, sources, etc.). The LLM updates it on every ingest. When answering a query, the LLM reads the index first to find relevant pages, then drills into them. This works surprisingly well at moderate scale (~100 sources, ~hundreds of pages) and avoids the need for embedding-based RAG infrastructure.
+
+**log.md** is chronological. It's an append-only record of what happened and when — ingests, queries, lint passes. A useful tip: if each entry starts with a consistent prefix (e.g. `## [2026-04-02] ingest | Article Title`), the log becomes parseable with simple unix tools — `grep "^## \[" log.md | tail -5` gives you the last 5 entries. The log gives you a timeline of the wiki's evolution and helps the LLM understand what's been done recently.
+
+## Optional: CLI tools
+
+At some point you may want to build small tools that help the LLM operate on the wiki more efficiently. A search engine over the wiki pages is the most obvious one — at small scale the index file is enough, but as the wiki grows you want proper search. [qmd](https://github.com/tobi/qmd) is a good option: it's a local search engine for markdown files with hybrid BM25/vector search and LLM re-ranking, all on-device. It has both a CLI (so the LLM can shell out to it) and an MCP server (so the LLM can use it as a native tool). You could also build something simpler yourself — the LLM can help you vibe-code a naive search script as the need arises.
+
+## Tips and tricks
+
+- **Obsidian Web Clipper** is a browser extension that converts web articles to markdown. Very useful for quickly getting sources into your raw collection.
+- **Download images locally.** In Obsidian Settings → Files and links, set "Attachment folder path" to a fixed directory (e.g. `raw/assets/`). Then in Settings → Hotkeys, search for "Download" to find "Download attachments for current file" and bind it to a hotkey (e.g. Ctrl+Shift+D). After clipping an article, hit the hotkey and all images get downloaded to local disk. This is optional but useful — it lets the LLM view and reference images directly instead of relying on URLs that may break. Note that LLMs can't natively read markdown with inline images in one pass — the workaround is to have the LLM read the text first, then view some or all of the referenced images separately to gain additional context. It's a bit clunky but works well enough.
+- **Obsidian's graph view** is the best way to see the shape of your wiki — what's connected to what, which pages are hubs, which are orphans.
+- **Marp** is a markdown-based slide deck format. Obsidian has a plugin for it. Useful for generating presentations directly from wiki content.
+- **Dataview** is an Obsidian plugin that runs queries over page frontmatter. If your LLM adds YAML frontmatter to wiki pages (tags, dates, source counts), Dataview can generate dynamic tables and lists.
+- The wiki is just a git repo of markdown files. You get version history, branching, and collaboration for free.
+
+## Why this works
+
+The tedious part of maintaining a knowledge base is not the reading or the thinking — it's the bookkeeping. Updating cross-references, keeping summaries current, noting when new data contradicts old claims, maintaining consistency across dozens of pages. Humans abandon wikis because the maintenance burden grows faster than the value. LLMs don't get bored, don't forget to update a cross-reference, and can touch 15 files in one pass. The wiki stays maintained because the cost of maintenance is near zero.
+
+The human's job is to curate sources, direct the analysis, ask good questions, and think about what it all means. The LLM's job is everything else.
+
+The idea is related in spirit to Vannevar Bush's Memex (1945) — a personal, curated knowledge store with associative trails between documents. Bush's vision was closer to this than to what the web became: private, actively curated, with the connections between documents as valuable as the documents themselves. The part he couldn't solve was who does the maintenance. The LLM handles that.
+
+
+## Note
+
+This document is intentionally abstract. It describes the idea, not a specific implementation. The exact directory structure, the schema conventions, the page formats, the tooling — all of that will depend on your domain, your preferences, and your LLM of choice. Everything mentioned above is optional and modular — pick what's useful, ignore what isn't. For example: your sources might be text-only, so you don't need image handling at all. Your wiki might be small enough that the index file is all you need, no search engine required. You might not care about slide decks and just want markdown pages. You might want a completely different set of output formats. The right way to use this is to share it with your LLM agent and work together to instantiate a version that fits your needs. The document's only job is to communicate the pattern. Your LLM can figure out the rest.

--- a/docs/knowledge-base/SCHEMA.md
+++ b/docs/knowledge-base/SCHEMA.md
@@ -1,0 +1,174 @@
+# Mediforce Knowledge Base — Schema
+
+This is the Mediforce-specific instantiation of the [LLM Wiki pattern](./LLM-WIKI.md). It tells agents **where the raw sources live**, **what pages to write**, **what conventions to follow**, and **when to run ingest/query/lint**. Agents are expected to consult this schema before touching the wiki.
+
+The abstract pattern is in `LLM-WIKI.md` (Karpathy). This file is the concrete contract for this repo.
+
+## Layout
+
+```
+docs/knowledge-base/
+  LLM-WIKI.md          # abstract pattern (immutable — Karpathy verbatim)
+  SCHEMA.md            # this file — conventions for our repo
+  wiki/                # LLM-maintained wiki (agent owns this directory)
+    index.md           # catalog of every wiki page, grouped by category
+    log.md             # append-only chronological log (ingest/query/lint)
+    entities/          # one page per package, agent, plugin, workflow def
+    concepts/          # architectural patterns, domain concepts (CDISC, RECIST, autonomy)
+    decisions/         # ADR-style decision records
+    gotchas/           # non-obvious invariants, footguns, workarounds
+    syntheses/         # answers filed back from chat (comparisons, analyses)
+```
+
+Agents MUST NOT write anywhere outside `docs/knowledge-base/wiki/` as part of a wiki operation. Other repo files are **raw sources** and are immutable from the wiki's perspective.
+
+## Raw sources (immutable)
+
+What agents ingest from, but never modify during wiki ops:
+
+| Source | Where | Notes |
+|--------|-------|-------|
+| Project docs | `docs/*.md`, `docs/design/`, `docs/features/` | architecture, vision, E2E strategy |
+| Agents contract | `AGENTS.md`, `CLAUDE.md` | repo-level instructions |
+| Package READMEs | `packages/*/README.md`, `apps/*/README.md` | per-package docs |
+| Source code | `packages/*/src/`, `apps/*/` | read for entity pages; do not summarise line-by-line |
+| Workflow definitions | `**/*.wd.json` | plugin + step config |
+| Schemas | `packages/platform-core/src/schemas/` | Zod schemas — authoritative domain model |
+| Git history | `git log`, commit messages | decisions, rationale |
+| Pull requests | GitHub `appsilon/mediforce` | discussion, review context |
+| External refs | pharma standards (CDISC SDTM/ADaM, ICH-GCP, RECIST), tool docs | link by URL; snapshot key quotes |
+
+Agent ingest rule: **cite the source path or URL on every wiki page.** No page without citations.
+
+## Page types
+
+Each wiki page lives in one of these buckets. If a page doesn't fit, propose a new bucket in the log before adding it.
+
+### `entities/`
+One page per concrete named thing in the repo. Filename = slug of the entity.
+
+- `entities/packages/platform-core.md`, `entities/packages/workflow-engine.md`, …
+- `entities/plugins/claude-code-agent.md`, `entities/plugins/script-container.md`, …
+- `entities/workflows/<workflow-id>.md`
+- `entities/apps/supply-intelligence.md`
+
+Required sections: Purpose · Dependencies · Key exports / surface · Relationships (links to other entities/concepts) · Sources.
+
+### `concepts/`
+Architectural patterns and domain ideas. Filename = concept slug.
+
+- `concepts/repository-pattern.md`
+- `concepts/plugin-dispatch.md`
+- `concepts/autonomy-levels.md` (L0–L4)
+- `concepts/dual-schema-migration.md`
+- `concepts/cdisc-sdtm.md`, `concepts/ctcae-grading.md`, `concepts/recist-v1-1.md`
+
+Required sections: Definition (one paragraph) · How it shows up in the codebase · Links to entities that use it · Sources.
+
+### `decisions/`
+ADR-style records. Filename: `YYYY-MM-DD-slug.md`.
+
+Required sections: Context · Decision · Consequences · Alternatives considered · Sources (PRs, commits, discussions).
+
+### `gotchas/`
+Non-obvious things that have burned us. Filename: `<slug>.md`.
+
+Required sections: Symptom · Cause · Fix / workaround · How to avoid next time · Sources.
+
+### `syntheses/`
+Answers filed back from conversations — comparisons, deep-dives, investigations. Filename: `YYYY-MM-DD-slug.md`.
+
+Required sections: Question · Answer · Sources (including the chat context that triggered it, if useful).
+
+## Conventions
+
+- **Language**: English only (matches `AGENTS.md`).
+- **Frontmatter**: every wiki page starts with YAML frontmatter:
+  ```yaml
+  ---
+  type: entity | concept | decision | gotcha | synthesis
+  created: 2026-04-23
+  updated: 2026-04-23
+  sources: 3      # count of raw sources referenced
+  tags: [workflow-engine, plugin-system]
+  ---
+  ```
+- **Top line**: after frontmatter, one-sentence summary in bold. The index pulls this verbatim.
+- **Cross-references**: use relative markdown links (`[workflow-engine](../entities/packages/workflow-engine.md)`). No wikilinks — they don't render on GitHub.
+- **Sources section**: every page ends with `## Sources` listing raw paths, PR/commit SHAs, and external URLs. No hand-waving; if a claim has no source, it doesn't belong on the page.
+- **Contradictions**: when a new source contradicts an existing page, do not silently overwrite. Add a `> [!note]` callout inline explaining the contradiction and flag it in the log.
+- **No inline ADR-style prose in entities**: if a decision matters, link to a `decisions/` page.
+- **Filenames**: lowercase kebab-case.
+- **No emojis** in wiki content (matches repo-wide convention).
+
+## Pharma domain note
+
+This codebase processes pharmaceutical/clinical-trial data. Terms like "adverse event", "Grade 5", "hepatotoxicity", "mortality endpoint" are **technical domain content** (CDISC variables, CTCAE grading, RECIST criteria). Treat them as code-identifiers. No wellbeing framing — see `AGENTS.md` → "Pharma Domain Context".
+
+## Operations
+
+### Ingest
+
+Trigger: a new raw source appears that's worth compiling (significant doc, new package, merged PR that changes architecture, external article the user shares).
+
+Flow:
+1. Read the source end-to-end.
+2. Identify which existing wiki pages it touches (read `wiki/index.md`, follow links).
+3. For each affected entity/concept page: update inline, preserving existing sources.
+4. If the source introduces a new entity/concept/decision/gotcha: create the page.
+5. Update `wiki/index.md` (add new entries, bump counts).
+6. Append an entry to `wiki/log.md`:
+   ```
+   ## [YYYY-MM-DD] ingest | <source title or path>
+   touched: <list of wiki pages>
+   summary: <one line>
+   ```
+7. Report to the user what changed.
+
+Default is **one source at a time**. Batch ingest only when explicitly requested.
+
+### Query
+
+Trigger: the user asks a "how does X work / what is Y / why did we choose Z" question, OR an agent needs background before starting work.
+
+Flow:
+1. Read `wiki/index.md` first.
+2. Open the relevant pages and their linked pages.
+3. Answer with citations back to wiki pages (and through them, to raw sources).
+4. **File-back rule**: if the question took non-trivial synthesis (pulling from 2+ pages, writing a comparison, investigating), file the answer as a `syntheses/` page and link it from the index. Add a log entry.
+
+### Lint
+
+Trigger: before pushing a PR that touched `wiki/` pages, plus a scheduled pass at least once per week.
+
+Checks:
+- **Contradictions** between pages (search for the same entity/concept described differently).
+- **Stale claims** — a page references code that no longer exists (grep the paths/symbols it cites).
+- **Orphans** — pages with no inbound links from other wiki pages or `index.md`.
+- **Missing pages** — concepts/entities referenced in text but without their own page.
+- **Broken cross-references** — relative links that no longer resolve.
+- **Stale frontmatter** — `updated` field older than the last substantive edit.
+- **Source rot** — external URLs that return 4xx/5xx (spot-check with curl).
+
+Output: a single markdown report to the user + an entry in `log.md`. Fixes go in the same PR if trivial; otherwise file them as TODOs at the top of `index.md`.
+
+## When agents MUST update the wiki
+
+These are hard triggers, not suggestions:
+
+- **After a non-trivial architectural change** (new plugin, new package, moved boundary between packages, swapped infra layer) → update the corresponding entity page + append log.
+- **After discovering a gotcha** (time spent >15 min chasing something non-obvious) → add `gotchas/<slug>.md`.
+- **After a decision with lasting impact** (picking a library, picking a pattern, deciding not to do something) → add `decisions/YYYY-MM-DD-slug.md`.
+- **After a synthesis answer** the user asked that required pulling from multiple sources → file under `syntheses/`.
+
+## When agents MUST consult the wiki
+
+- **Before answering architecture/"how does X work" questions** — read `wiki/index.md` first.
+- **Before starting work in an unfamiliar package** — check its `entities/packages/*.md` page.
+- **Before making a decision that smells similar to a past one** — grep `decisions/` for the topic.
+
+If the wiki has nothing on the topic, that's itself a signal: once the work is done, file the resulting knowledge.
+
+## Scale
+
+Current scale is small (bootstrap). At ~100 pages, revisit: may want per-category sub-indexes, and possibly a search tool (e.g. `qmd`). Until then, `index.md` is sufficient.

--- a/docs/knowledge-base/SCHEMA.md
+++ b/docs/knowledge-base/SCHEMA.md
@@ -101,6 +101,41 @@ Required sections: Question · Answer · Sources (including the chat context tha
 - **Filenames**: lowercase kebab-case.
 - **No emojis** in wiki content (matches repo-wide convention).
 
+## Writing style: caveman
+
+Wiki prose uses caveman style — terse, fragments, dropped articles. Roughly 60–75% fewer output tokens than full prose with same technical substance. Optimised for agents reading the wiki in-session, where every wasted token costs context budget.
+
+**Canonical always-on prompt** (from [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) — the viral Claude-Code plugin, April 2026):
+
+```
+Terse like caveman. Technical substance exact. Only fluff die.
+Drop: articles, filler (just/really/basically), pleasantries, hedging.
+Fragments OK. Short synonyms. Code unchanged.
+Pattern: [thing] [action] [reason]. [next step].
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift.
+Code/commits/PRs: normal. Off: "stop caveman" / "normal mode".
+```
+
+**Intensity levels** (pick one per page type):
+
+| Level | Use for | Example |
+|-------|---------|---------|
+| **Lite** | decisions, syntheses — reasoning needs connective tissue | "Picked Firestore over Supabase because the team already runs Firebase." |
+| **Full** (default) | entities, concepts, gotchas | "Firestore over Supabase. Team already runs Firebase. Less ops." |
+| **Ultra** | tables, cross-reference lists, index entries | "Firestore > Supabase. Team on Firebase. Less ops." |
+
+**Passthrough untouched** (never compress these — substance, not prose):
+- frontmatter YAML
+- code blocks, shell commands, file paths
+- URLs, external references
+- Zod / symbol / variable names
+- section headers
+- numbers, dates, version strings
+
+**Caveman applies to the *body prose* only.** Tables, lists, and typed examples are already compressed by form — caveman rarely helps there.
+
+**When to break the rule**: when terseness breaks comprehension. A reader (human or agent) who can't parse a fragment is the failure mode — if the prose needs an article or a connective to be unambiguous, keep it.
+
 ## Pharma domain note
 
 This codebase processes pharmaceutical/clinical-trial data. Terms like "adverse event", "Grade 5", "hepatotoxicity", "mortality endpoint" are **technical domain content** (CDISC variables, CTCAE grading, RECIST criteria). Treat them as code-identifiers. No wellbeing framing — see `AGENTS.md` → "Pharma Domain Context".

--- a/docs/knowledge-base/SCHEMA.md
+++ b/docs/knowledge-base/SCHEMA.md
@@ -1,209 +1,93 @@
 # Mediforce Knowledge Base — Schema
 
-This is the Mediforce-specific instantiation of the [LLM Wiki pattern](./LLM-WIKI.md). It tells agents **where the raw sources live**, **what pages to write**, **what conventions to follow**, and **when to run ingest/query/lint**. Agents are expected to consult this schema before touching the wiki.
-
-The abstract pattern is in `LLM-WIKI.md` (Karpathy). This file is the concrete contract for this repo.
+Concrete instantiation of the abstract [LLM Wiki pattern](./LLM-WIKI.md) (Karpathy). Pairs with [`STYLE.md`](./STYLE.md) (caveman) + the `/knowledge-base` skill (`skills/knowledge-base/SKILL.md` — operations: ingest, query, file, lint). Read all three before touching the wiki.
 
 ## Layout
 
 ```
 docs/knowledge-base/
-  LLM-WIKI.md          # abstract pattern (immutable — Karpathy verbatim)
-  SCHEMA.md            # this file — conventions for our repo
-  wiki/                # LLM-maintained wiki (agent owns this directory)
-    index.md           # catalog of every wiki page, grouped by category
-    log.md             # append-only chronological log (ingest/query/lint)
-    entities/          # one page per package, agent, plugin, workflow def
-    concepts/          # architectural patterns, domain concepts (CDISC, RECIST, autonomy)
-    decisions/         # ADR-style decision records
-    gotchas/           # non-obvious invariants, footguns, workarounds
-    syntheses/         # answers filed back from chat (comparisons, analyses)
+  LLM-WIKI.md   # abstract pattern (Karpathy, verbatim, immutable)
+  SCHEMA.md     # this file — what/where/how for our repo
+  STYLE.md      # caveman writing rules
+  wiki/
+    index.md    # catalog; read first on every query
+    log.md      # append-only (bootstrap / ingest / file-back / lint)
+    entities/   # packages, plugins, apps, workflows
+    concepts/   # patterns, architectural ideas, domain standards
+    decisions/  # ADR-style, write-once
+    gotchas/    # footguns, non-obvious invariants, "already exists" traps
+    syntheses/  # filed-back answers from chats
 ```
 
-Agents MUST NOT write anywhere outside `docs/knowledge-base/wiki/` as part of a wiki operation. Other repo files are **raw sources** and are immutable from the wiki's perspective.
+Wiki ops write only inside `wiki/`. Everything else = raw source.
 
-## Raw sources (immutable)
+## Raw sources (immutable during wiki ops)
 
-What agents ingest from, but never modify during wiki ops:
+| Source | Where |
+|--------|-------|
+| Project docs | `docs/*.md`, `docs/design/`, `docs/features/` |
+| Agents contract | `AGENTS.md`, `CLAUDE.md` |
+| Package READMEs | `packages/*/README.md`, `apps/*/README.md` |
+| Source code | `packages/*/src/`, `apps/*/` |
+| Workflow defs | `**/*.wd.json` |
+| Zod schemas | `packages/platform-core/src/schemas/` |
+| Git history | commits, PR descriptions |
+| External refs | pharma standards (CDISC, ICH-GCP, RECIST), tool docs |
 
-| Source | Where | Notes |
-|--------|-------|-------|
-| Project docs | `docs/*.md`, `docs/design/`, `docs/features/` | architecture, vision, E2E strategy |
-| Agents contract | `AGENTS.md`, `CLAUDE.md` | repo-level instructions |
-| Package READMEs | `packages/*/README.md`, `apps/*/README.md` | per-package docs |
-| Source code | `packages/*/src/`, `apps/*/` | read for entity pages; do not summarise line-by-line |
-| Workflow definitions | `**/*.wd.json` | plugin + step config |
-| Schemas | `packages/platform-core/src/schemas/` | Zod schemas — authoritative domain model |
-| Git history | `git log`, commit messages | decisions, rationale |
-| Pull requests | GitHub `appsilon/mediforce` | discussion, review context |
-| External refs | pharma standards (CDISC SDTM/ADaM, ICH-GCP, RECIST), tool docs | link by URL; snapshot key quotes |
+Every wiki page cites its sources. No page without citations.
 
-Agent ingest rule: **cite the source path or URL on every wiki page.** No page without citations.
+## Page buckets
 
-## Page types
+| Bucket | Filename | Holds |
+|--------|----------|-------|
+| `entities/` | `<category>/<slug>.md` (e.g. `packages/platform-ui.md`) | concrete named things: packages, plugins, apps, workflows |
+| `concepts/` | `<slug>.md` | architectural patterns + domain standards (CDISC, CTCAE, RECIST, autonomy-levels, plugin-dispatch, …) |
+| `decisions/` | `YYYY-MM-DD-<slug>.md` | ADR-style, write-once |
+| `gotchas/` | `<slug>.md` | footguns, "already exists" traps, non-obvious invariants |
+| `syntheses/` | `YYYY-MM-DD-<slug>.md` | file-back answers from chats |
 
-Each wiki page lives in one of these buckets. If a page doesn't fit, propose a new bucket in the log before adding it.
+Section shape: look at existing pages in each bucket — agents learn from examples, not from rules. If a page doesn't fit any bucket, propose a new one in `log.md` before filing.
 
-### `entities/`
-One page per concrete named thing in the repo. Filename = slug of the entity.
+## Frontmatter
 
-- `entities/packages/platform-core.md`, `entities/packages/workflow-engine.md`, …
-- `entities/plugins/claude-code-agent.md`, `entities/plugins/script-container.md`, …
-- `entities/workflows/<workflow-id>.md`
-- `entities/apps/supply-intelligence.md`
+Every page starts with:
 
-Required sections: Purpose · Dependencies · Key exports / surface · Relationships (links to other entities/concepts) · Sources.
+```yaml
+---
+type: entity | concept | decision | gotcha | synthesis
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+sources: <count of raw sources referenced>
+tags: [workflow-engine, plugin-system]
+---
+```
 
-### `concepts/`
-Architectural patterns and domain ideas. Filename = concept slug.
-
-- `concepts/repository-pattern.md`
-- `concepts/plugin-dispatch.md`
-- `concepts/autonomy-levels.md` (L0–L4)
-- `concepts/dual-schema-migration.md`
-- `concepts/cdisc-sdtm.md`, `concepts/ctcae-grading.md`, `concepts/recist-v1-1.md`
-
-Required sections: Definition (one paragraph) · How it shows up in the codebase · Links to entities that use it · Sources.
-
-### `decisions/`
-ADR-style records. Filename: `YYYY-MM-DD-slug.md`.
-
-Required sections: Context · Decision · Consequences · Alternatives considered · Sources (PRs, commits, discussions).
-
-### `gotchas/`
-Non-obvious things that have burned us. Filename: `<slug>.md`.
-
-Required sections: Symptom · Cause · Fix / workaround · How to avoid next time · Sources.
-
-### `syntheses/`
-Answers filed back from conversations — comparisons, deep-dives, investigations. Filename: `YYYY-MM-DD-slug.md`.
-
-Required sections: Question · Answer · Sources (including the chat context that triggered it, if useful).
+Then: one-sentence **bold summary** (used verbatim in `index.md`). Then sections. Last section always `## Sources` listing raw paths / commit SHAs / URLs.
 
 ## Conventions
 
-- **Language**: English only (matches `AGENTS.md`).
-- **Frontmatter**: every wiki page starts with YAML frontmatter:
-  ```yaml
-  ---
-  type: entity | concept | decision | gotcha | synthesis
-  created: 2026-04-23
-  updated: 2026-04-23
-  sources: 3      # count of raw sources referenced
-  tags: [workflow-engine, plugin-system]
-  ---
-  ```
-- **Top line**: after frontmatter, one-sentence summary in bold. The index pulls this verbatim.
-- **Cross-references**: use relative markdown links (`[workflow-engine](../entities/packages/workflow-engine.md)`). No wikilinks — they don't render on GitHub.
-- **Sources section**: every page ends with `## Sources` listing raw paths, PR/commit SHAs, and external URLs. No hand-waving; if a claim has no source, it doesn't belong on the page.
-- **Contradictions**: when a new source contradicts an existing page, do not silently overwrite. Add a `> [!note]` callout inline explaining the contradiction and flag it in the log.
-- **No inline ADR-style prose in entities**: if a decision matters, link to a `decisions/` page.
-- **Filenames**: lowercase kebab-case.
-- **No emojis** in wiki content (matches repo-wide convention).
+- English only (matches `AGENTS.md`).
+- Cross-refs: relative markdown (`[pkg](../entities/packages/workflow-engine.md)`). No wikilinks — GitHub doesn't render them.
+- Relative `.md` links stay inside `wiki/`; cite anything outside (e.g. `AGENTS.md`) in plain text.
+- Filenames: lowercase kebab-case.
+- No emojis.
+- Contradictions with new sources: don't silently overwrite. Add a `> [!note]` callout + flag in `log.md`.
+- ADR-style prose goes in `decisions/`, not in entity pages — entities link to decisions.
 
-## Writing style: caveman
+## Pharma domain
 
-Wiki prose uses caveman style — terse, fragments, dropped articles. Roughly 60–75% fewer output tokens than full prose with same technical substance. Optimised for agents reading the wiki in-session, where every wasted token costs context budget.
+Clinical terms (CTCAE grade, RECIST, CDISC vars, AE codes, drug names) = identifiers. No wellbeing framing. Full rule: `AGENTS.md` → "Pharma Domain Context". Runtime carrier: `WorkflowDefinition.preamble` → `buildPrompt()` in `BaseContainerAgentPlugin`.
 
-**Canonical always-on prompt** (from [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) — the viral Claude-Code plugin, April 2026):
+## Workflows
+
+Ingest, query, file-back, lint — all documented in `skills/knowledge-base/SKILL.md`. Append a `log.md` entry per op:
 
 ```
-Terse like caveman. Technical substance exact. Only fluff die.
-Drop: articles, filler (just/really/basically), pleasantries, hedging.
-Fragments OK. Short synonyms. Code unchanged.
-Pattern: [thing] [action] [reason]. [next step].
-ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift.
-Code/commits/PRs: normal. Off: "stop caveman" / "normal mode".
+## [YYYY-MM-DD] <op> | <title>
+touched: <pages>
+summary: <one line>
 ```
-
-**Intensity levels** (pick one per page type):
-
-| Level | Use for | Example |
-|-------|---------|---------|
-| **Lite** | decisions, syntheses — reasoning needs connective tissue | "Picked Firestore over Supabase because the team already runs Firebase." |
-| **Full** (default) | entities, concepts, gotchas | "Firestore over Supabase. Team already runs Firebase. Less ops." |
-| **Ultra** | tables, cross-reference lists, index entries | "Firestore > Supabase. Team on Firebase. Less ops." |
-
-**Passthrough untouched** (never compress these — substance, not prose):
-- frontmatter YAML
-- code blocks, shell commands, file paths
-- URLs, external references
-- Zod / symbol / variable names
-- section headers
-- numbers, dates, version strings
-
-**Caveman applies to the *body prose* only.** Tables, lists, and typed examples are already compressed by form — caveman rarely helps there.
-
-**When to break the rule**: when terseness breaks comprehension. A reader (human or agent) who can't parse a fragment is the failure mode — if the prose needs an article or a connective to be unambiguous, keep it.
-
-## Pharma domain note
-
-This codebase processes pharmaceutical/clinical-trial data. Terms like "adverse event", "Grade 5", "hepatotoxicity", "mortality endpoint" are **technical domain content** (CDISC variables, CTCAE grading, RECIST criteria). Treat them as code-identifiers. No wellbeing framing — see `AGENTS.md` → "Pharma Domain Context".
-
-## Operations
-
-### Ingest
-
-Trigger: a new raw source appears that's worth compiling (significant doc, new package, merged PR that changes architecture, external article the user shares).
-
-Flow:
-1. Read the source end-to-end.
-2. Identify which existing wiki pages it touches (read `wiki/index.md`, follow links).
-3. For each affected entity/concept page: update inline, preserving existing sources.
-4. If the source introduces a new entity/concept/decision/gotcha: create the page.
-5. Update `wiki/index.md` (add new entries, bump counts).
-6. Append an entry to `wiki/log.md`:
-   ```
-   ## [YYYY-MM-DD] ingest | <source title or path>
-   touched: <list of wiki pages>
-   summary: <one line>
-   ```
-7. Report to the user what changed.
-
-Default is **one source at a time**. Batch ingest only when explicitly requested.
-
-### Query
-
-Trigger: the user asks a "how does X work / what is Y / why did we choose Z" question, OR an agent needs background before starting work.
-
-Flow:
-1. Read `wiki/index.md` first.
-2. Open the relevant pages and their linked pages.
-3. Answer with citations back to wiki pages (and through them, to raw sources).
-4. **File-back rule**: if the question took non-trivial synthesis (pulling from 2+ pages, writing a comparison, investigating), file the answer as a `syntheses/` page and link it from the index. Add a log entry.
-
-### Lint
-
-Trigger: before pushing a PR that touched `wiki/` pages, plus a scheduled pass at least once per week.
-
-Checks:
-- **Contradictions** between pages (search for the same entity/concept described differently).
-- **Stale claims** — a page references code that no longer exists (grep the paths/symbols it cites).
-- **Orphans** — pages with no inbound links from other wiki pages or `index.md`.
-- **Missing pages** — concepts/entities referenced in text but without their own page.
-- **Broken cross-references** — relative links that no longer resolve.
-- **Stale frontmatter** — `updated` field older than the last substantive edit.
-- **Source rot** — external URLs that return 4xx/5xx (spot-check with curl).
-
-Output: a single markdown report to the user + an entry in `log.md`. Fixes go in the same PR if trivial; otherwise file them as TODOs at the top of `index.md`.
-
-## When agents MUST update the wiki
-
-These are hard triggers, not suggestions:
-
-- **After a non-trivial architectural change** (new plugin, new package, moved boundary between packages, swapped infra layer) → update the corresponding entity page + append log.
-- **After discovering a gotcha** (time spent >15 min chasing something non-obvious) → add `gotchas/<slug>.md`.
-- **After a decision with lasting impact** (picking a library, picking a pattern, deciding not to do something) → add `decisions/YYYY-MM-DD-slug.md`.
-- **After a synthesis answer** the user asked that required pulling from multiple sources → file under `syntheses/`.
-
-## When agents MUST consult the wiki
-
-- **Before answering architecture/"how does X work" questions** — read `wiki/index.md` first.
-- **Before starting work in an unfamiliar package** — check its `entities/packages/*.md` page.
-- **Before making a decision that smells similar to a past one** — grep `decisions/` for the topic.
-
-If the wiki has nothing on the topic, that's itself a signal: once the work is done, file the resulting knowledge.
 
 ## Scale
 
-Current scale is small (bootstrap). At ~100 pages, revisit: may want per-category sub-indexes, and possibly a search tool (e.g. `qmd`). Until then, `index.md` is sufficient.
+Current: ~40 pages. `index.md` + grep are enough. At ~100 pages revisit: per-category sub-indexes, maybe [qmd](https://github.com/tobi/qmd) for BM25+vector search.

--- a/docs/knowledge-base/STYLE.md
+++ b/docs/knowledge-base/STYLE.md
@@ -1,0 +1,32 @@
+# Wiki writing style: caveman
+
+Wiki prose in caveman. ~60–75% fewer tokens than full prose, substance intact. Agents read wiki in-session — every token costs context.
+
+## Canonical prompt
+
+From [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) (April 2026):
+
+```
+Terse like caveman. Technical substance exact. Only fluff die.
+Drop: articles, filler (just/really/basically), pleasantries, hedging.
+Fragments OK. Short synonyms. Code unchanged.
+Pattern: [thing] [action] [reason]. [next step].
+ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift.
+Code/commits/PRs: normal. Off: "stop caveman" / "normal mode".
+```
+
+## Intensity
+
+| Level | Use for |
+|-------|---------|
+| Lite | decisions, syntheses (need connective tissue) |
+| Full (default) | entities, concepts, gotchas |
+| Ultra | tables, index rows |
+
+## Passthrough (never compress)
+
+Frontmatter · code blocks · file paths · URLs · Zod/symbol/variable names · numbers · dates · version strings · section headers.
+
+## When to break rule
+
+When terseness breaks comprehension. Reader who can't parse a fragment = failure mode.

--- a/docs/knowledge-base/wiki/concepts/autonomy-levels.md
+++ b/docs/knowledge-base/wiki/concepts/autonomy-levels.md
@@ -6,32 +6,32 @@ sources: 2
 tags: [concept, autonomy, agent-runtime, workflow]
 ---
 
-**Five-level scale (L0–L4) controlling how much agent action is allowed before a human must intervene. Enforced by `AgentRunner`, not by individual plugins.**
+**5-level scale (L0–L4). How much agent can do before human must intervene. Enforced by `AgentRunner`, not plugins.**
 
 ## Levels
 
 | Level | Name | Behavior |
 |-------|------|----------|
-| L0 | Human-only | No agent involvement — step runs as pure human task. |
-| L1 | Agent-assisted | Agent produces output, human decides what to do with it. |
-| L2 | Human-in-the-loop | Agent acts, human approves each change before it takes effect. |
-| L3 | Periodic review | Agent is autonomous; humans review in batches (e.g. daily). Used by `protocol-to-tfl`. |
-| L4 | Fully autonomous | Agent applies changes directly, no review. |
+| L0 | Human-only | No agent. Pure human task. |
+| L1 | Agent-assisted | Agent outputs. Human decides. |
+| L2 | Human-in-the-loop | Agent acts. Human approves each change. |
+| L3 | Periodic review | Agent autonomous. Human reviews in batches. Used by `protocol-to-tfl`. |
+| L4 | Fully autonomous | Agent applies changes. No review. |
 
-## How it shows up in code
+## In code
 
-- Type: `AutonomyLevel` exported from [`agent-runtime`](../entities/packages/agent-runtime.md) `src/interfaces/`.
-- Field: each `WorkflowDefinition` agent step carries an `autonomy` field (Zod schema in [`platform-core`](../entities/packages/platform-core.md) `src/schemas/workflow-definition.ts`).
-- Enforcement: [`AgentRunner`](./plugin-dispatch.md) — applies autonomy handling **after** the plugin emits its `result` event. Plugins themselves do not implement autonomy; the runner consults `step.autonomy` + `step.confidenceThreshold` and triggers the [`FallbackHandler`](../entities/packages/agent-runtime.md) when thresholds aren't met.
+- Type: `AutonomyLevel` from [`agent-runtime`](../entities/packages/agent-runtime.md) `src/interfaces/`.
+- Field: each `WorkflowDefinition` agent step has `autonomy`. Zod schema in [`platform-core`](../entities/packages/platform-core.md) `src/schemas/workflow-definition.ts`.
+- Enforcement: `AgentRunner` (see [plugin-dispatch](./plugin-dispatch.md)) — applies autonomy **after** plugin `result` event. Consults `step.autonomy` + `step.confidenceThreshold` → fires `FallbackHandler` if thresholds miss. Plugins themselves do not implement autonomy.
 
-## Confidence threshold coupling
+## Confidence coupling
 
-L3 and L4 typically pair with a `confidenceThreshold` (0.0–1.0). The plugin must emit `confidence` + `confidence_rationale` in its `AgentOutputEnvelope`; if `confidence < threshold`, `AgentRunner` escalates via fallback (human task, retry, or cancel) regardless of autonomy level.
+L3 + L4 pair with `confidenceThreshold` (0.0–1.0). Plugin emits `confidence` + `confidence_rationale` in `AgentOutputEnvelope`. If `confidence < threshold` → `AgentRunner` escalates (human task / retry / cancel) regardless of autonomy.
 
 ## Used by
 
-- [`protocol-to-tfl`](../entities/apps/protocol-to-tfl.md) — all agent steps at L3.
-- Any workflow step in [`platform-ui`](../entities/packages/platform-ui.md) catalog.
+- [`protocol-to-tfl`](../entities/apps/protocol-to-tfl.md) — all agent steps L3.
+- Any step in [`platform-ui`](../entities/packages/platform-ui.md) catalog.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/concepts/autonomy-levels.md
+++ b/docs/knowledge-base/wiki/concepts/autonomy-levels.md
@@ -1,0 +1,39 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, autonomy, agent-runtime, workflow]
+---
+
+**Five-level scale (L0–L4) controlling how much agent action is allowed before a human must intervene. Enforced by `AgentRunner`, not by individual plugins.**
+
+## Levels
+
+| Level | Name | Behavior |
+|-------|------|----------|
+| L0 | Human-only | No agent involvement — step runs as pure human task. |
+| L1 | Agent-assisted | Agent produces output, human decides what to do with it. |
+| L2 | Human-in-the-loop | Agent acts, human approves each change before it takes effect. |
+| L3 | Periodic review | Agent is autonomous; humans review in batches (e.g. daily). Used by `protocol-to-tfl`. |
+| L4 | Fully autonomous | Agent applies changes directly, no review. |
+
+## How it shows up in code
+
+- Type: `AutonomyLevel` exported from [`agent-runtime`](../entities/packages/agent-runtime.md) `src/interfaces/`.
+- Field: each `WorkflowDefinition` agent step carries an `autonomy` field (Zod schema in [`platform-core`](../entities/packages/platform-core.md) `src/schemas/workflow-definition.ts`).
+- Enforcement: [`AgentRunner`](./plugin-dispatch.md) — applies autonomy handling **after** the plugin emits its `result` event. Plugins themselves do not implement autonomy; the runner consults `step.autonomy` + `step.confidenceThreshold` and triggers the [`FallbackHandler`](../entities/packages/agent-runtime.md) when thresholds aren't met.
+
+## Confidence threshold coupling
+
+L3 and L4 typically pair with a `confidenceThreshold` (0.0–1.0). The plugin must emit `confidence` + `confidence_rationale` in its `AgentOutputEnvelope`; if `confidence < threshold`, `AgentRunner` escalates via fallback (human task, retry, or cancel) regardless of autonomy level.
+
+## Used by
+
+- [`protocol-to-tfl`](../entities/apps/protocol-to-tfl.md) — all agent steps at L3.
+- Any workflow step in [`platform-ui`](../entities/packages/platform-ui.md) catalog.
+
+## Sources
+
+- `packages/agent-runtime/src/runner/agent-runner.ts`
+- `AGENTS.md` → "Autonomy levels"

--- a/docs/knowledge-base/wiki/concepts/cdisc-sdtm.md
+++ b/docs/knowledge-base/wiki/concepts/cdisc-sdtm.md
@@ -1,0 +1,40 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, cdisc, sdtm, adam, clinical-data]
+---
+
+**CDISC SDTM = raw collected data. ADaM = analysis-ready derived data. TFL = submission output. Pipeline: SDTM → ADaM → TFL.**
+
+## Layers
+
+- **SDTM** — one domain per row-type. DM (demographics), AE (adverse events), LB (labs), CM (concomitant meds), EX (exposure), VS (vitals). Standard vars: `AEDECOD`, `AESER`, `AESTDTC`, `USUBJID`. One row per event.
+- **ADaM** — derived from SDTM. One row per analysis unit. Derived flags, treatment vars, visit windows.
+- **TFL** — Tables, Figures, Listings. Produced from ADaM.
+
+## Where
+
+- Variable names in prompts + plugin configs.
+- Runtime skills in `apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/`:
+  - `sdtm-to-adam` — ADaM derivation.
+  - `adam-to-tlg` — TFL generation.
+  - `adam-to-teal` — R-based Teal app.
+- Zod schemas in `packages/platform-core/src/schemas/` when clinical workflows touch it.
+
+## External
+
+- SDTM IG: https://www.cdisc.org/standards/foundational/sdtm
+- ADaM IG: https://www.cdisc.org/standards/foundational/adam
+
+## Related
+
+- [recist-v1-1](./recist-v1-1.md) — RECIST → ADRS (ADaM).
+- [ctcae-grading](./ctcae-grading.md) — grades in SDTM AE.
+- [protocol-to-tfl](../entities/apps/protocol-to-tfl.md) — consumer.
+
+## Sources
+
+- `apps/protocol-to-tfl/src/protocol-to-tfl.wd.json`
+- `AGENTS.md` → "Pharma Domain Context"

--- a/docs/knowledge-base/wiki/concepts/ctcae-grading.md
+++ b/docs/knowledge-base/wiki/concepts/ctcae-grading.md
@@ -1,0 +1,44 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, ctcae, adverse-events, grading, safety]
+---
+
+**CTCAE = Common Terminology Criteria for Adverse Events. 5-point severity scale on every AE. Grade 5 = death related to AE.**
+
+## Scale
+
+| Grade | Meaning |
+|-------|---------|
+| 1 | Mild. Asymptomatic or mild. No intervention. |
+| 2 | Moderate. Minimal / local / non-invasive intervention. |
+| 3 | Severe / medically significant. Hospitalisation indicated. Not immediately life-threatening. |
+| 4 | Life-threatening. Urgent intervention. |
+| 5 | Death related to AE. |
+
+## Where
+
+- Vars: `CTCAE_GRADE`, `AETOXGR` (SDTM AE).
+- Zod schemas in `packages/platform-core/src/schemas/` on clinical workflows.
+- Plugin prompts with severity thresholds ("grade 3+ hepatotoxicity").
+
+## Companion signals (not CTCAE grades)
+
+- **irAE** — immune-related AE. Checkpoint-inhibitor class.
+- **Hy's Law** — DILI signal. ALT ≥ 3× ULN + total bilirubin ≥ 2× ULN + no alt cause.
+
+## External
+
+- NCI CTCAE v5.0: https://ctep.cancer.gov/protocolDevelopment/electronic_applications/ctc.htm
+
+## Related
+
+- [cdisc-sdtm](./cdisc-sdtm.md) — AE domain carries grades.
+- [pharma-domain-context](./pharma-domain-context.md).
+
+## Sources
+
+- `AGENTS.md` → "Pharma Domain Context"
+- NCI CTCAE v5.0 (external)

--- a/docs/knowledge-base/wiki/concepts/docker-spawn-strategies.md
+++ b/docs/knowledge-base/wiki/concepts/docker-spawn-strategies.md
@@ -6,26 +6,28 @@ sources: 3
 tags: [concept, docker, spawn-strategy, redis, bullmq]
 ---
 
-**Two strategies for spawning agent containers: `LocalDockerSpawnStrategy` (default, child process) and `QueuedDockerSpawnStrategy` (BullMQ worker). Activation is toggled by the `REDIS_URL` env var.**
+**Two strategies. `LocalDockerSpawnStrategy` (default, child process) vs `QueuedDockerSpawnStrategy` (BullMQ worker). Toggled by `REDIS_URL` env var.**
 
 ## Strategies
 
 ### `LocalDockerSpawnStrategy` (default)
 
-- Spawns `docker run` as a child process from `platform-ui` or a dev shell.
-- Writes stdout/stderr to log files in real time.
-- Optional `lineProcessor` callback for JSONL parsing of agent output.
+- `docker run` as child process from `platform-ui` or dev shell.
+- stdout/stderr → log files in real time.
+- Optional `lineProcessor` callback for JSONL output parsing.
 
 ### `QueuedDockerSpawnStrategy` (`REDIS_URL` set)
 
-- Serialises input files through Redis.
-- Enqueues a job on BullMQ.
-- A worker (separate process, `pnpm dev:worker`) pops the job, runs the container remotely, and pushes output files back through Redis.
-- Enables distributed execution + isolation of container workload from the web server.
+- Inputs serialised through Redis.
+- Job enqueued on BullMQ.
+- Worker (separate process, `pnpm dev:worker`) pops job → runs container → pushes outputs back via Redis.
+- Distributed execution. Isolates container workload from web server.
 
 ## Activation
 
-Env var: `REDIS_URL`. If set, `agent-runtime` swaps `LocalDockerSpawnStrategy` for `QueuedDockerSpawnStrategy` via the optional `@mediforce/agent-queue` package. Dev commands for the queued path:
+Env var: `REDIS_URL`. Set → `agent-runtime` swaps Local for Queued via optional `@mediforce/agent-queue`.
+
+Dev commands for queued path:
 
 ```bash
 pnpm dev:redis          # Redis on 6379
@@ -33,13 +35,13 @@ pnpm dev:worker         # BullMQ worker
 pnpm dev:ui:queue       # platform-ui with queue enabled
 ```
 
-## Local vs container execution
+## Local (non-container) execution
 
-A separate gate: `ALLOW_LOCAL_AGENTS=true` skips Docker entirely and runs the agent CLI on the host. Used for `pnpm dev:local`. See `BaseContainerAgentPlugin` — it branches on this flag before touching the spawn strategy.
+Separate gate: `ALLOW_LOCAL_AGENTS=true` → skips Docker entirely, runs agent CLI on host. Used for `pnpm dev:local`. `BaseContainerAgentPlugin` branches on this before touching spawn strategy.
 
 ## Mock mode
 
-`MOCK_AGENT=true` short-circuits the spawn: `BaseContainerAgentPlugin.spawnDockerContainer()` calls the subclass's `getMockDockerArgs()` and mounts `mock-fixtures/` + optional `_config.json` dataDir. Returns fixture output instantly.
+`MOCK_AGENT=true` short-circuits spawn: `BaseContainerAgentPlugin.spawnDockerContainer()` calls subclass's `getMockDockerArgs()` + mounts `mock-fixtures/` + optional `_config.json` dataDir. Returns fixture output instantly.
 
 ## Used by
 

--- a/docs/knowledge-base/wiki/concepts/docker-spawn-strategies.md
+++ b/docs/knowledge-base/wiki/concepts/docker-spawn-strategies.md
@@ -1,0 +1,52 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [concept, docker, spawn-strategy, redis, bullmq]
+---
+
+**Two strategies for spawning agent containers: `LocalDockerSpawnStrategy` (default, child process) and `QueuedDockerSpawnStrategy` (BullMQ worker). Activation is toggled by the `REDIS_URL` env var.**
+
+## Strategies
+
+### `LocalDockerSpawnStrategy` (default)
+
+- Spawns `docker run` as a child process from `platform-ui` or a dev shell.
+- Writes stdout/stderr to log files in real time.
+- Optional `lineProcessor` callback for JSONL parsing of agent output.
+
+### `QueuedDockerSpawnStrategy` (`REDIS_URL` set)
+
+- Serialises input files through Redis.
+- Enqueues a job on BullMQ.
+- A worker (separate process, `pnpm dev:worker`) pops the job, runs the container remotely, and pushes output files back through Redis.
+- Enables distributed execution + isolation of container workload from the web server.
+
+## Activation
+
+Env var: `REDIS_URL`. If set, `agent-runtime` swaps `LocalDockerSpawnStrategy` for `QueuedDockerSpawnStrategy` via the optional `@mediforce/agent-queue` package. Dev commands for the queued path:
+
+```bash
+pnpm dev:redis          # Redis on 6379
+pnpm dev:worker         # BullMQ worker
+pnpm dev:ui:queue       # platform-ui with queue enabled
+```
+
+## Local vs container execution
+
+A separate gate: `ALLOW_LOCAL_AGENTS=true` skips Docker entirely and runs the agent CLI on the host. Used for `pnpm dev:local`. See `BaseContainerAgentPlugin` — it branches on this flag before touching the spawn strategy.
+
+## Mock mode
+
+`MOCK_AGENT=true` short-circuits the spawn: `BaseContainerAgentPlugin.spawnDockerContainer()` calls the subclass's `getMockDockerArgs()` and mounts `mock-fixtures/` + optional `_config.json` dataDir. Returns fixture output instantly.
+
+## Used by
+
+- [`claude-code-agent`](../entities/plugins/claude-code-agent.md), [`opencode-agent`](../entities/plugins/opencode-agent.md), [`script-container`](../entities/plugins/script-container.md) — all three run through this machinery.
+
+## Sources
+
+- `packages/agent-runtime/src/plugins/docker-spawn-strategy.ts`
+- `packages/agent-runtime/src/plugins/base-container-agent-plugin.ts`
+- `AGENTS.md` → "Docker spawn strategies", "Additional Commands"

--- a/docs/knowledge-base/wiki/concepts/dual-schema-migration.md
+++ b/docs/knowledge-base/wiki/concepts/dual-schema-migration.md
@@ -1,0 +1,36 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, migration, workflow-definitions, dual-schema]
+---
+
+**Legacy `processDefinitions` + `processConfigs` coexist with the unified `workflowDefinitions`. Resolution logic routes reads to whichever schema has the data. Live migration in progress.**
+
+## Why it exists
+
+The platform originally stored process logic in two Firestore collections: `processDefinitions` (structure) and `processConfigs` (per-step config). The unified `workflowDefinitions` collection merges both. Rather than a big-bang migration, the system resolves at read time.
+
+## Where resolution happens
+
+`packages/platform-ui/src/lib/resolve-definition-steps.ts` — the single resolver. It consults both schemas and returns a normalised `WorkflowDefinition`-shaped object. Every feature that reads steps goes through this function.
+
+## Before writing new code
+
+- Reading step definitions? **Use `resolveDefinitionSteps()`.** Do not hit `processDefinitions` or `workflowDefinitions` directly.
+- Writing new workflow logic? **Write against `WorkflowDefinition` only** (Zod schema in [`platform-core`](../entities/packages/platform-core.md)). The legacy path is read-only.
+- Migrating? Use the migration endpoints under `packages/platform-ui/src/app/api/migrations/`.
+
+## Schema authority
+
+`WorkflowDefinition` lives in `packages/platform-core/src/schemas/workflow-definition.ts`. Union type covering agent / review / cowork / handoff step variants.
+
+## Immutability
+
+All definition versions (both legacy and unified) are **write-once** in Firestore. Re-publishing increments the version. Enforced by [repository-pattern](./repository-pattern.md) errors: `DefinitionVersionAlreadyExistsError`.
+
+## Sources
+
+- `packages/platform-ui/src/lib/resolve-definition-steps.ts`
+- `AGENTS.md` → "Key architectural patterns" → "Dual-schema migration"

--- a/docs/knowledge-base/wiki/concepts/dual-schema-migration.md
+++ b/docs/knowledge-base/wiki/concepts/dual-schema-migration.md
@@ -6,29 +6,29 @@ sources: 2
 tags: [concept, migration, workflow-definitions, dual-schema]
 ---
 
-**Legacy `processDefinitions` + `processConfigs` coexist with the unified `workflowDefinitions`. Resolution logic routes reads to whichever schema has the data. Live migration in progress.**
+**Legacy `processDefinitions` + `processConfigs` coexist with unified `workflowDefinitions`. Read-time resolution. Live migration in progress.**
 
-## Why it exists
+## Why
 
-The platform originally stored process logic in two Firestore collections: `processDefinitions` (structure) and `processConfigs` (per-step config). The unified `workflowDefinitions` collection merges both. Rather than a big-bang migration, the system resolves at read time.
+Originally: two Firestore collections — `processDefinitions` (structure) + `processConfigs` (per-step config). New: unified `workflowDefinitions`. No big-bang migration → system resolves at read time.
 
-## Where resolution happens
+## Where resolution lives
 
-`packages/platform-ui/src/lib/resolve-definition-steps.ts` — the single resolver. It consults both schemas and returns a normalised `WorkflowDefinition`-shaped object. Every feature that reads steps goes through this function.
+`packages/platform-ui/src/lib/resolve-definition-steps.ts`. Single resolver. Consults both schemas → returns normalised `WorkflowDefinition`-shaped object. Every feature that reads steps goes through this.
 
-## Before writing new code
+## Before writing code
 
-- Reading step definitions? **Use `resolveDefinitionSteps()`.** Do not hit `processDefinitions` or `workflowDefinitions` directly.
-- Writing new workflow logic? **Write against `WorkflowDefinition` only** (Zod schema in [`platform-core`](../entities/packages/platform-core.md)). The legacy path is read-only.
-- Migrating? Use the migration endpoints under `packages/platform-ui/src/app/api/migrations/`.
+- Reading step definitions? **Use `resolveDefinitionSteps()`.** Never hit `processDefinitions` / `workflowDefinitions` Firestore directly. See [dual-schema-routing gotcha](../gotchas/dual-schema-routing.md).
+- New workflow logic? **Write against `WorkflowDefinition` only.** Legacy = read-only.
+- Migrating? `packages/platform-ui/src/app/api/migrations/`.
 
 ## Schema authority
 
-`WorkflowDefinition` lives in `packages/platform-core/src/schemas/workflow-definition.ts`. Union type covering agent / review / cowork / handoff step variants.
+`WorkflowDefinition` in `packages/platform-core/src/schemas/workflow-definition.ts`. Union over agent / review / cowork / handoff step variants.
 
 ## Immutability
 
-All definition versions (both legacy and unified) are **write-once** in Firestore. Re-publishing increments the version. Enforced by [repository-pattern](./repository-pattern.md) errors: `DefinitionVersionAlreadyExistsError`.
+All definition versions write-once in Firestore. Republish → version bump. Enforced via [repository-pattern](./repository-pattern.md): `DefinitionVersionAlreadyExistsError`.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/concepts/expression-evaluator.md
+++ b/docs/knowledge-base/wiki/concepts/expression-evaluator.md
@@ -1,0 +1,37 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, expression, dsl, transitions, workflow-engine]
+---
+
+**Custom DSL for transition when-expressions — e.g. `${variables.field} == "value"`. Evaluated by `evaluateExpression()` in `workflow-engine`. Not JavaScript eval, not JSONata — a small in-house DSL.**
+
+## Purpose
+
+Transitions in a `WorkflowDefinition` carry an optional `when` expression that decides whether the transition fires. The DSL is deliberately narrow — variable reads, comparisons, boolean combinators — to keep audit/review simple and sidestep eval-style injection risks.
+
+## Where it lives
+
+- `packages/workflow-engine/src/expressions/expression-evaluator.ts` — the evaluator.
+- `packages/workflow-engine/src/engine/transition-resolver.ts` — the caller; uses it in `resolveTransitions()`.
+- Tests: `packages/workflow-engine/src/expressions/__tests__/`.
+
+## Before adding a DSL feature
+
+- Check the existing evaluator — new constructs should go there, not parallel implementations in UI or plugin code.
+- Transition logic should never bypass `resolveTransitions()`. If an expression can't express what you need, extend the DSL rather than routing around it.
+
+## Context
+
+The evaluator reads from the step's `variables` object (the accumulated workflow context). Mutation happens in `StepExecutor`, not in expressions — expressions are pure.
+
+## Used by
+
+- [`workflow-engine`](../entities/packages/workflow-engine.md) — every `WorkflowDefinition` transition with a `when` clause.
+
+## Sources
+
+- `packages/workflow-engine/src/expressions/expression-evaluator.ts`
+- `packages/workflow-engine/src/engine/transition-resolver.ts`

--- a/docs/knowledge-base/wiki/concepts/expression-evaluator.md
+++ b/docs/knowledge-base/wiki/concepts/expression-evaluator.md
@@ -6,26 +6,26 @@ sources: 2
 tags: [concept, expression, dsl, transitions, workflow-engine]
 ---
 
-**Custom DSL for transition when-expressions — e.g. `${variables.field} == "value"`. Evaluated by `evaluateExpression()` in `workflow-engine`. Not JavaScript eval, not JSONata — a small in-house DSL.**
+**Custom DSL for transition `when` clauses. E.g. `${variables.field} == "value"`. Evaluated by `evaluateExpression()` in `workflow-engine`. Not JS eval. Not JSONata. Small in-house DSL.**
 
 ## Purpose
 
-Transitions in a `WorkflowDefinition` carry an optional `when` expression that decides whether the transition fires. The DSL is deliberately narrow — variable reads, comparisons, boolean combinators — to keep audit/review simple and sidestep eval-style injection risks.
+Transitions in a `WorkflowDefinition` carry optional `when` expression. Narrow DSL on purpose — variable reads, comparisons, boolean combinators — keeps audit/review simple. Sidesteps eval-style injection risks.
 
-## Where it lives
+## Where
 
-- `packages/workflow-engine/src/expressions/expression-evaluator.ts` — the evaluator.
-- `packages/workflow-engine/src/engine/transition-resolver.ts` — the caller; uses it in `resolveTransitions()`.
+- Evaluator: `packages/workflow-engine/src/expressions/expression-evaluator.ts`.
+- Caller: `packages/workflow-engine/src/engine/transition-resolver.ts` — uses it in `resolveTransitions()`.
 - Tests: `packages/workflow-engine/src/expressions/__tests__/`.
 
-## Before adding a DSL feature
+## Before adding DSL features
 
-- Check the existing evaluator — new constructs should go there, not parallel implementations in UI or plugin code.
-- Transition logic should never bypass `resolveTransitions()`. If an expression can't express what you need, extend the DSL rather than routing around it.
+- Check the existing evaluator. New constructs go there. Don't write parallel evaluators in UI / plugin code.
+- Transition logic never bypasses `resolveTransitions()`. If an expression can't express what you need, extend the DSL instead of routing around it.
 
 ## Context
 
-The evaluator reads from the step's `variables` object (the accumulated workflow context). Mutation happens in `StepExecutor`, not in expressions — expressions are pure.
+Reads from step's `variables` (accumulated workflow context). Mutation happens in `StepExecutor`, not in expressions. Expressions are pure.
 
 ## Used by
 

--- a/docs/knowledge-base/wiki/concepts/ich-gcp.md
+++ b/docs/knowledge-base/wiki/concepts/ich-gcp.md
@@ -1,0 +1,43 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, ich-gcp, regulatory, compliance]
+---
+
+**ICH-GCP = International Council for Harmonisation, Good Clinical Practice (E6 R3). Regulatory framework for clinical-trial conduct on humans.**
+
+## Scope
+
+- Informed consent.
+- IRB/IEC oversight.
+- Investigator + sponsor obligations.
+- Essential documents (TMF).
+- Data integrity — **ALCOA+**: Attributable, Legible, Contemporaneous, Original, Accurate, + Complete, Consistent, Enduring, Available.
+- AE reporting obligations.
+
+## Why it matters here
+
+Every agent action on clinical data = audit event. Don't bypass audit logging. Regulatory requirement, not performance knob.
+
+Mapping:
+
+- **Immutable versions** (`DefinitionVersionAlreadyExistsError`) → ALCOA+ data integrity.
+- **Audit events** (`AuditRepository`, `StepExecution`) → ALCOA+ attributability + contemporaneity.
+- **Autonomy levels** → regulated oversight patterns. Submission-bound = L2/L3. See [autonomy-levels](./autonomy-levels.md).
+
+## External
+
+- ICH E6(R3): https://www.ich.org/page/efficacy-guidelines
+
+## Related
+
+- [pharma-domain-context](./pharma-domain-context.md).
+- [autonomy-levels](./autonomy-levels.md).
+- [repository-pattern](./repository-pattern.md) — audit trail is first-class.
+
+## Sources
+
+- `AGENTS.md` → "Pharma Domain Context"
+- ICH E6(R3) (external)

--- a/docs/knowledge-base/wiki/concepts/llm-no-computation-rule.md
+++ b/docs/knowledge-base/wiki/concepts/llm-no-computation-rule.md
@@ -1,0 +1,35 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, llm, domain-logic, auditability]
+---
+
+**LLMs generate prose; they never compute domain numbers. Numbers come from deterministic pure functions and are templated into prompts. Applied across supply-intelligence and should be the default elsewhere.**
+
+## The rule
+
+When a plugin produces output that includes numbers (risk scores, stockout weeks, allocation counts, priority rankings), those numbers **must** come from a deterministic function. The LLM's job is to write readable prose around pre-computed values, not to do arithmetic or classification itself.
+
+## Why
+
+- **Auditability** — every claim in the output traces back to a verifiable function call.
+- **Reproducibility** — same inputs → same numbers, regardless of LLM randomness.
+- **Testability** — domain logic is covered by unit tests without mocking LLMs.
+
+## Applied in
+
+- [`supply-intelligence-plugins`](../entities/packages/supply-intelligence-plugins.md) — numbers come from [`supply-intelligence`](../entities/packages/supply-intelligence.md) (`fefoAllocation`, `stockoutProjection`, `classifyRisk`) and `lib/risk-computations.ts`. Prose comes from LLM with those numbers templated into the prompt.
+
+## Pattern for new plugins
+
+1. Put the domain calculation in a pure function (package or lib module).
+2. Unit-test the function without mocks.
+3. Template numbers into the prompt via a deterministic prompt-builder (see `packages/supply-intelligence-plugins/src/prompts/`).
+4. LLM fills in prose. Never ask the LLM for the number.
+
+## Sources
+
+- `packages/supply-intelligence-plugins/src/driver-agent-plugin.ts`
+- `packages/supply-intelligence/src/risk/`

--- a/docs/knowledge-base/wiki/concepts/llm-no-computation-rule.md
+++ b/docs/knowledge-base/wiki/concepts/llm-no-computation-rule.md
@@ -6,28 +6,28 @@ sources: 2
 tags: [concept, llm, domain-logic, auditability]
 ---
 
-**LLMs generate prose; they never compute domain numbers. Numbers come from deterministic pure functions and are templated into prompts. Applied across supply-intelligence and should be the default elsewhere.**
+**LLMs write prose. Never compute domain numbers. Numbers come from pure functions, templated into prompts. Default across supply-intelligence; should be default everywhere.**
 
-## The rule
+## Rule
 
-When a plugin produces output that includes numbers (risk scores, stockout weeks, allocation counts, priority rankings), those numbers **must** come from a deterministic function. The LLM's job is to write readable prose around pre-computed values, not to do arithmetic or classification itself.
+Output includes numbers (risk scores, stockout weeks, allocation counts, priority rankings)? Numbers **must** come from a deterministic function. LLM's job: readable prose around pre-computed values. Not arithmetic. Not classification.
 
 ## Why
 
-- **Auditability** — every claim in the output traces back to a verifiable function call.
-- **Reproducibility** — same inputs → same numbers, regardless of LLM randomness.
-- **Testability** — domain logic is covered by unit tests without mocking LLMs.
+- **Auditable** — every claim in output traces to a verifiable function call.
+- **Reproducible** — same inputs → same numbers. LLM randomness irrelevant.
+- **Testable** — domain logic covered by unit tests without LLM mocks.
 
 ## Applied in
 
-- [`supply-intelligence-plugins`](../entities/packages/supply-intelligence-plugins.md) — numbers come from [`supply-intelligence`](../entities/packages/supply-intelligence.md) (`fefoAllocation`, `stockoutProjection`, `classifyRisk`) and `lib/risk-computations.ts`. Prose comes from LLM with those numbers templated into the prompt.
+- [`supply-intelligence-plugins`](../entities/packages/supply-intelligence-plugins.md) — numbers from [`supply-intelligence`](../entities/packages/supply-intelligence.md) (`fefoAllocation`, `stockoutProjection`, `classifyRisk`) + `lib/risk-computations.ts`. Prose from LLM with numbers templated in.
 
 ## Pattern for new plugins
 
-1. Put the domain calculation in a pure function (package or lib module).
-2. Unit-test the function without mocks.
-3. Template numbers into the prompt via a deterministic prompt-builder (see `packages/supply-intelligence-plugins/src/prompts/`).
-4. LLM fills in prose. Never ask the LLM for the number.
+1. Domain calculation → pure function (package or lib module).
+2. Unit-test without mocks.
+3. Template numbers into prompt via deterministic builder (see `packages/supply-intelligence-plugins/src/prompts/`).
+4. LLM fills prose. Never ask LLM for the number.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/concepts/mcp-resolution.md
+++ b/docs/knowledge-base/wiki/concepts/mcp-resolution.md
@@ -1,0 +1,47 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [concept, mcp, agent-runtime, tool-catalog]
+---
+
+**Per-step resolution of MCP (Model Context Protocol) servers and tool filters. Inputs: agent-definition bindings + step-level restrictions + tool catalog. Output: a concrete `mcp-config.json` written into the container.**
+
+## Two paths
+
+### Workflow-mode (recommended)
+
+- `context.resolvedMcpConfig` is pre-resolved by [`agent-runtime`](../entities/packages/agent-runtime.md) `resolveMcpForStep()`.
+- Inputs: `AgentDefinition` bindings (which MCP servers the agent may use), step-level `allowedTools` restrictions, tool catalog entries from Firestore.
+- Used by: workflow steps running through `BaseContainerAgentPlugin`.
+
+### Legacy path
+
+- `agentConfig.mcpServers` array supplied inline in the process config.
+- Flattened via `flattenResolvedMcpToLegacy()`.
+- Used by: the legacy `processConfigs` schema (see [dual-schema-migration](./dual-schema-migration.md)).
+
+## What gets written
+
+`/output/mcp-config.json` inside the container, with:
+
+- `mcpServers` map — each entry is either `stdio` (command + args) or `http` (URL).
+- `allowedTools` filter per server — subset declared by the step.
+
+## Env var templating
+
+`{{SECRET}}` placeholders in the server config are resolved at write time from `workflowSecrets` (encrypted at rest, decrypted via `secrets-cipher` in [`platform-infra`](../entities/packages/platform-infra.md)).
+
+## Before adding a new MCP integration
+
+- Register the server in the tool catalog (`packages/platform-core/src/schemas/` → tool catalog entries).
+- Bind it on an `AgentDefinition` (Firestore).
+- Restrict it per-step with `allowedTools` in the `WorkflowDefinition`.
+- Do **not** hardcode server URLs in plugin code — go through `resolveMcpForStep()`.
+
+## Sources
+
+- `packages/agent-runtime/src/mcp/resolve-mcp-for-step.ts`
+- `packages/agent-runtime/src/plugins/base-container-agent-plugin.ts`
+- `packages/platform-core/src/mcp/resolve-effective-mcp.ts`

--- a/docs/knowledge-base/wiki/concepts/mcp-resolution.md
+++ b/docs/knowledge-base/wiki/concepts/mcp-resolution.md
@@ -6,39 +6,39 @@ sources: 3
 tags: [concept, mcp, agent-runtime, tool-catalog]
 ---
 
-**Per-step resolution of MCP (Model Context Protocol) servers and tool filters. Inputs: agent-definition bindings + step-level restrictions + tool catalog. Output: a concrete `mcp-config.json` written into the container.**
+**Per-step MCP resolution. Inputs: agent-def bindings + step-level restrictions + tool catalog. Output: concrete `mcp-config.json` written into container.**
 
 ## Two paths
 
 ### Workflow-mode (recommended)
 
-- `context.resolvedMcpConfig` is pre-resolved by [`agent-runtime`](../entities/packages/agent-runtime.md) `resolveMcpForStep()`.
-- Inputs: `AgentDefinition` bindings (which MCP servers the agent may use), step-level `allowedTools` restrictions, tool catalog entries from Firestore.
+- `context.resolvedMcpConfig` — pre-resolved by [`agent-runtime`](../entities/packages/agent-runtime.md) `resolveMcpForStep()`.
+- Inputs: `AgentDefinition` bindings (which MCP servers agent may use), step-level `allowedTools`, tool catalog entries from Firestore.
 - Used by: workflow steps running through `BaseContainerAgentPlugin`.
 
 ### Legacy path
 
-- `agentConfig.mcpServers` array supplied inline in the process config.
+- `agentConfig.mcpServers` array inline in process config.
 - Flattened via `flattenResolvedMcpToLegacy()`.
-- Used by: the legacy `processConfigs` schema (see [dual-schema-migration](./dual-schema-migration.md)).
+- Used by: legacy `processConfigs` (see [dual-schema-migration](./dual-schema-migration.md)).
 
 ## What gets written
 
-`/output/mcp-config.json` inside the container, with:
+`/output/mcp-config.json` inside container:
 
-- `mcpServers` map — each entry is either `stdio` (command + args) or `http` (URL).
-- `allowedTools` filter per server — subset declared by the step.
+- `mcpServers` map — `stdio` (command + args) or `http` (URL).
+- `allowedTools` filter per server — subset declared by step.
 
 ## Env var templating
 
-`{{SECRET}}` placeholders in the server config are resolved at write time from `workflowSecrets` (encrypted at rest, decrypted via `secrets-cipher` in [`platform-infra`](../entities/packages/platform-infra.md)).
+`{{SECRET}}` placeholders in server config resolved at write time from `workflowSecrets`. Encrypted at rest, decrypted via `secrets-cipher` in [`platform-infra`](../entities/packages/platform-infra.md).
 
 ## Before adding a new MCP integration
 
-- Register the server in the tool catalog (`packages/platform-core/src/schemas/` → tool catalog entries).
-- Bind it on an `AgentDefinition` (Firestore).
-- Restrict it per-step with `allowedTools` in the `WorkflowDefinition`.
-- Do **not** hardcode server URLs in plugin code — go through `resolveMcpForStep()`.
+- Register the server in tool catalog (`packages/platform-core/src/schemas/` → tool catalog entries).
+- Bind on `AgentDefinition` (Firestore).
+- Restrict per-step with `allowedTools` in `WorkflowDefinition`.
+- **Do not** hardcode server URLs in plugin code. Go through `resolveMcpForStep()`.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/concepts/pharma-domain-context.md
+++ b/docs/knowledge-base/wiki/concepts/pharma-domain-context.md
@@ -1,0 +1,36 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, pharma, domain, cdisc, ich-gcp]
+---
+
+**Clinical terms in code = technical domain content. Not natural-language discussion.**
+
+## Rule (AGENTS.md)
+
+Drug names (Keytruda, Herceptin, Ozempic), adverse events (hepatotoxicity, pneumonitis), disease classifications (NSCLC, melanoma), CTCAE grading (incl. Grade 5 = death), mortality endpoints, Hy's Law, RECIST, irAEs — refer to:
+
+- Zod schema fields (`AEDECOD`, `AESER`, `CTCAE_GRADE`).
+- Clinical standards (CDISC SDTM/ADaM, ICH-GCP, RECIST v1.1).
+- Workflow step configs + plugin params.
+- Seed data, test fixtures.
+
+Treat as identifiers. No wellbeing framing. Don't inflate complexity for medical terminology. Execute large refactors normally.
+
+## Runtime carrier
+
+`WorkflowDefinition.preamble` → `buildPrompt()` in `BaseContainerAgentPlugin` → Claude Code / OpenCode / script plugins. Clinical workflows inherit framing from there.
+
+## Related
+
+- [cdisc-sdtm](./cdisc-sdtm.md)
+- [ctcae-grading](./ctcae-grading.md)
+- [recist-v1-1](./recist-v1-1.md)
+- [ich-gcp](./ich-gcp.md)
+
+## Sources
+
+- `AGENTS.md` → "Pharma Domain Context"
+- `packages/agent-runtime/src/plugins/base-container-agent-plugin.ts` (`buildPrompt()`)

--- a/docs/knowledge-base/wiki/concepts/plugin-dispatch.md
+++ b/docs/knowledge-base/wiki/concepts/plugin-dispatch.md
@@ -1,0 +1,49 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 4
+tags: [concept, plugin-dispatch, agent-runtime, registry]
+---
+
+**How a workflow step gets routed to the right agent plugin — `AgentRunner` + `PluginRegistry` + `AgentPlugin` contract.**
+
+## Definition
+
+The agent-runtime uses a registry + dispatch pattern. Plugins are looked up by name from a `PluginRegistry`, the runner drives their lifecycle, and results flow through a schema-validated envelope.
+
+## Flow
+
+1. `WorkflowDefinition` step declares `agent: <name>` (e.g. `claude-code-agent`, `supply-intelligence/driver-agent`).
+2. `AgentRunner` calls `registry.get(name)` — throws `PluginNotFoundError` if absent.
+3. Runner calls `plugin.initialize(context)` — stores `AgentContext` (step input, config, LLM client, resolved MCP, workflow secrets).
+4. Runner calls `plugin.run(emit)` — plugin emits `status`, `annotation`, and exactly one `result` event.
+5. `result` event is validated against `AgentOutputEnvelopeSchema` — must include `confidence` (0.0–1.0) and `confidence_rationale`.
+6. Runner applies [autonomy](./autonomy-levels.md) + confidence threshold checks. If failed, triggers `FallbackHandler` (human escalation, retry, or cancel).
+
+## Registration points
+
+- **Built-in plugins** — `getPlatformServices()` in [`platform-ui`](../entities/packages/platform-ui.md) registers `claude-code-agent`, `opencode-agent`, `script-container` (and `MockClaudeCodeAgentPlugin` when `MOCK_AGENT=true`).
+- **Domain plugins** — `registerSupplyIntelligencePlugins(registry)` called from the same `getPlatformServices()`.
+- **Ad-hoc / tests** — `registry.register(name, plugin)` directly.
+
+## Registry API
+
+`PluginRegistry` at `packages/agent-runtime/src/runner/plugin-registry.ts`:
+- `register(name, plugin)`
+- `get(name)` — throws `PluginNotFoundError`
+- `has(name)`
+- `names()`, `list()`
+
+## Writing a new plugin
+
+Start from [`example-agent`](../entities/plugins/example-agent.md). For Docker-backed LLM plugins, extend `BaseContainerAgentPlugin` (see [docker-spawn-strategies](./docker-spawn-strategies.md)) and implement `getAgentCommand()`, `getMockDockerArgs()`, `parseAgentOutput()`.
+
+**Before writing a plugin, check the registry** — grep for plugins already covering the capability you need. See [`entities/plugins/`](../entities/plugins/).
+
+## Sources
+
+- `packages/agent-runtime/src/runner/agent-runner.ts`
+- `packages/agent-runtime/src/runner/plugin-registry.ts`
+- `packages/platform-ui/src/lib/platform-services.ts`
+- `AGENTS.md` → "Plugin system"

--- a/docs/knowledge-base/wiki/concepts/plugin-dispatch.md
+++ b/docs/knowledge-base/wiki/concepts/plugin-dispatch.md
@@ -6,30 +6,27 @@ sources: 4
 tags: [concept, plugin-dispatch, agent-runtime, registry]
 ---
 
-**How a workflow step gets routed to the right agent plugin — `AgentRunner` + `PluginRegistry` + `AgentPlugin` contract.**
-
-## Definition
-
-The agent-runtime uses a registry + dispatch pattern. Plugins are looked up by name from a `PluginRegistry`, the runner drives their lifecycle, and results flow through a schema-validated envelope.
+**Registry + dispatch. `AgentRunner` + `PluginRegistry` + `AgentPlugin` contract. Lookup by name → drive lifecycle → validate schema envelope.**
 
 ## Flow
 
-1. `WorkflowDefinition` step declares `agent: <name>` (e.g. `claude-code-agent`, `supply-intelligence/driver-agent`).
-2. `AgentRunner` calls `registry.get(name)` — throws `PluginNotFoundError` if absent.
-3. Runner calls `plugin.initialize(context)` — stores `AgentContext` (step input, config, LLM client, resolved MCP, workflow secrets).
-4. Runner calls `plugin.run(emit)` — plugin emits `status`, `annotation`, and exactly one `result` event.
-5. `result` event is validated against `AgentOutputEnvelopeSchema` — must include `confidence` (0.0–1.0) and `confidence_rationale`.
-6. Runner applies [autonomy](./autonomy-levels.md) + confidence threshold checks. If failed, triggers `FallbackHandler` (human escalation, retry, or cancel).
+1. Step declares `agent: <name>` (e.g. `claude-code-agent`, `supply-intelligence/driver-agent`).
+2. `AgentRunner.registry.get(name)` → `PluginNotFoundError` if missing.
+3. `plugin.initialize(context)` — store `AgentContext` (step input, config, LLM client, resolved MCP → [mcp-resolution](./mcp-resolution.md), workflow secrets).
+4. `plugin.run(emit)` — plugin emits `status`, `annotation`, exactly one `result`.
+5. `result` validated vs `AgentOutputEnvelopeSchema`. Must include `confidence` (0.0–1.0) + `confidence_rationale`.
+6. Runner applies [autonomy](./autonomy-levels.md) + confidence threshold. Fail → `FallbackHandler` (human escalation / retry / cancel).
 
 ## Registration points
 
-- **Built-in plugins** — `getPlatformServices()` in [`platform-ui`](../entities/packages/platform-ui.md) registers `claude-code-agent`, `opencode-agent`, `script-container` (and `MockClaudeCodeAgentPlugin` when `MOCK_AGENT=true`).
-- **Domain plugins** — `registerSupplyIntelligencePlugins(registry)` called from the same `getPlatformServices()`.
+- **Built-in** — `getPlatformServices()` in [platform-ui](../entities/packages/platform-ui.md) registers `claude-code-agent`, `opencode-agent`, `script-container`. `MOCK_AGENT=true` → mocks.
+- **Domain** — `registerSupplyIntelligencePlugins(registry)` called from `getPlatformServices()`.
 - **Ad-hoc / tests** — `registry.register(name, plugin)` directly.
 
 ## Registry API
 
 `PluginRegistry` at `packages/agent-runtime/src/runner/plugin-registry.ts`:
+
 - `register(name, plugin)`
 - `get(name)` — throws `PluginNotFoundError`
 - `has(name)`
@@ -37,9 +34,9 @@ The agent-runtime uses a registry + dispatch pattern. Plugins are looked up by n
 
 ## Writing a new plugin
 
-Start from [`example-agent`](../entities/plugins/example-agent.md). For Docker-backed LLM plugins, extend `BaseContainerAgentPlugin` (see [docker-spawn-strategies](./docker-spawn-strategies.md)) and implement `getAgentCommand()`, `getMockDockerArgs()`, `parseAgentOutput()`.
+Start: [`example-agent`](../entities/plugins/example-agent.md). Docker-backed LLM plugins → extend `BaseContainerAgentPlugin` (see [docker-spawn-strategies](./docker-spawn-strategies.md)). Implement `getAgentCommand()`, `getMockDockerArgs()`, `parseAgentOutput()`.
 
-**Before writing a plugin, check the registry** — grep for plugins already covering the capability you need. See [`entities/plugins/`](../entities/plugins/).
+**Check [entities/plugins/](../entities/plugins/) first. Don't duplicate.**
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/concepts/recist-v1-1.md
+++ b/docs/knowledge-base/wiki/concepts/recist-v1-1.md
@@ -1,0 +1,45 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, recist, oncology, tumour-response]
+---
+
+**RECIST v1.1 = Response Evaluation Criteria In Solid Tumours. Standard rules for tumour-burden change classification: CR, PR, SD, PD.**
+
+## Categories
+
+| Code | Meaning |
+|------|---------|
+| CR | Complete Response. Target lesions gone. |
+| PR | ≥30% decrease in sum of diameters vs baseline. |
+| SD | Neither PR nor PD. |
+| PD | ≥20% increase vs nadir OR new lesions. |
+
+Derived endpoints: ORR, DCR, PFS, DoR.
+
+## Where
+
+- ADRS in ADaM (see [cdisc-sdtm](./cdisc-sdtm.md)).
+- TR / TU domains in SDTM (target + non-target lesions).
+- Plugin prompts for tumour-response narrative.
+
+## Variants
+
+- **iRECIST** — immunotherapy (handles pseudo-progression).
+- **RECIL** — lymphoma.
+
+## External
+
+- Eisenhauer et al., *Eur J Cancer* 2009, 45(2):228–247.
+
+## Related
+
+- [cdisc-sdtm](./cdisc-sdtm.md) — RECIST → ADRS.
+- [pharma-domain-context](./pharma-domain-context.md).
+
+## Sources
+
+- `AGENTS.md` → "Pharma Domain Context"
+- Eisenhauer et al. (external)

--- a/docs/knowledge-base/wiki/concepts/repository-pattern.md
+++ b/docs/knowledge-base/wiki/concepts/repository-pattern.md
@@ -6,40 +6,42 @@ sources: 3
 tags: [concept, repository-pattern, platform-core, platform-infra]
 ---
 
-**Interfaces in `platform-core`, concrete Firestore implementations in `platform-infra`, in-memory test doubles in `platform-core/testing`. Constructor injection — no global singletons inside repositories.**
+**Interfaces in `platform-core`, Firestore impls in `platform-infra`, in-memory doubles in `platform-core/testing`. Constructor injection — no global singletons inside repos.**
 
-## Definition
+## Layers
 
-Every persistent entity (process definitions, instances, audit events, human tasks, handoffs, agent runs, cowork sessions, cron trigger state, tool catalog, agent definitions, namespaces) has:
+Every persistent entity has four slots:
 
-1. A Zod schema in `packages/platform-core/src/schemas/`.
-2. A repository interface in `packages/platform-core/src/interfaces/`.
-3. A Firestore implementation in `packages/platform-infra/src/firestore/`.
-4. An in-memory double in `packages/platform-core/src/testing/`.
+1. Zod schema in `packages/platform-core/src/schemas/`.
+2. Repository interface in `packages/platform-core/src/interfaces/`.
+3. Firestore impl in `packages/platform-infra/src/firestore/`.
+4. In-memory double in `packages/platform-core/src/testing/`.
 
-This keeps business logic (workflow-engine, agent-runtime) free of Firestore knowledge — they consume the interfaces only.
+Covers: process definitions + instances, audit events, human tasks, handoffs, agent runs, cowork sessions, cron trigger state, tool catalog, agent definitions, namespaces.
 
-## Before writing a new repository
+Keeps workflow-engine + agent-runtime free of Firestore knowledge — they consume interfaces only.
 
-- Check `packages/platform-core/src/interfaces/` for an existing interface you can extend.
-- Check `packages/platform-infra/src/firestore/` for a similar implementation pattern.
-- Check `packages/platform-core/src/testing/` for a test double to match.
+## Before writing a new repo
 
-If you're reaching for direct Firestore access from `workflow-engine`, `agent-runtime`, or plugins — stop. That breaks the boundary. Add the interface to `platform-core` instead.
+- Check `packages/platform-core/src/interfaces/` for an existing interface to extend.
+- Check `packages/platform-infra/src/firestore/` for a similar impl pattern.
+- Check `packages/platform-core/src/testing/` for the double.
+
+Reaching for direct Firestore access from workflow-engine / agent-runtime / plugins? **Stop.** Breaks the boundary. Add the interface to `platform-core` instead.
 
 ## Versioning invariant
 
-`FirestoreProcessRepository` and workflow-definition repositories enforce **write-once versioning** — throw `DefinitionVersionAlreadyExistsError` / `ConfigVersionAlreadyExistsError` on overwrite. See [`platform-infra`](../entities/packages/platform-infra.md).
+Firestore process + workflow-definition repos are **write-once**. Overwrite → `DefinitionVersionAlreadyExistsError` / `ConfigVersionAlreadyExistsError`. See [`platform-infra`](../entities/packages/platform-infra.md).
 
-## Testing implications
+## Testing
 
-Never mock Firestore directly. Use `InMemory*Repository` doubles from `@mediforce/platform-core/testing`:
+Never mock Firestore. Use `InMemory*Repository` from `@mediforce/platform-core/testing`:
 
 ```typescript
 import { buildProcessInstance, buildHumanTask, buildAgentRun } from '@mediforce/platform-core/testing';
 ```
 
-See `AGENTS.md` → "Test factories".
+See [in-memory-repos-not-mocks gotcha](../gotchas/in-memory-repos-not-mocks.md).
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/concepts/repository-pattern.md
+++ b/docs/knowledge-base/wiki/concepts/repository-pattern.md
@@ -1,0 +1,49 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [concept, repository-pattern, platform-core, platform-infra]
+---
+
+**Interfaces in `platform-core`, concrete Firestore implementations in `platform-infra`, in-memory test doubles in `platform-core/testing`. Constructor injection — no global singletons inside repositories.**
+
+## Definition
+
+Every persistent entity (process definitions, instances, audit events, human tasks, handoffs, agent runs, cowork sessions, cron trigger state, tool catalog, agent definitions, namespaces) has:
+
+1. A Zod schema in `packages/platform-core/src/schemas/`.
+2. A repository interface in `packages/platform-core/src/interfaces/`.
+3. A Firestore implementation in `packages/platform-infra/src/firestore/`.
+4. An in-memory double in `packages/platform-core/src/testing/`.
+
+This keeps business logic (workflow-engine, agent-runtime) free of Firestore knowledge — they consume the interfaces only.
+
+## Before writing a new repository
+
+- Check `packages/platform-core/src/interfaces/` for an existing interface you can extend.
+- Check `packages/platform-infra/src/firestore/` for a similar implementation pattern.
+- Check `packages/platform-core/src/testing/` for a test double to match.
+
+If you're reaching for direct Firestore access from `workflow-engine`, `agent-runtime`, or plugins — stop. That breaks the boundary. Add the interface to `platform-core` instead.
+
+## Versioning invariant
+
+`FirestoreProcessRepository` and workflow-definition repositories enforce **write-once versioning** — throw `DefinitionVersionAlreadyExistsError` / `ConfigVersionAlreadyExistsError` on overwrite. See [`platform-infra`](../entities/packages/platform-infra.md).
+
+## Testing implications
+
+Never mock Firestore directly. Use `InMemory*Repository` doubles from `@mediforce/platform-core/testing`:
+
+```typescript
+import { buildProcessInstance, buildHumanTask, buildAgentRun } from '@mediforce/platform-core/testing';
+```
+
+See [`AGENTS.md` → "Test factories"](../../../AGENTS.md).
+
+## Sources
+
+- `packages/platform-core/src/interfaces/`
+- `packages/platform-infra/src/firestore/`
+- `packages/platform-core/src/testing/factories.ts`
+- `AGENTS.md` → "Key architectural patterns"

--- a/docs/knowledge-base/wiki/concepts/repository-pattern.md
+++ b/docs/knowledge-base/wiki/concepts/repository-pattern.md
@@ -39,7 +39,7 @@ Never mock Firestore directly. Use `InMemory*Repository` doubles from `@mediforc
 import { buildProcessInstance, buildHumanTask, buildAgentRun } from '@mediforce/platform-core/testing';
 ```
 
-See [`AGENTS.md` → "Test factories"](../../../AGENTS.md).
+See `AGENTS.md` → "Test factories".
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/concepts/service-singleton.md
+++ b/docs/knowledge-base/wiki/concepts/service-singleton.md
@@ -1,0 +1,35 @@
+---
+type: concept
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [concept, service-singleton, platform-ui, composition-root]
+---
+
+**`getPlatformServices()` in `platform-ui/src/lib/platform-services.ts` is the single composition root — it lazily wires every repository, the workflow engine, agent runner, and plugin registry. Shared across API routes and server components.**
+
+## Why it matters
+
+Every API route that touches persistence or agents goes through this function. If you're about to instantiate a `FirestoreProcessRepository`, a `WorkflowEngine`, or an `AgentRunner` inside a handler, **stop** — call `getPlatformServices()` instead. That's the only way to reuse the lazy singletons and keep plugin registration consistent.
+
+## What it builds
+
+- Every Firestore repository (via [`platform-infra`](../entities/packages/platform-infra.md)).
+- `WorkflowEngine` + `StepExecutor` (via [`workflow-engine`](../entities/packages/workflow-engine.md)).
+- `AgentRunner` + `PluginRegistry` (via [`agent-runtime`](../entities/packages/agent-runtime.md)).
+- Firebase Auth + User Directory services.
+- The built-in plugins: `claude-code-agent`, `opencode-agent`, `script-container` (or their mocks when `MOCK_AGENT=true`).
+- [`supply-intelligence-plugins`](../entities/packages/supply-intelligence-plugins.md) via `registerSupplyIntelligencePlugins(registry)`.
+
+## Fail-fast
+
+Validates required encryption keys (`secrets-cipher`) on first call. Missing or misconfigured keys throw immediately rather than failing on first workflow execution.
+
+## Lifecycle
+
+Lazy-initialised on first call. Subsequent calls return the same instance. Next.js route handlers + RSC + API routes all share it within a single server process.
+
+## Sources
+
+- `packages/platform-ui/src/lib/platform-services.ts`
+- `AGENTS.md` → "Key architectural patterns" → "Service singleton"

--- a/docs/knowledge-base/wiki/concepts/service-singleton.md
+++ b/docs/knowledge-base/wiki/concepts/service-singleton.md
@@ -6,28 +6,28 @@ sources: 2
 tags: [concept, service-singleton, platform-ui, composition-root]
 ---
 
-**`getPlatformServices()` in `platform-ui/src/lib/platform-services.ts` is the single composition root — it lazily wires every repository, the workflow engine, agent runner, and plugin registry. Shared across API routes and server components.**
+**`getPlatformServices()` in `platform-ui/src/lib/platform-services.ts`. Single composition root. Lazy-wires every repo, workflow engine, agent runner, plugin registry. Shared across API routes + server components.**
 
 ## Why it matters
 
-Every API route that touches persistence or agents goes through this function. If you're about to instantiate a `FirestoreProcessRepository`, a `WorkflowEngine`, or an `AgentRunner` inside a handler, **stop** — call `getPlatformServices()` instead. That's the only way to reuse the lazy singletons and keep plugin registration consistent.
+Every API route that touches persistence or agents goes through this. About to instantiate `FirestoreProcessRepository`, `WorkflowEngine`, or `AgentRunner` inside a handler? **Stop.** Call `getPlatformServices()` instead. Only way to reuse lazy singletons + keep plugin registration consistent.
 
 ## What it builds
 
 - Every Firestore repository (via [`platform-infra`](../entities/packages/platform-infra.md)).
 - `WorkflowEngine` + `StepExecutor` (via [`workflow-engine`](../entities/packages/workflow-engine.md)).
 - `AgentRunner` + `PluginRegistry` (via [`agent-runtime`](../entities/packages/agent-runtime.md)).
-- Firebase Auth + User Directory services.
-- The built-in plugins: `claude-code-agent`, `opencode-agent`, `script-container` (or their mocks when `MOCK_AGENT=true`).
+- Firebase Auth + User Directory.
+- Built-in plugins: `claude-code-agent`, `opencode-agent`, `script-container` (mocks when `MOCK_AGENT=true`).
 - [`supply-intelligence-plugins`](../entities/packages/supply-intelligence-plugins.md) via `registerSupplyIntelligencePlugins(registry)`.
 
 ## Fail-fast
 
-Validates required encryption keys (`secrets-cipher`) on first call. Missing or misconfigured keys throw immediately rather than failing on first workflow execution.
+Validates encryption keys (`secrets-cipher`) on first call. Missing keys → throw immediately. No deferred failure at workflow runtime.
 
 ## Lifecycle
 
-Lazy-initialised on first call. Subsequent calls return the same instance. Next.js route handlers + RSC + API routes all share it within a single server process.
+Lazy-init on first call. Subsequent calls reuse. Next.js route handlers + RSC + API routes share it within one server process.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/entities/apps/community-digest.md
+++ b/docs/knowledge-base/wiki/entities/apps/community-digest.md
@@ -1,0 +1,39 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [app, community-digest, discord, github, cron]
+---
+
+**Scheduled workflow app that gathers GitHub activity, ranks changes, and drafts Discord posts. Runs daily Mon–Fri at 08:00 or on-demand.**
+
+## Purpose
+
+Automates the "what happened this week" update. Triggered by cron or manual dispatch. Uses the [`script-container`](../plugins/script-container.md) plugin (not an LLM plugin) for GitHub data gathering, then DeepSeek for ranking, then drafts Discord posts for human review before posting.
+
+## Workflow definition
+
+File: `apps/community-digest/src/community-digest.wd.json`.
+
+Trigger: `cron` — daily 08:00 Mon–Fri — or manual.
+
+Partial step list:
+1. `select-period` (human)
+2. `gather-changes` (script, `script-container`)
+3. `rank-changes` (agent)
+4. `draft-posts` (agent)
+5. `post-to-discord` (agent)
+
+## Container
+
+Custom Docker image `mediforce-agent:community-digest`, built from `apps/community-digest/container/Dockerfile`.
+
+## Relationships
+
+- Depends on: [`script-container`](../plugins/script-container.md), [`agent-runtime`](../packages/agent-runtime.md).
+
+## Sources
+
+- `apps/community-digest/src/community-digest.wd.json`
+- `apps/community-digest/container/Dockerfile`

--- a/docs/knowledge-base/wiki/entities/apps/community-digest.md
+++ b/docs/knowledge-base/wiki/entities/apps/community-digest.md
@@ -6,28 +6,21 @@ sources: 2
 tags: [app, community-digest, discord, github, cron]
 ---
 
-**Scheduled workflow app that gathers GitHub activity, ranks changes, and drafts Discord posts. Runs daily Mon–Fri at 08:00 or on-demand.**
+**Scheduled workflow. Gathers GitHub activity → ranks changes → drafts Discord posts. Daily Mon–Fri 08:00 or manual.**
 
-## Purpose
+## Steps
 
-Automates the "what happened this week" update. Triggered by cron or manual dispatch. Uses the [`script-container`](../plugins/script-container.md) plugin (not an LLM plugin) for GitHub data gathering, then DeepSeek for ranking, then drafts Discord posts for human review before posting.
+File: `apps/community-digest/src/community-digest.wd.json`. Trigger: cron or manual.
 
-## Workflow definition
-
-File: `apps/community-digest/src/community-digest.wd.json`.
-
-Trigger: `cron` — daily 08:00 Mon–Fri — or manual.
-
-Partial step list:
 1. `select-period` (human)
-2. `gather-changes` (script, `script-container`)
-3. `rank-changes` (agent)
+2. `gather-changes` (script, [`script-container`](../plugins/script-container.md))
+3. `rank-changes` (agent — DeepSeek)
 4. `draft-posts` (agent)
 5. `post-to-discord` (agent)
 
 ## Container
 
-Custom Docker image `mediforce-agent:community-digest`, built from `apps/community-digest/container/Dockerfile`.
+Custom Docker image `mediforce-agent:community-digest` built from `apps/community-digest/container/Dockerfile`.
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/apps/protocol-to-tfl.md
+++ b/docs/knowledge-base/wiki/entities/apps/protocol-to-tfl.md
@@ -1,0 +1,55 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [app, protocol-to-tfl, clinical, cdisc, workflow]
+---
+
+**Meta-workflow app that transforms a clinical trial protocol (PDF) plus SAP into production Tables, Figures, Listings (TFLs). Six automated/human steps plus terminal.**
+
+## Purpose
+
+Pipeline for clinical submissions. Starts from raw PDFs (protocol + statistical analysis plan), extracts metadata, generates TLG shells, ingests SDTM data, derives ADaM datasets with R code, and produces final TFLs. Agent-heavy (L3 autonomy — periodic human review) with two `git-mode` steps that commit output to the `Appsilon/mediforce-clinical-workspace` repo.
+
+## Workflow definition
+
+File: `apps/protocol-to-tfl/src/protocol-to-tfl.wd.json`.
+
+| # | Step | Type | Agent | Autonomy |
+|---|------|------|-------|----------|
+| 1 | upload-documents | human | — | — |
+| 2 | extract-metadata | agent | claude-code-agent | L3 |
+| 3 | generate-tlg-shells | agent | claude-code-agent | L3 |
+| 4 | upload-sdtm | human | — | — |
+| 5 | generate-adam | agent | claude-code-agent (git-mode) | L3 |
+| 6 | generate-tlg | agent | claude-code-agent (git-mode) | L3 |
+| 7 | done | terminal | — | — |
+
+## Skills (runtime)
+
+Registered in `apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/_registry.yml`:
+
+- `trial-metadata-extractor` — extracts trial metadata from protocol PDF.
+- `mock-tlg-generator` — generates mock TLG specs from metadata.
+- `sdtm-to-adam` — derives ADaM datasets from SDTM (see [cdisc-sdtm concept](../../concepts/cdisc-sdtm.md)).
+- `adam-to-tlg` — produces final TFLs from ADaM.
+- `adam-to-teal` — R-based Teal app generator.
+
+These are runtime skills, resolved by [`agent-runtime`](../packages/agent-runtime.md) via the workflow definition's `skillsDir` field — paths are hardcoded in the `.wd.json`. Do not move them.
+
+## Process configs
+
+Multiple variants under `apps/protocol-to-tfl/`:
+- `process-config-claude.json`, `process-config-opencode.json`, `process-config-local.json`
+
+## Relationships
+
+- Depends on: [`claude-code-agent`](../plugins/claude-code-agent.md), [`agent-runtime`](../packages/agent-runtime.md).
+- External repo: `Appsilon/mediforce-clinical-workspace` — target of `git-mode` commits.
+
+## Sources
+
+- `apps/protocol-to-tfl/src/protocol-to-tfl.wd.json`
+- `apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/_registry.yml`
+- `AGENTS.md` → "Skills and Agents"

--- a/docs/knowledge-base/wiki/entities/apps/protocol-to-tfl.md
+++ b/docs/knowledge-base/wiki/entities/apps/protocol-to-tfl.md
@@ -6,13 +6,9 @@ sources: 3
 tags: [app, protocol-to-tfl, clinical, cdisc, workflow]
 ---
 
-**Meta-workflow app that transforms a clinical trial protocol (PDF) plus SAP into production Tables, Figures, Listings (TFLs). Six automated/human steps plus terminal.**
+**Protocol PDF + SAP → TFLs. 6 steps + terminal. L3 autonomy, two `git-mode` steps commit to `Appsilon/mediforce-clinical-workspace`.**
 
-## Purpose
-
-Pipeline for clinical submissions. Starts from raw PDFs (protocol + statistical analysis plan), extracts metadata, generates TLG shells, ingests SDTM data, derives ADaM datasets with R code, and produces final TFLs. Agent-heavy (L3 autonomy — periodic human review) with two `git-mode` steps that commit output to the `Appsilon/mediforce-clinical-workspace` repo.
-
-## Workflow definition
+## Steps
 
 File: `apps/protocol-to-tfl/src/protocol-to-tfl.wd.json`.
 
@@ -26,22 +22,23 @@ File: `apps/protocol-to-tfl/src/protocol-to-tfl.wd.json`.
 | 6 | generate-tlg | agent | claude-code-agent (git-mode) | L3 |
 | 7 | done | terminal | — | — |
 
-## Skills (runtime)
+See [autonomy-levels](../../concepts/autonomy-levels.md), [cdisc-sdtm](../../concepts/cdisc-sdtm.md).
+
+## Runtime skills
 
 Registered in `apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/_registry.yml`:
 
-- `trial-metadata-extractor` — extracts trial metadata from protocol PDF.
-- `mock-tlg-generator` — generates mock TLG specs from metadata.
-- `sdtm-to-adam` — derives ADaM datasets from SDTM (see [cdisc-sdtm concept](../../concepts/cdisc-sdtm.md)).
-- `adam-to-tlg` — produces final TFLs from ADaM.
-- `adam-to-teal` — R-based Teal app generator.
+- `trial-metadata-extractor` — protocol PDF → metadata.
+- `mock-tlg-generator` — metadata → mock TLG specs.
+- `sdtm-to-adam` — SDTM → ADaM.
+- `adam-to-tlg` — ADaM → final TFLs.
+- `adam-to-teal` — R-based Teal app.
 
-These are runtime skills, resolved by [`agent-runtime`](../packages/agent-runtime.md) via the workflow definition's `skillsDir` field — paths are hardcoded in the `.wd.json`. Do not move them.
+**Paths hardcoded in `.wd.json` via `skillsDir`. Don't move them.** See [runtime-skill-path-coupling](../../gotchas/runtime-skill-path-coupling.md).
 
 ## Process configs
 
-Multiple variants under `apps/protocol-to-tfl/`:
-- `process-config-claude.json`, `process-config-opencode.json`, `process-config-local.json`
+Variants: `process-config-claude.json`, `process-config-opencode.json`, `process-config-local.json`.
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/apps/supply-intelligence.md
+++ b/docs/knowledge-base/wiki/entities/apps/supply-intelligence.md
@@ -1,0 +1,44 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [app, supply-intelligence, nextjs]
+---
+
+**Standalone Next.js dashboard for supply-chain risk analysis, visualization, and issue management.**
+
+## Purpose
+
+User-facing UI on top of the [`supply-intelligence`](../packages/supply-intelligence.md) domain. Distinct from the main [`platform-ui`](../packages/platform-ui.md) — lives in `apps/supply-intelligence/` and ships independently. Visualises risk rollups (therapeutic category, SKU detail, operational view) and surfaces draft issues produced by the [`supply-intelligence/risk-detection` plugin](../plugins/supply-intelligence-risk-detection.md).
+
+## Stack
+
+- Next.js 16 App Router
+- Radix UI + TanStack Table + Recharts
+- Firebase (Firestore + Auth)
+- Zod
+
+## Routes
+
+- `/` → redirects to `/overview`
+- `/overview` — portfolio dashboard
+- `/operational` — operational view
+- `/sku/[id]` — SKU detail
+
+## Dev / test
+
+- Dev: `npm run dev` on port **9004** (distinct from `platform-ui` on 9003).
+- E2E: Playwright; `NEXT_PUBLIC_USE_EMULATORS=true` for emulator-backed tests.
+
+## Relationships
+
+- Depends on: [`supply-intelligence`](../packages/supply-intelligence.md).
+- Consumes Firestore writes from: [`supply-intelligence/risk-detection`](../plugins/supply-intelligence-risk-detection.md).
+- Does **not** import `platform-ui` or `platform-infra`.
+
+## Sources
+
+- `apps/supply-intelligence/src/app/page.tsx`
+- `apps/supply-intelligence/src/app/layout.tsx`
+- `apps/supply-intelligence/package.json`

--- a/docs/knowledge-base/wiki/entities/apps/supply-intelligence.md
+++ b/docs/knowledge-base/wiki/entities/apps/supply-intelligence.md
@@ -6,11 +6,11 @@ sources: 3
 tags: [app, supply-intelligence, nextjs]
 ---
 
-**Standalone Next.js dashboard for supply-chain risk analysis, visualization, and issue management.**
+**Standalone Next.js dashboard. Supply-chain risk visualization + issue management. Port 9004.**
 
 ## Purpose
 
-User-facing UI on top of the [`supply-intelligence`](../packages/supply-intelligence.md) domain. Distinct from the main [`platform-ui`](../packages/platform-ui.md) — lives in `apps/supply-intelligence/` and ships independently. Visualises risk rollups (therapeutic category, SKU detail, operational view) and surfaces draft issues produced by the [`supply-intelligence/risk-detection` plugin](../plugins/supply-intelligence-risk-detection.md).
+UI over [`supply-intelligence`](../packages/supply-intelligence.md). Ships separate from [platform-ui](../packages/platform-ui.md). Visualises risk rollups (category, SKU, operational). Surfaces draft issues from [risk-detection plugin](../plugins/supply-intelligence-risk-detection.md).
 
 ## Stack
 
@@ -21,21 +21,21 @@ User-facing UI on top of the [`supply-intelligence`](../packages/supply-intellig
 
 ## Routes
 
-- `/` → redirects to `/overview`
+- `/` → `/overview`
 - `/overview` — portfolio dashboard
 - `/operational` — operational view
 - `/sku/[id]` — SKU detail
 
 ## Dev / test
 
-- Dev: `npm run dev` on port **9004** (distinct from `platform-ui` on 9003).
-- E2E: Playwright; `NEXT_PUBLIC_USE_EMULATORS=true` for emulator-backed tests.
+- Dev: `npm run dev` → port **9004** (not 9003 — that's platform-ui).
+- E2E: Playwright; `NEXT_PUBLIC_USE_EMULATORS=true` for emulator tests.
 
 ## Relationships
 
 - Depends on: [`supply-intelligence`](../packages/supply-intelligence.md).
-- Consumes Firestore writes from: [`supply-intelligence/risk-detection`](../plugins/supply-intelligence-risk-detection.md).
-- Does **not** import `platform-ui` or `platform-infra`.
+- Reads Firestore writes from: [`supply-intelligence/risk-detection`](../plugins/supply-intelligence-risk-detection.md).
+- **Does not** import: `platform-ui`, `platform-infra`.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/entities/apps/workflow-designer.md
+++ b/docs/knowledge-base/wiki/entities/apps/workflow-designer.md
@@ -1,0 +1,37 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [app, workflow-designer, meta-workflow]
+---
+
+**Meta-workflow app that designs new Mediforce `WorkflowDefinition`s via AI + human review. Three workflow variants shipped (base, cowork, voice).**
+
+## Purpose
+
+Bootstraps new workflows. User describes an idea in natural language; an agent generates a candidate `WorkflowDefinition` JSON; human reviews and approves; the system registers it. Role-gated: `workflow-designer` role required.
+
+## Workflow definitions
+
+- `apps/workflow-designer/src/workflow-designer.wd.json` — base
+- `apps/workflow-designer/src/cowork-workflow-designer.wd.json` — co-authoring variant
+- `apps/workflow-designer/src/voice-workflow-designer.wd.json` — voice input variant
+
+Partial step list (base):
+1. `choose-mode` (human) — create-new vs edit-existing
+2. `describe-idea` (human) — natural language + workflow name
+3. `fetch-workflows` (agent) — list available workflows
+4. `design-steps` (agent) — generate WorkflowDefinition JSON
+5. `human-review` (human) — approve / reject
+6. `register` (agent) — validate + register
+
+## Relationships
+
+- Produces: `WorkflowDefinition` entries consumed by [`workflow-engine`](../packages/workflow-engine.md) and [`platform-ui`](../packages/platform-ui.md).
+- Schema authority: `WorkflowDefinition` lives in [`platform-core`](../packages/platform-core.md) `src/schemas/workflow-definition.ts`.
+
+## Sources
+
+- `apps/workflow-designer/src/workflow-designer.wd.json`
+- `apps/workflow-designer/src/cowork-workflow-designer.wd.json`

--- a/docs/knowledge-base/wiki/entities/apps/workflow-designer.md
+++ b/docs/knowledge-base/wiki/entities/apps/workflow-designer.md
@@ -6,11 +6,7 @@ sources: 2
 tags: [app, workflow-designer, meta-workflow]
 ---
 
-**Meta-workflow app that designs new Mediforce `WorkflowDefinition`s via AI + human review. Three workflow variants shipped (base, cowork, voice).**
-
-## Purpose
-
-Bootstraps new workflows. User describes an idea in natural language; an agent generates a candidate `WorkflowDefinition` JSON; human reviews and approves; the system registers it. Role-gated: `workflow-designer` role required.
+**Meta-workflow. Designs new `WorkflowDefinition`s via AI + human review. Three variants (base, cowork, voice). Role-gated: `workflow-designer`.**
 
 ## Workflow definitions
 
@@ -18,18 +14,19 @@ Bootstraps new workflows. User describes an idea in natural language; an agent g
 - `apps/workflow-designer/src/cowork-workflow-designer.wd.json` — co-authoring variant
 - `apps/workflow-designer/src/voice-workflow-designer.wd.json` — voice input variant
 
-Partial step list (base):
+## Steps (base)
+
 1. `choose-mode` (human) — create-new vs edit-existing
-2. `describe-idea` (human) — natural language + workflow name
-3. `fetch-workflows` (agent) — list available workflows
-4. `design-steps` (agent) — generate WorkflowDefinition JSON
+2. `describe-idea` (human) — natural language + name
+3. `fetch-workflows` (agent) — list available
+4. `design-steps` (agent) — generate `WorkflowDefinition` JSON
 5. `human-review` (human) — approve / reject
 6. `register` (agent) — validate + register
 
 ## Relationships
 
-- Produces: `WorkflowDefinition` entries consumed by [`workflow-engine`](../packages/workflow-engine.md) and [`platform-ui`](../packages/platform-ui.md).
-- Schema authority: `WorkflowDefinition` lives in [`platform-core`](../packages/platform-core.md) `src/schemas/workflow-definition.ts`.
+- Produces: `WorkflowDefinition` entries consumed by [workflow-engine](../packages/workflow-engine.md) + [platform-ui](../packages/platform-ui.md).
+- Schema authority: `WorkflowDefinition` in [platform-core](../packages/platform-core.md) `src/schemas/workflow-definition.ts`.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/entities/packages/agent-runtime.md
+++ b/docs/knowledge-base/wiki/entities/packages/agent-runtime.md
@@ -1,0 +1,51 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 5
+tags: [package, agent-runtime, plugins, docker]
+---
+
+**Agent execution engine — dispatches plugin runs (Claude Code, OpenCode, scripts), enforces autonomy levels, handles fallbacks, manages Docker spawn strategies, binds MCP per step.**
+
+## Purpose
+
+Given an agent step in a workflow, loads the right plugin, assembles its prompt (skill file + custom prompt + previous outputs + confidence instructions), spawns the container (local or queued), validates the emitted `result` envelope against `AgentOutputEnvelopeSchema`, and applies fallbacks (timeout, low confidence, error). Provides the `AgentPlugin` interface that all agents implement.
+
+## Dependencies
+
+- Internal: [`platform-core`](./platform-core.md) (required); `@mediforce/agent-queue` (optional, activated when `REDIS_URL` is set)
+- External: `firebase-admin`, `zod`
+
+## Key exports
+
+- **Interfaces**: `AgentPlugin`, `AgentContext`, `WorkflowAgentContext`, `AutonomyLevel` (see [autonomy-levels concept](../../concepts/autonomy-levels.md)), `LlmClient`, `LlmResponse`.
+- **Plugin base**: `BaseContainerAgentPlugin` (1400+ lines — Docker/CLI spawning, volume mounts, git workflows, MCP config write, output extraction).
+- **Concrete plugins**: [`ClaudeCodeAgentPlugin`](../plugins/claude-code-agent.md), [`OpenCodeAgentPlugin`](../plugins/opencode-agent.md), [`ScriptContainerPlugin`](../plugins/script-container.md), `MockClaudeCodeAgentPlugin`.
+- **Runner**: `AgentRunner` (see [plugin-dispatch concept](../../concepts/plugin-dispatch.md)), `PluginRegistry`, `FallbackHandler`.
+- **LLM**: `OpenRouterLlmClient`.
+- **Event log**: `FirestoreAgentEventLog`, `InMemoryAgentEventLog`.
+- **MCP**: `resolveMcpForStep`, `flattenResolvedMcpToLegacy`.
+- **Environment**: `validateWorkflowEnv`.
+
+## Key internal modules
+
+- `src/runner/` — `agent-runner.ts` (600+ lines, main execution loop), `plugin-registry.ts`, `fallback-handler.ts`, `agent-event-log.ts`.
+- `src/plugins/` — `base-container-agent-plugin.ts`, concrete plugins, `docker-spawn-strategy.ts` (see [docker-spawn-strategies concept](../../concepts/docker-spawn-strategies.md)), `docker-image-builder.ts`, `resolve-env.ts`.
+- `src/interfaces/` — `AgentPlugin` contract, context shapes.
+- `src/mcp/` — step-scoped MCP resolution.
+- `src/testing/` — `InMemoryAgentEventLog`, `NoopLlmClient`.
+
+## Relationships
+
+- Consumed by: [`platform-ui`](./platform-ui.md), [`example-agent`](../plugins/example-agent.md), [`supply-intelligence-plugins`](./supply-intelligence-plugins.md).
+- Depends on: [`platform-core`](./platform-core.md), optionally `agent-queue`.
+
+## Sources
+
+- `packages/agent-runtime/src/index.ts`
+- `packages/agent-runtime/src/runner/agent-runner.ts`
+- `packages/agent-runtime/src/runner/plugin-registry.ts`
+- `packages/agent-runtime/src/plugins/base-container-agent-plugin.ts`
+- `packages/agent-runtime/src/plugins/docker-spawn-strategy.ts`
+- `AGENTS.md` → "Plugin system", "Docker spawn strategies"

--- a/docs/knowledge-base/wiki/entities/packages/agent-runtime.md
+++ b/docs/knowledge-base/wiki/entities/packages/agent-runtime.md
@@ -6,34 +6,34 @@ sources: 5
 tags: [package, agent-runtime, plugins, docker]
 ---
 
-**Agent execution engine — dispatches plugin runs (Claude Code, OpenCode, scripts), enforces autonomy levels, handles fallbacks, manages Docker spawn strategies, binds MCP per step.**
+**Agent execution engine. Plugin dispatch, autonomy enforcement, fallback, Docker spawn strategies, per-step MCP binding.**
 
 ## Purpose
 
-Given an agent step in a workflow, loads the right plugin, assembles its prompt (skill file + custom prompt + previous outputs + confidence instructions), spawns the container (local or queued), validates the emitted `result` envelope against `AgentOutputEnvelopeSchema`, and applies fallbacks (timeout, low confidence, error). Provides the `AgentPlugin` interface that all agents implement.
+Given an agent step: load plugin, assemble prompt (skill file + custom prompt + previous outputs + confidence instructions), spawn container (local or queued), validate `result` vs `AgentOutputEnvelopeSchema`, apply fallbacks (timeout / low-confidence / error). Owns the `AgentPlugin` interface.
 
 ## Dependencies
 
-- Internal: [`platform-core`](./platform-core.md) (required); `@mediforce/agent-queue` (optional, activated when `REDIS_URL` is set)
-- External: `firebase-admin`, `zod`
+- Internal: [`platform-core`](./platform-core.md) (required); `@mediforce/agent-queue` (optional, on `REDIS_URL`).
+- External: `firebase-admin`, `zod`.
 
 ## Key exports
 
-- **Interfaces**: `AgentPlugin`, `AgentContext`, `WorkflowAgentContext`, `AutonomyLevel` (see [autonomy-levels concept](../../concepts/autonomy-levels.md)), `LlmClient`, `LlmResponse`.
-- **Plugin base**: `BaseContainerAgentPlugin` (1400+ lines — Docker/CLI spawning, volume mounts, git workflows, MCP config write, output extraction).
-- **Concrete plugins**: [`ClaudeCodeAgentPlugin`](../plugins/claude-code-agent.md), [`OpenCodeAgentPlugin`](../plugins/opencode-agent.md), [`ScriptContainerPlugin`](../plugins/script-container.md), `MockClaudeCodeAgentPlugin`.
-- **Runner**: `AgentRunner` (see [plugin-dispatch concept](../../concepts/plugin-dispatch.md)), `PluginRegistry`, `FallbackHandler`.
+- **Interfaces**: `AgentPlugin`, `AgentContext`, `WorkflowAgentContext`, `AutonomyLevel` → [autonomy-levels](../../concepts/autonomy-levels.md), `LlmClient`, `LlmResponse`.
+- **Plugin base**: `BaseContainerAgentPlugin` (1400+ lines — spawn, mounts, git, MCP config, output extract).
+- **Concrete**: [`ClaudeCodeAgentPlugin`](../plugins/claude-code-agent.md), [`OpenCodeAgentPlugin`](../plugins/opencode-agent.md), [`ScriptContainerPlugin`](../plugins/script-container.md), `MockClaudeCodeAgentPlugin`.
+- **Runner**: `AgentRunner` → [plugin-dispatch](../../concepts/plugin-dispatch.md), `PluginRegistry`, `FallbackHandler`.
 - **LLM**: `OpenRouterLlmClient`.
 - **Event log**: `FirestoreAgentEventLog`, `InMemoryAgentEventLog`.
 - **MCP**: `resolveMcpForStep`, `flattenResolvedMcpToLegacy`.
-- **Environment**: `validateWorkflowEnv`.
+- **Env**: `validateWorkflowEnv`.
 
 ## Key internal modules
 
-- `src/runner/` — `agent-runner.ts` (600+ lines, main execution loop), `plugin-registry.ts`, `fallback-handler.ts`, `agent-event-log.ts`.
-- `src/plugins/` — `base-container-agent-plugin.ts`, concrete plugins, `docker-spawn-strategy.ts` (see [docker-spawn-strategies concept](../../concepts/docker-spawn-strategies.md)), `docker-image-builder.ts`, `resolve-env.ts`.
-- `src/interfaces/` — `AgentPlugin` contract, context shapes.
-- `src/mcp/` — step-scoped MCP resolution.
+- `src/runner/` — `agent-runner.ts` (600+ lines), `plugin-registry.ts`, `fallback-handler.ts`, `agent-event-log.ts`.
+- `src/plugins/` — `base-container-agent-plugin.ts`, concretes, `docker-spawn-strategy.ts` → [docker-spawn-strategies](../../concepts/docker-spawn-strategies.md), `docker-image-builder.ts`, `resolve-env.ts`.
+- `src/interfaces/` — `AgentPlugin`, context shapes.
+- `src/mcp/` — step-scoped MCP.
 - `src/testing/` — `InMemoryAgentEventLog`, `NoopLlmClient`.
 
 ## Relationships

--- a/docs/knowledge-base/wiki/entities/packages/platform-core.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-core.md
@@ -6,33 +6,37 @@ sources: 4
 tags: [package, platform-core, schemas, foundation]
 ---
 
-**Foundational package — Zod schemas, repository interfaces, and test factories for every domain entity; zero `@mediforce/*` dependencies.**
+**Foundation. Zod schemas + repository interfaces + test factories. Zero `@mediforce/*` deps.**
 
 ## Purpose
 
-Owns the cross-cutting contracts used by every other package: domain schemas (process definitions, workflow definitions, agent runs, human tasks, handoffs, MCP bindings), repository interfaces, service interfaces (auth, notifications, user directory), and validation/parsing utilities. Foundation for the dependency graph — depends on nothing in `@mediforce/*`.
+Cross-cutting contracts every other package consumes: domain schemas, repository + service interfaces, validation/parsing utils, in-memory test doubles. Bottom of dependency graph.
 
 ## Dependencies
 
-- Internal: none
-- External: `zod`, `yaml`
+- Internal: none.
+- External: `zod`, `yaml`.
 
 ## Key exports
 
-- **Schemas (Zod + inferred types)**: `ProcessDefinition`, `Step`, `Transition`, `Trigger`, `ProcessInstance`, `StepExecution`, `AuditEvent`, `ProcessConfig`, `AgentRun`, `HumanTask`, `HandoffEntity`, `Namespace`, `WorkflowDefinition`, `CoworkSession`, `AgentMcpBinding`, MCP server/tool catalog entries.
-- **Repository interfaces**: `ProcessRepository`, `ProcessInstanceRepository`, `AuditRepository`, `HumanTaskRepository`, `HandoffRepository`, `CoworkSessionRepository`, `CronTriggerStateRepository`, `ToolCatalogRepository`, `AgentDefinitionRepository`.
-- **Service interfaces**: `AuthService`, `NotificationService`, `UserDirectoryService`.
-- **Utilities**: `parseProcessDefinition` (YAML), `validateProcessConfig`, `resolveEffectiveMcp`, `RbacService`, `handoffTypeRegistry`.
-- **Testing** (`@mediforce/platform-core/testing`): in-memory repository doubles, factory builders (`buildProcessInstance`, `buildHumanTask`, `buildAgentRun`, etc.).
+**Schemas (Zod + inferred types)**: `ProcessDefinition`, `Step`, `Transition`, `Trigger`, `ProcessInstance`, `StepExecution`, `AuditEvent`, `ProcessConfig`, `AgentRun`, `HumanTask`, `HandoffEntity`, `Namespace`, `WorkflowDefinition`, `CoworkSession`, `AgentMcpBinding`, MCP server/tool catalog entries.
+
+**Repository interfaces**: `ProcessRepository`, `ProcessInstanceRepository`, `AuditRepository`, `HumanTaskRepository`, `HandoffRepository`, `CoworkSessionRepository`, `CronTriggerStateRepository`, `ToolCatalogRepository`, `AgentDefinitionRepository`.
+
+**Service interfaces**: `AuthService`, `NotificationService`, `UserDirectoryService`.
+
+**Utilities**: `parseProcessDefinition` (YAML), `validateProcessConfig`, `resolveEffectiveMcp`, `RbacService`, `handoffTypeRegistry`.
+
+**Testing** (`@mediforce/platform-core/testing`): in-memory repos + factories (`buildProcessInstance`, `buildHumanTask`, `buildAgentRun`, …).
 
 ## Key internal modules
 
-- `src/schemas/` — 40+ Zod schemas, including `workflow-definition.ts` (unions over agent, review, cowork, handoff step variants).
-- `src/interfaces/` — repository and service contracts.
-- `src/parser/` — YAML process definition parsing.
-- `src/mcp/` — MCP server resolution + tool catalog validation.
-- `src/validation/` — `ProcessConfig` validation against `ProcessDefinition`.
-- `src/collaboration/` — handoff type registry, `RbacService`.
+- `src/schemas/` — 40+ Zod schemas. `workflow-definition.ts` = union over agent/review/cowork/handoff variants.
+- `src/interfaces/` — repo + service contracts.
+- `src/parser/` — YAML process-def parsing.
+- `src/mcp/` — MCP server resolution + catalog validation.
+- `src/validation/` — `ProcessConfig` vs `ProcessDefinition`.
+- `src/collaboration/` — handoff registry, `RbacService`.
 - `src/testing/` — in-memory doubles + factories.
 
 ## Relationships
@@ -42,7 +46,7 @@ Owns the cross-cutting contracts used by every other package: domain schemas (pr
 
 ## Sources
 
-- `packages/platform-core/src/index.ts` — barrel exports
+- `packages/platform-core/src/index.ts`
 - `packages/platform-core/src/schemas/workflow-definition.ts`
 - `packages/platform-core/src/schemas/process-definition.ts`
 - `packages/platform-core/src/testing/factories.ts`

--- a/docs/knowledge-base/wiki/entities/packages/platform-core.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-core.md
@@ -1,0 +1,50 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 4
+tags: [package, platform-core, schemas, foundation]
+---
+
+**Foundational package — Zod schemas, repository interfaces, and test factories for every domain entity; zero `@mediforce/*` dependencies.**
+
+## Purpose
+
+Owns the cross-cutting contracts used by every other package: domain schemas (process definitions, workflow definitions, agent runs, human tasks, handoffs, MCP bindings), repository interfaces, service interfaces (auth, notifications, user directory), and validation/parsing utilities. Foundation for the dependency graph — depends on nothing in `@mediforce/*`.
+
+## Dependencies
+
+- Internal: none
+- External: `zod`, `yaml`
+
+## Key exports
+
+- **Schemas (Zod + inferred types)**: `ProcessDefinition`, `Step`, `Transition`, `Trigger`, `ProcessInstance`, `StepExecution`, `AuditEvent`, `ProcessConfig`, `AgentRun`, `HumanTask`, `HandoffEntity`, `Namespace`, `WorkflowDefinition`, `CoworkSession`, `AgentMcpBinding`, MCP server/tool catalog entries.
+- **Repository interfaces**: `ProcessRepository`, `ProcessInstanceRepository`, `AuditRepository`, `HumanTaskRepository`, `HandoffRepository`, `CoworkSessionRepository`, `CronTriggerStateRepository`, `ToolCatalogRepository`, `AgentDefinitionRepository`.
+- **Service interfaces**: `AuthService`, `NotificationService`, `UserDirectoryService`.
+- **Utilities**: `parseProcessDefinition` (YAML), `validateProcessConfig`, `resolveEffectiveMcp`, `RbacService`, `handoffTypeRegistry`.
+- **Testing** (`@mediforce/platform-core/testing`): in-memory repository doubles, factory builders (`buildProcessInstance`, `buildHumanTask`, `buildAgentRun`, etc.).
+
+## Key internal modules
+
+- `src/schemas/` — 40+ Zod schemas, including `workflow-definition.ts` (unions over agent, review, cowork, handoff step variants).
+- `src/interfaces/` — repository and service contracts.
+- `src/parser/` — YAML process definition parsing.
+- `src/mcp/` — MCP server resolution + tool catalog validation.
+- `src/validation/` — `ProcessConfig` validation against `ProcessDefinition`.
+- `src/collaboration/` — handoff type registry, `RbacService`.
+- `src/testing/` — in-memory doubles + factories.
+
+## Relationships
+
+- Consumed by: [`workflow-engine`](./workflow-engine.md), [`agent-runtime`](./agent-runtime.md), [`platform-infra`](./platform-infra.md), [`platform-ui`](./platform-ui.md), [`supply-intelligence-plugins`](./supply-intelligence-plugins.md).
+- Depends on: nothing internal.
+
+## Sources
+
+- `packages/platform-core/src/index.ts` — barrel exports
+- `packages/platform-core/src/schemas/workflow-definition.ts`
+- `packages/platform-core/src/schemas/process-definition.ts`
+- `packages/platform-core/src/testing/factories.ts`
+- `packages/platform-core/package.json`
+- `AGENTS.md` → "Package dependency graph"

--- a/docs/knowledge-base/wiki/entities/packages/platform-infra.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-infra.md
@@ -6,39 +6,39 @@ sources: 4
 tags: [package, platform-infra, firestore, firebase]
 ---
 
-**Firebase/Firestore infrastructure layer — concrete repository implementations, auth services, notification senders, and secrets cipher.**
+**Firebase/Firestore infra layer. Concrete repos, auth services, notifications, secrets cipher.**
 
 ## Purpose
 
-Implements the repository interfaces from `platform-core` against Firestore and wraps Firebase Auth. Encapsulates collection/document shape, immutable version constraints, dual client-vs-admin SDK initialisation, and notification delivery (SendGrid + webhooks). Constructor-injected into services — no global singletons.
+Implements repo interfaces from `platform-core` against Firestore. Wraps Firebase Auth. Owns collection/doc shape, immutable version constraints, dual client-vs-admin SDK init, notification delivery (SendGrid + webhooks). Constructor-injected. No global singletons inside repos.
 
 ## Dependencies
 
-- Internal: [`platform-core`](./platform-core.md)
-- External: `firebase`, `firebase-admin`, `@sendgrid/mail`
+- Internal: [`platform-core`](./platform-core.md).
+- External: `firebase`, `firebase-admin`, `@sendgrid/mail`.
 
 ## Key exports
 
 - **Repositories**: `FirestoreProcessRepository`, `FirestoreProcessInstanceRepository`, `FirestoreAuditRepository`, `FirestoreAgentRunRepository`, `FirestoreHumanTaskRepository`, `FirestoreAgentDefinitionRepository`, `FirestoreNamespaceRepository`, `FirestoreCoworkSessionRepository`, `FirestoreCronTriggerStateRepository`, `FirestoreToolCatalogRepository`.
 - **Auth**: `FirebaseAuthService`, `FirebaseUserDirectoryService`, `FirebaseInviteService`.
-- **Configuration**: `initializeFirebase`, `getFirestoreDb`, `getFirebaseAuth`, `getAdminFirestore`, `getAdminAuth`.
-- **Crypto**: `validateSecretsKey` (HMAC validation for encrypted workflow secrets).
-- **Errors**: `DefinitionVersionAlreadyExistsError`, `ConfigVersionAlreadyExistsError` — enforce write-once semantics (see [repository-pattern concept](../../concepts/repository-pattern.md)).
+- **Config**: `initializeFirebase`, `getFirestoreDb`, `getFirebaseAuth`, `getAdminFirestore`, `getAdminAuth`.
+- **Crypto**: `validateSecretsKey` (HMAC for workflow secrets).
+- **Errors**: `DefinitionVersionAlreadyExistsError`, `ConfigVersionAlreadyExistsError` — write-once enforcement → see [repository-pattern](../../concepts/repository-pattern.md).
 
 ## Key internal modules
 
-- `src/firestore/` — one repository per domain entity.
-- `src/auth/` — Firebase Auth wrappers, user directory, invite service.
-- `src/config/firebase-init.ts` — dual mode (client SDK vs admin SDK) init.
+- `src/firestore/` — one repo per domain entity.
+- `src/auth/` — Firebase Auth wrappers, user directory, invites.
+- `src/config/firebase-init.ts` — client vs admin SDK init.
 - `src/crypto/secrets-cipher.ts` — HMAC validation.
-- `src/notifications/` — SendGrid + webhook delivery.
-- `src/__tests__/` — repository CRUD, versioning, auth claims, cipher.
+- `src/notifications/` — SendGrid + webhooks.
+- `src/__tests__/` — repo CRUD, versioning, auth, cipher.
 
 ## Relationships
 
 - Consumed by: [`platform-ui`](./platform-ui.md).
 - Depends on: [`platform-core`](./platform-core.md).
-- Does **not** depend on: workflow-engine, agent-runtime, supply-intelligence.
+- **Does not** depend on: workflow-engine, agent-runtime, supply-intelligence.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/entities/packages/platform-infra.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-infra.md
@@ -1,0 +1,49 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 4
+tags: [package, platform-infra, firestore, firebase]
+---
+
+**Firebase/Firestore infrastructure layer — concrete repository implementations, auth services, notification senders, and secrets cipher.**
+
+## Purpose
+
+Implements the repository interfaces from `platform-core` against Firestore and wraps Firebase Auth. Encapsulates collection/document shape, immutable version constraints, dual client-vs-admin SDK initialisation, and notification delivery (SendGrid + webhooks). Constructor-injected into services — no global singletons.
+
+## Dependencies
+
+- Internal: [`platform-core`](./platform-core.md)
+- External: `firebase`, `firebase-admin`, `@sendgrid/mail`
+
+## Key exports
+
+- **Repositories**: `FirestoreProcessRepository`, `FirestoreProcessInstanceRepository`, `FirestoreAuditRepository`, `FirestoreAgentRunRepository`, `FirestoreHumanTaskRepository`, `FirestoreAgentDefinitionRepository`, `FirestoreNamespaceRepository`, `FirestoreCoworkSessionRepository`, `FirestoreCronTriggerStateRepository`, `FirestoreToolCatalogRepository`.
+- **Auth**: `FirebaseAuthService`, `FirebaseUserDirectoryService`, `FirebaseInviteService`.
+- **Configuration**: `initializeFirebase`, `getFirestoreDb`, `getFirebaseAuth`, `getAdminFirestore`, `getAdminAuth`.
+- **Crypto**: `validateSecretsKey` (HMAC validation for encrypted workflow secrets).
+- **Errors**: `DefinitionVersionAlreadyExistsError`, `ConfigVersionAlreadyExistsError` — enforce write-once semantics (see [repository-pattern concept](../../concepts/repository-pattern.md)).
+
+## Key internal modules
+
+- `src/firestore/` — one repository per domain entity.
+- `src/auth/` — Firebase Auth wrappers, user directory, invite service.
+- `src/config/firebase-init.ts` — dual mode (client SDK vs admin SDK) init.
+- `src/crypto/secrets-cipher.ts` — HMAC validation.
+- `src/notifications/` — SendGrid + webhook delivery.
+- `src/__tests__/` — repository CRUD, versioning, auth claims, cipher.
+
+## Relationships
+
+- Consumed by: [`platform-ui`](./platform-ui.md).
+- Depends on: [`platform-core`](./platform-core.md).
+- Does **not** depend on: workflow-engine, agent-runtime, supply-intelligence.
+
+## Sources
+
+- `packages/platform-infra/src/index.ts`
+- `packages/platform-infra/src/config/firebase-init.ts`
+- `packages/platform-infra/src/firestore/process-repository.ts`
+- `packages/platform-infra/src/__tests__/process-repository.test.ts`
+- `AGENTS.md` → "Key architectural patterns" (repository pattern, immutable versions)

--- a/docs/knowledge-base/wiki/entities/packages/platform-ui.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-ui.md
@@ -6,11 +6,11 @@ sources: 5
 tags: [package, platform-ui, nextjs, app-router]
 ---
 
-**Main web application — Next.js 15 App Router, hosts all workspace routes, API routes, and the `getPlatformServices()` singleton that wires every other package together.**
+**Main web app. Next.js 15 App Router. Hosts every route + API + `getPlatformServices()` composition root.**
 
 ## Purpose
 
-User-facing entry point. Serves workspace-scoped pages (agents, tasks, processes, workflows, catalog, monitoring, cowork, runs, tickets, configs, settings), exposes the REST API consumed by agents and external clients, and composes the platform-services singleton that instantiates repositories, the workflow engine, agent runners, and the plugin registry. All other packages are orchestrated from here.
+User-facing entry. Workspace-scoped pages (agents, tasks, processes, workflows, catalog, monitoring, cowork, runs, tickets, configs, settings). REST API for agents + external clients. `getPlatformServices()` wires every other package: repos, workflow engine, agent runners, plugin registry. Top of dependency graph.
 
 ## Dependencies
 
@@ -19,45 +19,45 @@ User-facing entry point. Serves workspace-scoped pages (agents, tasks, processes
 
 ## Key entry points
 
-- **Route groups**: `src/app/(app)/[handle]/{agents,catalog,configs,cowork,monitoring,processes,runs,settings,tasks,tools,workflows}`.
+- **Routes**: `src/app/(app)/[handle]/{agents,catalog,configs,cowork,monitoring,processes,runs,settings,tasks,tools,workflows}`.
 - **Auth pages**: `/login`, `/change-password`, `/test-login`, `/workspace-selection`.
-- **API routes**: `src/app/api/{processes,definitions,tasks,users,configs,cowork,workflow-definitions,agents,tickets,cron,migrations}`.
-- **Service singleton**: `src/lib/platform-services.ts` — `getPlatformServices()` lazy-creates everything, shared across API routes. Registers the three built-in plugins (`claude-code-agent`, `opencode-agent`, `script-container`) plus supply-intelligence plugins.
-- **Middleware**: `src/middleware.ts` — JWT/API key auth, CORS, Firebase token validation (emulator-aware via `NEXT_PUBLIC_USE_EMULATORS`).
+- **API**: `src/app/api/{processes,definitions,tasks,users,configs,cowork,workflow-definitions,agents,tickets,cron,migrations}`.
+- **Service singleton**: `src/lib/platform-services.ts` — `getPlatformServices()` lazy-wires everything. Registers built-in plugins (`claude-code-agent`, `opencode-agent`, `script-container`) + supply-intelligence plugins. See [service-singleton](../../concepts/service-singleton.md).
+- **Middleware**: `src/middleware.ts` — JWT/API-key auth, CORS, Firebase token verify (emulator-aware via `NEXT_PUBLIC_USE_EMULATORS`).
 
 ## Key internal modules
 
-- `src/lib/platform-services.ts` — service composition root.
-- `src/lib/execute-agent-step.ts`, `src/lib/resolve-task.ts` — workflow/task resolution.
-- `src/lib/resolve-definition-steps.ts` — bridges legacy `processDefinitions` + `processConfigs` to unified `workflowDefinitions` (see [dual-schema-migration concept](../../concepts/dual-schema-migration.md)).
+- `src/lib/platform-services.ts` — composition root.
+- `src/lib/execute-agent-step.ts`, `src/lib/resolve-task.ts` — workflow + task resolution.
+- `src/lib/resolve-definition-steps.ts` — bridges legacy `processDefinitions`+`processConfigs` to unified `workflowDefinitions`. **Always go through this.** See [dual-schema-migration](../../concepts/dual-schema-migration.md) + [dual-schema-routing gotcha](../../gotchas/dual-schema-routing.md).
 - `src/components/{agents,tasks,processes,workflows}` — feature UI.
 - `src/contexts/auth-context.tsx` — Firebase Auth React context.
 
 ## Notable patterns
 
-- **Service singleton** (see [service-singleton concept](../../concepts/service-singleton.md)): `getPlatformServices()` with fail-fast encryption-key validation.
-- **Custom `@mediforce/source` TS condition** — imports resolve to source `.ts` during dev, compiled `dist/` in prod (see [gotchas/mediforce-source-custom-condition](../../gotchas/mediforce-source-custom-condition.md)).
-- **Firebase emulator toggle** — `NEXT_PUBLIC_USE_EMULATORS=true` switches JWT verification from `jwtVerify` (production, JWKS) to `decodeJwt` (emulator, unsigned).
-- **App Router server components** — async RSC throughout route groups.
+- **Service singleton** → [service-singleton](../../concepts/service-singleton.md).
+- **`@mediforce/source` TS condition** — dev = source `.ts`, prod = `dist/`. See [mediforce-source-custom-condition gotcha](../../gotchas/mediforce-source-custom-condition.md).
+- **Firebase emulator toggle** — `NEXT_PUBLIC_USE_EMULATORS=true` → JWT verify switches `jwtVerify` (prod JWKS) to `decodeJwt` (emulator unsigned).
+- **App Router RSC** — async server components throughout.
 
 ## Testing surface
 
-- Unit: `src/test/*.test.ts` (Vitest, jsdom).
+- Unit: `src/test/*.test.ts` (Vitest jsdom).
 - Journey: `src/test/*-journey.test.ts` — handler-level, in-memory repos.
-- E2E: `e2e/journeys/` (Playwright, port 9007 emulator mode), `e2e/smoke.spec.ts`.
+- E2E: `e2e/journeys/` (Playwright, port 9007 emulator), `e2e/smoke.spec.ts`. Remote env? → [remote-e2e-setup gotcha](../../gotchas/remote-e2e-setup.md).
 - Real-LLM E2E: `e2e/api/*.test.ts` via `pnpm test:mcp-real`.
 
 ## Ports / infra
 
-- Dev: port `9003` (`pnpm dev`).
-- Emulator E2E: port `9007`.
+- Dev: `9003` (`pnpm dev`).
+- Emulator E2E: `9007`.
 - Firebase emulators: Auth `9099`, Firestore `8080`.
-- Production: Firebase App Hosting (`apphosting.yaml`).
+- Prod: Firebase App Hosting (`apphosting.yaml`).
 
 ## Relationships
 
-- Consumes all other Mediforce packages.
-- Consumed by: nothing (top of the dependency graph).
+- Consumes: every other Mediforce package.
+- Consumed by: nothing (top of graph).
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/entities/packages/platform-ui.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-ui.md
@@ -22,7 +22,7 @@ User-facing entry point. Serves workspace-scoped pages (agents, tasks, processes
 - **Route groups**: `src/app/(app)/[handle]/{agents,catalog,configs,cowork,monitoring,processes,runs,settings,tasks,tools,workflows}`.
 - **Auth pages**: `/login`, `/change-password`, `/test-login`, `/workspace-selection`.
 - **API routes**: `src/app/api/{processes,definitions,tasks,users,configs,cowork,workflow-definitions,agents,tickets,cron,migrations}`.
-- **Service singleton**: [`src/lib/platform-services.ts`](../../../../packages/platform-ui/src/lib/platform-services.ts) — `getPlatformServices()` lazy-creates everything, shared across API routes. Registers the three built-in plugins (`claude-code-agent`, `opencode-agent`, `script-container`) plus supply-intelligence plugins.
+- **Service singleton**: `src/lib/platform-services.ts` — `getPlatformServices()` lazy-creates everything, shared across API routes. Registers the three built-in plugins (`claude-code-agent`, `opencode-agent`, `script-container`) plus supply-intelligence plugins.
 - **Middleware**: `src/middleware.ts` — JWT/API key auth, CORS, Firebase token validation (emulator-aware via `NEXT_PUBLIC_USE_EMULATORS`).
 
 ## Key internal modules

--- a/docs/knowledge-base/wiki/entities/packages/platform-ui.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-ui.md
@@ -1,0 +1,68 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 5
+tags: [package, platform-ui, nextjs, app-router]
+---
+
+**Main web application — Next.js 15 App Router, hosts all workspace routes, API routes, and the `getPlatformServices()` singleton that wires every other package together.**
+
+## Purpose
+
+User-facing entry point. Serves workspace-scoped pages (agents, tasks, processes, workflows, catalog, monitoring, cowork, runs, tickets, configs, settings), exposes the REST API consumed by agents and external clients, and composes the platform-services singleton that instantiates repositories, the workflow engine, agent runners, and the plugin registry. All other packages are orchestrated from here.
+
+## Dependencies
+
+- Internal: [`platform-infra`](./platform-infra.md), [`platform-core`](./platform-core.md), [`workflow-engine`](./workflow-engine.md), [`agent-runtime`](./agent-runtime.md), `mcp-client`, [`supply-intelligence-plugins`](./supply-intelligence-plugins.md); optionally `agent-queue`.
+- External: `next@15`, `react`, `radix-ui`, `firebase`, `playwright`.
+
+## Key entry points
+
+- **Route groups**: `src/app/(app)/[handle]/{agents,catalog,configs,cowork,monitoring,processes,runs,settings,tasks,tools,workflows}`.
+- **Auth pages**: `/login`, `/change-password`, `/test-login`, `/workspace-selection`.
+- **API routes**: `src/app/api/{processes,definitions,tasks,users,configs,cowork,workflow-definitions,agents,tickets,cron,migrations}`.
+- **Service singleton**: [`src/lib/platform-services.ts`](../../../../packages/platform-ui/src/lib/platform-services.ts) — `getPlatformServices()` lazy-creates everything, shared across API routes. Registers the three built-in plugins (`claude-code-agent`, `opencode-agent`, `script-container`) plus supply-intelligence plugins.
+- **Middleware**: `src/middleware.ts` — JWT/API key auth, CORS, Firebase token validation (emulator-aware via `NEXT_PUBLIC_USE_EMULATORS`).
+
+## Key internal modules
+
+- `src/lib/platform-services.ts` — service composition root.
+- `src/lib/execute-agent-step.ts`, `src/lib/resolve-task.ts` — workflow/task resolution.
+- `src/lib/resolve-definition-steps.ts` — bridges legacy `processDefinitions` + `processConfigs` to unified `workflowDefinitions` (see [dual-schema-migration concept](../../concepts/dual-schema-migration.md)).
+- `src/components/{agents,tasks,processes,workflows}` — feature UI.
+- `src/contexts/auth-context.tsx` — Firebase Auth React context.
+
+## Notable patterns
+
+- **Service singleton** (see [service-singleton concept](../../concepts/service-singleton.md)): `getPlatformServices()` with fail-fast encryption-key validation.
+- **Custom `@mediforce/source` TS condition** — imports resolve to source `.ts` during dev, compiled `dist/` in prod (see [gotchas/mediforce-source-custom-condition](../../gotchas/mediforce-source-custom-condition.md)).
+- **Firebase emulator toggle** — `NEXT_PUBLIC_USE_EMULATORS=true` switches JWT verification from `jwtVerify` (production, JWKS) to `decodeJwt` (emulator, unsigned).
+- **App Router server components** — async RSC throughout route groups.
+
+## Testing surface
+
+- Unit: `src/test/*.test.ts` (Vitest, jsdom).
+- Journey: `src/test/*-journey.test.ts` — handler-level, in-memory repos.
+- E2E: `e2e/journeys/` (Playwright, port 9007 emulator mode), `e2e/smoke.spec.ts`.
+- Real-LLM E2E: `e2e/api/*.test.ts` via `pnpm test:mcp-real`.
+
+## Ports / infra
+
+- Dev: port `9003` (`pnpm dev`).
+- Emulator E2E: port `9007`.
+- Firebase emulators: Auth `9099`, Firestore `8080`.
+- Production: Firebase App Hosting (`apphosting.yaml`).
+
+## Relationships
+
+- Consumes all other Mediforce packages.
+- Consumed by: nothing (top of the dependency graph).
+
+## Sources
+
+- `packages/platform-ui/package.json`
+- `packages/platform-ui/src/middleware.ts`
+- `packages/platform-ui/src/lib/platform-services.ts`
+- `packages/platform-ui/src/lib/resolve-definition-steps.ts`
+- `AGENTS.md` → "Platform UI structure", "Package dependency graph"

--- a/docs/knowledge-base/wiki/entities/packages/supply-intelligence-plugins.md
+++ b/docs/knowledge-base/wiki/entities/packages/supply-intelligence-plugins.md
@@ -6,39 +6,39 @@ sources: 4
 tags: [package, plugins, supply-intelligence]
 ---
 
-**Agent plugins that wrap the pure `supply-intelligence` domain with LLM narratives and Firestore draft-issue writes. Registered into `PluginRegistry` via `registerSupplyIntelligencePlugins()`.**
+**Agent plugins wrapping pure [`supply-intelligence`](./supply-intelligence.md) with LLM narratives + Firestore draft-issue writes. Registered via `registerSupplyIntelligencePlugins()`.**
 
 ## Purpose
 
-Adapter layer between the pure [`supply-intelligence`](./supply-intelligence.md) domain and the agent runtime. Computes risk rows from supply data, templates numbers into prompts, calls an LLM for narrative only (not for calculations), and writes draft issues to Firestore. Two plugins are registered.
+Adapter between pure domain + agent runtime. Compute risk rows → template numbers into prompts → LLM writes prose only (never numbers) → Firestore writes for issue drafts. See [llm-no-computation-rule](../../concepts/llm-no-computation-rule.md).
 
 ## Dependencies
 
-- Internal: [`agent-runtime`](./agent-runtime.md), [`platform-core`](./platform-core.md), [`supply-intelligence`](./supply-intelligence.md)
-- External: `firebase-admin`, `date-fns`
+- Internal: [`agent-runtime`](./agent-runtime.md), [`platform-core`](./platform-core.md), [`supply-intelligence`](./supply-intelligence.md).
+- External: `firebase-admin`, `date-fns`.
 
 ## Plugins registered
 
-| Plugin name | Class | Purpose |
-|---|---|---|
-| `supply-intelligence/driver-agent` | `DriverAgentPlugin` | Narrative risk summaries for SKU+warehouse pairs, therapeutic categories, portfolio overview. |
-| `supply-intelligence/risk-detection` | `RiskDetectionPlugin` | Scans red-flagged SKU+warehouse pairs, computes priority scores, creates draft issues in Firestore `draftIssues` collection. |
+| Name | Class | What |
+|------|-------|------|
+| `supply-intelligence/driver-agent` | `DriverAgentPlugin` | Narrative risk summaries: SKU+warehouse, category, overview. |
+| `supply-intelligence/risk-detection` | `RiskDetectionPlugin` | Scan red-flags → priority score → write drafts to Firestore `draftIssues`. |
 
-Registration entry point: `registerSupplyIntelligencePlugins(registry)` in `src/plugin-registration.ts`. Called from [`platform-ui`](./platform-ui.md) `getPlatformServices()`.
+Registration: `registerSupplyIntelligencePlugins(registry)` in `src/plugin-registration.ts`. Called from [platform-ui](./platform-ui.md) `getPlatformServices()`.
 
 ## Key internal modules
 
-- `src/driver-agent-plugin.ts` — narrative generation.
+- `src/driver-agent-plugin.ts` — narratives.
 - `src/risk-detection-plugin.ts` — issue creation.
-- `src/lib/risk-computations.ts` — `RiskRow`, KPI calculations.
-- `src/lib/issue-writer.ts` — Firestore draft-issue writes.
-- `src/lib/priority-score.ts` — risk severity ranking.
+- `src/lib/risk-computations.ts` — `RiskRow`, KPIs.
+- `src/lib/issue-writer.ts` — Firestore writes.
+- `src/lib/priority-score.ts` — severity ranking.
 - `src/lib/supply-data-fetcher.ts` — Firebase queries.
-- `src/prompts/` — four prompt builders (SKU, category, overview, issue).
+- `src/prompts/` — 4 prompt builders (SKU / category / overview / issue).
 
 ## Division of labour
 
-LLMs never compute risk numbers — they only generate prose around pre-computed values. Numbers come from `lib/risk-computations.ts`; prose comes from prompts templated with those numbers. This keeps outputs auditable.
+Numbers = deterministic functions. Prose = LLM. LLM never computes risk. Auditable: every claim traces to a function call.
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/packages/supply-intelligence-plugins.md
+++ b/docs/knowledge-base/wiki/entities/packages/supply-intelligence-plugins.md
@@ -1,0 +1,54 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 4
+tags: [package, plugins, supply-intelligence]
+---
+
+**Agent plugins that wrap the pure `supply-intelligence` domain with LLM narratives and Firestore draft-issue writes. Registered into `PluginRegistry` via `registerSupplyIntelligencePlugins()`.**
+
+## Purpose
+
+Adapter layer between the pure [`supply-intelligence`](./supply-intelligence.md) domain and the agent runtime. Computes risk rows from supply data, templates numbers into prompts, calls an LLM for narrative only (not for calculations), and writes draft issues to Firestore. Two plugins are registered.
+
+## Dependencies
+
+- Internal: [`agent-runtime`](./agent-runtime.md), [`platform-core`](./platform-core.md), [`supply-intelligence`](./supply-intelligence.md)
+- External: `firebase-admin`, `date-fns`
+
+## Plugins registered
+
+| Plugin name | Class | Purpose |
+|---|---|---|
+| `supply-intelligence/driver-agent` | `DriverAgentPlugin` | Narrative risk summaries for SKU+warehouse pairs, therapeutic categories, portfolio overview. |
+| `supply-intelligence/risk-detection` | `RiskDetectionPlugin` | Scans red-flagged SKU+warehouse pairs, computes priority scores, creates draft issues in Firestore `draftIssues` collection. |
+
+Registration entry point: `registerSupplyIntelligencePlugins(registry)` in `src/plugin-registration.ts`. Called from [`platform-ui`](./platform-ui.md) `getPlatformServices()`.
+
+## Key internal modules
+
+- `src/driver-agent-plugin.ts` — narrative generation.
+- `src/risk-detection-plugin.ts` — issue creation.
+- `src/lib/risk-computations.ts` — `RiskRow`, KPI calculations.
+- `src/lib/issue-writer.ts` — Firestore draft-issue writes.
+- `src/lib/priority-score.ts` — risk severity ranking.
+- `src/lib/supply-data-fetcher.ts` — Firebase queries.
+- `src/prompts/` — four prompt builders (SKU, category, overview, issue).
+
+## Division of labour
+
+LLMs never compute risk numbers — they only generate prose around pre-computed values. Numbers come from `lib/risk-computations.ts`; prose comes from prompts templated with those numbers. This keeps outputs auditable.
+
+## Relationships
+
+- Consumed by: [`platform-ui`](./platform-ui.md) (registered in `getPlatformServices()`).
+- Depends on: [`agent-runtime`](./agent-runtime.md), [`platform-core`](./platform-core.md), [`supply-intelligence`](./supply-intelligence.md).
+
+## Sources
+
+- `packages/supply-intelligence-plugins/src/plugin-registration.ts`
+- `packages/supply-intelligence-plugins/src/driver-agent-plugin.ts`
+- `packages/supply-intelligence-plugins/src/risk-detection-plugin.ts`
+- `packages/supply-intelligence-plugins/src/lib/risk-computations.ts`
+- `AGENTS.md` → "Plugin system"

--- a/docs/knowledge-base/wiki/entities/packages/supply-intelligence.md
+++ b/docs/knowledge-base/wiki/entities/packages/supply-intelligence.md
@@ -1,0 +1,53 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 4
+tags: [package, supply-intelligence, domain, pure]
+---
+
+**Pure supply-chain domain package — SKU / warehouse / batch / forecast schemas plus pure-function risk services. No Firebase, no platform-core dependency.**
+
+## Purpose
+
+Domain logic for pharmaceutical supply-chain intelligence. Defines the data model (SKUs, warehouses, batches with lot numbers and expiry dates, demand forecasts) and deterministic risk algorithms (FEFO allocation, stockout projection, red/orange/green classification). Intentionally free of infrastructure and `@mediforce/*` dependencies so it can be embedded anywhere — used by the `supply-intelligence` app and wrapped by `supply-intelligence-plugins`.
+
+## Dependencies
+
+- Internal: none
+- External: `zod`, `date-fns`
+
+## Key exports
+
+- **Schemas (Zod)**: `SkuSchema`, `WarehouseSchema`, `BatchSchema`, `InboundShipmentSchema`, `DemandForecastSchema`, `RiskConfigSchema`.
+- **Risk services** (pure functions):
+  - `fefoAllocation()` — FIFO-by-expiry batch allocation.
+  - `stockoutProjection()` — 4-week demand forecast.
+  - `classifyRisk()` — red / orange / green classification combining absolute thresholds with urgency triggers.
+- **Seed**: `src/seed/run-seed.ts` — dev data generator.
+
+## Key internal modules
+
+- `src/schemas/` — domain entity schemas.
+- `src/risk/` — pure algorithm functions (`fefo-allocation.ts`, `stockout-projection.ts`, `risk-classification.ts`).
+- `src/risk/__tests__/` — Vitest unit tests with fixtures; no mocks needed because there are no side effects.
+- `src/seed/` — data generator.
+
+## Notable properties
+
+- No external infrastructure — no Firebase, no HTTP, no filesystem.
+- Pure functions everywhere — testable without mocks.
+- Risk urgency logic: urgency triggers (expiry days, stockout weeks) only fire when base risk > 0.
+
+## Relationships
+
+- Consumed by: [`supply-intelligence-plugins`](./supply-intelligence-plugins.md), [`apps/supply-intelligence`](../apps/supply-intelligence.md).
+- Depends on: nothing internal.
+
+## Sources
+
+- `packages/supply-intelligence/src/index.ts`
+- `packages/supply-intelligence/src/schemas/sku.ts`
+- `packages/supply-intelligence/src/risk/risk-classification.ts`
+- `packages/supply-intelligence/src/risk/__tests__/fefo-allocation.test.ts`
+- `packages/supply-intelligence/package.json`

--- a/docs/knowledge-base/wiki/entities/packages/supply-intelligence.md
+++ b/docs/knowledge-base/wiki/entities/packages/supply-intelligence.md
@@ -6,38 +6,38 @@ sources: 4
 tags: [package, supply-intelligence, domain, pure]
 ---
 
-**Pure supply-chain domain package — SKU / warehouse / batch / forecast schemas plus pure-function risk services. No Firebase, no platform-core dependency.**
+**Pure supply-chain domain. SKU / warehouse / batch / forecast schemas + pure-function risk services. Zero Firebase, zero `@mediforce/*` deps.**
 
 ## Purpose
 
-Domain logic for pharmaceutical supply-chain intelligence. Defines the data model (SKUs, warehouses, batches with lot numbers and expiry dates, demand forecasts) and deterministic risk algorithms (FEFO allocation, stockout projection, red/orange/green classification). Intentionally free of infrastructure and `@mediforce/*` dependencies so it can be embedded anywhere — used by the `supply-intelligence` app and wrapped by `supply-intelligence-plugins`.
+Domain logic for pharma supply-chain intelligence. Data model (SKUs, warehouses, batches with lot numbers + expiry, demand forecasts) + deterministic risk algorithms (FEFO allocation, stockout projection, red/orange/green classification). Infra-free by design — embeddable anywhere. Consumed by the [supply-intelligence app](../apps/supply-intelligence.md) + wrapped by [supply-intelligence-plugins](./supply-intelligence-plugins.md).
 
 ## Dependencies
 
-- Internal: none
-- External: `zod`, `date-fns`
+- Internal: none.
+- External: `zod`, `date-fns`.
 
 ## Key exports
 
 - **Schemas (Zod)**: `SkuSchema`, `WarehouseSchema`, `BatchSchema`, `InboundShipmentSchema`, `DemandForecastSchema`, `RiskConfigSchema`.
-- **Risk services** (pure functions):
+- **Risk services** (pure):
   - `fefoAllocation()` — FIFO-by-expiry batch allocation.
   - `stockoutProjection()` — 4-week demand forecast.
-  - `classifyRisk()` — red / orange / green classification combining absolute thresholds with urgency triggers.
-- **Seed**: `src/seed/run-seed.ts` — dev data generator.
+  - `classifyRisk()` — red / orange / green = threshold + urgency triggers.
+- **Seed**: `src/seed/run-seed.ts`.
 
 ## Key internal modules
 
 - `src/schemas/` — domain entity schemas.
-- `src/risk/` — pure algorithm functions (`fefo-allocation.ts`, `stockout-projection.ts`, `risk-classification.ts`).
-- `src/risk/__tests__/` — Vitest unit tests with fixtures; no mocks needed because there are no side effects.
+- `src/risk/` — pure algo functions.
+- `src/risk/__tests__/` — Vitest fixtures, no mocks needed.
 - `src/seed/` — data generator.
 
 ## Notable properties
 
-- No external infrastructure — no Firebase, no HTTP, no filesystem.
-- Pure functions everywhere — testable without mocks.
-- Risk urgency logic: urgency triggers (expiry days, stockout weeks) only fire when base risk > 0.
+- No external infra. No Firebase, no HTTP, no filesystem.
+- Pure functions. Testable without mocks.
+- Urgency triggers (expiry days, stockout weeks) fire only when base risk > 0.
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/packages/workflow-engine.md
+++ b/docs/knowledge-base/wiki/entities/packages/workflow-engine.md
@@ -33,7 +33,7 @@ Runs the workflow loop. Given a `ProcessInstance`, it advances steps, routes tra
 - `src/graph/` — step graph validator.
 - `src/review/` — `ReviewTracker` (verdict accumulation, decision finalisation).
 - `src/triggers/` — manual / webhook / cron handlers.
-- `src/__tests__/` — engine integration tests (see [`docs/ENGINE-TESTING.md`](../../../ENGINE-TESTING.md)).
+- `src/__tests__/` — engine integration tests (see `docs/ENGINE-TESTING.md`).
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/packages/workflow-engine.md
+++ b/docs/knowledge-base/wiki/entities/packages/workflow-engine.md
@@ -6,33 +6,33 @@ sources: 3
 tags: [package, workflow-engine, orchestration]
 ---
 
-**Process instance orchestrator — step execution, transition routing, review tracking, trigger handling, and expression evaluation.**
+**Process instance orchestrator. Step execution, transition routing, review tracking, triggers, when-expression DSL.**
 
 ## Purpose
 
-Runs the workflow loop. Given a `ProcessInstance`, it advances steps, routes transitions via a when-expression DSL, tracks review verdicts, validates step graphs, and dispatches manual / webhook / cron triggers. Stateless by design — state lives in repositories injected from `platform-core`.
+Runs the workflow loop. Given `ProcessInstance`: advance steps, route transitions, track review verdicts, validate step graphs, dispatch triggers. Stateless — state lives in repos from `platform-core`.
 
 ## Dependencies
 
-- Internal: [`platform-core`](./platform-core.md)
-- External: `zod`
+- Internal: [`platform-core`](./platform-core.md).
+- External: `zod`.
 
 ## Key exports
 
-- **Engine**: `WorkflowEngine` (main orchestrator — advance / pause / resume / abort), `StepExecutor`, `ReviewTracker`.
+- **Engine**: `WorkflowEngine` (main — advance/pause/resume/abort), `StepExecutor`, `ReviewTracker`.
 - **Routing**: `resolveTransitions`, `TransitionValidationError`, `NoMatchingTransitionError`.
-- **Expressions**: `evaluateExpression` (see [expression-evaluator concept](../../concepts/expression-evaluator.md)).
+- **Expressions**: `evaluateExpression` → see [expression-evaluator](../../concepts/expression-evaluator.md).
 - **Triggers**: `ManualTrigger`, `WebhookTrigger`, `CronTrigger`, `TriggerHandler`, `validateCronSchedule`, `isDue`.
-- **Graph validation**: `validateStepGraph` (DAG + cycle checks).
+- **Graph**: `validateStepGraph` (DAG + cycle check).
 - **Errors**: `StepFailureError`, `RoutingError`, `InvalidTransitionError`, `MaxIterationsExceededError`.
 
 ## Key internal modules
 
-- `src/engine/` — `workflow-engine.ts` (main loop, 600+ lines), `step-executor.ts`, `transition-resolver.ts`, `errors.ts`.
-- `src/expressions/` — custom when-expression evaluator (`${variables.field} == "value"` DSL).
-- `src/graph/` — step graph validator.
-- `src/review/` — `ReviewTracker` (verdict accumulation, decision finalisation).
-- `src/triggers/` — manual / webhook / cron handlers.
+- `src/engine/` — `workflow-engine.ts` (600+ lines), `step-executor.ts`, `transition-resolver.ts`, `errors.ts`.
+- `src/expressions/` — when-DSL evaluator (`${variables.field} == "value"`).
+- `src/graph/` — graph validator.
+- `src/review/` — `ReviewTracker`.
+- `src/triggers/` — manual / webhook / cron.
 - `src/__tests__/` — engine integration tests (see `docs/ENGINE-TESTING.md`).
 
 ## Relationships

--- a/docs/knowledge-base/wiki/entities/packages/workflow-engine.md
+++ b/docs/knowledge-base/wiki/entities/packages/workflow-engine.md
@@ -1,0 +1,49 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [package, workflow-engine, orchestration]
+---
+
+**Process instance orchestrator — step execution, transition routing, review tracking, trigger handling, and expression evaluation.**
+
+## Purpose
+
+Runs the workflow loop. Given a `ProcessInstance`, it advances steps, routes transitions via a when-expression DSL, tracks review verdicts, validates step graphs, and dispatches manual / webhook / cron triggers. Stateless by design — state lives in repositories injected from `platform-core`.
+
+## Dependencies
+
+- Internal: [`platform-core`](./platform-core.md)
+- External: `zod`
+
+## Key exports
+
+- **Engine**: `WorkflowEngine` (main orchestrator — advance / pause / resume / abort), `StepExecutor`, `ReviewTracker`.
+- **Routing**: `resolveTransitions`, `TransitionValidationError`, `NoMatchingTransitionError`.
+- **Expressions**: `evaluateExpression` (see [expression-evaluator concept](../../concepts/expression-evaluator.md)).
+- **Triggers**: `ManualTrigger`, `WebhookTrigger`, `CronTrigger`, `TriggerHandler`, `validateCronSchedule`, `isDue`.
+- **Graph validation**: `validateStepGraph` (DAG + cycle checks).
+- **Errors**: `StepFailureError`, `RoutingError`, `InvalidTransitionError`, `MaxIterationsExceededError`.
+
+## Key internal modules
+
+- `src/engine/` — `workflow-engine.ts` (main loop, 600+ lines), `step-executor.ts`, `transition-resolver.ts`, `errors.ts`.
+- `src/expressions/` — custom when-expression evaluator (`${variables.field} == "value"` DSL).
+- `src/graph/` — step graph validator.
+- `src/review/` — `ReviewTracker` (verdict accumulation, decision finalisation).
+- `src/triggers/` — manual / webhook / cron handlers.
+- `src/__tests__/` — engine integration tests (see [`docs/ENGINE-TESTING.md`](../../../ENGINE-TESTING.md)).
+
+## Relationships
+
+- Consumed by: [`platform-ui`](./platform-ui.md), [`platform-infra`](./platform-infra.md).
+- Depends on: [`platform-core`](./platform-core.md).
+
+## Sources
+
+- `packages/workflow-engine/src/index.ts`
+- `packages/workflow-engine/src/engine/workflow-engine.ts`
+- `packages/workflow-engine/src/engine/transition-resolver.ts`
+- `AGENTS.md` → "Key architectural patterns"
+- `docs/ENGINE-TESTING.md`

--- a/docs/knowledge-base/wiki/entities/plugins/claude-code-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/claude-code-agent.md
@@ -1,0 +1,37 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [plugin, claude-code, agent-runtime, container]
+---
+
+**Built-in container plugin that runs Claude Code inside a Docker image to execute an agent step. Registered in `PluginRegistry` under `claude-code-agent`.**
+
+## Purpose
+
+Default container-backed agent. Assembles a prompt from the step's skill file + custom prompt + previous outputs + confidence instructions, spawns Claude Code in a Docker container (local or queued), extracts the emitted output envelope. `MOCK_AGENT=true` swaps it for `MockClaudeCodeAgentPlugin` which returns fixtures without running the CLI.
+
+## How it fits
+
+- Concrete subclass of [`BaseContainerAgentPlugin`](../../concepts/plugin-dispatch.md) in [`agent-runtime`](../packages/agent-runtime.md).
+- Registered by `getPlatformServices()` in [`platform-ui`](../packages/platform-ui.md).
+- Subclass responsibilities: `getAgentCommand()`, `getMockDockerArgs()`, `parseAgentOutput()`.
+- Spawning: delegates to [`LocalDockerSpawnStrategy`](../../concepts/docker-spawn-strategies.md) by default, or `QueuedDockerSpawnStrategy` when `REDIS_URL` is set.
+
+## Input / output contract
+
+- Input: `AgentContext` with step input, config, resolved MCP, workflow secrets.
+- Output: must emit a `result` event conforming to `AgentOutputEnvelopeSchema`, including `confidence` (0.0–1.0) and `confidence_rationale`. `AgentRunner` validates `confidence` against the step's `confidenceThreshold` and fires a fallback if the threshold isn't met.
+
+## Relationships
+
+- Registered in: [`platform-ui`](../packages/platform-ui.md).
+- Inherits from: [`agent-runtime`](../packages/agent-runtime.md) `BaseContainerAgentPlugin`.
+- Used by: any workflow step with `type: agent` and `agent: claude-code-agent`.
+
+## Sources
+
+- `packages/agent-runtime/src/plugins/claude-code-agent-plugin.ts`
+- `packages/agent-runtime/src/plugins/base-container-agent-plugin.ts`
+- `packages/platform-ui/src/lib/platform-services.ts`

--- a/docs/knowledge-base/wiki/entities/plugins/claude-code-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/claude-code-agent.md
@@ -6,29 +6,25 @@ sources: 3
 tags: [plugin, claude-code, agent-runtime, container]
 ---
 
-**Built-in container plugin that runs Claude Code inside a Docker image to execute an agent step. Registered in `PluginRegistry` under `claude-code-agent`.**
-
-## Purpose
-
-Default container-backed agent. Assembles a prompt from the step's skill file + custom prompt + previous outputs + confidence instructions, spawns Claude Code in a Docker container (local or queued), extracts the emitted output envelope. `MOCK_AGENT=true` swaps it for `MockClaudeCodeAgentPlugin` which returns fixtures without running the CLI.
+**Default container plugin. Runs Claude Code in Docker for agent steps. Registered as `claude-code-agent`. `MOCK_AGENT=true` → `MockClaudeCodeAgentPlugin`.**
 
 ## How it fits
 
-- Concrete subclass of [`BaseContainerAgentPlugin`](../../concepts/plugin-dispatch.md) in [`agent-runtime`](../packages/agent-runtime.md).
+- Subclass of `BaseContainerAgentPlugin` in [`agent-runtime`](../packages/agent-runtime.md). See [plugin-dispatch](../../concepts/plugin-dispatch.md).
 - Registered by `getPlatformServices()` in [`platform-ui`](../packages/platform-ui.md).
-- Subclass responsibilities: `getAgentCommand()`, `getMockDockerArgs()`, `parseAgentOutput()`.
-- Spawning: delegates to [`LocalDockerSpawnStrategy`](../../concepts/docker-spawn-strategies.md) by default, or `QueuedDockerSpawnStrategy` when `REDIS_URL` is set.
+- Subclass must implement: `getAgentCommand()`, `getMockDockerArgs()`, `parseAgentOutput()`.
+- Spawning: [`LocalDockerSpawnStrategy`](../../concepts/docker-spawn-strategies.md) by default. `REDIS_URL` set → `QueuedDockerSpawnStrategy`.
 
-## Input / output contract
+## I/O contract
 
-- Input: `AgentContext` with step input, config, resolved MCP, workflow secrets.
-- Output: must emit a `result` event conforming to `AgentOutputEnvelopeSchema`, including `confidence` (0.0–1.0) and `confidence_rationale`. `AgentRunner` validates `confidence` against the step's `confidenceThreshold` and fires a fallback if the threshold isn't met.
+- Input: `AgentContext` — step input, config, resolved MCP (see [mcp-resolution](../../concepts/mcp-resolution.md)), workflow secrets.
+- Output: emit exactly one `result` event conforming to `AgentOutputEnvelopeSchema`. Must include `confidence` (0.0–1.0) + `confidence_rationale`. `AgentRunner` validates vs `step.confidenceThreshold` → fires fallback if below.
 
 ## Relationships
 
 - Registered in: [`platform-ui`](../packages/platform-ui.md).
 - Inherits from: [`agent-runtime`](../packages/agent-runtime.md) `BaseContainerAgentPlugin`.
-- Used by: any workflow step with `type: agent` and `agent: claude-code-agent`.
+- Used by: any step with `type: agent` + `agent: claude-code-agent`.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/entities/plugins/example-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/example-agent.md
@@ -1,0 +1,28 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [plugin, example, reference]
+---
+
+**Reference implementation of the `AgentPlugin` interface — a 50-line template showing the event-emission pattern.**
+
+## Purpose
+
+Smallest possible working plugin. Demonstrates the two-method lifecycle: `initialize(context)` to capture step input / config / LLM client, then `run(emit)` to emit `status`, `annotation`, and `result` events. Copy-paste starting point when writing a new plugin. Does not register itself — it's consumed from tests or ad-hoc scripts.
+
+## Lifecycle reminder
+
+1. `initialize(context)` — store `AgentContext`.
+2. `run(emit)` — emit events. Must emit exactly one `result` event with an `AgentOutputEnvelope`.
+3. Autonomy handling (threshold checks, escalations) is applied by [`AgentRunner`](../packages/agent-runtime.md) **after** `run` returns, not inside the plugin.
+
+## Relationships
+
+- Depends on: [`agent-runtime`](../packages/agent-runtime.md).
+
+## Sources
+
+- `packages/example-agent/src/index.ts`
+- `packages/example-agent/src/example-agent.ts`

--- a/docs/knowledge-base/wiki/entities/plugins/example-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/example-agent.md
@@ -6,21 +6,20 @@ sources: 2
 tags: [plugin, example, reference]
 ---
 
-**Reference implementation of the `AgentPlugin` interface — a 50-line template showing the event-emission pattern.**
+**Reference `AgentPlugin` implementation. 50-line template. Copy-paste start for new plugins.**
 
-## Purpose
-
-Smallest possible working plugin. Demonstrates the two-method lifecycle: `initialize(context)` to capture step input / config / LLM client, then `run(emit)` to emit `status`, `annotation`, and `result` events. Copy-paste starting point when writing a new plugin. Does not register itself — it's consumed from tests or ad-hoc scripts.
-
-## Lifecycle reminder
+## Lifecycle
 
 1. `initialize(context)` — store `AgentContext`.
-2. `run(emit)` — emit events. Must emit exactly one `result` event with an `AgentOutputEnvelope`.
-3. Autonomy handling (threshold checks, escalations) is applied by [`AgentRunner`](../packages/agent-runtime.md) **after** `run` returns, not inside the plugin.
+2. `run(emit)` — emit events. Exactly one `result` event with `AgentOutputEnvelope`.
+3. Autonomy handling (thresholds, escalations) applied by `AgentRunner` **after** `run` returns. Plugin does not implement autonomy.
+
+See [plugin-dispatch](../../concepts/plugin-dispatch.md) for full flow.
 
 ## Relationships
 
 - Depends on: [`agent-runtime`](../packages/agent-runtime.md).
+- Not registered — consumed from tests / ad-hoc scripts.
 
 ## Sources
 

--- a/docs/knowledge-base/wiki/entities/plugins/opencode-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/opencode-agent.md
@@ -6,17 +6,13 @@ sources: 2
 tags: [plugin, opencode, agent-runtime, ollama, local-llm]
 ---
 
-**Built-in container plugin that runs OpenCode as the agent. Supports local Ollama and cloud providers through the same Docker envelope. Registered as `opencode-agent`.**
-
-## Purpose
-
-Alternative to [`claude-code-agent`](./claude-code-agent.md) for steps that should use OpenCode (e.g. local Ollama runs during dev, or swapping providers for cost/latency). Same container-plugin envelope, different CLI inside.
+**Container plugin running OpenCode. Local Ollama + cloud providers via same Docker envelope. Registered as `opencode-agent`.**
 
 ## How it fits
 
-- Concrete subclass of `BaseContainerAgentPlugin` in [`agent-runtime`](../packages/agent-runtime.md).
+- Alt to [`claude-code-agent`](./claude-code-agent.md) for steps picking `agent: opencode-agent`. Same envelope, different CLI.
+- Subclass of `BaseContainerAgentPlugin` in [`agent-runtime`](../packages/agent-runtime.md).
 - Registered by `getPlatformServices()` in [`platform-ui`](../packages/platform-ui.md).
-- Used by workflow steps that pick `agent: opencode-agent`.
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/plugins/opencode-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/opencode-agent.md
@@ -1,0 +1,29 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [plugin, opencode, agent-runtime, ollama, local-llm]
+---
+
+**Built-in container plugin that runs OpenCode as the agent. Supports local Ollama and cloud providers through the same Docker envelope. Registered as `opencode-agent`.**
+
+## Purpose
+
+Alternative to [`claude-code-agent`](./claude-code-agent.md) for steps that should use OpenCode (e.g. local Ollama runs during dev, or swapping providers for cost/latency). Same container-plugin envelope, different CLI inside.
+
+## How it fits
+
+- Concrete subclass of `BaseContainerAgentPlugin` in [`agent-runtime`](../packages/agent-runtime.md).
+- Registered by `getPlatformServices()` in [`platform-ui`](../packages/platform-ui.md).
+- Used by workflow steps that pick `agent: opencode-agent`.
+
+## Relationships
+
+- Registered in: [`platform-ui`](../packages/platform-ui.md).
+- Inherits from: [`agent-runtime`](../packages/agent-runtime.md) `BaseContainerAgentPlugin`.
+
+## Sources
+
+- `packages/agent-runtime/src/plugins/opencode-agent-plugin.ts`
+- `packages/platform-ui/src/lib/platform-services.ts`

--- a/docs/knowledge-base/wiki/entities/plugins/script-container.md
+++ b/docs/knowledge-base/wiki/entities/plugins/script-container.md
@@ -1,0 +1,32 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [plugin, script-container, agent-runtime, deterministic]
+---
+
+**Built-in container plugin for deterministic scripts — runs a scripted container without calling an LLM. Registered as `script-container`.**
+
+## Purpose
+
+Use when a workflow step needs to execute reproducible, LLM-free code (data transformations, file packaging, API calls). The container still goes through the same spawn + output-envelope machinery as LLM plugins, which keeps workflow steps homogeneous and audit events consistent.
+
+Used by the [`community-digest` app](../apps/community-digest.md) for GitHub data gathering and Discord posting.
+
+## How it fits
+
+- Concrete subclass of `BaseContainerAgentPlugin` in [`agent-runtime`](../packages/agent-runtime.md).
+- Registered by `getPlatformServices()` in [`platform-ui`](../packages/platform-ui.md).
+- Output still conforms to `AgentOutputEnvelopeSchema`, but `confidence` is typically pinned to `1.0` (deterministic).
+
+## Relationships
+
+- Registered in: [`platform-ui`](../packages/platform-ui.md).
+- Inherits from: [`agent-runtime`](../packages/agent-runtime.md) `BaseContainerAgentPlugin`.
+- Used by: [`community-digest`](../apps/community-digest.md).
+
+## Sources
+
+- `packages/agent-runtime/src/plugins/script-container-plugin.ts`
+- `packages/platform-ui/src/lib/platform-services.ts`

--- a/docs/knowledge-base/wiki/entities/plugins/script-container.md
+++ b/docs/knowledge-base/wiki/entities/plugins/script-container.md
@@ -6,19 +6,17 @@ sources: 2
 tags: [plugin, script-container, agent-runtime, deterministic]
 ---
 
-**Built-in container plugin for deterministic scripts — runs a scripted container without calling an LLM. Registered as `script-container`.**
+**Deterministic script container. No LLM. Registered as `script-container`. Used by [community-digest](../apps/community-digest.md).**
 
-## Purpose
+## Why
 
-Use when a workflow step needs to execute reproducible, LLM-free code (data transformations, file packaging, API calls). The container still goes through the same spawn + output-envelope machinery as LLM plugins, which keeps workflow steps homogeneous and audit events consistent.
-
-Used by the [`community-digest` app](../apps/community-digest.md) for GitHub data gathering and Discord posting.
+Some steps need reproducible LLM-free code (data transforms, packaging, API calls). Script container reuses the same spawn + envelope machinery as LLM plugins → homogeneous workflow steps + consistent audit events.
 
 ## How it fits
 
-- Concrete subclass of `BaseContainerAgentPlugin` in [`agent-runtime`](../packages/agent-runtime.md).
+- Subclass of `BaseContainerAgentPlugin` in [`agent-runtime`](../packages/agent-runtime.md). See [plugin-dispatch](../../concepts/plugin-dispatch.md).
 - Registered by `getPlatformServices()` in [`platform-ui`](../packages/platform-ui.md).
-- Output still conforms to `AgentOutputEnvelopeSchema`, but `confidence` is typically pinned to `1.0` (deterministic).
+- Output conforms to `AgentOutputEnvelopeSchema`; `confidence` typically pinned to `1.0` (deterministic).
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-driver-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-driver-agent.md
@@ -1,0 +1,38 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [plugin, supply-intelligence, narrative, llm]
+---
+
+**Narrative risk summarizer — generates prose for SKU+warehouse pairs, therapeutic categories, and portfolio overview. Registered as `supply-intelligence/driver-agent`.**
+
+## Purpose
+
+Given pre-computed risk numbers (from [`supply-intelligence`](../packages/supply-intelligence.md) + `lib/risk-computations.ts`), produces a narrative summary via LLM. Numbers are templated into the prompt; the LLM is never asked to compute them. Keeps outputs auditable — you can trace any claim in the narrative back to a number.
+
+## Inputs
+
+Decided by prompt target:
+- SKU-level (specific SKU × warehouse)
+- Category-level (therapeutic category rollup)
+- Overview (portfolio-wide)
+
+Prompt builders live in `packages/supply-intelligence-plugins/src/prompts/`.
+
+## How it fits
+
+- Registered via `registerSupplyIntelligencePlugins(registry)` called from [`platform-ui`](../packages/platform-ui.md) `getPlatformServices()`.
+- Data fetched through `lib/supply-data-fetcher.ts` (Firestore).
+
+## Relationships
+
+- Sibling: [`supply-intelligence/risk-detection`](./supply-intelligence-risk-detection.md).
+- Depends on: [`supply-intelligence`](../packages/supply-intelligence.md), [`agent-runtime`](../packages/agent-runtime.md).
+
+## Sources
+
+- `packages/supply-intelligence-plugins/src/driver-agent-plugin.ts`
+- `packages/supply-intelligence-plugins/src/prompts/` (4 builders)
+- `packages/supply-intelligence-plugins/src/lib/risk-computations.ts`

--- a/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-driver-agent.md
+++ b/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-driver-agent.md
@@ -6,25 +6,26 @@ sources: 3
 tags: [plugin, supply-intelligence, narrative, llm]
 ---
 
-**Narrative risk summarizer — generates prose for SKU+warehouse pairs, therapeutic categories, and portfolio overview. Registered as `supply-intelligence/driver-agent`.**
+**Narrative risk summarizer. Prose for SKU+warehouse, category, portfolio overview. Registered as `supply-intelligence/driver-agent`.**
 
-## Purpose
+## What it does
 
-Given pre-computed risk numbers (from [`supply-intelligence`](../packages/supply-intelligence.md) + `lib/risk-computations.ts`), produces a narrative summary via LLM. Numbers are templated into the prompt; the LLM is never asked to compute them. Keeps outputs auditable — you can trace any claim in the narrative back to a number.
+Takes pre-computed risk numbers (from [`supply-intelligence`](../packages/supply-intelligence.md) + `lib/risk-computations.ts`) → templates into prompt → LLM writes prose. LLM never computes numbers → [llm-no-computation-rule](../../concepts/llm-no-computation-rule.md). Every narrative claim traces to a number.
 
-## Inputs
+## Targets
 
-Decided by prompt target:
+Per prompt target:
+
 - SKU-level (specific SKU × warehouse)
-- Category-level (therapeutic category rollup)
+- Category-level (therapeutic rollup)
 - Overview (portfolio-wide)
 
-Prompt builders live in `packages/supply-intelligence-plugins/src/prompts/`.
+Prompt builders: `packages/supply-intelligence-plugins/src/prompts/`.
 
 ## How it fits
 
-- Registered via `registerSupplyIntelligencePlugins(registry)` called from [`platform-ui`](../packages/platform-ui.md) `getPlatformServices()`.
-- Data fetched through `lib/supply-data-fetcher.ts` (Firestore).
+- Registered via `registerSupplyIntelligencePlugins(registry)` from [platform-ui](../packages/platform-ui.md) `getPlatformServices()`.
+- Data: `lib/supply-data-fetcher.ts` (Firestore).
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-risk-detection.md
+++ b/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-risk-detection.md
@@ -1,0 +1,33 @@
+---
+type: entity
+created: 2026-04-23
+updated: 2026-04-23
+sources: 3
+tags: [plugin, supply-intelligence, issues, firestore]
+---
+
+**Scans red-flagged SKU+warehouse pairs, computes priority scores, and writes draft issues to Firestore. Registered as `supply-intelligence/risk-detection`.**
+
+## Purpose
+
+Surfaces actionable supply-chain risks. Pulls supply data, runs `classifyRisk()` from [`supply-intelligence`](../packages/supply-intelligence.md), filters to red rows, ranks them with `lib/priority-score.ts`, and produces draft issues — each with an LLM-generated title, summary, and proposed action — written to Firestore collection `draftIssues`.
+
+## Output
+
+Firestore writes in collection `draftIssues`. The LLM contributes text only; priority score and thresholds are deterministic.
+
+## How it fits
+
+- Registered via `registerSupplyIntelligencePlugins(registry)` from [`platform-ui`](../packages/platform-ui.md).
+- Shares data-fetching and risk-computation libs with the [driver-agent plugin](./supply-intelligence-driver-agent.md).
+
+## Relationships
+
+- Sibling: [`supply-intelligence/driver-agent`](./supply-intelligence-driver-agent.md).
+- Depends on: [`supply-intelligence`](../packages/supply-intelligence.md), [`agent-runtime`](../packages/agent-runtime.md), `firebase-admin`.
+
+## Sources
+
+- `packages/supply-intelligence-plugins/src/risk-detection-plugin.ts`
+- `packages/supply-intelligence-plugins/src/lib/priority-score.ts`
+- `packages/supply-intelligence-plugins/src/lib/issue-writer.ts`

--- a/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-risk-detection.md
+++ b/docs/knowledge-base/wiki/entities/plugins/supply-intelligence-risk-detection.md
@@ -6,20 +6,20 @@ sources: 3
 tags: [plugin, supply-intelligence, issues, firestore]
 ---
 
-**Scans red-flagged SKU+warehouse pairs, computes priority scores, and writes draft issues to Firestore. Registered as `supply-intelligence/risk-detection`.**
+**Red-flag scanner → priority score → writes draft issues to Firestore `draftIssues`. Registered as `supply-intelligence/risk-detection`.**
 
-## Purpose
+## What it does
 
-Surfaces actionable supply-chain risks. Pulls supply data, runs `classifyRisk()` from [`supply-intelligence`](../packages/supply-intelligence.md), filters to red rows, ranks them with `lib/priority-score.ts`, and produces draft issues — each with an LLM-generated title, summary, and proposed action — written to Firestore collection `draftIssues`.
+Pull supply data → `classifyRisk()` from [`supply-intelligence`](../packages/supply-intelligence.md) → filter red rows → rank via `lib/priority-score.ts` → emit draft issues. Each issue: LLM-generated title + summary + proposed action; priority + thresholds are deterministic. See [llm-no-computation-rule](../../concepts/llm-no-computation-rule.md).
 
 ## Output
 
-Firestore writes in collection `draftIssues`. The LLM contributes text only; priority score and thresholds are deterministic.
+Firestore collection `draftIssues`. LLM contributes text only.
 
 ## How it fits
 
-- Registered via `registerSupplyIntelligencePlugins(registry)` from [`platform-ui`](../packages/platform-ui.md).
-- Shares data-fetching and risk-computation libs with the [driver-agent plugin](./supply-intelligence-driver-agent.md).
+- Registered via `registerSupplyIntelligencePlugins(registry)` from [platform-ui](../packages/platform-ui.md).
+- Shares data-fetcher + risk-computations with [driver-agent](./supply-intelligence-driver-agent.md).
 
 ## Relationships
 

--- a/docs/knowledge-base/wiki/gotchas/dual-schema-routing.md
+++ b/docs/knowledge-base/wiki/gotchas/dual-schema-routing.md
@@ -1,0 +1,38 @@
+---
+type: gotcha
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [gotcha, workflow-definitions, dual-schema, routing]
+---
+
+**Reading workflow steps? Go through `resolveDefinitionSteps()`. Never hit `processDefinitions` or `workflowDefinitions` Firestore collections directly.**
+
+## Symptom
+
+- New feature works on new `workflowDefinitions`-backed workflows but silently breaks on legacy workflows.
+- Or vice versa.
+- "But the workflow exists — why do reads come back empty?"
+
+## Cause
+
+Two schemas coexist: legacy `processDefinitions` + `processConfigs` (pre-migration) and unified `workflowDefinitions` (post-migration). Different workflows live in different collections during the live migration. See [dual-schema-migration concept](../concepts/dual-schema-migration.md).
+
+## Fix / workaround
+
+- Every read of step definitions: **`resolveDefinitionSteps()`** in `packages/platform-ui/src/lib/resolve-definition-steps.ts`.
+- That function consults both schemas and returns a normalised `WorkflowDefinition`-shaped object.
+- Writes: new code only targets `workflowDefinitions`. Legacy is read-only.
+
+## How to avoid next time
+
+Before writing any Firestore query for step data, grep for `resolveDefinitionSteps` — chances are the code you need already exists.
+
+```bash
+grep -rn 'resolveDefinitionSteps' packages/
+```
+
+## Sources
+
+- `packages/platform-ui/src/lib/resolve-definition-steps.ts`
+- `AGENTS.md` → "Key architectural patterns" → "Dual-schema migration"

--- a/docs/knowledge-base/wiki/gotchas/in-memory-repos-not-mocks.md
+++ b/docs/knowledge-base/wiki/gotchas/in-memory-repos-not-mocks.md
@@ -1,0 +1,52 @@
+---
+type: gotcha
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [gotcha, testing, repository-pattern, mocks]
+---
+
+**Don't mock Firestore in tests. Use in-memory repository doubles from `@mediforce/platform-core/testing`.**
+
+## Symptom
+
+- Tests mock `firebase-admin` or `firestore` directly.
+- Brittle mocks drift from real repository behaviour.
+- Changes to Firestore repositories don't get caught by tests until runtime.
+
+## Cause
+
+Repositories follow the [repository-pattern](../concepts/repository-pattern.md): interface in `platform-core`, Firestore impl in `platform-infra`, in-memory double in `platform-core/testing`. Mocking `firebase-admin` bypasses the interface entirely — tests verify nothing useful.
+
+## Fix / workaround
+
+```typescript
+import {
+  InMemoryProcessRepository,
+  InMemoryProcessInstanceRepository,
+  buildProcessInstance,
+  buildHumanTask,
+  buildAgentRun,
+} from '@mediforce/platform-core/testing';
+
+const repo = new InMemoryProcessInstanceRepository();
+const instance = buildProcessInstance({ status: 'paused' });
+```
+
+In-memory doubles implement the same interface — real behaviour, no Firestore.
+
+## How to avoid next time
+
+Writing a new test? Grep first:
+
+```bash
+grep -rn 'InMemory' packages/platform-core/src/testing/
+grep -rn 'build.*({' packages/platform-core/src/testing/factories.ts
+```
+
+If no double exists for the repo you need, add it to `platform-core/testing/` alongside the interface. Don't mock.
+
+## Sources
+
+- `AGENTS.md` → "Test factories"
+- `packages/platform-core/src/testing/factories.ts`

--- a/docs/knowledge-base/wiki/gotchas/mediforce-source-custom-condition.md
+++ b/docs/knowledge-base/wiki/gotchas/mediforce-source-custom-condition.md
@@ -1,0 +1,35 @@
+---
+type: gotcha
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [gotcha, typescript, monorepo, build]
+---
+
+**`@mediforce/source` custom TS condition resolves `@mediforce/*` imports to `./src/index.ts` during dev, `./dist/` in prod. Skips the build step entirely in dev.**
+
+## Symptom
+
+- Edit a file in `packages/platform-core/src/` — `platform-ui` picks it up instantly without a rebuild.
+- Run Vitest — it uses source TS directly, no compiled output.
+- Change `package.json` `exports` or `tsconfig.json` `customConditions` → everything breaks.
+
+## Cause
+
+Every `@mediforce/*` package's `package.json` declares an `exports` map with a `"@mediforce/source"` condition pointing to source `.ts`. Root `tsconfig.json` sets `customConditions: ["@mediforce/source"]`. `vitest.config.ts` sets `resolve.conditions: ["@mediforce/source"]`. In production / published builds the condition is absent → falls back to `./dist/`.
+
+## Fix / workaround
+
+- **Don't** add a manual build step to dev. Source resolution is on purpose.
+- **Don't** import from `@mediforce/*/dist/…` paths anywhere.
+- New subpath export? Add to all three: `package.json` exports, `tsconfig.json` paths (if present), Vitest conditions should pick up automatically.
+- New `@mediforce/*` package? Copy the pattern from `platform-core/package.json` — `exports` block with `@mediforce/source` condition.
+
+## How to avoid next time
+
+Grep before touching: `grep -rn '@mediforce/source' packages/ apps/ tsconfig.json vitest.config.ts`. That's the full surface.
+
+## Sources
+
+- `AGENTS.md` → "How inter-package imports work"
+- Root `tsconfig.json` + `vitest.config.ts`

--- a/docs/knowledge-base/wiki/gotchas/remote-e2e-setup.md
+++ b/docs/knowledge-base/wiki/gotchas/remote-e2e-setup.md
@@ -1,0 +1,51 @@
+---
+type: gotcha
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [gotcha, e2e, playwright, firebase-emulator, remote]
+---
+
+**Remote environments (Claude Code web, CI, fresh machines) need manual E2E prep. Run `python3 packages/platform-ui/scripts/bootstrap_e2e.py` before any E2E test. Idempotent.**
+
+## Symptom
+
+- E2E test fails with "Firebase SDK not initialised", "API key missing", or Playwright "chromium executable not found".
+- `test:e2e:auth` hangs on emulator startup in a proxied environment.
+- `test:e2e:gif` errors on `ffmpeg: command not found`.
+
+## Cause
+
+Local dev boxes have `.env.local`, Playwright browsers, ffmpeg, and a running Firebase emulator already. Remote agent environments don't. Google Fonts may also fail to download — Next.js falls back to system fonts, tests still work.
+
+## Fix / workaround
+
+Run the bootstrap script. It handles:
+
+| What | Why |
+|------|-----|
+| `.env.local` with demo creds | Firebase SDK needs API key even in emulator mode. |
+| `/tmp/firebase-e2e.json` with `"ui": {"enabled": false}` | Emulator UI download crashes in proxied environments. |
+| Start Firebase emulators (Auth 9099, Firestore 8080) | Required by tests. |
+| `npx playwright install --with-deps chromium` | Binary must match `@playwright/test` version. |
+| `apt-get install ffmpeg` | Needed for GIF conversion. |
+| `fuser -k 9007/tcp` | Kill stale dev server. |
+
+```bash
+python3 packages/platform-ui/scripts/bootstrap_e2e.py
+```
+
+Then:
+
+```bash
+cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth
+```
+
+## How to avoid next time
+
+Always run bootstrap before E2E in a new environment. It's idempotent — no harm in running every session. Part of the pre-push checklist in `AGENTS.md`.
+
+## Sources
+
+- `AGENTS.md` → "Remote E2E setup", "Before pushing" checklist
+- `packages/platform-ui/scripts/bootstrap_e2e.py`

--- a/docs/knowledge-base/wiki/gotchas/runtime-skill-path-coupling.md
+++ b/docs/knowledge-base/wiki/gotchas/runtime-skill-path-coupling.md
@@ -1,0 +1,45 @@
+---
+type: gotcha
+created: 2026-04-23
+updated: 2026-04-23
+sources: 2
+tags: [gotcha, skills, runtime, workflow-definitions]
+---
+
+**Runtime skills live at `apps/*/plugins/*/skills/`. Paths are hardcoded in `*.wd.json` via `skillsDir`. Don't move them.**
+
+## Symptom
+
+- Rename or relocate a runtime skill directory.
+- Workflow fails at step execution: `BaseContainerAgentPlugin.readSkillFile()` can't find the skill.
+
+## Cause
+
+Agent-runtime resolves skills via `skillsDir` field in the `WorkflowDefinition` JSON. That field is a literal path, not a registry lookup. Read by `BaseContainerAgentPlugin.readSkillFile()` at step execution time.
+
+## Fix / workaround
+
+- **Don't** move runtime skills without updating every `*.wd.json` that references the directory.
+- **Don't** confuse runtime skills (`apps/*/plugins/*/skills/`) with development skills (`skills/` + `.claude/skills/` symlinks).
+
+Two tiers — different resolution:
+
+| Tier | Location | Resolved by |
+|------|----------|-------------|
+| Runtime | `apps/*/plugins/*/skills/` | `agent-runtime` via `skillsDir` in `.wd.json` |
+| Development | `skills/` (symlinked to `.claude/skills/`) | Claude Code slash-command loader |
+
+## How to avoid next time
+
+Each app has its own runtime `_registry.yml` — that's the index for that app's runtime skills:
+
+- `apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/_registry.yml`
+- `apps/community-digest/plugins/community-digest/skills/_registry.yml`
+- `apps/workflow-designer/plugins/workflow-designer/skills/_registry.yml`
+
+Before refactoring, grep for `skillsDir`: `grep -rn 'skillsDir' apps/ packages/`.
+
+## Sources
+
+- `AGENTS.md` → "Skills and Agents"
+- `packages/agent-runtime/src/plugins/base-container-agent-plugin.ts` (`readSkillFile`)

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -2,7 +2,7 @@
 
 Catalog of every page in the Mediforce knowledge base. Agents update this on every ingest. Read this first when answering a query.
 
-Conventions and workflow: see [`../SCHEMA.md`](../SCHEMA.md). Abstract pattern: see [`../LLM-WIKI.md`](../LLM-WIKI.md).
+Conventions: [`../SCHEMA.md`](../SCHEMA.md). Writing style: [`../STYLE.md`](../STYLE.md). Abstract pattern: [`../LLM-WIKI.md`](../LLM-WIKI.md).
 
 ## TODO (pending work flagged by lint)
 

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -35,7 +35,10 @@ _Pending — ingest `**/*.wd.json` files._
 
 ### Apps
 
-_Pending commit 3 — supply-intelligence, protocol-to-tfl, community-digest, workflow-designer._
+- [supply-intelligence](./entities/apps/supply-intelligence.md) — standalone Next.js dashboard (port 9004); consumes `supply-intelligence` domain.
+- [protocol-to-tfl](./entities/apps/protocol-to-tfl.md) — protocol PDF → TFL pipeline, 6 steps, 5 runtime skills, git-mode commits to `mediforce-clinical-workspace`.
+- [community-digest](./entities/apps/community-digest.md) — cron-triggered GitHub→Discord digest; uses `script-container` plugin.
+- [workflow-designer](./entities/apps/workflow-designer.md) — meta-workflow that designs new WorkflowDefinitions via AI + human review.
 
 ## Concepts
 

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -42,9 +42,21 @@ _Pending — ingest `**/*.wd.json` files._
 
 ## Concepts
 
-_Pending commit 4 — autonomy-levels, plugin-dispatch, repository-pattern, docker-spawn-strategies, dual-schema-migration, expression-evaluator, service-singleton._
+### Architectural
 
-_Pending commit 5 (pharma domain) — cdisc-sdtm, ctcae-grading, recist-v1-1, pharma-domain-context._
+- [autonomy-levels](./concepts/autonomy-levels.md) — L0–L4 scale enforced by `AgentRunner`, coupled with confidence thresholds.
+- [plugin-dispatch](./concepts/plugin-dispatch.md) — `AgentRunner` + `PluginRegistry` + `AgentOutputEnvelope`; how steps route to plugins.
+- [repository-pattern](./concepts/repository-pattern.md) — interfaces in platform-core, Firestore in platform-infra, in-memory doubles for tests.
+- [docker-spawn-strategies](./concepts/docker-spawn-strategies.md) — local child-process vs BullMQ-queued; toggled by REDIS_URL.
+- [dual-schema-migration](./concepts/dual-schema-migration.md) — legacy `processDefinitions`+`processConfigs` coexist with unified `workflowDefinitions`; go through `resolveDefinitionSteps()`.
+- [expression-evaluator](./concepts/expression-evaluator.md) — custom DSL for transition `when` clauses.
+- [service-singleton](./concepts/service-singleton.md) — `getPlatformServices()` composition root in platform-ui.
+- [mcp-resolution](./concepts/mcp-resolution.md) — per-step MCP config; workflow-mode (recommended) vs legacy flattened path.
+- [llm-no-computation-rule](./concepts/llm-no-computation-rule.md) — LLMs generate prose, numbers come from pure functions.
+
+### Pharma domain
+
+_Pending commit 5 — cdisc-sdtm, ctcae-grading, recist-v1-1, pharma-domain-context._
 
 ## Decisions
 

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -68,7 +68,11 @@ _Pending._
 
 ## Gotchas
 
-_Pending commit 6 — mediforce-source-custom-condition, remote-e2e-setup, dual-schema-routing._
+- [mediforce-source-custom-condition](./gotchas/mediforce-source-custom-condition.md) — TS condition resolves `@mediforce/*` to source `.ts` in dev, `dist/` in prod; don't rebuild in dev.
+- [remote-e2e-setup](./gotchas/remote-e2e-setup.md) — run `bootstrap_e2e.py` before E2E in remote envs; idempotent.
+- [dual-schema-routing](./gotchas/dual-schema-routing.md) — always read via `resolveDefinitionSteps()`; never hit `processDefinitions` / `workflowDefinitions` directly.
+- [runtime-skill-path-coupling](./gotchas/runtime-skill-path-coupling.md) — runtime skill paths hardcoded in `.wd.json`; runtime vs dev skills are two tiers.
+- [in-memory-repos-not-mocks](./gotchas/in-memory-repos-not-mocks.md) — use `InMemory*Repository` from `@mediforce/platform-core/testing`; don't mock firebase-admin.
 
 ## Syntheses
 

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -56,7 +56,11 @@ _Pending — ingest `**/*.wd.json` files._
 
 ### Pharma domain
 
-_Pending commit 5 — cdisc-sdtm, ctcae-grading, recist-v1-1, pharma-domain-context._
+- [pharma-domain-context](./concepts/pharma-domain-context.md) — clinical terms = identifiers; no wellbeing framing; preamble carries framing to runtime.
+- [cdisc-sdtm](./concepts/cdisc-sdtm.md) — SDTM → ADaM → TFL pipeline; variable-name standard; ties into protocol-to-tfl.
+- [ctcae-grading](./concepts/ctcae-grading.md) — 1–5 AE severity; Grade 5 = death; companion signals (irAE, Hy's Law).
+- [recist-v1-1](./concepts/recist-v1-1.md) — CR/PR/SD/PD tumour-response; ORR/DCR/PFS/DoR endpoints; iRECIST variant.
+- [ich-gcp](./concepts/ich-gcp.md) — regulatory framework; ALCOA+ data integrity; audit events = regulatory requirement.
 
 ## Decisions
 

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -12,11 +12,17 @@ _Empty — wiki bootstrap. Add TODOs here during lint passes (missing pages, bro
 
 ### Packages
 
-_Pending — ingest per-package READMEs under `packages/` and `apps/` to populate._
+- [platform-core](./entities/packages/platform-core.md) — foundational Zod schemas, repository interfaces, test factories; zero internal deps.
+- [platform-infra](./entities/packages/platform-infra.md) — Firestore repositories, Firebase auth, notifications, secrets cipher.
+- [workflow-engine](./entities/packages/workflow-engine.md) — process instance orchestrator, transition routing, triggers, expression evaluator.
+- [agent-runtime](./entities/packages/agent-runtime.md) — agent execution engine, plugin dispatch, Docker spawn strategies, fallback handling.
+- [platform-ui](./entities/packages/platform-ui.md) — Next.js 15 web app, API routes, `getPlatformServices()` composition root.
+- [supply-intelligence](./entities/packages/supply-intelligence.md) — pure supply-chain domain (SKU, warehouse, batch, FEFO allocation, risk classification).
+- [supply-intelligence-plugins](./entities/packages/supply-intelligence-plugins.md) — LLM narratives + Firestore draft-issue writes wrapping supply-intelligence.
 
 ### Plugins
 
-_Pending — ingest plugins registered in `PluginRegistry` (claude-code, opencode, script-container, supply-intelligence)._
+_Pending commit 2 — claude-code-agent, opencode-agent, script-container, example-agent, supply-intelligence plugins._
 
 ### Workflows
 
@@ -24,11 +30,13 @@ _Pending — ingest `**/*.wd.json` files._
 
 ### Apps
 
-_Pending — ingest `apps/*/` (supply-intelligence, protocol-to-tfl, community-digest, workflow-designer)._
+_Pending commit 3 — supply-intelligence, protocol-to-tfl, community-digest, workflow-designer._
 
 ## Concepts
 
-_Pending — candidate seed list: repository-pattern, plugin-dispatch, autonomy-levels, dual-schema-migration, docker-spawn-strategies, expression-evaluator, cdisc-sdtm, ctcae-grading, recist-v1-1._
+_Pending commit 4 — autonomy-levels, plugin-dispatch, repository-pattern, docker-spawn-strategies, dual-schema-migration, expression-evaluator, service-singleton._
+
+_Pending commit 5 (pharma domain) — cdisc-sdtm, ctcae-grading, recist-v1-1, pharma-domain-context._
 
 ## Decisions
 
@@ -36,7 +44,7 @@ _Pending._
 
 ## Gotchas
 
-_Pending._
+_Pending commit 6 — mediforce-source-custom-condition, remote-e2e-setup, dual-schema-routing._
 
 ## Syntheses
 

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -1,0 +1,43 @@
+# Wiki Index
+
+Catalog of every page in the Mediforce knowledge base. Agents update this on every ingest. Read this first when answering a query.
+
+Conventions and workflow: see [`../SCHEMA.md`](../SCHEMA.md). Abstract pattern: see [`../LLM-WIKI.md`](../LLM-WIKI.md).
+
+## TODO (pending work flagged by lint)
+
+_Empty — wiki bootstrap. Add TODOs here during lint passes (missing pages, broken links, source rot)._
+
+## Entities
+
+### Packages
+
+_Pending — ingest per-package READMEs under `packages/` and `apps/` to populate._
+
+### Plugins
+
+_Pending — ingest plugins registered in `PluginRegistry` (claude-code, opencode, script-container, supply-intelligence)._
+
+### Workflows
+
+_Pending — ingest `**/*.wd.json` files._
+
+### Apps
+
+_Pending — ingest `apps/*/` (supply-intelligence, protocol-to-tfl, community-digest, workflow-designer)._
+
+## Concepts
+
+_Pending — candidate seed list: repository-pattern, plugin-dispatch, autonomy-levels, dual-schema-migration, docker-spawn-strategies, expression-evaluator, cdisc-sdtm, ctcae-grading, recist-v1-1._
+
+## Decisions
+
+_Pending._
+
+## Gotchas
+
+_Pending._
+
+## Syntheses
+
+_Pending — answers filed back from chats._

--- a/docs/knowledge-base/wiki/index.md
+++ b/docs/knowledge-base/wiki/index.md
@@ -22,7 +22,12 @@ _Empty — wiki bootstrap. Add TODOs here during lint passes (missing pages, bro
 
 ### Plugins
 
-_Pending commit 2 — claude-code-agent, opencode-agent, script-container, example-agent, supply-intelligence plugins._
+- [claude-code-agent](./entities/plugins/claude-code-agent.md) — default container plugin running Claude Code; MOCK_AGENT swaps for fixtures.
+- [opencode-agent](./entities/plugins/opencode-agent.md) — container plugin running OpenCode; local Ollama + cloud providers.
+- [script-container](./entities/plugins/script-container.md) — deterministic scripted container (no LLM); used by community-digest.
+- [example-agent](./entities/plugins/example-agent.md) — reference AgentPlugin template; 50-line event-emission pattern.
+- [supply-intelligence/driver-agent](./entities/plugins/supply-intelligence-driver-agent.md) — narrative risk summaries (SKU, category, overview).
+- [supply-intelligence/risk-detection](./entities/plugins/supply-intelligence-risk-detection.md) — red-flag scanner, writes draft issues to Firestore.
 
 ### Workflows
 

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -82,3 +82,19 @@ Every concept page names the before-you-write-new-code check — e.g. "use `reso
 
 touched: `index.md`, 9 new concept pages.
 summary: covered the nine architectural concepts referenced most often in AGENTS.md + entity pages. Pharma-domain concepts queued for commit 5.
+
+## [2026-04-23] ingest | Pharma domain concepts (5)
+
+Written in caveman style (user directive mid-commit — see note below). Filed:
+- `concepts/pharma-domain-context.md`
+- `concepts/cdisc-sdtm.md`
+- `concepts/ctcae-grading.md`
+- `concepts/recist-v1-1.md`
+- `concepts/ich-gcp.md`
+
+Each page: what the standard is, where it shows up in our code (vars, schemas, skills, prompts), canonical external source, related pages.
+
+**Style change from this commit onward**: wiki pages written in caveman style (terse, dropped articles, fragments, tables, imperatives) for context-frugal reads by agents. SCHEMA.md to be updated with the full caveman prompt in a follow-up commit. Earlier pages (commits 1–4) written in fuller prose — lint should eventually rewrite for consistency.
+
+touched: `index.md`, 5 new pharma-concept pages.
+summary: covered pharma framing + 4 clinical standards that tie into `protocol-to-tfl` and clinical-workflow schemas.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -121,3 +121,17 @@ High-value anti-duplicate-work surface. Each gotcha = "agent burned >15 min on t
 
 touched: `index.md`, 5 new gotcha pages.
 summary: covered the most common reimplement-what-already-exists traps called out by AGENTS.md.
+
+## [2026-04-23] lint | First full pass
+
+Ran relative-`.md`-link + orphan check on all 38 wiki pages.
+
+- Broken links: 3 found, 3 fixed.
+  - `concepts/repository-pattern.md` → `../../../AGENTS.md` — wrong depth; replaced with plain-text reference.
+  - `entities/packages/workflow-engine.md` → `../../../ENGINE-TESTING.md` — wrong depth; replaced with plain-text reference.
+  - `entities/packages/platform-ui.md` → `../../../../packages/platform-ui/src/lib/platform-services.ts` — code-file link with wrong depth; replaced with plain-text reference. Code paths stay in `## Sources` only.
+- Orphan pages: 0.
+- Rule for future edits: don't use relative `.md` links to reach files outside `docs/knowledge-base/wiki/` — cite them in plain text (paths are in `## Sources`). Relative links inside wiki/ are fine.
+
+touched: 3 pages above, `index.md` unchanged.
+summary: 38 pages, 0 broken links, 0 orphans. Ready to push.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -98,3 +98,26 @@ Each page: what the standard is, where it shows up in our code (vars, schemas, s
 
 touched: `index.md`, 5 new pharma-concept pages.
 summary: covered pharma framing + 4 clinical standards that tie into `protocol-to-tfl` and clinical-workflow schemas.
+
+## [2026-04-23] decision | Adopt caveman style for wiki prose
+
+Embedded JuliusBrussee/caveman canonical always-on prompt in `SCHEMA.md` → "Writing style: caveman". Rationale: 60–75% fewer tokens vs full prose, same substance. Wiki read in-session by agents → context budget dominates.
+
+Intensity levels added: lite (decisions/syntheses), full (entities/concepts/gotchas — default), ultra (index/table rows). Passthrough list: frontmatter, code, URLs, symbols, numbers — never compress.
+
+Pharma commit already caveman. Earlier commits (1–4) in fuller prose — follow-up rewrite pass TBD.
+
+touched: `SCHEMA.md`.
+
+## [2026-04-23] ingest | Gotchas (5)
+
+High-value anti-duplicate-work surface. Each gotcha = "agent burned >15 min on this" or "agent likely to reimplement the wrong way". Filed in caveman:
+
+- `gotchas/mediforce-source-custom-condition.md` — TS condition trap.
+- `gotchas/remote-e2e-setup.md` — bootstrap_e2e.py before E2E in remote envs.
+- `gotchas/dual-schema-routing.md` — go through resolveDefinitionSteps; pairs with dual-schema-migration concept.
+- `gotchas/runtime-skill-path-coupling.md` — runtime vs dev skills, skillsDir hardcoded.
+- `gotchas/in-memory-repos-not-mocks.md` — test doubles > firebase-admin mocks.
+
+touched: `index.md`, 5 new gotcha pages.
+summary: covered the most common reimplement-what-already-exists traps called out by AGENTS.md.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -1,0 +1,20 @@
+# Wiki Log
+
+Append-only chronological record. Newest entries at the bottom. Every ingest / query-file-back / lint pass must add an entry.
+
+Format: `## [YYYY-MM-DD] <op> | <title>` where `<op>` ∈ `{bootstrap, ingest, file-back, lint}`. See [`../SCHEMA.md`](../SCHEMA.md).
+
+Quick tail: `grep "^## \[" docs/knowledge-base/wiki/log.md | tail -10`
+
+---
+
+## [2026-04-23] bootstrap | Knowledge base scaffolding
+
+Added `docs/knowledge-base/` with:
+- `LLM-WIKI.md` (Karpathy idea file, verbatim)
+- `SCHEMA.md` (Mediforce-specific conventions)
+- `wiki/index.md` + `wiki/log.md`
+
+Wired into `AGENTS.md` → Knowledge Base section + Skills Router. Skill `knowledge-base` added at `skills/knowledge-base/SKILL.md`.
+
+Wiki is empty of content pages. Next ingests should prioritise: package entities (platform-core, workflow-engine, agent-runtime, platform-ui, platform-infra), the autonomy-levels concept, and the plugin-dispatch concept — these are referenced heavily in `AGENTS.md` and most questions route through them.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -49,3 +49,18 @@ Key fact worth promoting into a concept page: built-in plugins are registered in
 
 touched: `index.md`, 6 new plugin pages.
 summary: covered the three built-in container plugins, the reference example-agent, and both supply-intelligence plugins.
+
+## [2026-04-23] ingest | App entities (4)
+
+Sourced from `apps/*/src/*.wd.json` + `apps/*/plugins/*/skills/_registry.yml`. Filed:
+- `entities/apps/supply-intelligence.md`
+- `entities/apps/protocol-to-tfl.md`
+- `entities/apps/community-digest.md`
+- `entities/apps/workflow-designer.md`
+
+Key facts noted for downstream concepts:
+- Runtime skills (app-specific) resolve via `skillsDir` in `.wd.json`; paths are hardcoded there — this is a potential gotcha worth filing (queued for commit 6: runtime-skill-path-coupling).
+- `protocol-to-tfl` uses `git-mode` steps that commit to an external repo — this is a concept (`git-mode-workflows`) worth filing eventually.
+
+touched: `index.md`, 4 new app pages.
+summary: covered every `apps/*` directory.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -135,3 +135,21 @@ Ran relative-`.md`-link + orphan check on all 38 wiki pages.
 
 touched: 3 pages above, `index.md` unchanged.
 summary: 38 pages, 0 broken links, 0 orphans. Ready to push.
+
+## [2026-04-23] rewrite | Caveman pass on commits 1–4 (26 pages)
+
+Rewrote every page from commits 1–4 in caveman style per `SCHEMA.md` → "Writing style: caveman". Kept untouched: frontmatter, section headers, code blocks, file paths, URLs, Zod/symbol/variable names, numbers, dates, markdown links. Compressed only prose — dropped articles, filler ("it's worth noting", "in practice"), pleasantries; used fragments; pushed facts into tables + bullets where possible.
+
+Pages rewritten:
+
+- Packages (7): platform-core, workflow-engine, agent-runtime, platform-infra, platform-ui, supply-intelligence, supply-intelligence-plugins.
+- Plugins (6): claude-code-agent, opencode-agent, script-container, example-agent, supply-intelligence-driver-agent, supply-intelligence-risk-detection.
+- Apps (4): supply-intelligence, protocol-to-tfl, community-digest, workflow-designer.
+- Concepts (9): autonomy-levels, plugin-dispatch, repository-pattern, docker-spawn-strategies, dual-schema-migration, expression-evaluator, service-singleton, mcp-resolution, llm-no-computation-rule.
+
+Also added forward cross-references from entity pages to the relevant gotchas (e.g. platform-ui → mediforce-source-custom-condition, remote-e2e-setup, dual-schema-routing; protocol-to-tfl → runtime-skill-path-coupling; repository-pattern → in-memory-repos-not-mocks; dual-schema-migration → dual-schema-routing). These were missing before because gotchas landed in a later commit.
+
+Lint after rewrite: 38 files, 0 broken links, 0 orphans.
+
+touched: 26 existing pages rewritten + `log.md`.
+summary: wiki now fully in caveman, consistent across all 38 pages. Context-frugal for in-session agent reads.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -153,3 +153,18 @@ Lint after rewrite: 38 files, 0 broken links, 0 orphans.
 
 touched: 26 existing pages rewritten + `log.md`.
 summary: wiki now fully in caveman, consistent across all 38 pages. Context-frugal for in-session agent reads.
+
+## [2026-04-23] lint | SCHEMA trim + STYLE split
+
+`SCHEMA.md` trimmed 209 → 93 lines (−56% lines, −66% words). Caveman writing rules moved to their own `STYLE.md` (32 lines). Rationale: Karpathy's own LLM-WIKI.md is 77 lines and says "the exact directory structure, schema conventions, page formats — all of that will depend on your domain… everything above is optional and modular". Our original SCHEMA was 3× Karpathy's size and duplicated:
+
+- MUST-update / MUST-consult triggers (authoritative copy in `AGENTS.md` / personal `CLAUDE.local.md`).
+- Ingest / query / lint step-by-step (authoritative in `skills/knowledge-base/SKILL.md`).
+- Caveman prompt (now only in `STYLE.md`).
+
+New SCHEMA keeps only what's unique to this repo: layout, raw-source locations, page buckets with filename patterns, frontmatter, conventions, pharma-domain pointer, scale note.
+
+Also: removed "required sections per SCHEMA.md" wording from SKILL.md — replaced with "match the section shape of existing pages; examples beat rules". Fewer rules, better adherence.
+
+touched: `SCHEMA.md` (rewrite), `STYLE.md` (new), `skills/knowledge-base/SKILL.md` (one line), `wiki/index.md` (header pointers).
+summary: single source of truth for each rule; wiki docs are lean.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -64,3 +64,21 @@ Key facts noted for downstream concepts:
 
 touched: `index.md`, 4 new app pages.
 summary: covered every `apps/*` directory.
+
+## [2026-04-23] ingest | Architectural concepts (9)
+
+Synthesised from AGENTS.md + the entity pages filed in earlier commits. Filed:
+- `concepts/autonomy-levels.md`
+- `concepts/plugin-dispatch.md`
+- `concepts/repository-pattern.md`
+- `concepts/docker-spawn-strategies.md`
+- `concepts/dual-schema-migration.md`
+- `concepts/expression-evaluator.md`
+- `concepts/service-singleton.md`
+- `concepts/mcp-resolution.md`
+- `concepts/llm-no-computation-rule.md`
+
+Every concept page names the before-you-write-new-code check — e.g. "use `resolveDefinitionSteps()` before hitting Firestore directly", "check `entities/plugins/` before writing a plugin", "numbers come from pure functions, not LLMs". These pages are the primary anti-duplicate-work surface for agents.
+
+touched: `index.md`, 9 new concept pages.
+summary: covered the nine architectural concepts referenced most often in AGENTS.md + entity pages. Pharma-domain concepts queued for commit 5.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -18,3 +18,19 @@ Added `docs/knowledge-base/` with:
 Wired into `AGENTS.md` → Knowledge Base section + Skills Router. Skill `knowledge-base` added at `skills/knowledge-base/SKILL.md`.
 
 Wiki is empty of content pages. Next ingests should prioritise: package entities (platform-core, workflow-engine, agent-runtime, platform-ui, platform-infra), the autonomy-levels concept, and the plugin-dispatch concept — these are referenced heavily in `AGENTS.md` and most questions route through them.
+
+## [2026-04-23] ingest | Package entities (7)
+
+Sourced from parallel Explore surveys of `packages/` + `AGENTS.md` → "Package dependency graph". Filed:
+- `entities/packages/platform-core.md`
+- `entities/packages/platform-infra.md`
+- `entities/packages/workflow-engine.md`
+- `entities/packages/agent-runtime.md`
+- `entities/packages/platform-ui.md`
+- `entities/packages/supply-intelligence.md`
+- `entities/packages/supply-intelligence-plugins.md`
+
+Forward-linked to concept pages (plugin-dispatch, autonomy-levels, repository-pattern, docker-spawn-strategies, dual-schema-migration, expression-evaluator, service-singleton) and gotchas (mediforce-source-custom-condition) that are queued for later commits — those links are currently broken and will be flagged by lint until commits 4–6 land.
+
+touched: `index.md`, 7 new entity pages.
+summary: covered every `packages/*` directory; `platform-ui` is top of the dependency graph, `platform-core` and `supply-intelligence` are leaves.

--- a/docs/knowledge-base/wiki/log.md
+++ b/docs/knowledge-base/wiki/log.md
@@ -34,3 +34,18 @@ Forward-linked to concept pages (plugin-dispatch, autonomy-levels, repository-pa
 
 touched: `index.md`, 7 new entity pages.
 summary: covered every `packages/*` directory; `platform-ui` is top of the dependency graph, `platform-core` and `supply-intelligence` are leaves.
+
+## [2026-04-23] ingest | Plugin entities (6)
+
+Sourced from Explore survey of plugin registration mechanism + `packages/supply-intelligence-plugins/src/` + `packages/agent-runtime/src/plugins/`. Filed:
+- `entities/plugins/claude-code-agent.md`
+- `entities/plugins/opencode-agent.md`
+- `entities/plugins/script-container.md`
+- `entities/plugins/example-agent.md`
+- `entities/plugins/supply-intelligence-driver-agent.md`
+- `entities/plugins/supply-intelligence-risk-detection.md`
+
+Key fact worth promoting into a concept page: built-in plugins are registered in `platform-ui` `getPlatformServices()` under names `claude-code-agent`, `opencode-agent`, `script-container`; domain plugins register via `registerSupplyIntelligencePlugins(registry)`. Queued for `concepts/plugin-dispatch.md` (commit 4).
+
+touched: `index.md`, 6 new plugin pages.
+summary: covered the three built-in container plugins, the reference example-agent, and both supply-intelligence plugins.

--- a/skills/_registry.yml
+++ b/skills/_registry.yml
@@ -1,7 +1,7 @@
 version: "1.0"
-generated: "2026-03-25"
+generated: "2026-04-23"
 standard: "agentskills.io/specification"
-total_skills: 6
+total_skills: 7
 
 # Runtime skills have their own per-app registries:
 #   apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/_registry.yml
@@ -42,3 +42,8 @@ domains:
         complexity: basic
         language: multi
         description: Review and validate Renovate dependency PRs
+      - id: knowledge-base
+        path: skills/knowledge-base/SKILL.md
+        complexity: basic
+        language: multi
+        description: Ingest, query, and lint the LLM-compiled wiki (Karpathy LLM Wiki pattern)

--- a/skills/knowledge-base/SKILL.md
+++ b/skills/knowledge-base/SKILL.md
@@ -29,7 +29,7 @@ Maintains `docs/knowledge-base/wiki/` following the [LLM Wiki pattern](../../doc
 1. Read the source end-to-end.
 2. Read `docs/knowledge-base/wiki/index.md` to identify existing pages this source touches.
 3. For each affected page: update inline. Preserve existing citations; add new ones.
-4. If the source introduces a new entity / concept / decision / gotcha: create the page under the right bucket (`entities/`, `concepts/`, `decisions/`, `gotchas/`) with required sections per `SCHEMA.md`.
+4. If the source introduces a new entity / concept / decision / gotcha: create the page under the right bucket (`entities/`, `concepts/`, `decisions/`, `gotchas/`). Match the section shape of existing pages in that bucket — examples beat rules. Filename patterns + frontmatter per `SCHEMA.md`.
 5. Update `wiki/index.md` (new entries, bump counts, remove stale TODOs).
 6. Append a log entry:
    ```

--- a/skills/knowledge-base/SKILL.md
+++ b/skills/knowledge-base/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: knowledge-base
+description: Ingest sources into the LLM-maintained wiki, query it, and lint it. Use when adding new docs, answering architecture/domain questions, filing a synthesis answer back, or before pushing a PR that touched wiki pages.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+metadata:
+  version: "1.0"
+  domain: development
+  complexity: basic
+  tags: knowledge-base, wiki, documentation, karpathy-llm-wiki
+---
+
+# Knowledge Base
+
+Maintains `docs/knowledge-base/wiki/` following the [LLM Wiki pattern](../../docs/knowledge-base/LLM-WIKI.md) under [Mediforce schema conventions](../../docs/knowledge-base/SCHEMA.md).
+
+**Always read `docs/knowledge-base/SCHEMA.md` before acting.** It defines raw-source locations, page types, frontmatter, filenames, and the rules below.
+
+## Usage
+
+```
+/knowledge-base ingest <path-or-url>      # compile a new source into the wiki
+/knowledge-base query <question>          # answer from the wiki, file back if non-trivial
+/knowledge-base file <topic>              # file current-conversation synthesis back as a page
+/knowledge-base lint                      # health check the wiki
+```
+
+## Ingest
+
+1. Read the source end-to-end.
+2. Read `docs/knowledge-base/wiki/index.md` to identify existing pages this source touches.
+3. For each affected page: update inline. Preserve existing citations; add new ones.
+4. If the source introduces a new entity / concept / decision / gotcha: create the page under the right bucket (`entities/`, `concepts/`, `decisions/`, `gotchas/`) with required sections per `SCHEMA.md`.
+5. Update `wiki/index.md` (new entries, bump counts, remove stale TODOs).
+6. Append a log entry:
+   ```
+   ## [YYYY-MM-DD] ingest | <source title or path>
+   touched: <comma-separated page paths>
+   summary: <one line>
+   ```
+7. Report to the user: new pages, updated pages, contradictions flagged.
+
+Default: **one source at a time.** Only batch when explicitly asked.
+
+## Query
+
+1. `cat docs/knowledge-base/wiki/index.md` first.
+2. Read relevant pages + their linked pages.
+3. Answer with citations to wiki paths (which themselves cite raw sources).
+4. If the answer required pulling from 2+ pages or writing a comparison/analysis: **file it back** as a `syntheses/YYYY-MM-DD-<slug>.md`, update the index, append a `file-back` log entry.
+
+## File
+
+Use when the user explicitly says "file this" or the current conversation produced a non-trivial synthesis worth keeping. Same flow as the file-back step of `query`.
+
+## Lint
+
+Run `bash skills/knowledge-base/scripts/lint.sh` if the helper exists; otherwise do the checks manually:
+
+- **Contradictions** — grep key entity/concept names across wiki pages; flag divergent descriptions.
+- **Stale claims** — for each `file:line` or symbol citation, verify it still exists (`git ls-files`, `grep -r`).
+- **Orphans** — pages not linked from `index.md` or any other page.
+- **Missing pages** — concepts/entities mentioned in text without their own page.
+- **Broken cross-references** — every relative `.md` link must resolve.
+- **Stale frontmatter** — `updated` older than the last substantive edit to the page (`git log -1 --format=%cs <page>`).
+- **Source rot** — external URLs; `curl -s -o /dev/null -w "%{http_code}"` each one.
+
+Output: single markdown report + log entry. Trivial fixes go in the same PR; otherwise add to `index.md` → TODO section.
+
+## Triggers (from `AGENTS.md`)
+
+Agents MUST update the wiki after:
+- A non-trivial architectural change → update entity page.
+- Discovering a gotcha (>15 min chasing something non-obvious) → add `gotchas/`.
+- A lasting decision (library pick, pattern change, "we chose not to") → add `decisions/`.
+- A synthesis answer pulled from multiple sources → add `syntheses/`.
+
+Agents MUST consult the wiki before:
+- Answering architecture / "how does X work" questions.
+- Starting work in an unfamiliar package.
+- Making a decision that echoes a previous one.
+
+## Do not
+
+- Do not write wiki pages without citations to raw sources.
+- Do not modify raw sources (`docs/*.md` except under `docs/knowledge-base/wiki/`, code, `AGENTS.md`) as part of a wiki op.
+- Do not overwrite contradictory claims silently — flag them with a callout and note in the log.
+- Do not use wikilinks (`[[…]]`); use relative markdown links.
+- Do not add emojis.


### PR DESCRIPTION
## Summary

Adds a persistent, LLM-compiled knowledge base under `docs/knowledge-base/` following Andrej Karpathy's [LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) (April 2026, improved version, inlined verbatim as `LLM-WIKI.md`). Layered with a short Mediforce-specific `SCHEMA.md` + `STYLE.md` (caveman writing rules from [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)) + a `/knowledge-base` skill for ingest/query/lint operations.

Goal: agents find things fast and don't reimplement what already exists.

**Scope:** content + skill only. `AGENTS.md` is untouched — no team-wide auto-triggers in this PR. See [PR #255 (draft)](https://github.com/Appsilon/mediforce/pull/255) for the follow-up that flips the switch once validated.

## What's in it (38 wiki pages + scaffolding)

**Scaffolding (4 files)**
- `docs/knowledge-base/LLM-WIKI.md` — Karpathy's abstract pattern, verbatim.
- `docs/knowledge-base/SCHEMA.md` — 93 lines: layout, raw-source map, page buckets, frontmatter, conventions, pharma-domain pointer. Only what's unique to this repo.
- `docs/knowledge-base/STYLE.md` — 32 lines: caveman prompt + intensity levels + passthrough rules.
- `skills/knowledge-base/SKILL.md` + symlink + `_registry.yml` entry: `/knowledge-base ingest|query|file|lint`.

**Entities (17)**
- 7 packages: platform-core, platform-infra, workflow-engine, agent-runtime, platform-ui, supply-intelligence, supply-intelligence-plugins.
- 6 plugins: claude-code-agent, opencode-agent, script-container, example-agent, supply-intelligence/driver-agent, supply-intelligence/risk-detection.
- 4 apps: supply-intelligence (dashboard), protocol-to-tfl, community-digest, workflow-designer.

**Concepts (14)**
- Architectural (9): autonomy-levels, plugin-dispatch, repository-pattern, docker-spawn-strategies, dual-schema-migration, expression-evaluator, service-singleton, mcp-resolution, llm-no-computation-rule.
- Pharma domain (5): pharma-domain-context, cdisc-sdtm, ctcae-grading, recist-v1-1, ich-gcp.

**Gotchas (5)** — the core anti-duplicate-work surface
- mediforce-source-custom-condition, remote-e2e-setup, dual-schema-routing, runtime-skill-path-coupling, in-memory-repos-not-mocks.

Every page has frontmatter, a one-line summary, sections, cited source paths, and cross-links to related entities / concepts / gotchas. All written in caveman style — measured compression on the rewritten pages: −12% bytes, −19% words.

## Testing plan — opt-in validation before broadcasting

This PR deliberately does **not** modify `AGENTS.md`. The wiki exists + the skill is callable, but nothing in the team-wide agent contract tells agents to consult it. Merging this PR has zero effect on anyone who doesn't opt in.

**How validation works:**

1. **Merge this PR** → `docs/knowledge-base/` + skill + `CLAUDE.local.md` gitignore entry land on main.
2. **Opt in locally** — create a gitignored `CLAUDE.local.md` at repo root containing the Knowledge Base section + addendum bullets (Skills Router row, post-change checklist step). Claude Code auto-loads it alongside `CLAUDE.md`/`AGENTS.md`, so triggers fire in that engineer's sessions only. Example content pre-drafted locally by the author.
3. **Run a few real PRs with triggers active.** Watch for:
   - Agent cites wiki pages (`wiki/entities/`, `wiki/concepts/`, `wiki/gotchas/`) instead of re-deriving knowledge.
   - Agent files new gotchas / entity updates / decisions when the triggers apply.
   - Fewer duplicate implementations, faster orientation in unfamiliar packages, better answers to "how does X work".
4. **Validated → un-draft [PR #255](https://github.com/Appsilon/mediforce/pull/255) and merge.** That PR adds the Knowledge Base section to `AGENTS.md` — auto-triggers become team-wide, personal `CLAUDE.local.md` overrides become redundant.
5. **Not useful → close #255, iterate on wiki, try again.**

## Follow-up PR

- [**#255 (draft)**](https://github.com/Appsilon/mediforce/pull/255) — flips team-wide auto-triggers in `AGENTS.md`. Held until validation.

## Non-goals / known debt

- No decisions or syntheses filed yet — those accrue organically from conversations.
- Runtime skills (`apps/*/plugins/*/skills/`) are documented inside the `protocol-to-tfl` entity page but don't have per-skill wiki entries. Add when they stabilise.
- `index.md` is hand-maintained. At ~100 pages we should revisit (sub-indexes or a [qmd](https://github.com/tobi/qmd)-style search).

## Review notes

- No code changes. No tests need to run because no source files changed. Impact: docs + one new skill file + `.gitignore` entry (`CLAUDE.local.md`).
- Lint gate on the wiki passed: 38 pages, 0 broken internal markdown links, 0 orphans.
- Spot-check suggestion: read `entities/packages/platform-ui.md` vs actual code to sanity-check accuracy.
