### PR TITLE
ci(firestore-indexes): retry + post-mortem of 2026-04-24 revert

### DIFF
--- a/.github/workflows/_deploy-firestore-indexes.yml
+++ b/.github/workflows/_deploy-firestore-indexes.yml
@@ -1,0 +1,119 @@
+name: Deploy Firestore indexes (reusable)
+
+# Deploy Firestore composite indexes from firestore.indexes.json and wait
+# until every index reports state "READY" before returning. Designed to be
+# the first job in deploy-staging / deploy-production, so the SSH app deploy
+# never lands code that queries an index Firestore is still building.
+#
+# Caller passes the per-environment Firebase project as a secret; the same
+# CI token works against any project the token's owner has access to.
+
+on:
+  workflow_call:
+    inputs:
+      environment-name:
+        description: Human-readable label used in log lines and error messages (e.g. "staging", "production").
+        required: true
+        type: string
+    secrets:
+      FIREBASE_CI_TOKEN:
+        required: true
+      FIREBASE_PROJECT:
+        required: true
+
+jobs:
+  deploy-firestore-indexes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+      FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROJECT }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install firebase-tools (and jq if missing)
+        run: |
+          npm install -g firebase-tools@15.15.0
+          if command -v jq >/dev/null 2>&1; then
+            echo "jq already installed: $(jq --version)"
+          else
+            echo "jq not found, installing..."
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq jq
+          fi
+
+      - name: Log current Firestore index state (${{ inputs.environment-name }})
+        run: |
+          if [ -z "$FIREBASE_PROJECT" ]; then
+            echo "::error::FIREBASE project secret for ${{ inputs.environment-name }} is empty"
+            exit 1
+          fi
+          if [ -z "$FIREBASE_TOKEN" ]; then
+            echo "::error::FIREBASE_CI_TOKEN secret is empty"
+            exit 1
+          fi
+          echo "Current indexes in project '$FIREBASE_PROJECT' before deploy:"
+          if current_json=$(firebase firestore:indexes --project "$FIREBASE_PROJECT" --json 2>&1); then
+            if echo "$current_json" | jq -e '.result.indexes' >/dev/null 2>&1; then
+              echo "$current_json" | jq '.result.indexes | length as $n | "Total: \($n)"'
+              echo "$current_json" | jq -r '.result.indexes[] | "  - \(.collectionGroup // "?") [\(.state // "?")] \((.fields // []) | map(.fieldPath) | join(", "))"'
+            else
+              echo "::warning::Unexpected JSON shape from firebase firestore:indexes — logging raw output"
+              echo "$current_json"
+            fi
+          else
+            echo "::warning::Could not fetch current index state (continuing with deploy): $current_json"
+          fi
+
+      - name: Deploy Firestore indexes (${{ inputs.environment-name }})
+        run: |
+          firebase deploy --only firestore:indexes \
+            --project "$FIREBASE_PROJECT" \
+            --non-interactive
+
+      - name: Wait for all indexes to report READY (${{ inputs.environment-name }})
+        run: |
+          deadline=$(( $(date +%s) + 30 * 60 ))
+          consecutive_failures=0
+          max_failures=3
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            if ! indexes_json=$(firebase firestore:indexes \
+              --project "$FIREBASE_PROJECT" \
+              --json 2>&1); then
+              consecutive_failures=$((consecutive_failures + 1))
+              echo "::warning::firebase firestore:indexes failed (attempt $consecutive_failures/$max_failures): $indexes_json"
+              if [ "$consecutive_failures" -ge "$max_failures" ]; then
+                echo "::error::firebase firestore:indexes failed $max_failures times in a row — aborting"
+                exit 1
+              fi
+              sleep 20
+              continue
+            fi
+
+            if ! echo "$indexes_json" | jq -e '.result.indexes' >/dev/null 2>&1; then
+              echo "::error::Unexpected JSON shape from firebase firestore:indexes — .result.indexes missing. Raw output:"
+              echo "$indexes_json"
+              exit 1
+            fi
+
+            consecutive_failures=0
+            pending=$(echo "$indexes_json" \
+              | jq '[.result.indexes[] | select(.state != "READY")] | length')
+
+            if [ "$pending" = "0" ]; then
+              echo "All Firestore indexes are READY"
+              exit 0
+            fi
+
+            echo "Waiting for $pending index(es) to reach READY:"
+            echo "$indexes_json" \
+              | jq -r '.result.indexes[] | select(.state != "READY") | "  - \(.collectionGroup // "?") [\(.state // "?")] \((.fields // []) | map(.fieldPath) | join(", "))"'
+            sleep 20
+          done
+          echo "::error::Timed out after 30 minutes waiting for indexes to become READY"
+          firebase firestore:indexes --project "$FIREBASE_PROJECT" --json || true
+          exit 1

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,9 +6,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Deploy Firestore composite indexes BEFORE the application so production
+  # queries never land before their backing index exists. Index builds run
+  # asynchronously inside Firestore (minutes on cold collections, longer on
+  # populated ones) — the reusable workflow polls until every index is READY
+  # before unblocking the SSH deploy gate below.
+  deploy-firestore-indexes:
+    uses: ./.github/workflows/_deploy-firestore-indexes.yml
+    with:
+      environment-name: production
+    secrets:
+      FIREBASE_CI_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+      FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROD_PROJECT }}
+
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: deploy-firestore-indexes
 
     steps:
       - name: Deploy via SSH

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,9 +6,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Deploy Firestore composite indexes BEFORE the application so the deployed
+  # app never queries an index Firestore is still building. Index builds run
+  # asynchronously inside Firestore (minutes on cold collections, longer on
+  # populated ones) — the reusable workflow polls until every index is READY
+  # before unblocking the SSH deploy gate below.
+  deploy-firestore-indexes:
+    uses: ./.github/workflows/_deploy-firestore-indexes.yml
+    with:
+      environment-name: staging
+    secrets:
+      FIREBASE_CI_TOKEN: ${{ secrets.FIREBASE_CI_TOKEN }}
+      FIREBASE_PROJECT: ${{ secrets.FIREBASE_STAGING_PROJECT }}
+
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: deploy-firestore-indexes
 
     steps:
       - name: Deploy via SSH

