### PR TITLE
docs(renovate-review): add diagnostic + reasoning-comment workflow

### DIFF
--- a/skills/renovate-review/SKILL.md
+++ b/skills/renovate-review/SKILL.md
@@ -107,16 +107,70 @@ If tests fail, assess whether the fix is simple (< 15 min of work):
 - **Yes**: fix it, commit, and note what you changed
 - **No**: describe the problem clearly — what fails, why, and what fixing it would require
 
-### 6. Recommend
+### 6. Diagnose failures before recommending CLOSE
+
+Never recommend CLOSE based only on surface symptoms (red check, failing test). Always dig to root cause first — the fix may be trivial (pnpm override, rebase) and not require closing at all.
+
+Common failure modes and how to diagnose each:
+
+| Symptom | Real root cause to check | How |
+|---------|--------------------------|-----|
+| `renovate/artifacts` FAILURE | Branch is stale vs main — peer pins in the branch lockfile conflict with newer versions merged on main since the PR was opened | `gh pr view <N> --json mergeable,headRefOid` → look for `CONFLICTING`. Count commits behind: `gh pr view <N> --json baseRefOid,headRefOid` then `git log --oneline <base>..main \| wc -l` |
+| `Vercel` / prod build FAILURE but dev tests pass | Pre-existing prod bug on main, fixed after this PR's last commit — not caused by this PR | Compare PR's commit SHA timestamp against `git log main` for fix commits on build config (e.g., `next.config.mjs`, webpack aliases, transpile lists) |
+| Runtime crash in e2e but unit tests pass | Duplicate transitive dependency — two copies of the same package at different versions, breaking identity checks (`instanceof`, `NodeProp`, singletons) | `pnpm why <transitive>` — look for multiple version lines. Diff the PR lockfile for `'<pkg>@X.Y.Z': {}` blocks that didn't exist before |
+| Major version bump tests pass but risk is "high" | Override-only (pinned in `pnpm.overrides` for transitive deps), not a direct dependency — true blast radius is limited | `grep -n "<pkg>" package.json` — if it's only under `"overrides"` or `"pnpm.overrides"`, downgrade risk one level |
+
+Cheap diagnostic commands to run before deciding:
+
+```bash
+# Is the branch stale vs main?
+gh pr view <N> --json mergeable,mergeStateStatus,headRefOid,baseRefOid
+# What actually changed in the lockfile?
+gh pr diff <N> -- pnpm-lock.yaml | head -100
+# Which failed check matters? Get the failure log:
+gh run view <run-id> --log-failed | grep -iE "error|typeerror|cannot|failed" | head -40
+# For Vercel/prod failures, fetch the target URL from the check
+gh pr checks <N>
+```
+
+### 7. Recommend
 
 Use exactly one of these verdicts:
 
 - **MERGE** — tests pass, change is safe
 - **MERGE after fix** — minor fix applied or needed, describe what
-- **CLOSE** — breaking change too large, dependency unnecessary, or better to wait for a later version
+- **CLOSE** — breaking change too large, dependency unnecessary, or the branch is so stale that recreating is cleaner than rebasing
 - **HOLD** — depends on another PR, needs a human decision, or blocked by something
 
-### 7. Report
+### 8. Post a reasoning comment on the PR — always
+
+Before the merge/close action, post a GitHub comment on the PR explaining the reasoning. This creates an audit trail so a human (or future-you) can understand *why* the decision was made without re-running the analysis.
+
+**Structure (merge cases)** — short, one short paragraph:
+- What was checked (CI state, scope of change, risk level)
+- Why it's safe to merge (e.g., "override-only, transitive impact", "dev-only dep", "additive breaking change per changelog")
+
+**Structure (close/hold cases)** — detailed, sectioned:
+- `### Why closed — detailed diagnosis` header
+- **Root cause** section naming the real problem (not the surface symptom)
+- **Evidence** — specific SHAs, file paths, version numbers, stack traces
+- **Fix path** — concrete options with pros/cons, so the next run knows what to do
+
+Example merge comment:
+```
+Reviewed via `renovate-review` skill. `protobufjs` is pinned in `pnpm.overrides`,
+transitive-only. Checked the v8 changelog — the only breaking change is added
+Edition 2024 support (additive, nothing removed). Full CI green. Merging.
+```
+
+Example close comment (see PR #175 / #233 for full templates): always name the root cause in the first line, then evidence, then fix path.
+
+Post via:
+```bash
+gh pr comment <N> --body "<markdown>"
+```
+
+### 9. Report
 
 Provide a one-sentence summary and wait for the merge/close decision. Format:
 
@@ -135,5 +189,9 @@ Provide a one-sentence summary and wait for the merge/close decision. Format:
 
 - Always return to the original branch after review: `git checkout -`
 - Do not merge or close the PR yourself — only recommend
+- **Always post a reasoning comment on the PR before the merge/close action** (see step 8)
+- **Never close with `--delete-branch` on a PR you might want to reopen** — branch deletion makes reopen impossible without recreating the branch from the original commit SHA (`git push origin <sha>:refs/heads/<branch>` then `gh pr reopen`). If unsure, close without `--delete-branch`
 - For **High** risk changes, always run the full test suite including E2E
 - If `pnpm install` changes the lockfile beyond what Renovate committed, note it
+- **Override-only deps are a special case**: a major bump of a package listed only under `pnpm.overrides` affects transitive consumers, not direct imports. Full CI passing is strong evidence — usually safe to merge even for major bumps
+- **Duplicate transitive dep crashes** are almost always fixable with a single-line `pnpm.overrides` entry pinning the duplicated package to one version — try this before recommending CLOSE


### PR DESCRIPTION
## Summary

Extends the `renovate-review` skill with lessons learned from reviewing 6 open Renovate PRs this session.

## What changed

- **Step 6 (new)** — diagnose failures before recommending CLOSE. Adds a table mapping common symptoms to real root causes:
  - `renovate/artifacts` FAILURE → branch stale vs main, peer pins conflict
  - Vercel/prod FAIL with dev tests green → pre-existing prod bug on main, fixed after PR's last commit
  - Runtime crash in e2e only → duplicate transitive dep at different versions
  - Major bump, override-only → risk downgrade
- **Step 8 (new)** — always post a reasoning comment on the PR before merge/close. Merge comments are a short paragraph (what was checked + why safe). Close/hold comments are sectioned: root cause, evidence (SHAs, files, versions), fix path.
- **Important section** — explicit warning: do **not** `gh pr close --delete-branch` a PR that might be reopened. Branch deletion blocks reopen unless the branch is recreated from the original SHA. Also notes the pnpm-override fix pattern for duplicate transitive dep crashes.

## Why

During this session we:
- Merged 4 renovate PRs (#252, #248, #249, #253) and closed 2 (#233, #175).
- Later needed to reopen #233 + #175 — they had been closed with `--delete-branch`, which broke `gh pr reopen` until the branches were reconstructed from the original commit SHAs.
- Discovered #175's real root cause (duplicate `@lezer/common` — fixable via `pnpm.overrides`) only on a second investigation pass. The first pass saw "e2e fails" and went straight to CLOSE, missing a trivial fix.

The updated skill bakes in both lessons so future runs diagnose before closing and leave an auditable comment trail.

## Test plan

- [ ] Next Renovate PR review follows the new steps (diagnose + comment)