### PR TITLE
fix(staging): mount Firebase Admin SDK service account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ dist/
 *.pem
 minutes/*.html
 
+# service-account keys / runtime-mounted secrets
+secrets/
+
 # claude
 .claude/settings.local.json
 memory/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -61,9 +61,13 @@ services:
       - DOCKER_OPENROUTER_API_KEY=${DOCKER_OPENROUTER_API_KEY}
       - DOCKER_APP_BASE_URL=http://platform-ui:3000
       - MEDIFORCE_ROOT=/repo
+      # Firebase Admin SDK credentials for server-side Firestore/Auth access.
+      # Mounted read-only from host ./secrets/firebase-admin-sa.json.
+      - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-sa.json
     volumes:
       - /tmp:/tmp
       - .:/repo:ro
+      - ./secrets/firebase-admin-sa.json:/run/secrets/firebase-sa.json:ro
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Follow-up to #276. Fixes staging 500s that reappeared after #276 merged — the real issue was **Firebase Admin SDK had nowhere to get credentials** on the Hetzner VPS. #276 was a prerequisite (seed-file import was failing first); this PR is the load-bearing auth fix.

## Root cause

The Admin SDK migration (16eadb3) and everything built on top of it assumed Application Default Credentials would "just work". On Firebase App Hosting / GCP (pharmaverse) it does — the metadata server hands out credentials automatically. On a bare-metal VPS (staging), there's no metadata server and no ADC file, so `getFirestore()` throws:

```
Error: Could not load the default credentials.
Browse to https://cloud.google.com/docs/authentication/getting-started
```

This had been latent since 16eadb3 because the top-level `readFileSync` in `seed-agent-definitions.ts` / `seed-tool-catalog.ts` crashed module import first. #276 unblocked the seed files, and the auth failure surfaced on the next request.

## Fix

- `docker-compose.prod.yml` — bind-mount `./secrets/firebase-admin-sa.json` into the container at `/run/secrets/firebase-sa.json` and set `GOOGLE_APPLICATION_CREDENTIALS` to that path. Admin SDK auto-detects.
- `.gitignore` — add `secrets/` so a misplaced key never gets committed.

No code changes. Scope: staging + any future bare-metal Docker deploy.

## Operator procedure (for new environments)

1. Firebase Console → project `mediforce-1c761` → Settings → Service accounts → Generate new private key
2. Upload to `/opt/mediforce/secrets/firebase-admin-sa.json`, `chmod 600`
3. Redeploy (`./scripts/deploy-staging.sh <sha>`)

**Already done on current staging** (204.168.165.57) — key in place, `chmod 600`, `project_id=mediforce-1c761` confirmed. Just needs this PR merged + redeploy.

## Not affected

- Firebase App Hosting deploys (pharmaverse.yaml, supply-intelligence.yaml, apphosting.yaml) — metadata server provides ADC, no mount needed.
- Local dev — Firebase emulator path (`NEXT_PUBLIC_USE_EMULATORS=true`) skips Admin SDK auth entirely.

## Test plan

- [ ] Merge + `./scripts/deploy-staging.sh <sha>` on staging
- [ ] `curl -sH "X-Api-Key: \$PLATFORM_API_KEY" https://staging.mediforce.ai/api/agent-definitions` → 200 with `{ agents: [...] }`
- [ ] `curl -sH "X-Api-Key: \$PLATFORM_API_KEY" 'https://staging.mediforce.ai/api/admin/tool-catalog?namespace=filip'` → 200 with `{ entries: [...] }`
- [ ] `docker compose logs platform-ui | grep -i credential` → no Admin-SDK credential errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)