--- a/docs/ci/firestore-index-deploy.md
+++ b/docs/ci/firestore-index-deploy.md
@@ -1,0 +1,150 @@
+# Firestore index deploy in CI
+
+Tracks the `deploy-firestore-indexes` job that runs ahead of the SSH-based app
+deploy on staging and production. The intent is to make "code that needs an
+index" and "the index exists in Firestore" land in lockstep, gated by CI — see
+#261 for the motivation.
+
+This doc exists because the first attempt at the job (merged in #261) broke
+staging deploys for ~2 hours on 2026-04-24. The revert commit removing the job
+was `f0066f1`; this PR re-introduces the job and records what was tried so the
+next attempt does not repeat the same dead ends.
+
+## What went wrong on 2026-04-24
+
+Marek's PR #261 merged at 10:21 UTC. The first staging run failed immediately
+with:
+
+```
+::error::FIREBASE project secret for staging is empty
+```
+
+None of the three secrets the workflow required existed yet on the repository:
+
+- `FIREBASE_CI_TOKEN`
+- `FIREBASE_STAGING_PROJECT`
+- `FIREBASE_PROD_PROJECT`
+
+Creating them and iterating produced a sequence of progressively more specific
+failures.
+
+### Attempt 1 — `FIREBASE_CI_TOKEN` from `firebase login:ci`
+
+**Worked locally, failed from GitHub runners.** A token minted via
+`firebase login:ci` authenticated every Firebase CLI call from a developer
+laptop (`firebase firestore:indexes --project mediforce-1c761 --json` returned
+the full index list). The byte-identical token, uploaded as a repo secret,
+failed the same call from GitHub runners with:
+
+```
+HTTP 401, Request had invalid authentication credentials
+```
+
+Verified via an in-workflow diagnostic that the secret arrived intact — length
+103, sha256 prefix `a419219edf56`, no whitespace or newlines — matching the
+local token byte-for-byte. firebase-tools surfaces a deprecation warning on
+this flow ("Authenticating with `FIREBASE_TOKEN` is deprecated") and the
+failure mode is consistent with Google rejecting `login:ci` refresh tokens
+from datacenter IP ranges. This path is a dead end; do not retry it.
+
+### Attempt 2 — Service account key via `GOOGLE_APPLICATION_CREDENTIALS`
+
+**Auth succeeded, API calls 403.** Created a service account
+`mediforce-ci-deploy@mediforce-1c761.iam.gserviceaccount.com`, uploaded the
+JSON key as `FIREBASE_SA_KEY_STAGING`, wrote it to disk in the workflow, and
+exported `GOOGLE_APPLICATION_CREDENTIALS`. firebase-tools picked up the
+identity (the `jq -r .client_email` echo matched), but every API call failed:
+
+```
+HTTP 403, Permission denied on resource project ***
+  (firestore.googleapis.com/v1/.../collectionGroups/.../indexes)
+HTTP 400, Project 'projects/***' not found or deleted
+  (serviceusage.googleapis.com/v1/projects/.../services/firestore.googleapis.com)
+```
+
+Granted roles, in order of desperation:
+
+- `roles/datastore.owner`
+- `roles/firebase.developAdmin`
+- `roles/serviceusage.serviceUsageConsumer`
+- `roles/datastore.indexAdmin`
+- `roles/serviceusage.serviceUsageAdmin`
+- `roles/firebase.admin`
+
+None cleared the 403/400. The same key read Firestore fine from a developer
+machine via `gcloud firestore operations list` and
+`gcloud services list --filter=firestore.googleapis.com` — proving the roles
+and the Firestore API were correctly provisioned on the project. The failure
+appears to be in how firebase-tools consumes ADC for this specific command
+set, not in the IAM grants.
+
+The SA was deleted on revert. Both `FIREBASE_CI_TOKEN` and
+`FIREBASE_SA_KEY_STAGING` repository secrets were deleted.
+
+`FIREBASE_STAGING_PROJECT` (`mediforce-1c761`) and `FIREBASE_PROD_PROJECT`
+(`mediforce-platform`) were kept — they are non-sensitive strings and the
+next attempt will need them.
+
+## What to try next
+
+In rough order of preference:
+
+1. **`google-github-actions/auth@v2` (Workload Identity Federation).**
+   The official action sets up ADC in a way firebase-tools recognises and
+   avoids storing long-lived keys in GitHub. WIF needs a one-time setup in
+   GCP (identity pool + provider, plus an IAM binding letting
+   `repo:Appsilon/mediforce:ref:refs/heads/main` impersonate
+   `mediforce-ci-deploy`). This is the path firebase-tools' own docs
+   recommend and likely bypasses whatever ADC-consumption quirk defeated
+   attempt 2.
+
+2. **Service account + `google-github-actions/auth@v2` with a static key.**
+   Same setup as attempt 2 but routed through the official action instead of
+   writing the key file by hand. Worth trying before WIF because the
+   machinery is nearly identical to what failed, so a success would narrow
+   the root cause to "firebase-tools needs the action's specific ADC shape".
+
+3. **Skip API enablement.** The 400 on `serviceusage.googleapis.com` fires
+   because firebase-tools unconditionally probes whether
+   `firestore.googleapis.com` is enabled. The API is already on for both
+   projects, so this step is pure overhead. If firebase-tools exposes a flag
+   to skip it (or we call the Firestore Admin API directly via `gcloud
+   firestore indexes ...`), the 400 disappears regardless of auth path.
+
+4. **`firestore.indexes.composites.*` via the Firestore Admin REST API.**
+   Bypass firebase-tools entirely. `firebase deploy --only firestore:indexes`
+   is thin glue over a handful of REST calls; a 40-line Python script against
+   `firestore.googleapis.com/v1/projects/.../databases/(default)/collectionGroups/.../indexes`
+   using ADC or an access token from `gcloud auth print-access-token` would
+   do the job and avoids every firebase-tools-specific failure mode seen in
+   attempts 1 and 2.
+
+Do **not** retry `login:ci` tokens — the 2026-04-24 timeline and
+firebase-tools' own deprecation warning both put this one firmly behind us.
+
+## Manual fallback (until CI is fixed)
+
+When a PR adds a new composite index to `firestore.indexes.json`, the index
+has to be deployed manually before the app starts querying it:
+
+```bash
+# staging
+firebase deploy --only firestore:indexes --project mediforce-1c761
+
+# production
+firebase deploy --only firestore:indexes --project mediforce-platform
+```
+
+This is the workflow that existed before #261 and is what #232's author
+had to remember manually — which is exactly the footgun the job is trying to
+close.
+
+## Secrets currently on the repo (as of 2026-04-24)
+
+| Secret | Status | Notes |
+|---|---|---|
+| `FIREBASE_STAGING_PROJECT` | present | `mediforce-1c761` |
+| `FIREBASE_PROD_PROJECT` | present | `mediforce-platform` |
+| `FIREBASE_CI_TOKEN` | deleted | `login:ci` path abandoned |
+| `FIREBASE_SA_KEY_STAGING` | deleted | SA also deleted |
+| `FIREBASE_PROJECT` | present | pre-existing, unused, left alone |


### PR DESCRIPTION
## Why

On 2026-04-24 #261 merged and started blocking every staging deploy: the
`deploy-firestore-indexes` job could not authenticate against
`mediforce-1c761` from GitHub runners. After ~2 hours of iteration we
reverted the whole job on `main` (see commit `f0066f1`) to unblock
deploys.

This PR reintroduces Marek's original change verbatim and pairs it with
`docs/ci/firestore-index-deploy.md`, which records what we tried, what
failed, and which directions are worth exploring next.

The intent from #261 is unchanged and still correct: we want "code that
needs an index" and "the index exists in Firestore" to arrive in
lockstep, gated by CI.

## What is in this PR

- Restores the three workflow files exactly as they existed on
  `claude/firestore-index-automation-aqrz` at `4ef702e` (the last commit
  on the original branch before merge).
- Adds `docs/ci/firestore-index-deploy.md` — the post-mortem.

No other changes.

## Why it's a draft

Landing this as-is would re-break staging. Before marking ready, the
auth story has to be replaced — see the doc for the short list of
paths. The recommended next try is
`google-github-actions/auth@v2` with Workload Identity Federation.

## References

- Original PR: #261
- Revert commit: `f0066f1`
- Secrets currently on the repo (post-incident): see table in the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)