### PR TITLE
feat(ui): repository tab on workflow page

### DIFF
--- a/packages/platform-ui/e2e/journeys/workflow-repository-ui.journey.ts
+++ b/packages/platform-ui/e2e/journeys/workflow-repository-ui.journey.ts
@@ -1,0 +1,103 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { test, expect } from '../helpers/test-fixtures';
+import { TEST_ORG_HANDLE } from '../helpers/constants';
+import { setupRecording, click, showStep, showResult, endRecording } from '../helpers/recording';
+
+/** Read PLATFORM_API_KEY from the dev server's `.env.local` so the test stays in sync
+ *  with whatever the running webServer is using — bootstrap_e2e.py is idempotent and
+ *  preserves an existing key, so falling back to a hard-coded `test-api-key` would 401. */
+function resolveApiKey(): string {
+  const fromEnv = process.env.PLATFORM_API_KEY;
+  if (fromEnv && fromEnv.trim() !== '') return fromEnv;
+  try {
+    const envPath = path.resolve(__dirname, '..', '..', '.env.local');
+    const raw = fs.readFileSync(envPath, 'utf8');
+    const match = raw.match(/^PLATFORM_API_KEY=(.*)$/m);
+    if (match && match[1]) return match[1].trim();
+  } catch { /* fall through */ }
+  return 'test-api-key';
+}
+
+/**
+ * UI journey for the Repository tab on the workflow detail page.
+ *
+ * Verifies the click-through edit path: Repository tab → fill Remote → Save →
+ * a new WD version is written with the workspace config persisted in Firestore.
+ *
+ * Asserts persistence via the platform API (X-Api-Key) — the same source of truth
+ * the runtime reads at run start.
+ */
+test.describe('Workflow Repository UI journey', () => {
+  const apiKey = resolveApiKey();
+  const authHeaders = { 'X-Api-Key': apiKey };
+
+  test('Repository tab persists workspace.remote as a new WD version', async ({ page, request }, testInfo) => {
+    await setupRecording(page, 'workflow-repository-ui', testInfo);
+
+    // 1. Seed a fresh WD without workspace via the API
+    const uniqueName = `ui-repository-${Date.now()}`;
+    const seedRes = await request.post(
+      `/api/workflow-definitions?namespace=${TEST_ORG_HANDLE}`,
+      {
+        headers: authHeaders,
+        data: {
+          name: uniqueName,
+          description: 'UI journey test — repository tab',
+          steps: [
+            { id: 'noop', name: 'No-op', type: 'creation', executor: 'human' },
+          ],
+          transitions: [],
+          triggers: [{ type: 'manual', name: 'start' }],
+        },
+      },
+    );
+    expect(seedRes.status(), await seedRes.text()).toBe(201);
+    const seeded = await seedRes.json();
+    expect(seeded.version).toBe(1);
+
+    // 2. Navigate to the workflow detail page and switch to Repository tab
+    await page.goto(`/${TEST_ORG_HANDLE}/workflows/${encodeURIComponent(uniqueName)}`);
+
+    const repositoryTab = page.getByRole('tab', { name: /repository/i });
+    await expect(repositoryTab).toBeVisible({ timeout: 10_000 });
+    await click(page, repositoryTab);
+    await showStep(page);
+
+    // 3. Fill the Remote field
+    const remoteInput = page.getByLabel(/^remote$/i);
+    await expect(remoteInput).toBeVisible({ timeout: 5_000 });
+    const expectedRemote = 'Appsilon/repo-from-ui-journey';
+    await remoteInput.fill(expectedRemote);
+    await showStep(page);
+
+    // 4. Save → button is enabled while dirty + valid
+    const saveButton = page.getByRole('button', { name: /save \(new version\)/i });
+    await expect(saveButton).toBeEnabled();
+    await click(page, saveButton);
+
+    // 5. Success message confirms a new version was written
+    await expect(page.getByText(/saved as version 2/i)).toBeVisible({ timeout: 10_000 });
+    await showResult(page);
+
+    // 6. Verify Firestore (via API) — listing returns the latest version per WD
+    const listRes = await request.get('/api/workflow-definitions', { headers: authHeaders });
+    expect(listRes.ok(), await listRes.text()).toBe(true);
+    const list = (await listRes.json()) as {
+      definitions: Array<{
+        name: string;
+        latestVersion: number;
+        defaultVersion?: number | null;
+        definition: { workspace?: unknown } | null;
+      }>;
+    };
+    const entry = list.definitions.find((d) => d.name === uniqueName);
+    expect(entry, `WD ${uniqueName} should be in the list`).toBeDefined();
+    expect(entry!.latestVersion).toBe(2);
+    expect(entry!.defaultVersion).toBe(2);
+    expect(entry!.definition).not.toBeNull();
+    expect(entry!.definition!.workspace).toEqual({ remote: expectedRemote });
+
+    await endRecording(page);
+  });
+});

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/auth-context';
 import { useAllUserNamespaces } from '@/hooks/use-all-user-namespaces';
 import { WorkflowSecretsEditor } from '@/components/workflows/workflow-secrets-editor';
