### PR TITLE
fix(docker): copy data/seeds into runtime image (staging 500s)

### DIFF
--- a/packages/platform-ui/Dockerfile
+++ b/packages/platform-ui/Dockerfile
@@ -61,6 +61,9 @@ COPY --from=builder /app/packages/platform-ui/.next/standalone ./
 COPY --from=builder /app/packages/platform-ui/.next/static ./packages/platform-ui/.next/static
 # Copy public assets (PWA icons, manifest, service worker)
 COPY --from=builder /app/packages/platform-ui/public ./packages/platform-ui/public
+# Seed JSONs (agent-definitions, tool-catalog) read at platform-services init.
+# Not reliably picked up by Next.js output file tracing in this build, so copy explicitly.
+COPY --from=builder /app/data ./data
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary

- Fixes production-wide 500s on staging (and any other Docker deploy) — every API route that touches `getPlatformServices()` crashed.
- Container logs showed: `ENOENT: no such file or directory, open '/app/data/seeds/agent-definitions.json'`.
- Explicitly `COPY --from=builder /app/data ./data` in the runner stage so Next.js output file tracing is not relied on to pick up the seed JSONs.

## Root cause

`packages/platform-api/src/services/seed-agent-definitions.ts:34` and `seed-tool-catalog.ts:32` both do a **top-level `readFileSync`** of `data/seeds/*.json`. When the file is missing, the module import throws, which propagates through `getPlatformServices()` — so every request hitting that singleton returns 500.

Next.js output file tracing picked these reads up in local builds (`.next/standalone/data/seeds/` existed locally), but not in the Docker builder stage on staging. Likely a trace-heuristic miss on the new `platform-api` workspace boundary (extracted in #232).

## Scope

Dockerfile-only. No code, schema, or test changes. No risk of runtime behaviour drift.

## Follow-up (not in this PR)

Make the seed loaders lazy so a missing JSON degrades to a logged warning instead of a process-wide crash. Belt-and-suspenders; this PR is the load-bearing fix.

## Test plan

- [x] Local `docker build -f packages/platform-ui/Dockerfile .` succeeds
- [ ] `docker run` → `/app/data/seeds/agent-definitions.json` present (verify in build)
- [ ] After merge: `./scripts/deploy-staging.sh <sha>` → staging endpoints return 200
- [ ] `curl https://staging.mediforce.ai/api/agent-definitions` — expect list, not 500
- [ ] `curl https://staging.mediforce.ai/api/admin/tool-catalog?namespace=filip` — expect 200 with `{ entries: [...] }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)