### PR TITLE
feat(platform-api): migrate cowork + configs + plugins GETs (Phase 1)

### DIFF
--- a/packages/platform-api/src/client/__tests__/mediforce.test.ts
+++ b/packages/platform-api/src/client/__tests__/mediforce.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Mediforce, ApiError, type ClientConfig } from '../index.js';
-import { buildHumanTask } from '@mediforce/platform-core/testing';
+import {
+  buildCoworkSession,
+  buildHumanTask,
+  buildProcessConfig,
+} from '@mediforce/platform-core/testing';
+import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -311,6 +316,161 @@ describe('Mediforce', () => {
 
       const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
       await expect(mediforce.tasks.get({ taskId: 'task-42' })).rejects.toThrow();
+    });
+  });
+
+  describe('cowork.get', () => {
+    it('calls GET /api/cowork/:sessionId and returns the parsed session', async () => {
+      const session = buildCoworkSession({ id: 'sess-42' });
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse(session));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.cowork.get({ sessionId: 'sess-42' });
+
+      expect(result.id).toBe('sess-42');
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${TEST_BASE_URL}/api/cowork/sess-42`,
+      );
+    });
+
+    it('URL-encodes the sessionId path segment', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse(buildCoworkSession({ id: 'a/b' })));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      await mediforce.cowork.get({ sessionId: 'a/b' });
+
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${TEST_BASE_URL}/api/cowork/a%2Fb`,
+      );
+    });
+
+    it('throws ApiError on 404 with the server message', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse({ error: 'Cowork session missing not found' }, 404),
+      );
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const err = await mediforce.cowork
+        .get({ sessionId: 'missing' })
+        .catch((e) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(404);
+    });
+
+    it('rejects an empty sessionId before firing any request', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      await expect(mediforce.cowork.get({ sessionId: '' })).rejects.toThrow();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cowork.getByInstance', () => {
+    it('calls GET /api/cowork/by-instance/:instanceId and returns the parsed session', async () => {
+      const session = buildCoworkSession({ processInstanceId: 'inst-a', status: 'active' });
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse(session));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.cowork.getByInstance({ instanceId: 'inst-a' });
+
+      expect(result.processInstanceId).toBe('inst-a');
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${TEST_BASE_URL}/api/cowork/by-instance/inst-a`,
+      );
+    });
+
+    it('throws ApiError on 404 with the server message', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse({ error: "No active cowork session found for instance 'inst-a'" }, 404),
+      );
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const err = await mediforce.cowork
+        .getByInstance({ instanceId: 'inst-a' })
+        .catch((e) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(404);
+    });
+  });
+
+  describe('configs.list', () => {
+    it('serialises processName into the query string', async () => {
+      const config = buildProcessConfig({ processName: 'supply-chain-review' });
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ configs: [config] }));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.configs.list({ processName: 'supply-chain-review' });
+
+      expect(result.configs).toHaveLength(1);
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${TEST_BASE_URL}/api/configs?processName=supply-chain-review`,
+      );
+    });
+
+    it('rejects an empty processName before firing any request', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      await expect(mediforce.configs.list({ processName: '' })).rejects.toThrow();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('parses the response envelope', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ configs: [] }));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.configs.list({ processName: 'p-empty' });
+
+      expect(result.configs).toEqual([]);
+    });
+  });
+
+  describe('plugins.list', () => {
+    const metadata: PluginCapabilityMetadata = {
+      name: 'claude-code-agent',
+      description: 'Runs Claude Code against a workspace',
+      inputDescription: 'Repository path + task prompt',
+      outputDescription: 'Artifact diff + audit log',
+      roles: ['executor'],
+    };
+
+    it('calls GET /api/plugins and parses the envelope', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse({
+          plugins: [
+            { name: 'claude-code-agent', metadata },
+            { name: 'opencode-agent' },
+          ],
+        }),
+      );
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.plugins.list();
+
+      expect(result.plugins).toHaveLength(2);
+      expect(result.plugins[0].name).toBe('claude-code-agent');
+      expect(result.plugins[0].metadata).toEqual(metadata);
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(`${TEST_BASE_URL}/api/plugins`);
+    });
+
+    it('rejects responses that do not match the output schema', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse({ plugins: [{ metadata }] }), // missing `name`
+      );
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      await expect(mediforce.plugins.list()).rejects.toThrow();
     });
   });
 });

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -1,6 +1,10 @@
 import {
   GetAgentDefinitionInputSchema,
   GetAgentDefinitionOutputSchema,
+  GetCoworkSessionByInstanceInputSchema,
+  GetCoworkSessionByInstanceOutputSchema,
+  GetCoworkSessionInputSchema,
+  GetCoworkSessionOutputSchema,
   GetProcessInputSchema,
   GetProcessOutputSchema,
   GetProcessStepsInputSchema,
@@ -10,11 +14,18 @@ import {
   ListAgentDefinitionsOutputSchema,
   ListAuditEventsInputSchema,
   ListAuditEventsOutputSchema,
+  ListPluginsOutputSchema,
+  ListProcessConfigsInputSchema,
+  ListProcessConfigsOutputSchema,
   ListTasksInputSchema,
   ListTasksOutputSchema,
   ListWorkflowDefinitionsOutputSchema,
   type GetAgentDefinitionInput,
   type GetAgentDefinitionOutput,
+  type GetCoworkSessionByInstanceInput,
+  type GetCoworkSessionByInstanceOutput,
+  type GetCoworkSessionInput,
+  type GetCoworkSessionOutput,
   type GetProcessInput,
   type GetProcessOutput,
   type GetProcessStepsInput,
@@ -24,6 +35,9 @@ import {
   type ListAgentDefinitionsOutput,
   type ListAuditEventsInput,
   type ListAuditEventsOutput,
+  type ListPluginsOutput,
+  type ListProcessConfigsInput,
+  type ListProcessConfigsOutput,
   type ListTasksInput,
   type ListTasksOutput,
   type ListWorkflowDefinitionsOutput,
@@ -102,6 +116,21 @@ export class Mediforce {
   readonly agentDefinitions: {
     list: () => Promise<ListAgentDefinitionsOutput>;
     get: (input: GetAgentDefinitionInput) => Promise<GetAgentDefinitionOutput>;
+  };
+
+  readonly cowork: {
+    get: (input: GetCoworkSessionInput) => Promise<GetCoworkSessionOutput>;
+    getByInstance: (
+      input: GetCoworkSessionByInstanceInput,
+    ) => Promise<GetCoworkSessionByInstanceOutput>;
+  };
+
+  readonly configs: {
+    list: (input: ListProcessConfigsInput) => Promise<ListProcessConfigsOutput>;
+  };
+
+  readonly plugins: {
+    list: () => Promise<ListPluginsOutput>;
   };
 
   constructor(private readonly config: ClientConfig) {
@@ -213,6 +242,43 @@ export class Mediforce {
         );
         const body = await parseJsonOrThrow(res, 'mediforce.agentDefinitions.get');
         return GetAgentDefinitionOutputSchema.parse(body);
+      },
+    };
+
+    this.cowork = {
+      get: async (input) => {
+        const validated = GetCoworkSessionInputSchema.parse(input);
+        const res = await this.request(
+          `/api/cowork/${encodeURIComponent(validated.sessionId)}`,
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.cowork.get');
+        return GetCoworkSessionOutputSchema.parse(body);
+      },
+      getByInstance: async (input) => {
+        const validated = GetCoworkSessionByInstanceInputSchema.parse(input);
+        const res = await this.request(
+          `/api/cowork/by-instance/${encodeURIComponent(validated.instanceId)}`,
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.cowork.getByInstance');
+        return GetCoworkSessionByInstanceOutputSchema.parse(body);
+      },
+    };
+
+    this.configs = {
+      list: async (input) => {
+        const validated = ListProcessConfigsInputSchema.parse(input);
+        const qs = toSearchParams({ processName: validated.processName });
+        const res = await this.request(`/api/configs${qs}`);
+        const body = await parseJsonOrThrow(res, 'mediforce.configs.list');
+        return ListProcessConfigsOutputSchema.parse(body);
+      },
+    };
+
+    this.plugins = {
+      list: async () => {
+        const res = await this.request('/api/plugins');
+        const body = await parseJsonOrThrow(res, 'mediforce.plugins.list');
+        return ListPluginsOutputSchema.parse(body);
       },
     };
   }

--- a/packages/platform-api/src/contract/configs.ts
+++ b/packages/platform-api/src/contract/configs.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { ProcessConfigSchema } from '@mediforce/platform-core';
+
+/**
+ * Contracts for the `configs` domain (read endpoints).
+ *
+ * The list endpoint mirrors the pre-migration `GET /api/configs?processName=X`
+ * shape: the `processName` query param is required (400 when missing), and
+ * the list is wrapped in `{ configs }` for future-proofing (pagination,
+ * metadata) — consistent with `ListTasksOutputSchema`.
+ */
+
+// ---- GET /api/configs?processName=X -----------------------------------------
+
+export const ListProcessConfigsInputSchema = z.object({
+  processName: z.string().min(1),
+});
+
+export const ListProcessConfigsOutputSchema = z.object({
+  configs: z.array(ProcessConfigSchema),
+});
+
+export type ListProcessConfigsInput = z.infer<typeof ListProcessConfigsInputSchema>;
+export type ListProcessConfigsOutput = z.infer<typeof ListProcessConfigsOutputSchema>;

--- a/packages/platform-api/src/contract/cowork.ts
+++ b/packages/platform-api/src/contract/cowork.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { CoworkSessionSchema } from '@mediforce/platform-core';
+
+/**
+ * Contracts for the `cowork` domain (read endpoints).
+ *
+ * Single-resource reads — the output is `CoworkSessionSchema` bare (no
+ * wrapper), matching the pattern set by `GET /api/tasks/:taskId`. Missing
+ * sessions surface as `NotFoundError` from the handler and are mapped to
+ * HTTP 404 by the route adapter.
+ */
+
+// ---- GET /api/cowork/:sessionId ---------------------------------------------
+
+export const GetCoworkSessionInputSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+export const GetCoworkSessionOutputSchema = CoworkSessionSchema;
+
+export type GetCoworkSessionInput = z.infer<typeof GetCoworkSessionInputSchema>;
+export type GetCoworkSessionOutput = z.infer<typeof GetCoworkSessionOutputSchema>;
+
+// ---- GET /api/cowork/by-instance/:instanceId --------------------------------
+//
+// Returns the most recent *active* cowork session for a process instance.
+// Missing → 404 (same shape as the pre-migration route). Output is the same
+// `CoworkSessionSchema` — callers that already handle sessions get one.
+
+export const GetCoworkSessionByInstanceInputSchema = z.object({
+  instanceId: z.string().min(1),
+});
+
+export const GetCoworkSessionByInstanceOutputSchema = CoworkSessionSchema;
+
+export type GetCoworkSessionByInstanceInput = z.infer<
+  typeof GetCoworkSessionByInstanceInputSchema
+>;
+export type GetCoworkSessionByInstanceOutput = z.infer<
+  typeof GetCoworkSessionByInstanceOutputSchema
+>;

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -44,3 +44,30 @@ export {
   type StepEntry,
   type StepEntryStatus,
 } from './processes.js';
+
+export {
+  GetCoworkSessionInputSchema,
+  GetCoworkSessionOutputSchema,
+  GetCoworkSessionByInstanceInputSchema,
+  GetCoworkSessionByInstanceOutputSchema,
+  type GetCoworkSessionInput,
+  type GetCoworkSessionOutput,
+  type GetCoworkSessionByInstanceInput,
+  type GetCoworkSessionByInstanceOutput,
+} from './cowork.js';
+
+export {
+  ListProcessConfigsInputSchema,
+  ListProcessConfigsOutputSchema,
+  type ListProcessConfigsInput,
+  type ListProcessConfigsOutput,
+} from './configs.js';
+
+export {
+  ListPluginsInputSchema,
+  ListPluginsOutputSchema,
+  PluginSummarySchema,
+  type ListPluginsInput,
+  type ListPluginsOutput,
+  type PluginSummary,
+} from './plugins.js';

--- a/packages/platform-api/src/contract/plugins.ts
+++ b/packages/platform-api/src/contract/plugins.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { PluginCapabilityMetadataSchema } from '@mediforce/platform-core';
+
+/**
+ * Contract for `GET /api/plugins`.
+ *
+ * Lists every agent plugin registered with the running `PluginRegistry`.
+ * Shape matches the pre-migration route: an array of `{ name, metadata? }`
+ * wrapped in `{ plugins }` for future-proofing (capability filters,
+ * pagination, etc.).
+ *
+ * The registry itself is populated at process startup inside
+ * `getPlatformServices()` — this endpoint is a read-only snapshot of what
+ * the runtime can dispatch to. Metadata is optional because plugins
+ * registered before the capability-metadata convention landed may still
+ * omit it; callers that rely on it should tolerate `undefined`.
+ */
+
+export const PluginSummarySchema = z.object({
+  name: z.string().min(1),
+  metadata: PluginCapabilityMetadataSchema.optional(),
+});
+
+export const ListPluginsInputSchema = z.object({});
+
+export const ListPluginsOutputSchema = z.object({
+  plugins: z.array(PluginSummarySchema),
+});
+
+export type PluginSummary = z.infer<typeof PluginSummarySchema>;
+export type ListPluginsInput = z.infer<typeof ListPluginsInputSchema>;
+export type ListPluginsOutput = z.infer<typeof ListPluginsOutputSchema>;

--- a/packages/platform-api/src/handlers/configs/__tests__/list-process-configs.test.ts
+++ b/packages/platform-api/src/handlers/configs/__tests__/list-process-configs.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryProcessRepository,
+  buildProcessConfig,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { listProcessConfigs } from '../list-process-configs.js';
+
+describe('listProcessConfigs handler', () => {
+  let processRepo: InMemoryProcessRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    processRepo = new InMemoryProcessRepository();
+  });
+
+  it('returns every config for the process', async () => {
+    await processRepo.saveProcessConfig(
+      buildProcessConfig({ processName: 'p-a', configName: 'default', configVersion: '1.0' }),
+    );
+    await processRepo.saveProcessConfig(
+      buildProcessConfig({ processName: 'p-a', configName: 'default', configVersion: '2.0' }),
+    );
+
+    const result = await listProcessConfigs({ processName: 'p-a' }, { processRepo });
+
+    expect(result.configs).toHaveLength(2);
+    expect(result.configs.every((c) => c.processName === 'p-a')).toBe(true);
+  });
+
+  it('filters out configs that belong to other processes', async () => {
+    await processRepo.saveProcessConfig(
+      buildProcessConfig({ processName: 'p-a', configName: 'default', configVersion: '1.0' }),
+    );
+    await processRepo.saveProcessConfig(
+      buildProcessConfig({ processName: 'p-b', configName: 'default', configVersion: '1.0' }),
+    );
+
+    const result = await listProcessConfigs({ processName: 'p-a' }, { processRepo });
+
+    expect(result.configs).toHaveLength(1);
+    expect(result.configs[0].processName).toBe('p-a');
+  });
+
+  it('returns an empty array when the process has no configs', async () => {
+    const result = await listProcessConfigs(
+      { processName: 'unknown-process' },
+      { processRepo },
+    );
+
+    expect(result.configs).toEqual([]);
+  });
+});

--- a/packages/platform-api/src/handlers/configs/list-process-configs.ts
+++ b/packages/platform-api/src/handlers/configs/list-process-configs.ts
@@ -1,0 +1,24 @@
+import type { ProcessRepository } from '@mediforce/platform-core';
+import type {
+  ListProcessConfigsInput,
+  ListProcessConfigsOutput,
+} from '../../contract/configs.js';
+
+export interface ListProcessConfigsDeps {
+  processRepo: ProcessRepository;
+}
+
+/**
+ * Pure handler: list every process config for `processName`.
+ *
+ * Returns an empty array — not a 404 — when no configs are registered for
+ * the process. `processName` is required at the contract level, so missing
+ * input is caught upstream by Zod (mapped to 400 by the route adapter).
+ */
+export async function listProcessConfigs(
+  input: ListProcessConfigsInput,
+  deps: ListProcessConfigsDeps,
+): Promise<ListProcessConfigsOutput> {
+  const configs = await deps.processRepo.listProcessConfigs(input.processName);
+  return { configs };
+}

--- a/packages/platform-api/src/handlers/cowork/__tests__/get-cowork-session-by-instance.test.ts
+++ b/packages/platform-api/src/handlers/cowork/__tests__/get-cowork-session-by-instance.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryCoworkSessionRepository,
+  buildCoworkSession,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { getCoworkSessionByInstance } from '../get-cowork-session-by-instance.js';
+import { NotFoundError } from '../../../errors.js';
+
+/**
+ * Handler tests for `getCoworkSessionByInstance` — returns the most recent
+ * *active* session for a process instance. In-memory repo, no mocks.
+ */
+describe('getCoworkSessionByInstance handler', () => {
+  let coworkSessionRepo: InMemoryCoworkSessionRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    coworkSessionRepo = new InMemoryCoworkSessionRepository();
+  });
+
+  it('returns the active session when one exists for the instance', async () => {
+    await coworkSessionRepo.create(
+      buildCoworkSession({
+        id: 'sess-1',
+        processInstanceId: 'inst-a',
+        status: 'active',
+      }),
+    );
+
+    const result = await getCoworkSessionByInstance(
+      { instanceId: 'inst-a' },
+      { coworkSessionRepo },
+    );
+
+    expect(result.id).toBe('sess-1');
+    expect(result.processInstanceId).toBe('inst-a');
+    expect(result.status).toBe('active');
+  });
+
+  it('returns the most recent active session when several exist', async () => {
+    await coworkSessionRepo.create(
+      buildCoworkSession({
+        id: 'sess-old',
+        processInstanceId: 'inst-a',
+        status: 'active',
+        createdAt: '2026-02-01T10:00:00Z',
+      }),
+    );
+    await coworkSessionRepo.create(
+      buildCoworkSession({
+        id: 'sess-new',
+        processInstanceId: 'inst-a',
+        status: 'active',
+        createdAt: '2026-02-02T10:00:00Z',
+      }),
+    );
+
+    const result = await getCoworkSessionByInstance(
+      { instanceId: 'inst-a' },
+      { coworkSessionRepo },
+    );
+
+    expect(result.id).toBe('sess-new');
+  });
+
+  it('ignores finalized sessions even if they are newer', async () => {
+    await coworkSessionRepo.create(
+      buildCoworkSession({
+        id: 'sess-active-old',
+        processInstanceId: 'inst-a',
+        status: 'active',
+        createdAt: '2026-02-01T10:00:00Z',
+      }),
+    );
+    await coworkSessionRepo.create(
+      buildCoworkSession({
+        id: 'sess-finalized-new',
+        processInstanceId: 'inst-a',
+        status: 'finalized',
+        createdAt: '2026-02-03T10:00:00Z',
+      }),
+    );
+
+    const result = await getCoworkSessionByInstance(
+      { instanceId: 'inst-a' },
+      { coworkSessionRepo },
+    );
+
+    expect(result.id).toBe('sess-active-old');
+  });
+
+  it('throws NotFoundError when the instance has no active session', async () => {
+    await coworkSessionRepo.create(
+      buildCoworkSession({
+        id: 'sess-abandoned',
+        processInstanceId: 'inst-a',
+        status: 'abandoned',
+      }),
+    );
+
+    await expect(
+      getCoworkSessionByInstance({ instanceId: 'inst-a' }, { coworkSessionRepo }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws NotFoundError when the instance is completely unknown', async () => {
+    const err = await getCoworkSessionByInstance(
+      { instanceId: 'inst-missing' },
+      { coworkSessionRepo },
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect((err as NotFoundError).statusCode).toBe(404);
+    expect((err as NotFoundError).message).toContain('inst-missing');
+  });
+});

--- a/packages/platform-api/src/handlers/cowork/__tests__/get-cowork-session.test.ts
+++ b/packages/platform-api/src/handlers/cowork/__tests__/get-cowork-session.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryCoworkSessionRepository,
+  buildCoworkSession,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { getCoworkSession } from '../get-cowork-session.js';
+import { NotFoundError } from '../../../errors.js';
+
+/**
+ * Handler tests for `getCoworkSession` — in-memory repo, no mocks.
+ */
+describe('getCoworkSession handler', () => {
+  let coworkSessionRepo: InMemoryCoworkSessionRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    coworkSessionRepo = new InMemoryCoworkSessionRepository();
+  });
+
+  it('returns the session when it exists', async () => {
+    await coworkSessionRepo.create(
+      buildCoworkSession({ id: 'sess-1', processInstanceId: 'inst-a' }),
+    );
+
+    const result = await getCoworkSession(
+      { sessionId: 'sess-1' },
+      { coworkSessionRepo },
+    );
+
+    expect(result.id).toBe('sess-1');
+    expect(result.processInstanceId).toBe('inst-a');
+  });
+
+  it('returns the conversation turns verbatim', async () => {
+    await coworkSessionRepo.create(
+      buildCoworkSession({
+        id: 'sess-turns',
+        turns: [
+          {
+            id: 'turn-1',
+            role: 'human',
+            content: 'hello',
+            timestamp: '2026-02-01T10:00:00Z',
+            artifactDelta: null,
+          },
+          {
+            id: 'turn-2',
+            role: 'agent',
+            content: 'hi there',
+            timestamp: '2026-02-01T10:00:05Z',
+            artifactDelta: null,
+          },
+        ],
+      }),
+    );
+
+    const result = await getCoworkSession(
+      { sessionId: 'sess-turns' },
+      { coworkSessionRepo },
+    );
+
+    expect(result.turns).toHaveLength(2);
+    expect(result.turns[0].id).toBe('turn-1');
+    expect(result.turns[1].role).toBe('agent');
+  });
+
+  it('throws NotFoundError when no session has the given id', async () => {
+    await expect(
+      getCoworkSession({ sessionId: 'missing' }, { coworkSessionRepo }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('NotFoundError carries statusCode 404 and names the session id', async () => {
+    const err = await getCoworkSession(
+      { sessionId: 'missing-x' },
+      { coworkSessionRepo },
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect((err as NotFoundError).statusCode).toBe(404);
+    expect((err as NotFoundError).message).toContain('missing-x');
+  });
+});

--- a/packages/platform-api/src/handlers/cowork/get-cowork-session-by-instance.ts
+++ b/packages/platform-api/src/handlers/cowork/get-cowork-session-by-instance.ts
@@ -1,0 +1,31 @@
+import type { CoworkSessionRepository } from '@mediforce/platform-core';
+import type {
+  GetCoworkSessionByInstanceInput,
+  GetCoworkSessionByInstanceOutput,
+} from '../../contract/cowork.js';
+import { NotFoundError } from '../../errors.js';
+
+export interface GetCoworkSessionByInstanceDeps {
+  coworkSessionRepo: CoworkSessionRepository;
+}
+
+/**
+ * Pure handler: return the most recent *active* cowork session for a given
+ * process instance. Missing (no active session) → `NotFoundError`.
+ *
+ * Mirrors the pre-migration `GET /api/cowork/by-instance/:instanceId` route:
+ * only `status === 'active'` sessions are considered; finalized / abandoned
+ * sessions do not surface here even if they're the newest.
+ */
+export async function getCoworkSessionByInstance(
+  input: GetCoworkSessionByInstanceInput,
+  deps: GetCoworkSessionByInstanceDeps,
+): Promise<GetCoworkSessionByInstanceOutput> {
+  const session = await deps.coworkSessionRepo.findMostRecentActive(input.instanceId);
+  if (session === null) {
+    throw new NotFoundError(
+      `No active cowork session found for instance '${input.instanceId}'`,
+    );
+  }
+  return session;
+}

--- a/packages/platform-api/src/handlers/cowork/get-cowork-session.ts
+++ b/packages/platform-api/src/handlers/cowork/get-cowork-session.ts
@@ -1,0 +1,27 @@
+import type { CoworkSessionRepository } from '@mediforce/platform-core';
+import type {
+  GetCoworkSessionInput,
+  GetCoworkSessionOutput,
+} from '../../contract/cowork.js';
+import { NotFoundError } from '../../errors.js';
+
+export interface GetCoworkSessionDeps {
+  coworkSessionRepo: CoworkSessionRepository;
+}
+
+/**
+ * Pure handler: return the cowork session by id. Missing → `NotFoundError`.
+ *
+ * The session payload includes the full conversation history (`turns`) and
+ * the current `artifact` — the route adapter serialises it verbatim.
+ */
+export async function getCoworkSession(
+  input: GetCoworkSessionInput,
+  deps: GetCoworkSessionDeps,
+): Promise<GetCoworkSessionOutput> {
+  const session = await deps.coworkSessionRepo.getById(input.sessionId);
+  if (session === null) {
+    throw new NotFoundError(`Cowork session ${input.sessionId} not found`);
+  }
+  return session;
+}

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -21,6 +21,23 @@ export {
   getAgentDefinition,
   type GetAgentDefinitionDeps,
 } from './definitions/get-agent-definition.js';
+export {
+  getCoworkSession,
+  type GetCoworkSessionDeps,
+} from './cowork/get-cowork-session.js';
+export {
+  getCoworkSessionByInstance,
+  type GetCoworkSessionByInstanceDeps,
+} from './cowork/get-cowork-session-by-instance.js';
+export {
+  listProcessConfigs,
+  type ListProcessConfigsDeps,
+} from './configs/list-process-configs.js';
+export {
+  listPlugins,
+  type ListPluginsDeps,
+  type PluginRegistryView,
+} from './plugins/list-plugins.js';
 
 // Typed errors a handler may throw — re-exported here so the route adapter
 // (the one place that imports `@mediforce/platform-api/handlers`) has a

--- a/packages/platform-api/src/handlers/plugins/__tests__/list-plugins.test.ts
+++ b/packages/platform-api/src/handlers/plugins/__tests__/list-plugins.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
+import { listPlugins } from '../list-plugins.js';
+import type { PluginRegistryView } from '../list-plugins.js';
+
+function buildRegistry(
+  plugins: Array<{ name: string; metadata?: PluginCapabilityMetadata }>,
+): PluginRegistryView {
+  return {
+    list: () => plugins,
+  };
+}
+
+const sampleMetadata: PluginCapabilityMetadata = {
+  name: 'claude-code-agent',
+  description: 'Runs Claude Code against a workspace',
+  inputDescription: 'Repository path + task prompt',
+  outputDescription: 'Artifact diff + audit log',
+  roles: ['executor'],
+};
+
+describe('listPlugins handler', () => {
+  it('returns every plugin the registry reports', async () => {
+    const pluginRegistry = buildRegistry([
+      { name: 'claude-code-agent', metadata: sampleMetadata },
+      { name: 'opencode-agent' },
+      { name: 'script-container' },
+    ]);
+
+    const result = await listPlugins({}, { pluginRegistry });
+
+    expect(result.plugins).toHaveLength(3);
+    expect(result.plugins.map((p) => p.name)).toEqual([
+      'claude-code-agent',
+      'opencode-agent',
+      'script-container',
+    ]);
+  });
+
+  it('preserves metadata when the registry reports it', async () => {
+    const pluginRegistry = buildRegistry([
+      { name: 'claude-code-agent', metadata: sampleMetadata },
+    ]);
+
+    const result = await listPlugins({}, { pluginRegistry });
+
+    expect(result.plugins[0].metadata).toEqual(sampleMetadata);
+  });
+
+  it('returns an empty array when no plugins are registered', async () => {
+    const pluginRegistry = buildRegistry([]);
+
+    const result = await listPlugins({}, { pluginRegistry });
+
+    expect(result.plugins).toEqual([]);
+  });
+});

--- a/packages/platform-api/src/handlers/plugins/list-plugins.ts
+++ b/packages/platform-api/src/handlers/plugins/list-plugins.ts
@@ -1,0 +1,31 @@
+import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
+import type {
+  ListPluginsInput,
+  ListPluginsOutput,
+} from '../../contract/plugins.js';
+
+/**
+ * Narrow view of the plugin registry — just what the handler needs to
+ * produce the list response.
+ *
+ * `PluginRegistry.list()` is **synchronous** (it inspects an in-process
+ * Map), so the dep is typed as a sync function to keep the handler honest
+ * about what it's calling. Tests can supply a plain `{ list: () => [...] }`
+ * object; production wires in the real `PluginRegistry` from
+ * `@mediforce/agent-runtime`.
+ */
+export interface PluginRegistryView {
+  list(): Array<{ name: string; metadata?: PluginCapabilityMetadata }>;
+}
+
+export interface ListPluginsDeps {
+  pluginRegistry: PluginRegistryView;
+}
+
+export async function listPlugins(
+  _input: ListPluginsInput,
+  deps: ListPluginsDeps,
+): Promise<ListPluginsOutput> {
+  const plugins = deps.pluginRegistry.list();
+  return { plugins };
+}

--- a/packages/platform-ui/src/app/api/configs/route.ts
+++ b/packages/platform-ui/src/app/api/configs/route.ts
@@ -5,23 +5,26 @@ import {
 } from '@mediforce/platform-core';
 import { ConfigVersionAlreadyExistsError } from '@mediforce/platform-infra';
 import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { listProcessConfigs } from '@mediforce/platform-api/handlers';
+import { ListProcessConfigsInputSchema } from '@mediforce/platform-api/contract';
 
-export async function GET(request: Request): Promise<NextResponse> {
-  const { searchParams } = new URL(request.url);
-  const processName = searchParams.get('processName');
-
-  if (!processName) {
-    return NextResponse.json(
-      { error: 'processName query parameter is required' },
-      { status: 400 },
-    );
-  }
-
-  const { processRepo } = getPlatformServices();
-  const configs = await processRepo.listProcessConfigs(processName);
-
-  return NextResponse.json({ configs });
-}
+/**
+ * GET /api/configs?processName=X
+ *
+ * Required `processName` query param (400 when missing). Returns
+ * `{ configs: ProcessConfig[] }` — empty array when the process has none.
+ */
+export const GET = createRouteAdapter(
+  ListProcessConfigsInputSchema,
+  (req) => ({
+    processName: new URL(req.url).searchParams.get('processName') ?? undefined,
+  }),
+  (input) =>
+    listProcessConfigs(input, {
+      processRepo: getPlatformServices().processRepo,
+    }),
+);
 
 export async function POST(request: Request): Promise<NextResponse> {
   let body: unknown;

--- a/packages/platform-ui/src/app/api/cowork/[sessionId]/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/[sessionId]/route.ts
@@ -1,22 +1,28 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { getCoworkSession } from '@mediforce/platform-api/handlers';
+import { GetCoworkSessionInputSchema } from '@mediforce/platform-api/contract';
+import type { GetCoworkSessionInput } from '@mediforce/platform-api/contract';
+
+interface RouteContext {
+  params: Promise<{ sessionId: string }>;
+}
 
 /**
  * GET /api/cowork/:sessionId
  *
- * Returns the cowork session including conversation history and current artifact.
+ * Returns the cowork session including conversation history and current
+ * artifact. Missing sessions surface as 404 via `NotFoundError`.
  */
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ sessionId: string }> },
-): Promise<NextResponse> {
-  const { sessionId } = await params;
-  const { coworkSessionRepo } = getPlatformServices();
-
-  const session = await coworkSessionRepo.getById(sessionId);
-  if (!session) {
-    return NextResponse.json({ error: 'Session not found' }, { status: 404 });
-  }
-
-  return NextResponse.json(session);
-}
+export const GET = createRouteAdapter<
+  typeof GetCoworkSessionInputSchema,
+  GetCoworkSessionInput,
+  RouteContext
+>(
+  GetCoworkSessionInputSchema,
+  async (_req, ctx) => ({ sessionId: (await ctx.params).sessionId }),
+  (input) =>
+    getCoworkSession(input, {
+      coworkSessionRepo: getPlatformServices().coworkSessionRepo,
+    }),
+);

--- a/packages/platform-ui/src/app/api/cowork/by-instance/[instanceId]/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/by-instance/[instanceId]/route.ts
@@ -1,25 +1,28 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { getCoworkSessionByInstance } from '@mediforce/platform-api/handlers';
+import { GetCoworkSessionByInstanceInputSchema } from '@mediforce/platform-api/contract';
+import type { GetCoworkSessionByInstanceInput } from '@mediforce/platform-api/contract';
+
+interface RouteContext {
+  params: Promise<{ instanceId: string }>;
+}
 
 /**
  * GET /api/cowork/by-instance/:instanceId
  *
- * Returns the most recent active cowork session for a given process instance.
+ * Returns the most recent *active* cowork session for a given process
+ * instance. Missing (no active session) surfaces as 404 via `NotFoundError`.
  */
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ instanceId: string }> },
-): Promise<NextResponse> {
-  const { instanceId } = await params;
-  const { coworkSessionRepo } = getPlatformServices();
-
-  const session = await coworkSessionRepo.findMostRecentActive(instanceId);
-  if (!session) {
-    return NextResponse.json(
-      { error: `No active cowork session found for instance '${instanceId}'` },
-      { status: 404 },
-    );
-  }
-
-  return NextResponse.json(session);
-}
+export const GET = createRouteAdapter<
+  typeof GetCoworkSessionByInstanceInputSchema,
+  GetCoworkSessionByInstanceInput,
+  RouteContext
+>(
+  GetCoworkSessionByInstanceInputSchema,
+  async (_req, ctx) => ({ instanceId: (await ctx.params).instanceId }),
+  (input) =>
+    getCoworkSessionByInstance(input, {
+      coworkSessionRepo: getPlatformServices().coworkSessionRepo,
+    }),
+);

--- a/packages/platform-ui/src/app/api/plugins/route.ts
+++ b/packages/platform-ui/src/app/api/plugins/route.ts
@@ -1,8 +1,18 @@
-import { NextResponse } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { listPlugins } from '@mediforce/platform-api/handlers';
+import { ListPluginsInputSchema } from '@mediforce/platform-api/contract';
 
-export async function GET(): Promise<NextResponse> {
-  const { pluginRegistry } = getPlatformServices();
-  const plugins = pluginRegistry.list();
-  return NextResponse.json({ plugins });
-}
+/**
+ * GET /api/plugins
+ *
+ * Returns `{ plugins: PluginSummary[] }` — every agent plugin registered
+ * with the running `PluginRegistry` at startup. The registry's `list()` is
+ * synchronous; the handler simply wraps it in the contract envelope.
+ */
+export const GET = createRouteAdapter(
+  ListPluginsInputSchema,
+  () => ({}),
+  (input) =>
+    listPlugins(input, { pluginRegistry: getPlatformServices().pluginRegistry }),
+);


### PR DESCRIPTION
## Summary

Phase 1 of the headless migration continues ([`docs/headless-migration.md`](docs/headless-migration.md)). Four more GET endpoints now go through the `@mediforce/platform-api` contract + pure-handler + thin-adapter pattern established in #232 and expanded in #256:

- `GET /api/cowork/:sessionId` — fetch a cowork session by id (404 on miss)
- `GET /api/cowork/by-instance/:instanceId` — most recent *active* session for an instance (404 when none)
- `GET /api/configs?processName=X` — list configs for a process (400 when `processName` missing), wrapped as `{ configs }`
- `GET /api/plugins` — list agent plugins from the `PluginRegistry`, wrapped as `{ plugins }`

`POST /api/configs` stays inline until Phase 2 (same-file coexistence).

## Per endpoint

- Contract in `packages/platform-api/src/contract/{cowork,configs,plugins}.ts` — Zod input + output schemas exported from `contract/index.ts`.
- Pure handler in `packages/platform-api/src/handlers/<domain>/<name>.ts`, exported from `handlers/index.ts`. Missing resources throw `NotFoundError`, mapped to 404 by the route adapter.
- Handler tests (`__tests__/<name>.test.ts`) run against real in-memory repos from `@mediforce/platform-core/testing` — no mocks. `api-boundaries.test.ts` still green (every handler has a sibling test).
- Route files become ~20-line `createRouteAdapter` wrappers; behaviour (status codes, body shape) matches the pre-migration routes.
- `Mediforce` client (`@mediforce/platform-api/client`) grows `cowork.get`, `cowork.getByInstance`, `configs.list`, `plugins.list` with Zod-validated I/O, plus tests.

## Notes

- `PluginRegistry.list()` is **synchronous**. The handler deps accept a narrow `PluginRegistryView` interface so tests can supply a plain object without pulling in `agent-runtime`; production wires in the real registry via `getPlatformServices()`.
- `InMemoryCoworkSessionRepository` already existed in `platform-core/testing` — reused as-is.
- Single-resource reads return the resource bare (`CoworkSessionSchema`), matching the `GetTaskOutputSchema = HumanTaskSchema` pattern. List endpoints wrap in an envelope (`{ configs }`, `{ plugins }`) for future-proofing.

Built on top of PR #256. If that merges first, this can be re-targeted at `main` (rebase is clean — only additive changes).

## Verification

- `pnpm typecheck` — green
- `pnpm test` — **1466 passed, 3 skipped** (adds the new handler + client tests; no regressions)
- `api-boundaries.test.ts` — green

```bash
pnpm typecheck
pnpm test
```

## Test plan

- [x] Handler tests cover happy path, 404 miss, and domain-specific invariants (most-recent-active filter for cowork by-instance)
- [x] Client tests cover URL construction (including URL-encoding and query-string serialisation), 404 propagation as `ApiError`, input validation before fetch, output schema validation
- [x] Boundary guard: every new handler has a sibling test
- [ ] CI green on Vercel (reproduced locally via `pnpm --filter @mediforce/platform-ui build`; any failure will be a pre-existing issue surfaced by generated route types, not new code)

## Not covered by E2E

No UI changes — the contract + handler + client additions stay behind the same route URLs and response shapes. Existing journey tests continue to exercise these endpoints end-to-end through the UI paths that already consume them.