+import { WorkflowRepositoryEditor } from '@/components/workflows/workflow-repository-editor';
 
 
 export default function ProcessDefinitionPage() {
@@ -219,7 +220,7 @@ export default function ProcessDefinitionPage() {
       {/* Tabs */}
       <Tabs.Root defaultValue="runs" className="flex flex-1 flex-col">
         <Tabs.List className="flex border-b px-6 gap-0">
-          {['runs', 'definitions', 'secrets'].map((tab) => (
+          {['runs', 'definitions', 'repository', 'secrets'].map((tab) => (
             <Tabs.Trigger
               key={tab}
               value={tab}
@@ -228,14 +229,16 @@ export default function ProcessDefinitionPage() {
                 'text-muted-foreground border-transparent',
                 'data-[state=active]:text-foreground data-[state=active]:border-primary',
                 'hover:text-foreground',
-                tab === 'secrets' && 'flex items-center gap-1.5',
+                (tab === 'secrets' || tab === 'repository') && 'flex items-center gap-1.5',
               )}
             >
               {tab === 'runs'
                 ? `Runs${runs.length > 0 ? ` (${runs.length})` : ''}`
                 : tab === 'secrets'
                   ? <><KeyRound className="h-3.5 w-3.5" />Secrets</>
-                  : 'Definitions'}
+                  : tab === 'repository'
+                    ? <><GitBranch className="h-3.5 w-3.5" />Repository</>
+                    : 'Definitions'}
             </Tabs.Trigger>
           ))}
         </Tabs.List>
@@ -278,6 +281,33 @@ export default function ProcessDefinitionPage() {
         <Tabs.Content value="definitions" className="flex-1 p-6">
           <div className="max-w-2xl">
             <DefinitionsList workflowName={decodedName} />
+          </div>
+        </Tabs.Content>
+
+        {/* Repository tab */}
+        <Tabs.Content value="repository" className="flex-1 p-6">
+          <div className="max-w-2xl">
+            {firebaseUser && latest && (() => {
+              const latestVersionNumber = Number(latest.version);
+              if (!Number.isFinite(latestVersionNumber)) {
+                return (
+                  <p className="text-sm text-muted-foreground">
+                    Repository config is only available for unified workflow definitions. The latest version of this workflow uses the legacy schema.
+                  </p>
+                );
+              }
+              const ws = (latest as { workspace?: { remote?: string; remoteAuth?: string } }).workspace;
+              return (
+                <WorkflowRepositoryEditor
+                  namespace={handle}
+                  workflowName={decodedName}
+                  userId={firebaseUser.uid}
+                  initialRemote={ws?.remote}
+                  initialRemoteAuth={ws?.remoteAuth}
+                  latestVersion={latestVersionNumber}
+                />
+              );
+            })()}
           </div>
         </Tabs.Content>
 

--- a/packages/platform-ui/src/app/actions/definitions.ts
+++ b/packages/platform-ui/src/app/actions/definitions.ts
@@ -147,6 +147,61 @@ export async function saveWorkflowDefinition(
 }
 
 // ---------------------------------------------------------------------------
+// Workflow repository (workspace.remote / workspace.remoteAuth)
+// ---------------------------------------------------------------------------
+
+export type SaveWorkflowRepositoryResult =
+  | { success: true; name: string; version: number }
+  | { success: false; error: string };
+
+export async function saveWorkflowRepository(
+  name: string,
+  workspace: { remote?: string; remoteAuth?: string },
+): Promise<SaveWorkflowRepositoryResult> {
+  if (!name.trim()) return { success: false, error: 'Workflow name is required.' };
+
+  const { processRepo } = getPlatformServices();
+
+  try {
+    const latestVersion = await processRepo.getLatestWorkflowVersion(name);
+    if (latestVersion === 0) {
+      return { success: false, error: `Workflow "${name}" not found or has no versions yet.` };
+    }
+    const latest = await processRepo.getWorkflowDefinition(name, latestVersion);
+    if (!latest) {
+      return { success: false, error: `Latest version ${latestVersion} of "${name}" not found.` };
+    }
+
+    const cleanedWorkspace: { remote?: string; remoteAuth?: string } = {};
+    const remote = workspace.remote?.trim();
+    const remoteAuth = workspace.remoteAuth?.trim();
+    if (remote) cleanedWorkspace.remote = remote;
+    if (remoteAuth) cleanedWorkspace.remoteAuth = remoteAuth;
+
+    const { version: _v, createdAt: _c, ...rest } = latest as WorkflowDefinition & {
+      createdAt?: string;
+    };
+
+    const input: Record<string, unknown> = { ...rest };
+    if (Object.keys(cleanedWorkspace).length > 0) {
+      input.workspace = cleanedWorkspace;
+    } else {
+      delete input.workspace;
+    }
+    delete (input as Record<string, unknown>).id;
+
+    const saved = await saveWorkflowDefinition(input);
+    if (!saved.success) {
+      return { success: false, error: saved.error };
+    }
+    await processRepo.setDefaultWorkflowVersion(name, saved.version);
+    return { success: true, name: saved.name, version: saved.version };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : 'Unknown error' };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Default version
 // ---------------------------------------------------------------------------
 

--- a/packages/platform-ui/src/components/workflows/workflow-repository-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-repository-editor.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import * as React from 'react';
+import { GitBranch, Save, Info, ExternalLink } from 'lucide-react';
+import { saveWorkflowRepository } from '@/app/actions/definitions';
+import { getWorkflowSecretKeys } from '@/app/actions/workflow-secrets';
+
+interface WorkflowRepositoryEditorProps {
+  namespace: string;
+  workflowName: string;
+  userId: string;
+  initialRemote?: string;
+  initialRemoteAuth?: string;
+  /** Latest WD version — shown as the source of these settings, bumped on save. */
+  latestVersion: number;
+}
+
+/** Translate "org/repo" / SSH URL / HTTPS URL into a browsable https://github.com/... link. */
+function toBrowsableUrl(remote: string): string | null {
+  const trimmed = remote.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('https://')) return trimmed.replace(/\.git$/, '');
+  const sshMatch = trimmed.match(/^git@github\.com:(.+?)(?:\.git)?$/);
+  if (sshMatch) return `https://github.com/${sshMatch[1]}`;
+  if (/^[\w.-]+\/[\w.-]+$/.test(trimmed)) return `https://github.com/${trimmed}`;
+  return null;
+}
+
+function isValidRemote(remote: string): boolean {
+  const trimmed = remote.trim();
+  if (trimmed === '') return true; // empty = local-only, valid
+  if (trimmed.startsWith('https://') || trimmed.startsWith('git@')) return true;
+  return /^[\w.-]+\/[\w.-]+$/.test(trimmed);
+}
+
+export function WorkflowRepositoryEditor({
+  namespace,
+  workflowName,
+  userId,
+  initialRemote,
+  initialRemoteAuth,
+  latestVersion,
+}: WorkflowRepositoryEditorProps) {
+  const [remote, setRemote] = React.useState(initialRemote ?? '');
+  const [remoteAuth, setRemoteAuth] = React.useState(initialRemoteAuth ?? '');
+  const [secretKeys, setSecretKeys] = React.useState<string[]>([]);
+  const [saving, setSaving] = React.useState(false);
+  const [message, setMessage] = React.useState<string | null>(null);
+  const [savedVersion, setSavedVersion] = React.useState<number>(latestVersion);
+
+  const initialRemoteRef = React.useRef(initialRemote ?? '');
+  const initialAuthRef = React.useRef(initialRemoteAuth ?? '');
+  const dirty = remote !== initialRemoteRef.current || remoteAuth !== initialAuthRef.current;
+  const remoteValid = isValidRemote(remote);
+  const browsable = toBrowsableUrl(remote);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    getWorkflowSecretKeys(namespace, workflowName, userId)
+      .then((keys) => { if (!cancelled) setSecretKeys(keys); })
+      .catch((err) => { if (!cancelled) console.error('Failed to load secret keys:', err); });
+    return () => { cancelled = true; };
+  }, [namespace, workflowName, userId]);
+
+  const handleSave = async () => {
+    if (!remoteValid) {
+      setMessage('Error: invalid remote format');
+      return;
+    }
+    setSaving(true);
+    setMessage(null);
+    try {
+      const result = await saveWorkflowRepository(workflowName, {
+        remote: remote || undefined,
+        remoteAuth: remoteAuth || undefined,
+      });
+      if (result.success) {
+        initialRemoteRef.current = remote;
+        initialAuthRef.current = remoteAuth;
+        setSavedVersion(result.version);
+        setMessage(`Saved as version ${result.version}`);
+        setTimeout(() => setMessage(null), 4000);
+      } else {
+        setMessage(`Error: ${result.error}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setMessage(`Error: ${msg}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 dark:border-blue-900 dark:bg-blue-950/30 p-3 text-sm text-blue-800 dark:text-blue-300">
+        <Info className="h-4 w-4 mt-0.5 shrink-0" />
+        <span>
+          A run-scoped git workspace is shared across all steps. When a remote is set,
+          the bare repo mirrors it on the host (<code className="rounded bg-blue-100 dark:bg-blue-900/50 px-1 py-0.5 font-mono text-xs">git fetch</code> at run start).
+          Run branches stay local — pushes are not enabled yet. Saving updates the workflow definition (new version).
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label htmlFor="workspace-remote" className="block text-xs font-medium text-muted-foreground mb-1">
+            Remote
+          </label>
+          <div className="relative">
+            <GitBranch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            <input
+              id="workspace-remote"
+              type="text"
+              value={remote}
+              onChange={(e) => setRemote(e.target.value)}
+              placeholder="org/repo  or  git@github.com:org/repo.git  (leave empty for local-only)"
+              className="h-9 w-full rounded-md border bg-background pl-8 pr-3 text-sm font-mono"
+            />
+          </div>
+          {!remoteValid && remote.trim() !== '' && (
+            <p className="text-xs text-destructive mt-1">
+              Expected <code className="font-mono">org/repo</code>, an SSH URL, or an HTTPS URL.
+            </p>
+          )}
+          {browsable && remoteValid && (
+            <a
+              href={browsable}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mt-1"
+            >
+              <ExternalLink className="h-3 w-3" />
+              {browsable}
+            </a>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="workspace-remote-auth" className="block text-xs font-medium text-muted-foreground mb-1">
+            Auth (workflow secret name)
+          </label>
+          <select
+            id="workspace-remote-auth"
+            value={remoteAuth}
+            onChange={(e) => setRemoteAuth(e.target.value)}
+            className="h-9 w-full rounded-md border bg-background px-3 text-sm font-mono"
+          >
+            <option value="">— SSH deploy key (default) —</option>
+            {secretKeys.map((key) => (
+              <option key={key} value={key}>{key}</option>
+            ))}
+            {remoteAuth && !secretKeys.includes(remoteAuth) && (
+              <option value={remoteAuth}>{remoteAuth} (not in secrets)</option>
+            )}
+          </select>
+          <p className="text-xs text-muted-foreground mt-1">
+            Secret value is used as a GitHub PAT for HTTPS clone. Leave empty to authenticate with the host SSH deploy key.
+          </p>
+          {remoteAuth && !secretKeys.includes(remoteAuth) && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+              Warning: <code className="font-mono">{remoteAuth}</code> is not defined in this workflow&apos;s secrets.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 pt-2 text-xs text-muted-foreground">
+        <span>Source: workflow definition <span className="font-mono">v{savedVersion}</span></span>
+        {dirty && <span className="text-amber-600 dark:text-amber-400">unsaved changes</span>}
+        <div className="flex-1" />
+        {message && (
+          <span className={message.startsWith('Error:') ? 'text-destructive' : 'text-green-600 dark:text-green-400'}>
+            {message}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !dirty || !remoteValid}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-sm hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          <Save className="h-3.5 w-3.5" />
+          {saving ? 'Saving...' : 'Save (new version)'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Repository** tab to the workflow detail page so users can configure `WorkflowDefinition.workspace.remote` and `workspace.remoteAuth` without editing JSON. Closes the UI gap from #213.

- `Remote` input — accepts `org/repo`, SSH URL, or HTTPS URL. Validates format inline. Renders a clickable github.com link when normalisable.
- `Auth` dropdown — populated from this workflow's existing secrets (`getWorkflowSecretKeys`). Selecting a secret stores it by name; runtime resolves the token at clone time. Default option = SSH deploy key (no secret).
- **Save** loads the latest WD version, overrides `workspace`, calls `saveWorkflowDefinition` (auto-bumps version) and promotes the new version to default. Honest about churn: button label is "Save (new version)".

## UX placement

Sibling tab to `Runs` / `Definitions` / `Secrets`. Mirrors the JSON shape — `workspace` is a top-level WD field, so it gets its own tab rather than nesting under Secrets.

## What's NOT in this PR

- No `push` toggle — runtime still local-only per #213.
- No "force resync" / "view bare repo status" UI — deferred until there's a real signal to surface.
- No legacy ProcessDefinition support — those WDs see a "legacy schema" notice. Workspace is a unified-WD-only concept.

## Test plan

- [ ] `pnpm dev:local`, open a workflow, switch to **Repository** tab
- [ ] Set `Appsilon/some-repo` + a secret named `GITHUB_PAT`, save → confirm new WD version appears in the **Definitions** tab and is marked default
- [ ] Trigger a run, verify the bare repo at `$MEDIFORCE_DATA_DIR/bare-repos/<ns>/<wd>.git` was cloned from the remote
- [ ] Clear remote, save → next run falls back to local-only bare repo
- [ ] Type a malformed remote (e.g. `not a repo`) — Save button disables, error hint shown