### PR TITLE
docs: add infrastructure section to development guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -147,3 +147,15 @@ pnpm build    # builds all packages
 ## Deployment
 
 The platform UI deploys via Firebase App Hosting. See `apphosting.yaml` for configuration.
+
+## Infrastructure
+
+Staging and production servers are hosted on **Hetzner**.
+
+| Environment | SSH access |
+|-------------|-----------|
+| Staging | `ssh deploy@204.168.165.57` |
+
+The staging machine also has an `sftpuser` account with SFTP enabled, used for the Data Landing Zone workflow demo.
+
+All credentials (SSH passwords, etc.) are stored in **1Password** under the **Mediforce** vault.


### PR DESCRIPTION
## Summary

- Documents Hetzner as the hosting provider for staging and production
- Staging SSH: `deploy@204.168.165.57`
- Notes `sftpuser` with SFTP enabled for the Data Landing Zone workflow demo
- Points developers to 1Password Mediforce vault for all credentials

Added at the bottom of `docs/development.md` alongside the existing Deployment section.

## E2E

Documentation-only change — no E2E tests required.