### PR TITLE
feat(cli): add mediforce CLI MVP

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     ]
   },
   "devDependencies": {
+    "@mediforce/cli": "workspace:*",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^24.12.2",
     "@vitest/coverage-v8": "^4.1.4",

--- a/packages/cli/bin/mediforce.cjs
+++ b/packages/cli/bin/mediforce.cjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Bin shim for @mediforce/cli.
+ *
+ * Resolves `tsx` from the package's own deps and delegates to it so the CLI
+ * runs straight from `src/cli.ts` without a build step. Keeps MVP iteration
+ * tight; once the CLI stabilises this can be replaced with a tsc-emitted
+ * `dist/cli.js` and the shebang moved there.
+ *
+ * `pnpm exec mediforce …` from anywhere in the workspace ends up here via
+ * the `bin` field in package.json.
+ */
+'use strict';
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const packageRoot = path.resolve(__dirname, '..');
+const entry = path.join(packageRoot, 'src', 'cli.ts');
+
+let tsxBin;
+try {
+  // require.resolve('tsx/cli') points at the CommonJS entry that runs the CLI.
+  tsxBin = require.resolve('tsx/cli', { paths: [packageRoot] });
+} catch (err) {
+  console.error(
+    'mediforce: could not resolve `tsx` runtime. Run `pnpm install` from the workspace root.',
+  );
+  console.error(String(err));
+  process.exit(2);
+}
+
+// `--conditions=@mediforce/source` makes Node's ESM resolver pick the
+// `./src/...` entry from each workspace package's `exports`, matching the
+// custom condition declared in tsconfig.json. Without it, the resolver
+// falls back to `./dist/...` which has not been built in dev.
+//
+// Passed via NODE_OPTIONS rather than as an argv flag because tsx parses
+// argv before the runtime sees it, and a leading `--conditions=…` would be
+// consumed by tsx's own arg parser instead of reaching the ESM loader.
+const env = { ...process.env };
+const existing = env.NODE_OPTIONS ?? '';
+env.NODE_OPTIONS = existing.includes('--conditions=@mediforce/source')
+  ? existing
+  : `${existing} --conditions=@mediforce/source`.trim();
+
+const result = spawnSync(
+  process.execPath,
+  [tsxBin, entry, ...process.argv.slice(2)],
+  { stdio: 'inherit', env },
+);
+
+if (result.error !== undefined) {
+  console.error(`mediforce: failed to spawn tsx — ${String(result.error)}`);
+  process.exit(2);
+}
+
+process.exit(result.status ?? 0);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@mediforce/cli",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "mediforce": "./bin/mediforce.cjs"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "@mediforce/source": "./src/index.ts",
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@mediforce/platform-api": "workspace:*",
+    "@mediforce/platform-core": "workspace:*",
+    "tsx": "latest",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@mediforce/platform-api": "workspace:*",
     "@mediforce/platform-core": "workspace:*",
-    "tsx": "latest",
+    "tsx": "^4.21.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { runCli } from '../cli.js';
+import { captureOutput } from './test-helpers.js';
+
+describe('runCli — top-level dispatch', () => {
+  it('prints help when called with no arguments', async () => {
+    const output = captureOutput();
+    const code = await runCli({ argv: [], env: {}, output });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/Usage: mediforce/);
+  });
+
+  it('prints help on --help', async () => {
+    const output = captureOutput();
+    const code = await runCli({ argv: ['--help'], env: {}, output });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/workflow register/);
+  });
+
+  it('prints help on -h', async () => {
+    const output = captureOutput();
+    const code = await runCli({ argv: ['-h'], env: {}, output });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/workflow register/);
+  });
+
+  it('returns exit 2 on unknown command', async () => {
+    const output = captureOutput();
+    const code = await runCli({ argv: ['weird'], env: {}, output });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/Unknown command/);
+  });
+
+  it('returns exit 2 on unknown subcommand under workflow', async () => {
+    const output = captureOutput();
+    const code = await runCli({ argv: ['workflow', 'magic'], env: {}, output });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/Unknown command/);
+  });
+});

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -37,4 +37,26 @@ describe('runCli — top-level dispatch', () => {
     expect(code).toBe(2);
     expect(output.stderrLines.join('\n')).toMatch(/Unknown command/);
   });
+
+  it('prints workflow-namespaced HELP when `workflow` is given with no subcommand', async () => {
+    const output = captureOutput();
+    const code = await runCli({ argv: ['workflow'], env: {}, output });
+    expect(code).toBe(2);
+    const stderr = output.stderrLines.join('\n');
+    expect(stderr).toMatch(/Usage: mediforce workflow/);
+    expect(stderr).toMatch(/register/);
+    expect(stderr).toMatch(/list/);
+    // Should NOT fall through to the generic `Unknown command: workflow undefined`.
+    expect(stderr).not.toMatch(/Unknown command/);
+  });
+
+  it('prints run-namespaced HELP when `run` is given with no subcommand', async () => {
+    const output = captureOutput();
+    const code = await runCli({ argv: ['run'], env: {}, output });
+    expect(code).toBe(2);
+    const stderr = output.stderrLines.join('\n');
+    expect(stderr).toMatch(/Usage: mediforce run/);
+    expect(stderr).toMatch(/get/);
+    expect(stderr).not.toMatch(/Unknown command/);
+  });
 });

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveApiKey,
+  resolveBaseUrl,
+  resolveConfig,
+  DEFAULT_BASE_URL,
+} from '../config.js';
+
+describe('resolveApiKey', () => {
+  it('prefers MEDIFORCE_API_KEY over PLATFORM_API_KEY', () => {
+    expect(
+      resolveApiKey({ MEDIFORCE_API_KEY: 'm', PLATFORM_API_KEY: 'p' }),
+    ).toBe('m');
+  });
+
+  it('falls back to PLATFORM_API_KEY when MEDIFORCE_API_KEY is unset', () => {
+    expect(resolveApiKey({ PLATFORM_API_KEY: 'p' })).toBe('p');
+  });
+
+  it('falls back to PLATFORM_API_KEY when MEDIFORCE_API_KEY is the empty string', () => {
+    expect(
+      resolveApiKey({ MEDIFORCE_API_KEY: '', PLATFORM_API_KEY: 'p' }),
+    ).toBe('p');
+  });
+
+  it('throws when neither variable is set', () => {
+    expect(() => resolveApiKey({})).toThrow(/MEDIFORCE_API_KEY/);
+  });
+});
+
+describe('resolveBaseUrl', () => {
+  it('prefers the --base-url flag over the env var', () => {
+    expect(
+      resolveBaseUrl({
+        flagBaseUrl: 'https://flag.example.com',
+        env: { MEDIFORCE_BASE_URL: 'https://env.example.com' },
+      }),
+    ).toBe('https://flag.example.com');
+  });
+
+  it('falls back to MEDIFORCE_BASE_URL when no flag is given', () => {
+    expect(
+      resolveBaseUrl({ env: { MEDIFORCE_BASE_URL: 'https://env.example.com' } }),
+    ).toBe('https://env.example.com');
+  });
+
+  it('falls back to the default when neither flag nor env is set', () => {
+    expect(resolveBaseUrl({ env: {} })).toBe(DEFAULT_BASE_URL);
+  });
+
+  it('treats an empty flag value as unset', () => {
+    expect(
+      resolveBaseUrl({
+        flagBaseUrl: '',
+        env: { MEDIFORCE_BASE_URL: 'https://env.example.com' },
+      }),
+    ).toBe('https://env.example.com');
+  });
+});
+
+describe('resolveConfig', () => {
+  it('combines apiKey + baseUrl resolution', () => {
+    const config = resolveConfig({
+      flagBaseUrl: 'https://flag',
+      env: { MEDIFORCE_API_KEY: 'k' },
+    });
+    expect(config).toEqual({ apiKey: 'k', baseUrl: 'https://flag' });
+  });
+});

