### PR TITLE
ci: deploy Firestore indexes before app deploy (staging + prod)

### DIFF
--- a/.github/workflows/_deploy-firestore-indexes.yml
+++ b/.github/workflows/_deploy-firestore-indexes.yml
@@ -35,13 +35,18 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install firebase-tools and jq
+      - name: Install firebase-tools (and jq if missing)
         run: |
           npm install -g firebase-tools@15.15.0
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq jq
+          if command -v jq >/dev/null 2>&1; then
+            echo "jq already installed: $(jq --version)"
+          else
+            echo "jq not found, installing..."
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq jq
+          fi
 
-      - name: Deploy Firestore indexes (${{ inputs.environment-name }})
+      - name: Log current Firestore index state (${{ inputs.environment-name }})
         run: |
           if [ -z "$FIREBASE_PROJECT" ]; then
             echo "::error::FIREBASE project secret for ${{ inputs.environment-name }} is empty"
@@ -51,6 +56,21 @@ jobs:
             echo "::error::FIREBASE_CI_TOKEN secret is empty"
             exit 1
           fi
+          echo "Current indexes in project '$FIREBASE_PROJECT' before deploy:"
+          if current_json=$(firebase firestore:indexes --project "$FIREBASE_PROJECT" --json 2>&1); then
+            if echo "$current_json" | jq -e '.result.indexes' >/dev/null 2>&1; then
+              echo "$current_json" | jq '.result.indexes | length as $n | "Total: \($n)"'
+              echo "$current_json" | jq -r '.result.indexes[] | "  - \(.collectionGroup // "?") [\(.state // "?")] \((.fields // []) | map(.fieldPath) | join(", "))"'
+            else
+              echo "::warning::Unexpected JSON shape from firebase firestore:indexes — logging raw output"
+              echo "$current_json"
+            fi
+          else
+            echo "::warning::Could not fetch current index state (continuing with deploy): $current_json"
+          fi
+
+      - name: Deploy Firestore indexes (${{ inputs.environment-name }})
+        run: |
           firebase deploy --only firestore:indexes \
             --project "$FIREBASE_PROJECT" \
             --non-interactive
@@ -58,18 +78,40 @@ jobs:
       - name: Wait for all indexes to report READY (${{ inputs.environment-name }})
         run: |
           deadline=$(( $(date +%s) + 30 * 60 ))
+          consecutive_failures=0
+          max_failures=3
           while [ "$(date +%s)" -lt "$deadline" ]; do
-            indexes_json=$(firebase firestore:indexes \
+            if ! indexes_json=$(firebase firestore:indexes \
               --project "$FIREBASE_PROJECT" \
-              --json 2>/dev/null || true)
+              --json 2>&1); then
+              consecutive_failures=$((consecutive_failures + 1))
+              echo "::warning::firebase firestore:indexes failed (attempt $consecutive_failures/$max_failures): $indexes_json"
+              if [ "$consecutive_failures" -ge "$max_failures" ]; then
+                echo "::error::firebase firestore:indexes failed $max_failures times in a row — aborting"
+                exit 1
+              fi
+              sleep 20
+              continue
+            fi
+
+            if ! echo "$indexes_json" | jq -e '.result.indexes' >/dev/null 2>&1; then
+              echo "::error::Unexpected JSON shape from firebase firestore:indexes — .result.indexes missing. Raw output:"
+              echo "$indexes_json"
+              exit 1
+            fi
+
+            consecutive_failures=0
             pending=$(echo "$indexes_json" \
-              | jq '[.result.indexes[]? | select(.state != "READY")] | length' \
-              2>/dev/null || echo "")
+              | jq '[.result.indexes[] | select(.state != "READY")] | length')
+
             if [ "$pending" = "0" ]; then
               echo "All Firestore indexes are READY"
               exit 0
             fi
