### PR TITLE
fix(start-run-button): always render, disable when no manual trigger

### DIFF
--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -118,7 +118,7 @@ export function getPlatformServices(): PlatformServices {
 
   services = {
     engine,
-    manualTrigger: new ManualTrigger(engine),
+    manualTrigger: new ManualTrigger(engine, processRepo),
     cronTrigger: new CronTrigger(engine),
     agentRunner,
     pluginRegistry,

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/definitions/[version]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/definitions/[version]/page.tsx
@@ -177,7 +177,12 @@ export default function WorkflowDefinitionVersionPage() {
 
           {/* Right: save controls */}
           <div className="flex items-center gap-3 shrink-0 pt-0.5">
-            <StartRunButton workflowName={decodedName} version={definition.version} />
+            <StartRunButton
+              workflowName={decodedName}
+              version={definition.version}
+              hasManualTrigger={definition.triggers?.some((trigger) => trigger.type === 'manual') ?? false}
+              archived={definition.archived === true}
+            />
             {saveState.status === 'saved' && (
               <span className="text-sm text-green-600 dark:text-green-400 font-medium">
                 Saved as v{saveState.version}

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
-import { ArrowLeft, Layers, GitBranch, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Info, Clock, Zap, Trash2, ArrowRightLeft, KeyRound, Eye, EyeOff } from 'lucide-react';
+import { ArrowLeft, Layers, GitBranch, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Clock, Zap, Trash2, ArrowRightLeft, KeyRound, Eye, EyeOff } from 'lucide-react';
 import * as Tabs from '@radix-ui/react-tabs';
 import { useProcessDefinitionVersions } from '@/hooks/use-process-definitions';
 import { useProcessInstances } from '@/hooks/use-process-instances';
@@ -256,14 +256,12 @@ export default function ProcessDefinitionPage() {
                 ? <><EyeOff className="h-3.5 w-3.5" />Hide archived</>
                 : <><Eye className="h-3.5 w-3.5" />Show archived</>}
             </button>
-            {hasManualTrigger ? (
-              <StartRunButton workflowName={decodedName} showVersionPicker />
-            ) : (
-              <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Info className="h-3.5 w-3.5" />
-                This workflow does not support manual start
-              </span>
-            )}
+            <StartRunButton
+              workflowName={decodedName}
+              showVersionPicker
+              hasManualTrigger={hasManualTrigger}
+              archived={latest?.archived === true}
+            />
           </div>
 
           <RunsTable

--- a/packages/platform-ui/src/components/processes/process-card.tsx
+++ b/packages/platform-ui/src/components/processes/process-card.tsx
@@ -198,9 +198,12 @@ export function ProcessCard({
               <span>No runs</span>
             )}
           </div>
-          {definition.hasManualTrigger && !definition.archived && (
-            <StartRunButton workflowName={definition.name} showVersionPicker />
-          )}
+          <StartRunButton
+            workflowName={definition.name}
+            showVersionPicker
+            hasManualTrigger={definition.hasManualTrigger}
+            archived={definition.archived === true}
+          />
         </div>
 
         {/* Runs preview — compact list only */}

--- a/packages/platform-ui/src/components/processes/start-run-button.tsx
+++ b/packages/platform-ui/src/components/processes/start-run-button.tsx
@@ -16,9 +16,22 @@ interface StartRunButtonProps {
   version?: number;
   /** Show version dropdown (split button). */
   showVersionPicker?: boolean;
+  /** Whether the workflow declares a `manual` trigger. When false the button
+   * renders disabled with an explanatory tooltip. Defaults to true so callers
+   * that haven't been migrated keep working. */
+  hasManualTrigger?: boolean;
+  /** Whether the workflow is archived. When true the button renders disabled
+   * with an explanatory tooltip. */
+  archived?: boolean;
 }
 
-export function StartRunButton({ workflowName, version, showVersionPicker }: StartRunButtonProps) {
+export function StartRunButton({
+  workflowName,
+  version,
+  showVersionPicker,
+  hasManualTrigger = true,
+  archived = false,
+}: StartRunButtonProps) {
   const router = useRouter();
   const handle = useHandleFromPath();
   const { firebaseUser } = useAuth();
@@ -64,7 +77,16 @@ export function StartRunButton({ workflowName, version, showVersionPicker }: Sta
     }
   }
 
-  if (effectiveVersion === 0) return null;
+  // Reasons the button cannot be used. Order matters — first match wins for tooltip text.
+  const disabledReason: string | null = archived
+    ? 'Workflow is archived'
+    : !hasManualTrigger
+      ? 'This workflow has no manual trigger'
+      : effectiveVersion === 0
+        ? 'No workflow version available'
+        : null;
+  const isDisabled = disabledReason !== null || starting;
+  const tooltip = disabledReason ?? undefined;
 
   const errorBanner = error ? (
     <p className="mt-1 text-xs text-destructive max-w-xs truncate" title={error}>{error}</p>
@@ -75,11 +97,13 @@ export function StartRunButton({ workflowName, version, showVersionPicker }: Sta
     return (
       <div>
         <button
-          disabled={starting}
+          disabled={isDisabled}
           onClick={() => handleStart()}
+          title={tooltip}
+          aria-disabled={isDisabled}
           className={cn(
             'inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors whitespace-nowrap',
-            starting && 'opacity-50 cursor-not-allowed',
+            isDisabled && 'opacity-50 cursor-not-allowed hover:bg-primary',
           )}
         >
           {starting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
@@ -95,19 +119,27 @@ export function StartRunButton({ workflowName, version, showVersionPicker }: Sta
     <div>
       <div className="relative inline-flex" ref={dropdownRef}>
         <button
-          disabled={starting}
+          disabled={isDisabled}
           onClick={() => handleStart()}
+          title={tooltip}
+          aria-disabled={isDisabled}
           className={cn(
             'inline-flex items-center gap-1.5 rounded-l-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors whitespace-nowrap',
-            starting && 'opacity-50 cursor-not-allowed',
+            isDisabled && 'opacity-50 cursor-not-allowed hover:bg-primary',
           )}
         >
           {starting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
           {starting ? 'Starting...' : 'Start Run'}
         </button>
         <button
+          disabled={isDisabled}
           onClick={() => setDropdownOpen((prev) => !prev)}
-          className="inline-flex items-center rounded-r-md border-l border-primary-foreground/20 bg-primary px-1.5 py-1.5 text-primary-foreground hover:bg-primary/90 transition-colors"
+          title={tooltip}
+          aria-disabled={isDisabled}
+          className={cn(
+            'inline-flex items-center rounded-r-md border-l border-primary-foreground/20 bg-primary px-1.5 py-1.5 text-primary-foreground hover:bg-primary/90 transition-colors',
+            isDisabled && 'opacity-50 cursor-not-allowed hover:bg-primary',
+          )}
         >
           <ChevronDown className={cn('h-3.5 w-3.5 transition-transform', dropdownOpen && 'rotate-180')} />
         </button>

--- a/packages/workflow-engine/src/__tests__/manual-trigger.test.ts
+++ b/packages/workflow-engine/src/__tests__/manual-trigger.test.ts
@@ -8,6 +8,7 @@ import type { WorkflowDefinition } from '@mediforce/platform-core';
 import {
   WorkflowEngine,
   ManualTrigger,
+  ManualTriggerNotDeclaredError,
 } from '../index.js';
 import type { WorkflowTriggerContext } from '../index.js';
 
@@ -27,6 +28,18 @@ const linearDef: WorkflowDefinition = {
   triggers: [{ type: 'manual', name: 'Start Process' }],
 };
 
+const cronOnlyDef: WorkflowDefinition = {
+  name: 'cron-only-process',
+  version: 1,
+  namespace: 'test',
+  steps: [
+    { id: 'start', name: 'Start', type: 'creation', executor: 'agent' },
+    { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },
+  ],
+  transitions: [{ from: 'start', to: 'done' }],
+  triggers: [{ type: 'cron', name: 'Nightly', schedule: '0 0 * * *' }],
+};
+
 describe('ManualTrigger', () => {
   let processRepo: InMemoryProcessRepository;
   let instanceRepo: InMemoryProcessInstanceRepository;
@@ -43,9 +56,10 @@ describe('ManualTrigger', () => {
       instanceRepo,
       auditRepo,
     );
-    trigger = new ManualTrigger(engine);
+    trigger = new ManualTrigger(engine, processRepo);
 
     await processRepo.saveWorkflowDefinition(linearDef);
+    await processRepo.saveWorkflowDefinition(cronOnlyDef);
   });
 
   function makeContext(
@@ -90,5 +104,38 @@ describe('ManualTrigger', () => {
     const uuidRegex =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     expect(result.instanceId).toMatch(uuidRegex);
+  });
+
+  describe('manual trigger declaration enforcement', () => {
+    it('rejects workflows that do not declare a manual trigger', async () => {
+      await expect(
+        trigger.fireWorkflow(
+          makeContext({ definitionName: 'cron-only-process' }),
+        ),
+      ).rejects.toThrow(ManualTriggerNotDeclaredError);
+    });
+
+    it('does not create an instance when manual trigger is missing', async () => {
+      try {
+        await trigger.fireWorkflow(
+          makeContext({ definitionName: 'cron-only-process' }),
+        );
+      } catch {
+        // expected
+      }
+      const all = await instanceRepo.getByDefinition('cron-only-process', '1');
+      expect(all).toHaveLength(0);
+    });
+
+    it('error message identifies the workflow and version', async () => {
+      await expect(
+        trigger.fireWorkflow(
+          makeContext({
+            definitionName: 'cron-only-process',
+            definitionVersion: 1,
+          }),
+        ),
+      ).rejects.toThrow(/cron-only-process.*v1/);
+    });
   });
 });

--- a/packages/workflow-engine/src/index.ts
+++ b/packages/workflow-engine/src/index.ts
@@ -38,5 +38,6 @@ export type { TriggerResult, WorkflowTriggerContext } from './triggers/trigger-t
 export {
   WebhookPayloadValidationError,
   TriggerNotFoundError,
+  ManualTriggerNotDeclaredError,
 } from './triggers/trigger-errors.js';
 export { validateCronSchedule, isDue } from './triggers/cron-utils.js';

--- a/packages/workflow-engine/src/triggers/manual-trigger.ts
+++ b/packages/workflow-engine/src/triggers/manual-trigger.ts
@@ -1,20 +1,53 @@
+import type { ProcessRepository } from '@mediforce/platform-core';
 import type { WorkflowEngine } from '../engine/workflow-engine.js';
 import type { TriggerResult, WorkflowTriggerContext } from './trigger-types.js';
+import { ManualTriggerNotDeclaredError } from './trigger-errors.js';
 
 /**
  * ManualTrigger: creates and starts a process instance via WorkflowEngine.
  *
  * Used for user-initiated flows where a human explicitly triggers
  * a new process execution.
+ *
+ * Validates that the target WorkflowDefinition declares a `manual` trigger
+ * before creating the instance. This is the server-side counterpart to the
+ * disabled state of the StartRunButton — it ensures that workflows without
+ * a manual trigger cannot be started by callers that bypass the UI gate.
  */
 export class ManualTrigger {
-  constructor(private readonly engine: WorkflowEngine) {}
+  constructor(
+    private readonly engine: WorkflowEngine,
+    private readonly processRepository: ProcessRepository,
+  ) {}
 
   /**
    * Creates and starts a workflow instance from a unified WorkflowDefinition.
    * No separate ProcessConfig required — all config is embedded in the definition.
+   *
+   * Throws {@link ManualTriggerNotDeclaredError} when the WD does not declare
+   * a `manual` trigger. The engine error for "definition not found" propagates
+   * unchanged.
    */
   async fireWorkflow(context: WorkflowTriggerContext): Promise<TriggerResult> {
+    const definition = await this.processRepository.getWorkflowDefinition(
+      context.definitionName,
+      context.definitionVersion,
+    );
+    if (!definition) {
+      throw new Error(
+        `Workflow definition '${context.definitionName}' version '${context.definitionVersion}' not found`,
+      );
+    }
+    const hasManualTrigger = definition.triggers.some(
+      (trigger) => trigger.type === 'manual',
+    );
+    if (!hasManualTrigger) {
+      throw new ManualTriggerNotDeclaredError(
+        context.definitionName,
+        context.definitionVersion,
+      );
+    }
+
     const instance = await this.engine.createInstance(
       context.definitionName,
       context.definitionVersion,

--- a/packages/workflow-engine/src/triggers/trigger-errors.ts
+++ b/packages/workflow-engine/src/triggers/trigger-errors.ts
@@ -13,3 +13,17 @@ export class TriggerNotFoundError extends Error {
     this.name = 'TriggerNotFoundError';
   }
 }
+
+/**
+ * Thrown when a manual run is requested for a workflow definition that
+ * does not declare a `manual` trigger in `triggers[]`. This is the
+ * server-side guard that mirrors the disabled state of the UI button.
+ */
+export class ManualTriggerNotDeclaredError extends Error {
+  constructor(definitionName: string, version: number) {
+    super(
+      `Workflow "${definitionName}" v${version} does not declare a manual trigger and cannot be started manually.`,
+    );
+    this.name = 'ManualTriggerNotDeclaredError';
+  }
+}


### PR DESCRIPTION
## Summary

Two-part fix for the manual-run gate:

1. **UI** — `StartRunButton` always renders. When the workflow declares no `manual` trigger or is archived, it renders disabled with a `title=` tooltip explaining why. The hide/show check moves out of every call site (process-card, workflow detail, definition-version page) and into the button itself, so the rule is enforced in one place.
2. **Server** — `ManualTrigger.fireWorkflow` now loads the WD and rejects with `ManualTriggerNotDeclaredError` when no `manual` trigger is declared. This closes the gap reported on the definition-version page where the UI button rendered but the server happily created instances anyway.

## Changes

**UI**
- `packages/platform-ui/src/components/processes/start-run-button.tsx` — adds `hasManualTrigger`, `archived` props (default `true`/`false` for back-compat); computes `disabledReason` and renders disabled with `title=` tooltip; removes early `return null` for empty effectiveVersion (now disabled with explanatory tooltip).
- `packages/platform-ui/src/components/processes/process-card.tsx` — drops the `hasManualTrigger && !archived &&` wrapper, passes the flags as props.
- `packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx` — drops the `hasManualTrigger ? ... : <Info ...>` ternary, passes the flags as props. The "This workflow does not support manual start" sibling banner is now redundant — the button's tooltip carries that info.
- `packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/definitions/[version]/page.tsx` — passes `hasManualTrigger` and `archived` derived from the loaded definition. Previously this page rendered the button unconditionally; now the disabled state is honoured here too.

**Server**
- `packages/workflow-engine/src/triggers/manual-trigger.ts` — injects `ProcessRepository`, validates the WD declares a `manual` trigger before calling `engine.createInstance`. Throws `ManualTriggerNotDeclaredError` otherwise.
- `packages/workflow-engine/src/triggers/trigger-errors.ts` — new `ManualTriggerNotDeclaredError` class.
- `packages/workflow-engine/src/index.ts` — re-exports the new error type.
- `packages/platform-api/src/services/platform-services.ts` — wires `processRepo` into `ManualTrigger`.

**Tests**
- `packages/workflow-engine/src/__tests__/manual-trigger.test.ts` — adds a `cron-only-process` fixture and three assertions:
  - rejects with `ManualTriggerNotDeclaredError`
  - no instance is persisted on rejection
  - error message mentions the workflow name + version

## Audit — entry points that create a manual run

Every server-side path that creates an instance with `triggerType: 'manual'` goes through `ManualTrigger.fireWorkflow` — and now through the new validation:

| Caller | File | Validates? |
|---|---|---|
| `startWorkflowRun` server action (Start Run button) | `packages/platform-ui/src/app/actions/processes.ts:27` | yes |
| `startProcessRun` legacy server action | `packages/platform-ui/src/app/actions/processes.ts:69` | yes |
| `POST /api/processes` route handler | `packages/platform-ui/src/app/api/processes/route.ts:29` | yes |
| `TriggerHandler.fire('manual', ...)` dispatcher | `packages/workflow-engine/src/triggers/trigger-handler.ts:21` | yes |

Other callers of `WorkflowEngine.createInstance(..., 'manual', ...)` are test fixtures (`packages/workflow-engine/src/**/__tests__/*`, `packages/agent-runtime/src/runner/*.test.ts`) and seed data (`packages/platform-ui/e2e/helpers/seed-data.ts` — calls `instanceRepo.create` directly). Those are intentional bypass paths for fixtures and don't need server-side gating.

`/api` was scanned for any handler that calls `engine.createInstance` directly without going through `manualTrigger` — none found. The cron path uses `cronTrigger.fireWorkflow` (different trigger type) and is out of scope.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:fast` — 1785 passed
- [x] `pnpm vitest run packages/workflow-engine/src/__tests__/manual-trigger.test.ts` — 8 passed (3 new)
- [ ] Manual: open a workflow with only a cron trigger and confirm the Start Run button is disabled with tooltip on all three surfaces (catalog card, workflow detail, definition version page)
- [ ] Manual: hit `POST /api/processes` for a cron-only workflow and confirm 500 with `ManualTriggerNotDeclaredError` message

## E2E

No E2E journey changed — the change is a purely additive prop on `StartRunButton`, plus a server-side guard. Existing journeys that exercise the Start Run button use workflows that declare a manual trigger, so behaviour is unchanged for them.