--- a/packages/cli/src/__tests__/output.test.ts
+++ b/packages/cli/src/__tests__/output.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runGetCommand } from '../commands/run-get.js';
+import { workflowRegisterCommand } from '../commands/workflow-register.js';
+import { printError } from '../output.js';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+/**
+ * Regression tests for the `printError` stream contract documented in
+ * `output.ts`:
+ *
+ *   --json mode → STDOUT
+ *   human mode → STDERR
+ *
+ * Both lanes are exercised here directly via `printError` and end-to-end
+ * via a real command path (a 4xx triggers `printError` from the catch).
+ */
+
+describe('printError stream contract — direct', () => {
+  it('writes the JSON payload to stdout in --json mode', () => {
+    const output = captureOutput();
+    printError(output, { error: 'boom', status: 404 }, true);
+    expect(output.stderrLines).toEqual([]);
+    expect(output.stdoutLines).toHaveLength(1);
+    const parsed: unknown = JSON.parse(output.stdoutLines[0]!);
+    expect(parsed).toMatchObject({ error: 'boom', status: 404 });
+  });
+
+  it('writes the plain message to stderr in human mode', () => {
+    const output = captureOutput();
+    printError(output, { error: 'boom', status: 404 }, false);
+    expect(output.stdoutLines).toEqual([]);
+    expect(output.stderrLines.join('\n')).toMatch(/Error.*HTTP 404.*boom/);
+  });
+});
+
+describe('printError stream contract — end-to-end via command path', () => {
+  it('--json error from `run get` lands on stdout, not stderr', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Run not found' }, 404),
+    );
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: ['nope', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    // The error JSON must be on stdout — the contract that machine
+    // consumers depend on. stderr stays clean.
+    expect(output.stderrLines).toEqual([]);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ status: 404 });
+  });
+
+  it('human-mode error from `run get` lands on stderr, not stdout', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Run not found' }, 404),
+    );
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: ['nope'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    // No JSON on stdout in human mode — clean separation lets shells
+    // pipe stdout into next-stage tools without errors corrupting it.
+    expect(output.stdoutLines).toEqual([]);
+    expect(output.stderrLines.join('\n')).toMatch(/Error.*HTTP 404/);
+  });
+
+  it('--json error from `workflow register` lands on stdout, not stderr', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Validation failed' }, 400),
+    );
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', '/no/such/file.json', '--namespace', 'ns', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    expect(output.stderrLines).toEqual([]);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ error: expect.stringMatching(/Failed to read file/) });
+  });
+});

--- a/packages/cli/src/__tests__/run-get.test.ts
+++ b/packages/cli/src/__tests__/run-get.test.ts
@@ -94,4 +94,16 @@ describe('run get command', () => {
     });
     expect(code).toBe(2);
   });
+
+  it('prints HELP on too many positionals (matches missing-positional UX)', async () => {
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: ['id1', 'id2', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(2);
+    const allOutput = output.stderrLines.join('\n') + output.stdoutLines.join('\n');
+    expect(allOutput).toMatch(/Usage: mediforce run get/);
+  });
 });

--- a/packages/cli/src/__tests__/run-get.test.ts
+++ b/packages/cli/src/__tests__/run-get.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runGetCommand } from '../commands/run-get.js';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * NOTE: The live `GET /api/runs/<runId>` endpoint ships on the n8n-migrator
+ * branch. Until that lands on `main`, these tests run only against fetch
+ * loopback. See packages/platform-api/src/contract/runs.ts for the contract
+ * comment with the same dependency note.
+ */
+
+describe('run get command', () => {
+  it('exits 2 when no runId positional is given', async () => {
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: [],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n') + output.stdoutLines.join('\n')).toMatch(
+      /runId is required/,
+    );
+  });
+
+  it('GETs /api/runs/<runId> and prints the result', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        runId: 'run-1',
+        status: 'completed',
+        currentStepId: 'final',
+        error: null,
+        finalOutput: { ok: true },
+      }),
+    );
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: ['run-1', '--base-url', 'http://localhost:5555'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://localhost:5555/api/runs/run-1');
+    expect(output.stdoutLines.join('\n')).toMatch(/run-1/);
+    expect(output.stdoutLines.join('\n')).toMatch(/completed/);
+  });
+
+  it('emits structured JSON when --json is set', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        runId: 'run-2',
+        status: 'running',
+        currentStepId: 'mid',
+        error: null,
+        finalOutput: null,
+      }),
+    );
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: ['run-2', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ runId: 'run-2', status: 'running' });
+  });
+
+  it('exits 1 with structured error JSON on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Run not found' }, 404),
+    );
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: ['nope', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ status: 404 });
+  });
+
+  it('exits 2 when more than one positional is given', async () => {
+    const output = captureOutput();
+    const code = await runGetCommand({
+      argv: ['run-1', 'run-2'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(2);
+  });
+});

--- a/packages/cli/src/__tests__/test-helpers.ts
+++ b/packages/cli/src/__tests__/test-helpers.ts
@@ -1,0 +1,24 @@
+import type { OutputSink } from '../output.js';
+
+export interface CapturedOutput extends OutputSink {
+  stdoutLines: string[];
+  stderrLines: string[];
+}
+
+export function captureOutput(): CapturedOutput {
+  const stdoutLines: string[] = [];
+  const stderrLines: string[] = [];
+  return {
+    stdoutLines,
+    stderrLines,
+    stdout: (line) => stdoutLines.push(line),
+    stderr: (line) => stderrLines.push(line),
+  };
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/packages/cli/src/__tests__/workflow-list.test.ts
+++ b/packages/cli/src/__tests__/workflow-list.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { workflowListCommand } from '../commands/workflow-list.js';
+import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('workflow list command', () => {
+  it('exits 2 when no API key is set', async () => {
+    const output = captureOutput();
+    const code = await workflowListCommand({ argv: [], env: {}, output });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/MEDIFORCE_API_KEY/);
+  });
+
+  it('GETs /api/workflow-definitions and prints the list', async () => {
+    const wd = buildWorkflowDefinition({ name: 'wf-a', version: 3 });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        definitions: [
+          { name: wd.name, latestVersion: 3, defaultVersion: 2, definition: wd },
+        ],
+      }),
+    );
+    const output = captureOutput();
+    const code = await workflowListCommand({
+      argv: ['--base-url', 'http://localhost:1234'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      'http://localhost:1234/api/workflow-definitions',
+    );
+    expect(output.stdoutLines.join('\n')).toMatch(/wf-a/);
+    expect(output.stdoutLines.join('\n')).toMatch(/v3/);
+  });
+
+  it('reports an empty list with a helpful message', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ definitions: [] }),
+    );
+    const output = captureOutput();
+    const code = await workflowListCommand({
+      argv: [],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/No workflow definitions/);
+  });
+
+  it('emits structured JSON when --json is set', async () => {
+    const wd = buildWorkflowDefinition({ name: 'wf-a', version: 1 });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        definitions: [
+          { name: wd.name, latestVersion: 1, defaultVersion: 1, definition: wd },
+        ],
+      }),
+    );
+    const output = captureOutput();
+    const code = await workflowListCommand({
+      argv: ['--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({
+      definitions: [
+        { name: 'wf-a', latestVersion: 1 },
+      ],
+    });
+  });
+
+  it('exits 1 with structured error on API failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'forbidden' }, 403),
+    );
+    const output = captureOutput();
+    const code = await workflowListCommand({
+      argv: ['--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ status: 403 });
+  });
+});

--- a/packages/cli/src/__tests__/workflow-register.test.ts
+++ b/packages/cli/src/__tests__/workflow-register.test.ts
@@ -85,6 +85,48 @@ describe('workflow register command', () => {
     expect(output.stdoutLines.join('\n')).toMatch(/dry-run/i);
   });
 