-            echo "Waiting for $pending index(es) to reach READY..."
+
+            echo "Waiting for $pending index(es) to reach READY:"
+            echo "$indexes_json" \
+              | jq -r '.result.indexes[] | select(.state != "READY") | "  - \(.collectionGroup // "?") [\(.state // "?")] \((.fields // []) | map(.fieldPath) | join(", "))"'
             sleep 20
           done
           echo "::error::Timed out after 30 minutes waiting for indexes to become READY"

--- a/.github/workflows/_deploy-firestore-indexes.yml
+++ b/.github/workflows/_deploy-firestore-indexes.yml
@@ -1,0 +1,77 @@
+name: Deploy Firestore indexes (reusable)
+
+# Deploy Firestore composite indexes from firestore.indexes.json and wait
+# until every index reports state "READY" before returning. Designed to be
+# the first job in deploy-staging / deploy-production, so the SSH app deploy
+# never lands code that queries an index Firestore is still building.
+#
+# Caller passes the per-environment Firebase project as a secret; the same
+# CI token works against any project the token's owner has access to.
+
+on:
+  workflow_call:
+    inputs:
+      environment-name:
+        description: Human-readable label used in log lines and error messages (e.g. "staging", "production").
+        required: true
+        type: string
+    secrets:
+      FIREBASE_CI_TOKEN:
+        required: true
+      FIREBASE_PROJECT:
+        required: true
+
+jobs:
+  deploy-firestore-indexes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+      FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROJECT }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install firebase-tools and jq
+        run: |
+          npm install -g firebase-tools@15.15.0
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq jq
+
+      - name: Deploy Firestore indexes (${{ inputs.environment-name }})
+        run: |
+          if [ -z "$FIREBASE_PROJECT" ]; then
+            echo "::error::FIREBASE project secret for ${{ inputs.environment-name }} is empty"
+            exit 1
+          fi
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "::error::FIREBASE_CI_TOKEN secret is empty"
+            exit 1
+          fi
+          firebase deploy --only firestore:indexes \
+            --project "$FIREBASE_PROJECT" \
+            --non-interactive
+
+      - name: Wait for all indexes to report READY (${{ inputs.environment-name }})
+        run: |
+          deadline=$(( $(date +%s) + 30 * 60 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            indexes_json=$(firebase firestore:indexes \
+              --project "$FIREBASE_PROJECT" \
+              --json 2>/dev/null || true)
+            pending=$(echo "$indexes_json" \
+              | jq '[.result.indexes[]? | select(.state != "READY")] | length' \
+              2>/dev/null || echo "")
+            if [ "$pending" = "0" ]; then
+              echo "All Firestore indexes are READY"
+              exit 0
+            fi
+            echo "Waiting for $pending index(es) to reach READY..."
+            sleep 20
+          done
+          echo "::error::Timed out after 30 minutes waiting for indexes to become READY"
+          firebase firestore:indexes --project "$FIREBASE_PROJECT" --json || true
+          exit 1

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,9 +6,72 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Deploy Firestore composite indexes BEFORE the application so production
+  # queries never land before their backing index exists. Rolling an index out
+  # takes minutes on a cold collection and can take much longer on a populated
+  # one, so we also poll until every index has state "READY" before releasing
+  # the SSH deploy gate. See docs/firestore-index-deploy.md for the runbook.
+  deploy-firestore-indexes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install firebase-tools and jq
+        run: |
+          npm install -g firebase-tools@15.15.0
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq jq
+
+      - name: Deploy Firestore indexes
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+          FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROD_PROJECT }}
+        run: |
+          if [ -z "$FIREBASE_PROJECT" ]; then
+            echo "::error::FIREBASE_PROD_PROJECT secret is not set"
+            exit 1
+          fi
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "::error::FIREBASE_CI_TOKEN secret is not set"
+            exit 1
+          fi
+          firebase deploy --only firestore:indexes \
+            --project "$FIREBASE_PROJECT" \
+            --non-interactive
+
+      - name: Wait for all indexes to report READY
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+          FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROD_PROJECT }}
+        run: |
+          deadline=$(( $(date +%s) + 30 * 60 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            indexes_json=$(firebase firestore:indexes \
+              --project "$FIREBASE_PROJECT" \
+              --json 2>/dev/null || true)
+            pending=$(echo "$indexes_json" \
+              | jq '[.result.indexes[]? | select(.state != "READY")] | length' \
+              2>/dev/null || echo "unknown")
+            if [ "$pending" = "0" ]; then
+              echo "All Firestore indexes are READY"
+              exit 0
+            fi
+            echo "Waiting for $pending index(es) to reach READY..."
+            sleep 20
+          done
+          echo "::error::Timed out after 30 minutes waiting for indexes to become READY"
+          firebase firestore:indexes --project "$FIREBASE_PROJECT" --json || true
+          exit 1
+
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: deploy-firestore-indexes
 
     steps:
       - name: Deploy via SSH

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,66 +7,17 @@ on:
 
 jobs:
   # Deploy Firestore composite indexes BEFORE the application so production
-  # queries never land before their backing index exists. Rolling an index out
-  # takes minutes on a cold collection and can take much longer on a populated
-  # one, so we also poll until every index has state "READY" before releasing
-  # the SSH deploy gate. See docs/firestore-index-deploy.md for the runbook.
+  # queries never land before their backing index exists. Index builds run
+  # asynchronously inside Firestore (minutes on cold collections, longer on
+  # populated ones) — the reusable workflow polls until every index is READY
+  # before unblocking the SSH deploy gate below.
   deploy-firestore-indexes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Install firebase-tools and jq
-        run: |
-          npm install -g firebase-tools@15.15.0
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq jq
-
-      - name: Deploy Firestore indexes
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
-          FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROD_PROJECT }}
-        run: |
-          if [ -z "$FIREBASE_PROJECT" ]; then
-            echo "::error::FIREBASE_PROD_PROJECT secret is not set"
-            exit 1
-          fi
-          if [ -z "$FIREBASE_TOKEN" ]; then
-            echo "::error::FIREBASE_CI_TOKEN secret is not set"
-            exit 1
-          fi
-          firebase deploy --only firestore:indexes \
-            --project "$FIREBASE_PROJECT" \
-            --non-interactive
-
-      - name: Wait for all indexes to report READY
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
-          FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROD_PROJECT }}
-        run: |
-          deadline=$(( $(date +%s) + 30 * 60 ))
-          while [ "$(date +%s)" -lt "$deadline" ]; do
-            indexes_json=$(firebase firestore:indexes \
-              --project "$FIREBASE_PROJECT" \
-              --json 2>/dev/null || true)
-            pending=$(echo "$indexes_json" \
-              | jq '[.result.indexes[]? | select(.state != "READY")] | length' \
-              2>/dev/null || echo "unknown")
-            if [ "$pending" = "0" ]; then
-              echo "All Firestore indexes are READY"
-              exit 0
-            fi
-            echo "Waiting for $pending index(es) to reach READY..."
-            sleep 20
-          done
-          echo "::error::Timed out after 30 minutes waiting for indexes to become READY"
-          firebase firestore:indexes --project "$FIREBASE_PROJECT" --json || true
-          exit 1
+    uses: ./.github/workflows/_deploy-firestore-indexes.yml
+    with:
+      environment-name: production
+    secrets:
+      FIREBASE_CI_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+      FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROD_PROJECT }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Deploy Firestore composite indexes BEFORE the application so production
-  # queries never land before their backing index exists. Index builds run
+  # Deploy Firestore composite indexes BEFORE the application so the deployed
+  # app never queries an index Firestore is still building. Index builds run
   # asynchronously inside Firestore (minutes on cold collections, longer on
   # populated ones) — the reusable workflow polls until every index is READY
   # before unblocking the SSH deploy gate below.

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,66 +7,17 @@ on:
 
 jobs:
   # Deploy Firestore composite indexes BEFORE the application so production