+  it('--dry-run rejects inputForNextRun referencing an unknown stepId (server parity)', async () => {
+    // Without superRefine, `RegisterWorkflowInputSchema` accepts this body
+    // and dry-run would pass while a real POST would 400. Mirroring
+    // `parseWorkflowDefinitionForCreation` server-side keeps the two in
+    // lockstep — see workflow-register.ts dry-run path.
+    const wd = buildWorkflowDefinition({ name: 'sample-wf' });
+    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
+    void _v;
+    void _n;
+    void _c;
+    const malformed = {
+      ...body,
+      inputForNextRun: [{ stepId: 'does-not-exist', output: 'x', as: 'y' }],
+    };
+    const malformedFile = path.join(tempDir, 'malformed.json');
+    await writeFile(malformedFile, JSON.stringify(malformed), 'utf-8');
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', malformedFile, '--namespace', 'Appsilon', '--dry-run', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ error: 'Validation failed' });
+    // Same issue shape the server emits — Zod issue array with a path
+    // pointing at the offending entry.
+    const issues = (parsed as { body: Array<{ path: Array<string | number> }> }).body;
+    expect(Array.isArray(issues)).toBe(true);
+    expect(
+      issues.some(
+        (issue) =>
+          Array.isArray(issue.path) &&
+          issue.path[0] === 'inputForNextRun' &&
+          issue.path[2] === 'stepId',
+      ),
+    ).toBe(true);
+  });
+
   it('POSTs to /api/workflow-definitions with namespace + apiKey', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')

--- a/packages/cli/src/__tests__/workflow-register.test.ts
+++ b/packages/cli/src/__tests__/workflow-register.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { workflowRegisterCommand } from '../commands/workflow-register.js';
+import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+let tempDir: string;
+let wdFile: string;
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  tempDir = await mkdtemp(path.join(tmpdir(), 'mediforce-cli-test-'));
+  wdFile = path.join(tempDir, 'workflow.json');
+  const wd = buildWorkflowDefinition({ name: 'sample-wf' });
+  const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
+  void _v;
+  void _n;
+  void _c;
+  await writeFile(wdFile, JSON.stringify(body), 'utf-8');
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('workflow register command', () => {
+  it('exits 2 with a useful error when --file is missing', async () => {
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--namespace', 'Appsilon'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/--file is required/);
+  });
+
+  it('exits 2 with a useful error when --namespace is missing', async () => {
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', wdFile],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/--namespace is required/);
+  });
+
+  it('exits 1 when the file is missing', async () => {
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', '/nope/does-not-exist.json', '--namespace', 'Appsilon'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    expect(output.stderrLines.join('\n')).toMatch(/Failed to read file/);
+  });
+
+  it('exits 1 when the file is invalid JSON', async () => {
+    const bad = path.join(tempDir, 'bad.json');
+    await writeFile(bad, '{ not json', 'utf-8');
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', bad, '--namespace', 'Appsilon'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    expect(output.stderrLines.join('\n')).toMatch(/Invalid JSON/);
+  });
+
+  it('--dry-run validates locally without calling the API', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', wdFile, '--namespace', 'Appsilon', '--dry-run'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(output.stdoutLines.join('\n')).toMatch(/dry-run/i);
+  });
+
+  it('POSTs to /api/workflow-definitions with namespace + apiKey', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ success: true, name: 'sample-wf', version: 1 }, 201));
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: [
+        '--file',
+        wdFile,
+        '--namespace',
+        'Appsilon',
+        '--base-url',
+        'http://localhost:9999',
+      ],
+      env: { MEDIFORCE_API_KEY: 'secret' },
+      output,
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('http://localhost:9999/api/workflow-definitions?namespace=Appsilon');
+    expect(init?.method).toBe('POST');
+    expect(new Headers(init?.headers).get('X-Api-Key')).toBe('secret');
+    expect(output.stdoutLines.join('\n')).toMatch(/Registered sample-wf v1/);
+  });
+
+  it('emits structured JSON when --json is set', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ success: true, name: 'sample-wf', version: 7 }, 201),
+    );
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', wdFile, '--namespace', 'Appsilon', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ success: true, name: 'sample-wf', version: 7 });
+  });
+
+  it('exits 1 with API-error JSON shape on non-2xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Validation failed' }, 400),
+    );
+    const output = captureOutput();
+    const code = await workflowRegisterCommand({
+      argv: ['--file', wdFile, '--namespace', 'Appsilon', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ error: 'Validation failed', status: 400 });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,6 +20,7 @@
  */
 
 import { workflowRegisterCommand } from './commands/workflow-register.js';
+import { workflowListCommand } from './commands/workflow-list.js';
 import { consoleOutput, type OutputSink } from './output.js';
 
 export interface RunCliInput {
@@ -58,6 +59,9 @@ export async function runCli(input: RunCliInput): Promise<number> {
 
   if (command === 'workflow' && subcommand === 'register') {
     return workflowRegisterCommand({ argv: rest, env: input.env, output });
+  }
+  if (command === 'workflow' && subcommand === 'list') {
+    return workflowListCommand({ argv: rest, env: input.env, output });
   }
 
   output.stderr(`Unknown command: ${[command, subcommand].filter(Boolean).join(' ')}`);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,78 @@
+/**
+ * `mediforce` CLI entrypoint.
+ *
+ * Subcommand dispatch is a single switch on `argv[2]/argv[3]` — keeps the
+ * binary dependency-free (only `node:util`'s `parseArgs` for flags).
+ *
+ * Surface (MVP):
+ *   mediforce workflow register --file <path> --namespace <ns> [...flags]
+ *   mediforce workflow list                                    [...flags]
+ *   mediforce run get <runId>                                  [...flags]
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — operational failure (HTTP error, validation error, file not found)
+ *   2 — usage error (unknown command, missing required flag)
+ *
+ * Commands are registered as `runCli` grows; this scaffold ships the help
+ * text and unknown-command path. Per-command dispatch is wired in subsequent
+ * commits as each command lands.
+ */
+
+import { consoleOutput, type OutputSink } from './output.js';
+
+export interface RunCliInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output?: OutputSink;
+}
+
+const HELP = `Usage: mediforce <command> [options]
+
+Commands:
+  workflow register --file <path> --namespace <ns>   Register a workflow definition
+  workflow list                                      List registered workflow definitions
+  run get <runId>                                    Fetch a single run's status
+
+Common flags:
+  --base-url <url>   API base URL (default: http://localhost:9003,
+                     or MEDIFORCE_BASE_URL env var)
+  --json             Emit JSON instead of human-readable output
+  --help, -h         Show this help text
+
+Authentication:
+  Set MEDIFORCE_API_KEY (or PLATFORM_API_KEY) in the environment.
+`;
+
+export async function runCli(input: RunCliInput): Promise<number> {
+  const output = input.output ?? consoleOutput;
+  const args = input.argv;
+
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    output.stdout(HELP);
+    return 0;
+  }
+
+  const [command, subcommand] = args;
+
+  output.stderr(`Unknown command: ${[command, subcommand].filter(Boolean).join(' ')}`);
+  output.stderr('');
+  output.stderr(HELP);
+  return 2;
+}
+
+// Direct execution: spawned by `bin/mediforce.cjs`.
+const isDirectInvocation =
+  typeof process !== 'undefined' && import.meta.url === `file://${process.argv[1]}`;
+if (isDirectInvocation) {
+  runCli({ argv: process.argv.slice(2), env: process.env })
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err: unknown) => {
+      // Any uncaught error inside a command path is treated as an operational
+      // failure — print to stderr and exit non-zero.
+      process.stderr.write(`mediforce: ${String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -19,6 +19,7 @@
  * commits as each command lands.
  */
 
+import { workflowRegisterCommand } from './commands/workflow-register.js';
 import { consoleOutput, type OutputSink } from './output.js';
 
 export interface RunCliInput {
@@ -53,7 +54,11 @@ export async function runCli(input: RunCliInput): Promise<number> {
     return 0;
   }
 
-  const [command, subcommand] = args;
+  const [command, subcommand, ...rest] = args;
+
+  if (command === 'workflow' && subcommand === 'register') {
+    return workflowRegisterCommand({ argv: rest, env: input.env, output });
+  }
 
   output.stderr(`Unknown command: ${[command, subcommand].filter(Boolean).join(' ')}`);
   output.stderr('');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -45,6 +45,28 @@ Common flags:
 
 Authentication:
   Set MEDIFORCE_API_KEY (or PLATFORM_API_KEY) in the environment.
+
+Output streams:
+  Success output and --json error payloads are written to stdout.
+  Human-mode error messages are written to stderr so success output
+  on stdout stays machine-parseable when piped.
+`;
+
+const WORKFLOW_HELP = `Usage: mediforce workflow <subcommand> [options]
+
+Subcommands:
+  register --file <path> --namespace <ns>   Register a workflow definition
+  list                                      List registered workflow definitions
+
+Run \`mediforce workflow <subcommand> --help\` for subcommand-specific flags.
+`;
+
+const RUN_HELP = `Usage: mediforce run <subcommand> [options]
+
+Subcommands:
+  get <runId>   Fetch a single run's status
+
+Run \`mediforce run <subcommand> --help\` for subcommand-specific flags.
 `;
 
 export async function runCli(input: RunCliInput): Promise<number> {
@@ -57,6 +79,21 @@ export async function runCli(input: RunCliInput): Promise<number> {
   }
 
   const [command, subcommand, ...rest] = args;
+
+  // Namespace-only invocation (no subcommand): print the namespaced HELP and
+  // exit 2 instead of the generic `Unknown command: workflow undefined`.
+  if (command === 'workflow' && subcommand === undefined) {
+    output.stderr('mediforce workflow: missing subcommand');
+    output.stderr('');
+    output.stderr(WORKFLOW_HELP);
+    return 2;
+  }
+  if (command === 'run' && subcommand === undefined) {
+    output.stderr('mediforce run: missing subcommand');
+    output.stderr('');
+    output.stderr(RUN_HELP);
+    return 2;
+  }
 
   if (command === 'workflow' && subcommand === 'register') {
     return workflowRegisterCommand({ argv: rest, env: input.env, output });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@
 
 import { workflowRegisterCommand } from './commands/workflow-register.js';
 import { workflowListCommand } from './commands/workflow-list.js';
+import { runGetCommand } from './commands/run-get.js';
 import { consoleOutput, type OutputSink } from './output.js';
 
 export interface RunCliInput {
@@ -62,6 +63,9 @@ export async function runCli(input: RunCliInput): Promise<number> {
   }
   if (command === 'workflow' && subcommand === 'list') {
     return workflowListCommand({ argv: rest, env: input.env, output });
+  }
+  if (command === 'run' && subcommand === 'get') {
+    return runGetCommand({ argv: rest, env: input.env, output });
   }
 
   output.stderr(`Unknown command: ${[command, subcommand].filter(Boolean).join(' ')}`);

--- a/packages/cli/src/commands/run-get.ts
+++ b/packages/cli/src/commands/run-get.ts
@@ -1,0 +1,111 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce run get <runId> [options]
+
+Fetch the current status of a single run.
+
+Optional flags:
+  --base-url <url>     API base URL (default: http://localhost:9003)
+  --json               Emit JSON instead of human-readable output
+  --help, -h           Show this help text
+`;
+
+const RUN_GET_OPTIONS = {
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function runGetCommand(input: CommandInput): Promise<number> {
+  let flags: {
+    'base-url'?: string;
+    json?: boolean;
+    help?: boolean;
+  };
+  let positionals: string[];
+  try {
+    const parsed = parseArgs({
+      args: input.argv,
+      options: RUN_GET_OPTIONS,
+      strict: true,
+      allowPositionals: true,
+    });
+    flags = parsed.values;
+    positionals = parsed.positionals;
+  } catch (err) {
+    input.output.stderr(`mediforce run get: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+  const jsonMode = flags.json === true;
+
+  if (flags.help === true) {
+    input.output.stdout(HELP);
+    return 0;
+  }
+
+  if (positionals.length === 0) {
+    printError(input.output, { error: 'runId is required' }, jsonMode);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+  if (positionals.length > 1) {
+    printError(
+      input.output,
+      { error: `Expected exactly one runId, got ${String(positionals.length)}` },
+      jsonMode,
+    );
+    return 2;
+  }
+
+  const runId = positionals[0]!;
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    const result = await mediforce.runs.get({ runId });
+    if (jsonMode) {
+      printJson(input.output, result);
+      return 0;
+    }
+    input.output.stdout(`Run ${result.runId}`);
+    input.output.stdout(`  status:        ${result.status}`);
+    input.output.stdout(
+      `  currentStep:   ${result.currentStepId ?? '(none)'}`,
+    );
+    input.output.stdout(`  error:         ${result.error ?? '(none)'}`);
+    if (result.finalOutput !== null && result.finalOutput !== undefined) {
+      input.output.stdout(`  finalOutput:   ${JSON.stringify(result.finalOutput)}`);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(
+        input.output,
+        { error: err.message, status: err.status, body: err.body },
+        jsonMode,
+      );
+    } else {
+      printError(input.output, { error: String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/run-get.ts
+++ b/packages/cli/src/commands/run-get.ts
@@ -66,6 +66,8 @@ export async function runGetCommand(input: CommandInput): Promise<number> {
       { error: `Expected exactly one runId, got ${String(positionals.length)}` },
       jsonMode,
     );
+    input.output.stderr('');
+    input.output.stderr(HELP);
     return 2;
   }
 

--- a/packages/cli/src/commands/workflow-list.ts
+++ b/packages/cli/src/commands/workflow-list.ts
@@ -1,0 +1,97 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce workflow list [options]
+
+List every registered workflow definition (latest version per name).
+
+Optional flags:
+  --base-url <url>     API base URL (default: http://localhost:9003)
+  --json               Emit JSON instead of human-readable output
+  --help, -h           Show this help text
+`;
+
+const LIST_OPTIONS = {
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function workflowListCommand(input: CommandInput): Promise<number> {
+  let flags: {
+    'base-url'?: string;
+    json?: boolean;
+    help?: boolean;
+  };
+  try {
+    const parsed = parseArgs({
+      args: input.argv,
+      options: LIST_OPTIONS,
+      strict: true,
+      allowPositionals: false,
+    });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce workflow list: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+  const jsonMode = flags.json === true;
+
+  if (flags.help === true) {
+    input.output.stdout(HELP);
+    return 0;
+  }
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    const result = await mediforce.workflows.list();
+    if (jsonMode) {
+      printJson(input.output, result);
+      return 0;
+    }
+    if (result.definitions.length === 0) {
+      input.output.stdout('No workflow definitions registered.');
+      return 0;
+    }
+    input.output.stdout(`Found ${String(result.definitions.length)} workflow(s):`);
+    for (const group of result.definitions) {
+      const defaultLabel =
+        group.defaultVersion === null
+          ? 'no default'
+          : `default: v${String(group.defaultVersion)}`;
+      input.output.stdout(
+        `  ${group.name}  latest: v${String(group.latestVersion)}  (${defaultLabel})`,
+      );
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(
+        input.output,
+        { error: err.message, status: err.status, body: err.body },
+        jsonMode,
+      );
+    } else {
+      printError(input.output, { error: String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/workflow-register.ts
+++ b/packages/cli/src/commands/workflow-register.ts
@@ -5,6 +5,7 @@ import {
   RegisterWorkflowInputSchema,
   type RegisterWorkflowInput,
 } from '@mediforce/platform-api/contract';
+import { parseWorkflowDefinitionForCreation } from '@mediforce/platform-core';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
 
@@ -113,6 +114,23 @@ export async function workflowRegisterCommand(input: CommandInput): Promise<numb
   }
 
   if (flags['dry-run'] === true) {
+    // Mirror the server-side parse exactly so dry-run can never pass while a
+    // real POST would fail. The server applies `parseWorkflowDefinitionForCreation`
+    // (= WorkflowDefinitionBase.omit({version, createdAt}).superRefine(validateInputForNextRun))
+    // after injecting the namespace from the query string. We do the same here
+    // and emit the same `{ error: 'Validation failed', issues }` shape.
+    const serverParse = parseWorkflowDefinitionForCreation({
+      ...body,
+      namespace: flags.namespace,
+    });
+    if (!serverParse.success) {
+      printError(
+        input.output,
+        { error: 'Validation failed', body: serverParse.error.issues },
+        jsonMode,
+      );
+      return 1;
+    }
     const summary = {
       success: true,
       dryRun: true,

--- a/packages/cli/src/commands/workflow-register.ts
+++ b/packages/cli/src/commands/workflow-register.ts
@@ -1,0 +1,168 @@
+import { parseArgs } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import {
+  RegisterWorkflowInputSchema,
+  type RegisterWorkflowInput,
+} from '@mediforce/platform-api/contract';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce workflow register --file <path> --namespace <ns> [options]
+
+Register a workflow definition from a JSON file. The file should contain a
+WorkflowDefinition without \`version\`, \`createdAt\`, or \`namespace\` — those
+are filled in server-side.
+
+Required flags:
+  --file <path>        Path to the workflow definition JSON file
+  --namespace <ns>     Namespace that owns the registered workflow
+
+Optional flags:
+  --base-url <url>     API base URL (default: http://localhost:9003)
+  --dry-run            Validate the file locally without calling the API
+  --json               Emit JSON instead of human-readable output
+  --help, -h           Show this help text
+`;
+
+const REGISTER_OPTIONS = {
+  file: { type: 'string' },
+  namespace: { type: 'string' },
+  'base-url': { type: 'string' },
+  'dry-run': { type: 'boolean' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function workflowRegisterCommand(input: CommandInput): Promise<number> {
+  let flags: {
+    file?: string;
+    namespace?: string;
+    'base-url'?: string;
+    'dry-run'?: boolean;
+    json?: boolean;
+    help?: boolean;
+  };
+  try {
+    const parsed = parseArgs({
+      args: input.argv,
+      options: REGISTER_OPTIONS,
+      strict: true,
+      allowPositionals: false,
+    });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce workflow register: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+  const jsonMode = flags.json === true;
+
+  if (flags.help === true) {
+    input.output.stdout(HELP);
+    return 0;
+  }
+
+  if (typeof flags.file !== 'string' || flags.file.length === 0) {
+    printError(input.output, { error: '--file is required' }, jsonMode);
+    return 2;
+  }
+  if (typeof flags.namespace !== 'string' || flags.namespace.length === 0) {
+    printError(input.output, { error: '--namespace is required' }, jsonMode);
+    return 2;
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(flags.file, 'utf-8');
+  } catch (err) {
+    printError(
+      input.output,
+      { error: `Failed to read file: ${flags.file} — ${String(err)}` },
+      jsonMode,
+    );
+    return 1;
+  }
+
+  let body: RegisterWorkflowInput;
+  try {
+    const parsedJson: unknown = JSON.parse(raw);
+    const result = RegisterWorkflowInputSchema.safeParse(parsedJson);
+    if (!result.success) {
+      printError(
+        input.output,
+        {
+          error: 'Invalid workflow definition',
+          body: result.error.issues,
+        },
+        jsonMode,
+      );
+      return 1;
+    }
+    body = result.data;
+  } catch (err) {
+    printError(input.output, { error: `Invalid JSON: ${String(err)}` }, jsonMode);
+    return 1;
+  }
+
+  if (flags['dry-run'] === true) {
+    const summary = {
+      success: true,
+      dryRun: true,
+      name: body.name,
+      namespace: flags.namespace,
+      stepCount: body.steps.length,
+      transitionCount: body.transitions.length,
+      triggerCount: body.triggers.length,
+    };
+    if (jsonMode) {
+      printJson(input.output, summary);
+    } else {
+      input.output.stdout(
+        `[dry-run] OK — ${body.name} (namespace: ${flags.namespace}, ${String(body.steps.length)} steps, ${String(body.transitions.length)} transitions, ${String(body.triggers.length)} triggers)`,
+      );
+    }
+    return 0;
+  }
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    const result = await mediforce.workflows.register(body, {
+      namespace: flags.namespace,
+    });
+    if (jsonMode) {
+      printJson(input.output, result);
+    } else {
+      input.output.stdout(
+        `Registered ${result.name} v${String(result.version)} (namespace: ${flags.namespace})`,
+      );
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(
+        input.output,
+        { error: err.message, status: err.status, body: err.body },
+        jsonMode,
+      );
+    } else {
+      printError(input.output, { error: String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolves the runtime config for every CLI invocation.
+ *
+ * Precedence:
+ *   - apiKey:  MEDIFORCE_API_KEY > PLATFORM_API_KEY (env only — not configurable via flag)
+ *   - baseUrl: --base-url flag > MEDIFORCE_BASE_URL env > DEFAULT_BASE_URL
+ *
+ * Pure function — pass `env` and `flagBaseUrl` explicitly so tests don't need
+ * to mutate `process.env`.
+ */
+
+export const DEFAULT_BASE_URL = 'http://localhost:9003';
+
+export interface ResolvedConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+export interface ResolveConfigInput {
+  flagBaseUrl?: string | undefined;
+  env: Record<string, string | undefined>;
+}
+
+export function resolveApiKey(env: Record<string, string | undefined>): string {
+  const fromMediforce = env['MEDIFORCE_API_KEY'];
+  if (typeof fromMediforce === 'string' && fromMediforce.length > 0) {
+    return fromMediforce;
+  }
+  const fromPlatform = env['PLATFORM_API_KEY'];
+  if (typeof fromPlatform === 'string' && fromPlatform.length > 0) {
+    return fromPlatform;
+  }
+  throw new Error(
+    'mediforce: missing API key. Set MEDIFORCE_API_KEY (or PLATFORM_API_KEY).',
+  );
+}
+
+export function resolveBaseUrl(input: ResolveConfigInput): string {
+  if (typeof input.flagBaseUrl === 'string' && input.flagBaseUrl.length > 0) {
+    return input.flagBaseUrl;
+  }
+  const fromEnv = input.env['MEDIFORCE_BASE_URL'];
+  if (typeof fromEnv === 'string' && fromEnv.length > 0) {
+    return fromEnv;
+  }
+  return DEFAULT_BASE_URL;
+}
+
+export function resolveConfig(input: ResolveConfigInput): ResolvedConfig {
+  return {
+    apiKey: resolveApiKey(input.env),
+    baseUrl: resolveBaseUrl(input),
+  };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,9 @@
+export { runCli, type RunCliInput } from './cli.js';
+export {
+  resolveConfig,
+  resolveApiKey,
+  resolveBaseUrl,
+  DEFAULT_BASE_URL,
+  type ResolvedConfig,
+  type ResolveConfigInput,
+} from './config.js';

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -29,6 +29,29 @@ export function printJson(sink: OutputSink, payload: unknown): void {
   sink.stdout(JSON.stringify(payload, null, 2));
 }
 
+/**
+ * Stream contract — load-bearing, do not change without updating tests:
+ *
+ *   --json mode:  error payload is written to STDOUT (single channel for
+ *                 machine consumers; pipe `... | jq` works for both
+ *                 success and error responses without flag-juggling).
+ *   human mode:   error message is written to STDERR (success output stays
+ *                 on stdout uncluttered, so `cmd > out.txt` only captures
+ *                 success and `cmd 2> err.log` only captures errors).
+ *
+ * The regression tests in `__tests__/output.test.ts` and the per-command
+ * tests in `__tests__/run-get.test.ts` and
+ * `__tests__/workflow-register.test.ts` lock this behaviour in. The
+ * top-level `mediforce --help` text also documents this contract under
+ * the "Output streams" section so consumers don't have to read code.
+ *
+ * Rationale:
+ *   - JSON mode: a single output channel is what `jq`, log shippers, and
+ *     CI parsers expect. Splitting JSON across stdout/stderr breaks them.
+ *   - Human mode: separating diagnostics from data lets shell users
+ *     compose commands (`cmd | next-tool`) without errors corrupting
+ *     the pipe.
+ */
 export function printError(
   sink: OutputSink,
   payload: ErrorPayload,

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,44 @@
+/**
+ * Output helpers — split human-readable vs JSON modes.
+ *
+ * Each command takes a `--json` flag. When set, the command emits a single
+ * JSON object to stdout and nothing else. When unset, it emits human-friendly
+ * lines to stderr (status/progress) and stdout (data only when relevant).
+ *
+ * Errors always go through `printError` — JSON mode emits the structured
+ * shape, human mode prints a plain message.
+ */
+
+export interface OutputSink {
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+}
+
+export const consoleOutput: OutputSink = {
+  stdout: (line) => process.stdout.write(`${line}\n`),
+  stderr: (line) => process.stderr.write(`${line}\n`),
+};
+
+export interface ErrorPayload {
+  error: string;
+  status?: number;
+  body?: unknown;
+}
+
+export function printJson(sink: OutputSink, payload: unknown): void {
+  sink.stdout(JSON.stringify(payload, null, 2));
+}
+
+export function printError(
+  sink: OutputSink,
+  payload: ErrorPayload,
+  jsonMode: boolean,
+): void {
+  if (jsonMode) {
+    sink.stdout(JSON.stringify(payload, null, 2));
+    return;
+  }
+  const suffix =
+    payload.status !== undefined ? ` (HTTP ${String(payload.status)})` : '';
+  sink.stderr(`Error${suffix}: ${payload.error}`);
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    conditions: ['@mediforce/source'],
+    alias: {
+      '@mediforce/platform-core/testing': path.resolve(
+        __dirname,
+        '../platform-core/src/testing/index.ts',
+      ),
+      '@mediforce/platform-core': path.resolve(
+        __dirname,
+        '../platform-core/src/index.ts',
+      ),
+      '@mediforce/platform-api/contract': path.resolve(
+        __dirname,
+        '../platform-api/src/contract/index.ts',
+      ),
+      '@mediforce/platform-api/client': path.resolve(
+        __dirname,
+        '../platform-api/src/client/index.ts',
+      ),
+      '@mediforce/platform-api': path.resolve(
+        __dirname,
+        '../platform-api/src/index.ts',
+      ),
+    },
+  },
+});

--- a/packages/platform-api/src/client/__tests__/runs.test.ts
+++ b/packages/platform-api/src/client/__tests__/runs.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Mediforce, ApiError } from '../index.js';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const TEST_BASE_URL = 'http://localhost';
+
+/**
+ * NOTE: GET /api/runs/<runId> ships on the n8n-migrator branch and is not
+ * yet on `main`. Tests run against a fetch loopback only; smoke against a
+ * live server unblocks once the endpoint merges.
+ */
+
+describe('mediforce.runs.get', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /api/runs/<runId> and validates the response', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        runId: 'run-123',
+        status: 'completed',
+        currentStepId: 'final',
+        error: null,
+        finalOutput: { ok: true },
+      }),
+    );
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    const result = await mediforce.runs.get({ runId: 'run-123' });
+
+    expect(result.runId).toBe('run-123');
+    expect(result.status).toBe('completed');
+    expect(result.finalOutput).toEqual({ ok: true });
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://localhost/api/runs/run-123');
+  });
+
+  it('URL-encodes runIds with reserved characters', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        runId: 'a/b c',
+        status: 'running',
+        currentStepId: null,
+        error: null,
+        finalOutput: null,
+      }),
+    );
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    await mediforce.runs.get({ runId: 'a/b c' });
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://localhost/api/runs/a%2Fb%20c');
+  });
+
+  it('rejects an empty runId before firing a request', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+
+    await expect(mediforce.runs.get({ runId: '' })).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws ApiError on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Run not found' }, 404),
+    );
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    const error = await mediforce.runs.get({ runId: 'nope' }).catch((err) => err);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(404);
+  });
+});

--- a/packages/platform-api/src/client/__tests__/workflows.test.ts
+++ b/packages/platform-api/src/client/__tests__/workflows.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Mediforce, ApiError } from '../index.js';
 import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+import { omitServerFields } from '../../contract/__tests__/_helpers.js';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -23,10 +24,7 @@ describe('mediforce.workflows.register', () => {
 
     const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
     const wd = buildWorkflowDefinition({ name: 'wf' });
-    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
-    void _v;
-    void _n;
-    void _c;
+    const body = omitServerFields(wd);
 
     const result = await mediforce.workflows.register(body, { namespace: 'Appsilon' });
 
@@ -44,10 +42,7 @@ describe('mediforce.workflows.register', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
     const wd = buildWorkflowDefinition();
-    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
-    void _v;
-    void _n;
-    void _c;
+    const body = omitServerFields(wd);
 
     await expect(
       mediforce.workflows.register(body, { namespace: '' }),
@@ -76,10 +71,7 @@ describe('mediforce.workflows.register', () => {
 
     const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
     const wd = buildWorkflowDefinition();
-    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
-    void _v;
-    void _n;
-    void _c;
+    const body = omitServerFields(wd);
 
     const error = await mediforce.workflows
       .register(body, { namespace: 'Appsilon' })

--- a/packages/platform-api/src/client/__tests__/workflows.test.ts
+++ b/packages/platform-api/src/client/__tests__/workflows.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Mediforce, ApiError } from '../index.js';
+import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const TEST_BASE_URL = 'http://localhost';
+
+describe('mediforce.workflows.register', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs JSON body to /api/workflow-definitions with namespace query', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ success: true, name: 'wf', version: 1 }, 201));
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    const wd = buildWorkflowDefinition({ name: 'wf' });
+    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
+    void _v;
+    void _n;
+    void _c;
+
+    const result = await mediforce.workflows.register(body, { namespace: 'Appsilon' });
+
+    expect(result).toEqual({ success: true, name: 'wf', version: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('http://localhost/api/workflow-definitions?namespace=Appsilon');
+    expect(init?.method).toBe('POST');
+    expect(new Headers(init?.headers).get('Content-Type')).toBe('application/json');
+    expect(new Headers(init?.headers).get('X-Api-Key')).toBe('k');
+    expect(init?.body).toBe(JSON.stringify(body));
+  });
+
+  it('rejects when namespace is empty', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    const wd = buildWorkflowDefinition();
+    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
+    void _v;
+    void _n;
+    void _c;
+
+    await expect(
+      mediforce.workflows.register(body, { namespace: '' }),
+    ).rejects.toThrow(/namespace.*required/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed input before calling fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+
+    await expect(
+      mediforce.workflows.register(
+        // Missing required fields like steps/transitions/triggers.
+        { name: 'wf' } as never,
+        { namespace: 'Appsilon' },
+      ),
+    ).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws ApiError on non-2xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Validation failed' }, 400),
+    );
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    const wd = buildWorkflowDefinition();
+    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
+    void _v;
+    void _n;
+    void _c;
+
+    const error = await mediforce.workflows
+      .register(body, { namespace: 'Appsilon' })
+      .catch((err) => err);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).status).toBe(400);
+  });
+});
+
+describe('mediforce.workflows.list', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /api/workflow-definitions and returns the parsed list', async () => {
+    const wd = buildWorkflowDefinition({ name: 'wf', version: 2 });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        definitions: [
+          {
+            name: wd.name,
+            latestVersion: 2,
+            defaultVersion: 1,
+            definition: wd,
+          },
+        ],
+      }),
+    );
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    const result = await mediforce.workflows.list();
+
+    expect(result.definitions).toHaveLength(1);
+    expect(result.definitions[0]?.name).toBe('wf');
+    expect(result.definitions[0]?.latestVersion).toBe(2);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      'http://localhost/api/workflow-definitions',
+    );
+  });
+
+  it('rejects when the server returns a malformed payload', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ definitions: [{ name: 'wf' /* missing latestVersion */ }] }),
+    );
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    await expect(mediforce.workflows.list()).rejects.toThrow();
+  });
+});

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -1,8 +1,19 @@
 import {
   ListTasksInputSchema,
   ListTasksOutputSchema,
+  RegisterWorkflowInputSchema,
+  RegisterWorkflowOutputSchema,
+  ListWorkflowsOutputSchema,
+  GetRunInputSchema,
+  GetRunOutputSchema,
   type ListTasksInput,
   type ListTasksOutput,
+  type RegisterWorkflowInput,
+  type RegisterWorkflowOutput,
+  type RegisterWorkflowOptions,
+  type ListWorkflowsOutput,
+  type GetRunInput,
+  type GetRunOutput,
 } from '../contract/index.js';
 
 /**
@@ -64,6 +75,18 @@ export class Mediforce {
     list: (input: ListTasksInput) => Promise<ListTasksOutput>;
   };
 
+  readonly workflows: {
+    register: (
+      input: RegisterWorkflowInput,
+      options: RegisterWorkflowOptions,
+    ) => Promise<RegisterWorkflowOutput>;
+    list: () => Promise<ListWorkflowsOutput>;
+  };
+
+  readonly runs: {
+    get: (input: GetRunInput) => Promise<GetRunOutput>;
+  };
+
   constructor(private readonly config: ClientConfig) {
     // Defense-in-depth against JS callers / bad casts that bypass the
     // discriminated union (e.g. `new Mediforce()` with no argument, which the
@@ -111,6 +134,42 @@ export class Mediforce {
         const res = await this.request(`/api/tasks${qs}`);
         const body = await parseJsonOrThrow(res, 'mediforce.tasks.list');
         return ListTasksOutputSchema.parse(body);
+      },
+    };
+
+    this.workflows = {
+      register: async (input, options) => {
+        const validatedInput = RegisterWorkflowInputSchema.parse(input);
+        const namespace = options.namespace;
+        if (typeof namespace !== 'string' || namespace.length === 0) {
+          throw new Error(
+            'mediforce.workflows.register: `namespace` is required (passed as an HTTP query parameter).',
+          );
+        }
+        const qs = toSearchParams({ namespace });
+        const res = await this.request(`/api/workflow-definitions${qs}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(validatedInput),
+        });
+        const body = await parseJsonOrThrow(res, 'mediforce.workflows.register');
+        return RegisterWorkflowOutputSchema.parse(body);
+      },
+      list: async () => {
+        const res = await this.request('/api/workflow-definitions');
+        const body = await parseJsonOrThrow(res, 'mediforce.workflows.list');
+        return ListWorkflowsOutputSchema.parse(body);
+      },
+    };
+
+    this.runs = {
+      get: async (input) => {
+        const validated = GetRunInputSchema.parse(input);
+        const res = await this.request(
+          `/api/runs/${encodeURIComponent(validated.runId)}`,
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.runs.get');
+        return GetRunOutputSchema.parse(body);
       },
     };
   }

--- a/packages/platform-api/src/contract/__tests__/_helpers.ts
+++ b/packages/platform-api/src/contract/__tests__/_helpers.ts
@@ -1,0 +1,24 @@
+import type { WorkflowDefinition } from '@mediforce/platform-core';
+
+/**
+ * Strip the server-managed fields (`version`, `namespace`, `createdAt`) from a
+ * `WorkflowDefinition` to produce the body shape that
+ * `RegisterWorkflowInputSchema` accepts on the wire.
+ *
+ * The server fills these three fields in itself: `version` from
+ * auto-increment, `namespace` from the query param, `createdAt` stamped at
+ * write time. Tests that build a full `WorkflowDefinition` (e.g. via
+ * `buildWorkflowDefinition`) and want to send it through the register path
+ * must omit them first.
+ *
+ * Lives in a tests-only file so production code never imports it.
+ */
+export function omitServerFields(
+  wd: WorkflowDefinition,
+): Omit<WorkflowDefinition, 'version' | 'namespace' | 'createdAt'> {
+  const { version: _version, namespace: _namespace, createdAt: _createdAt, ...body } = wd;
+  void _version;
+  void _namespace;
+  void _createdAt;
+  return body;
+}

--- a/packages/platform-api/src/contract/__tests__/runs.test.ts
+++ b/packages/platform-api/src/contract/__tests__/runs.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { GetRunInputSchema, GetRunOutputSchema } from '../runs.js';
+
+describe('GetRunInputSchema', () => {
+  it('accepts a non-empty runId', () => {
+    const result = GetRunInputSchema.safeParse({ runId: 'run-1' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty runId', () => {
+    const result = GetRunInputSchema.safeParse({ runId: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('GetRunOutputSchema', () => {
+  it('accepts a fully populated terminal run', () => {
+    const result = GetRunOutputSchema.safeParse({
+      runId: 'run-1',
+      status: 'completed',
+      currentStepId: 'last-step',
+      error: null,
+      finalOutput: { ok: true },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a still-running response with null finalOutput', () => {
+    const result = GetRunOutputSchema.safeParse({
+      runId: 'run-2',
+      status: 'running',
+      currentStepId: 'step-3',
+      error: null,
+      finalOutput: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a failed run with an error message', () => {
+    const result = GetRunOutputSchema.safeParse({
+      runId: 'run-3',
+      status: 'failed',
+      currentStepId: null,
+      error: 'boom',
+      finalOutput: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown status', () => {
+    const result = GetRunOutputSchema.safeParse({
+      runId: 'run-4',
+      status: 'magicked',
+      currentStepId: null,
+      error: null,
+      finalOutput: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing runId', () => {
+    const result = GetRunOutputSchema.safeParse({
+      status: 'running',
+      currentStepId: null,
+      error: null,
+      finalOutput: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/platform-api/src/contract/__tests__/workflows.test.ts
+++ b/packages/platform-api/src/contract/__tests__/workflows.test.ts
@@ -5,14 +5,12 @@ import {
   RegisterWorkflowOutputSchema,
   ListWorkflowsOutputSchema,
 } from '../workflows.js';
+import { omitServerFields } from './_helpers.js';
 
 describe('RegisterWorkflowInputSchema', () => {
   it('accepts a workflow definition body without version, createdAt, or namespace', () => {
     const wd = buildWorkflowDefinition();
-    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
-    void _v;
-    void _n;
-    void _c;
+    const body = omitServerFields(wd);
     const result = RegisterWorkflowInputSchema.safeParse(body);
     expect(result.success).toBe(true);
   });

--- a/packages/platform-api/src/contract/__tests__/workflows.test.ts
+++ b/packages/platform-api/src/contract/__tests__/workflows.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+import {
+  RegisterWorkflowInputSchema,
+  RegisterWorkflowOutputSchema,
+  ListWorkflowsOutputSchema,
+} from '../workflows.js';
+
+describe('RegisterWorkflowInputSchema', () => {
+  it('accepts a workflow definition body without version, createdAt, or namespace', () => {
+    const wd = buildWorkflowDefinition();
+    const { version: _v, namespace: _n, createdAt: _c, ...body } = wd;
+    void _v;
+    void _n;
+    void _c;
+    const result = RegisterWorkflowInputSchema.safeParse(body);
+    expect(result.success).toBe(true);
+  });
+
+  it('strips the server-managed version field on parse (omit drops the key)', () => {
+    const wd = buildWorkflowDefinition();
+    const { namespace: _n, createdAt: _c, ...body } = wd;
+    void _n;
+    void _c;
+    const result = RegisterWorkflowInputSchema.safeParse(body);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Documents the wire contract — version is server-managed, never client-supplied.
+      expect((result.data as Record<string, unknown>).version).toBeUndefined();
+    }
+  });
+
+  it('rejects a body missing required fields', () => {
+    const result = RegisterWorkflowInputSchema.safeParse({ name: 'wf' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('RegisterWorkflowOutputSchema', () => {
+  it('accepts the documented success response', () => {
+    const result = RegisterWorkflowOutputSchema.safeParse({
+      success: true,
+      name: 'wf',
+      version: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-true success literal', () => {
+    const result = RegisterWorkflowOutputSchema.safeParse({
+      success: false,
+      name: 'wf',
+      version: 3,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-positive version', () => {
+    const result = RegisterWorkflowOutputSchema.safeParse({
+      success: true,
+      name: 'wf',
+      version: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ListWorkflowsOutputSchema', () => {
+  it('accepts an empty list', () => {
+    const result = ListWorkflowsOutputSchema.safeParse({ definitions: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a populated group with the latest definition embedded', () => {
+    const wd = buildWorkflowDefinition({ version: 2 });
+    const result = ListWorkflowsOutputSchema.safeParse({
+      definitions: [
+        {
+          name: wd.name,
+          latestVersion: 2,
+          defaultVersion: 1,
+          definition: wd,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a group whose latest definition is null (pruned/missing)', () => {
+    const result = ListWorkflowsOutputSchema.safeParse({
+      definitions: [
+        {
+          name: 'wf',
+          latestVersion: 1,
+          defaultVersion: null,
+          definition: null,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -4,3 +4,22 @@ export {
   type ListTasksInput,
   type ListTasksOutput,
 } from './tasks.js';
+
+export {
+  RegisterWorkflowInputSchema,
+  RegisterWorkflowOutputSchema,
+  WorkflowDefinitionGroupSchema,
+  ListWorkflowsOutputSchema,
+  type RegisterWorkflowInput,
+  type RegisterWorkflowOutput,
+  type RegisterWorkflowOptions,
+  type WorkflowDefinitionGroupSummary,
+  type ListWorkflowsOutput,
+} from './workflows.js';
+
+export {
+  GetRunInputSchema,
+  GetRunOutputSchema,
+  type GetRunInput,
+  type GetRunOutput,
+} from './runs.js';

--- a/packages/platform-api/src/contract/runs.ts
+++ b/packages/platform-api/src/contract/runs.ts
@@ -4,15 +4,21 @@ import { InstanceStatusSchema } from '@mediforce/platform-core';
 /**
  * Contract for `GET /api/runs/<runId>`.
  *
- * NOTE — cross-branch concern: the live endpoint that serves this shape
- * (`packages/platform-ui/src/app/api/runs/[runId]/route.ts`) lives on the
- * `n8n-migrator` branch and is not yet merged to `main`. The schema below
- * is written to the spec so the CLI and SDK can ship today; once the
- * endpoint lands on `main`, the wire shape will already match.
+ * TODO — cross-branch coupling (spike #9, n8n-migrator):
  *
- * Until then the SDK method is exercised via fetch loopback in tests, with
- * no real-server smoke. After the endpoint merges this comment can be
- * dropped without any code change.
+ *   Source of truth for the wire shape this schema mirrors:
+ *     `packages/platform-ui/src/app/api/runs/[runId]/route.ts`
+ *   That route currently lives on the `n8n-migrator` branch and has not
+ *   yet been raised as a PR against `main` (status: not yet PR'd).
+ *
+ *   After spike #9 lands on `main`, run `mediforce run get <id>` against
+ *   the deployed `/api/runs/<id>` endpoint and confirm shape parity end
+ *   to end (runId, status, currentStepId, error, finalOutput). Adjust
+ *   either the schema below or the route handler if drift is found.
+ *
+ *   Until then, this contract is unverified at runtime — the SDK method
+ *   and CLI command are only exercised via fetch loopback in unit tests.
+ *   No CI guard for MVP; remove this TODO block once smoke succeeds.
  */
 
 export const GetRunInputSchema = z.object({

--- a/packages/platform-api/src/contract/runs.ts
+++ b/packages/platform-api/src/contract/runs.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { InstanceStatusSchema } from '@mediforce/platform-core';
+
+/**
+ * Contract for `GET /api/runs/<runId>`.
+ *
+ * NOTE — cross-branch concern: the live endpoint that serves this shape
+ * (`packages/platform-ui/src/app/api/runs/[runId]/route.ts`) lives on the
+ * `n8n-migrator` branch and is not yet merged to `main`. The schema below
+ * is written to the spec so the CLI and SDK can ship today; once the
+ * endpoint lands on `main`, the wire shape will already match.
+ *
+ * Until then the SDK method is exercised via fetch loopback in tests, with
+ * no real-server smoke. After the endpoint merges this comment can be
+ * dropped without any code change.
+ */
+
+export const GetRunInputSchema = z.object({
+  runId: z.string().min(1),
+});
+
+export const GetRunOutputSchema = z.object({
+  runId: z.string().min(1),
+  status: InstanceStatusSchema,
+  currentStepId: z.string().nullable(),
+  error: z.string().nullable(),
+  finalOutput: z.unknown(),
+});
+
+export type GetRunInput = z.infer<typeof GetRunInputSchema>;
+export type GetRunOutput = z.infer<typeof GetRunOutputSchema>;

--- a/packages/platform-api/src/contract/workflows.ts
+++ b/packages/platform-api/src/contract/workflows.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import {
+  WorkflowDefinitionBaseSchema,
+  WorkflowDefinitionSchema,
+} from '@mediforce/platform-core';
+
+/**
+ * Contract for `POST /api/workflow-definitions?namespace=<ns>` and
+ * `GET /api/workflow-definitions`.
+ *
+ * Register flow: client sends a workflow definition body without `version`,
+ * `createdAt`, or `namespace` (those are set server-side: `version` is
+ * auto-incremented, `createdAt` is stamped, `namespace` is taken from the
+ * required `namespace` query parameter and overrides any value in the body).
+ *
+ * The List output mirrors the shape returned by GET /api/workflow-definitions
+ * in `packages/platform-ui/src/app/api/workflow-definitions/route.ts`: one
+ * entry per workflow name, with `latestVersion`, `defaultVersion`, and the
+ * latest version's full definition (or null if the latest version has been
+ * pruned).
+ */
+
+export const RegisterWorkflowInputSchema = WorkflowDefinitionBaseSchema.omit({
+  version: true,
+  createdAt: true,
+  namespace: true,
+});
+
+export const RegisterWorkflowOutputSchema = z.object({
+  success: z.literal(true),
+  name: z.string().min(1),
+  version: z.number().int().positive(),
+});
+
+export const WorkflowDefinitionGroupSchema = z.object({
+  name: z.string().min(1),
+  latestVersion: z.number().int().positive(),
+  defaultVersion: z.number().int().positive().nullable(),
+  definition: WorkflowDefinitionSchema.nullable(),
+});
+
+export const ListWorkflowsOutputSchema = z.object({
+  definitions: z.array(WorkflowDefinitionGroupSchema),
+});
+
+export type RegisterWorkflowInput = z.infer<typeof RegisterWorkflowInputSchema>;
+export type RegisterWorkflowOutput = z.infer<typeof RegisterWorkflowOutputSchema>;
+export type WorkflowDefinitionGroupSummary = z.infer<typeof WorkflowDefinitionGroupSchema>;
+export type ListWorkflowsOutput = z.infer<typeof ListWorkflowsOutputSchema>;
+
+/**
+ * Options for `mediforce.workflows.register()`. Namespace is a required
+ * query parameter on the wire — modeled here as a separate options arg
+ * (not part of the body input) to mirror the HTTP shape exactly.
+ */
+export interface RegisterWorkflowOptions {
+  namespace: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
 
   .:
     devDependencies:
+      '@mediforce/cli':
+        specifier: workspace:*
+        version: link:packages/cli
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -102,6 +105,28 @@ importers:
       '@mediforce/agent-queue':
         specifier: workspace:*
         version: link:../agent-queue
+
+  packages/cli:
+    dependencies:
+      '@mediforce/platform-api':
+        specifier: workspace:*
+        version: link:../platform-api
+      '@mediforce/platform-core':
+        specifier: workspace:*
+        version: link:../platform-core
+      tsx:
+        specifier: latest
+        version: 4.21.0
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/example-agent:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
         specifier: workspace:*
         version: link:../platform-core
       tsx:
-        specifier: latest
+        specifier: ^4.21.0
         version: 4.21.0
       zod:
         specifier: ^4.0.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     { "path": "packages/agent-queue" },
     { "path": "packages/platform-api" },
     { "path": "packages/platform-ui" },
-    { "path": "packages/mcp-client" }
+    { "path": "packages/mcp-client" },
+    { "path": "packages/cli" }
   ]
 }


### PR DESCRIPTION
## Summary

- First MVP of `mediforce` CLI — typed wrapper on the Mediforce REST API
- Extends `@mediforce/platform-api` contract + client SDK with `workflows.{register,list}` and `runs.get`
- New `@mediforce/cli` workspace package, binary `mediforce` (built via `pnpm --filter @mediforce/cli build`)

## Commands shipped

- `mediforce workflow register --file <path> --namespace <ns> [--base-url <url>] [--dry-run] [--json]`
- `mediforce workflow list [--base-url <url>] [--json]`
- `mediforce run get <runId> [--base-url <url>] [--json]`

## Auth + base URL

- `MEDIFORCE_API_KEY` (or `PLATFORM_API_KEY`) env required
- `--base-url` flag > `MEDIFORCE_BASE_URL` env > default `http://localhost:9003`

## Out of scope (next iterations)

- `run start <workflow>` (manual trigger)
- `workflow show <name>` / `workflow delete`
- Firebase login flow (`bearerToken` already in SDK for browser callers)
- npm publish

## Notes for reviewers

- The `runs.get` contract was written to the shape produced by spike #9's `/api/runs/<runId>` route, currently on branch `n8n-migrator` (not yet merged). After spike #9 lands, the live smoke unblocks with no code change here.
- Bin resolution required two workarounds, both noted inline in `bin/mediforce.cjs`: `--conditions=@mediforce/source` is passed via `NODE_OPTIONS` (tsx swallowed it as argv), and `@mediforce/cli` is added as a root `devDependency` so `pnpm exec mediforce` resolves the bin.

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm test` — all packages green (platform-api: 73, cli: 32, full repo: 1732+)
- [ ] `pnpm exec mediforce --help` prints command list
- [ ] `pnpm exec mediforce workflow list --json` returns JSON-shaped output / clean error
- [ ] `pnpm exec mediforce run get bogus-id --json` exits non-zero with JSON error

🤖 Generated with [Claude Code](https://claude.com/claude-code)