-  # queries never land before their backing index exists. Rolling an index out
-  # takes minutes on a cold collection and can take much longer on a populated
-  # one, so we also poll until every index has state "READY" before releasing
-  # the SSH deploy gate. See docs/firestore-index-deploy.md for the runbook.
+  # queries never land before their backing index exists. Index builds run
+  # asynchronously inside Firestore (minutes on cold collections, longer on
+  # populated ones) — the reusable workflow polls until every index is READY
+  # before unblocking the SSH deploy gate below.
   deploy-firestore-indexes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Install firebase-tools and jq
-        run: |
-          npm install -g firebase-tools@15.15.0
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq jq
-
-      - name: Deploy Firestore indexes
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
-          FIREBASE_PROJECT: ${{ secrets.FIREBASE_STAGING_PROJECT }}
-        run: |
-          if [ -z "$FIREBASE_PROJECT" ]; then
-            echo "::error::FIREBASE_STAGING_PROJECT secret is not set"
-            exit 1
-          fi
-          if [ -z "$FIREBASE_TOKEN" ]; then
-            echo "::error::FIREBASE_CI_TOKEN secret is not set"
-            exit 1
-          fi
-          firebase deploy --only firestore:indexes \
-            --project "$FIREBASE_PROJECT" \
-            --non-interactive
-
-      - name: Wait for all indexes to report READY
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
-          FIREBASE_PROJECT: ${{ secrets.FIREBASE_STAGING_PROJECT }}
-        run: |
-          deadline=$(( $(date +%s) + 30 * 60 ))
-          while [ "$(date +%s)" -lt "$deadline" ]; do
-            indexes_json=$(firebase firestore:indexes \
-              --project "$FIREBASE_PROJECT" \
-              --json 2>/dev/null || true)
-            pending=$(echo "$indexes_json" \
-              | jq '[.result.indexes[]? | select(.state != "READY")] | length' \
-              2>/dev/null || echo "unknown")
-            if [ "$pending" = "0" ]; then
-              echo "All Firestore indexes are READY"
-              exit 0
-            fi
-            echo "Waiting for $pending index(es) to reach READY..."
-            sleep 20
-          done
-          echo "::error::Timed out after 30 minutes waiting for indexes to become READY"
-          firebase firestore:indexes --project "$FIREBASE_PROJECT" --json || true
-          exit 1
+    uses: ./.github/workflows/_deploy-firestore-indexes.yml
+    with:
+      environment-name: staging
+    secrets:
+      FIREBASE_CI_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+      FIREBASE_PROJECT: ${{ secrets.FIREBASE_STAGING_PROJECT }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,9 +6,72 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Deploy Firestore composite indexes BEFORE the application so production
+  # queries never land before their backing index exists. Rolling an index out
+  # takes minutes on a cold collection and can take much longer on a populated
+  # one, so we also poll until every index has state "READY" before releasing
+  # the SSH deploy gate. See docs/firestore-index-deploy.md for the runbook.
+  deploy-firestore-indexes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install firebase-tools and jq
+        run: |
+          npm install -g firebase-tools@15.15.0
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq jq
+
+      - name: Deploy Firestore indexes
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+          FIREBASE_PROJECT: ${{ secrets.FIREBASE_STAGING_PROJECT }}
+        run: |
+          if [ -z "$FIREBASE_PROJECT" ]; then
+            echo "::error::FIREBASE_STAGING_PROJECT secret is not set"
+            exit 1
+          fi
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "::error::FIREBASE_CI_TOKEN secret is not set"
+            exit 1
+          fi
+          firebase deploy --only firestore:indexes \
+            --project "$FIREBASE_PROJECT" \
+            --non-interactive
+
+      - name: Wait for all indexes to report READY
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+          FIREBASE_PROJECT: ${{ secrets.FIREBASE_STAGING_PROJECT }}
+        run: |
+          deadline=$(( $(date +%s) + 30 * 60 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            indexes_json=$(firebase firestore:indexes \
+              --project "$FIREBASE_PROJECT" \
+              --json 2>/dev/null || true)
+            pending=$(echo "$indexes_json" \
+              | jq '[.result.indexes[]? | select(.state != "READY")] | length' \
+              2>/dev/null || echo "unknown")
+            if [ "$pending" = "0" ]; then
+              echo "All Firestore indexes are READY"
+              exit 0
+            fi
+            echo "Waiting for $pending index(es) to reach READY..."
+            sleep 20
+          done
+          echo "::error::Timed out after 30 minutes waiting for indexes to become READY"
+          firebase firestore:indexes --project "$FIREBASE_PROJECT" --json || true
+          exit 1
+
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: deploy-firestore-indexes
 
     steps:
       - name: Deploy via SSH


### PR DESCRIPTION
## Why

Closes the deploy-time footgun caught manually by @filipstachura on PR #232: a new composite index landed in `firestore.indexes.json`, but nothing in CI deploys it. First production query against the new field would 500 with `FAILED_PRECONDITION: requires an index` — long after the offending PR is in.

This change makes "code that needs an index" and "the index actually existing in Firestore" arrive in lockstep, gated by CI.

## What

A single `deploy-firestore-indexes` job added to both `deploy-staging.yml` and `deploy-production.yml`. It runs **before** the existing SSH deploy (`needs:` gate), and:

1. Installs `firebase-tools@15.15.0` + `jq` on the runner.
2. `firebase deploy --only firestore:indexes --non-interactive` against the right project.
3. Polls `firebase firestore:indexes --json` every 20 s until **every** index reports `state: READY` (timeout 30 min).
4. Only after that does the SSH deploy job kick in.

Firestore index builds are asynchronous, often minutes long on populated collections — without the wait, the SSH deploy releases code that hits an unbuilt index and fails the same way it fails today.

## What this is NOT

Earlier draft included two extras that were trimmed for fitting "simplest thing that catches the bug":

- ❌ Standalone `docs/firestore-index-deploy.md` runbook — the YAML comments are sufficient
- ❌ Python script using the emulator's undocumented `:indexUsage` endpoint to detect missing composite indexes during E2E — fragile (undocumented API, can break on any `firebase-tools` update), and the staging deploy already catches this earlier in the pipeline (deploy fails clearly when an index is missing)

If we ever need a PR-time guard, a small structural Vitest scan of `packages/platform-infra/src/firestore/*-repository.ts` against `firestore.indexes.json` is the right shape — kept out of scope here.

## Required before this lands

Three new repository secrets:
- `FIREBASE_CI_TOKEN` — generated by `firebase login:ci`
- `FIREBASE_STAGING_PROJECT` — Firebase project id for staging
- `FIREBASE_PROD_PROJECT` — Firebase project id for production

Without these, the job exits 1 with a clear message (`::error::FIREBASE_*_PROJECT secret is not set`).

## Test plan

- [ ] Create the three secrets above on the repository
- [ ] Trigger `deploy-staging.yml` (push to `main` or `workflow_dispatch`) — confirm `deploy-firestore-indexes` runs first, reports `All Firestore indexes are READY`, then `deploy` (SSH) runs
- [ ] Verify the new `(assignedRole, createdAt)` `humanTasks` index from #232 is present in Firebase Console → Firestore → Indexes after the staging run
- [ ] Same for production via `deploy-production.yml`
- [ ] Confirm `GET /api/tasks?role=…` returns 200 from the deployed staging instance after indexes are READY (this query was the original blocker that motivated the work)

## Risk

Low. Pure CI addition, no application code touched. If the new job ever gets stuck, the `needs:` dependency will simply hold the SSH deploy until the 30-min timeout — at which point both jobs visibly fail and the previous deploy stays live. No silent partial deploys.

---
_Generated by [Claude Code](https://claude.ai/code/session_0152GFs4Ps4Tmb3J3a6bceDV)_