### PR TITLE
feat(platform-ui): eager env validation at server startup

### DIFF
--- a/packages/platform-ui/src/instrumentation.ts
+++ b/packages/platform-ui/src/instrumentation.ts
@@ -38,10 +38,16 @@ function validateEnv(): void {
         'GOOGLE_APPLICATION_CREDENTIALS is not set. '
         + 'Point it to your Firebase service account JSON file (e.g. /run/secrets/firebase-sa.json).',
       );
-    } else if (!require('fs').existsSync(credPath)) {
-      errors.push(
-        `GOOGLE_APPLICATION_CREDENTIALS points to "${credPath}" but the file does not exist.`,
-      );
+    } else {
+      // Dynamic import hidden from webpack static analysis
+      const nodeFs = 'fs';
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { existsSync } = require(nodeFs) as typeof import('fs');
+      if (!existsSync(credPath)) {
+        errors.push(
+          `GOOGLE_APPLICATION_CREDENTIALS points to "${credPath}" but the file does not exist.`,
+        );
+      }
     }
   }
 

--- a/packages/platform-ui/src/instrumentation.ts
+++ b/packages/platform-ui/src/instrumentation.ts
@@ -1,0 +1,78 @@
+import { existsSync } from 'fs';
+
+/**
+ * Validate critical environment variables at Next.js server startup.
+ *
+ * Runs once via the Next.js instrumentation hook so the process fails fast
+ * with a clear error listing ALL missing/invalid vars — instead of starting
+ * successfully and then 500-ing on the first API request.
+ *
+ * In emulator mode (`NEXT_PUBLIC_USE_EMULATORS=true`), only `PLATFORM_API_KEY`
+ * is checked because Firebase Admin SDK auto-connects to local emulators
+ * without credentials and secrets encryption is not exercised in dev.
+ */
+
+function validateEnv(): void {
+  const errors: string[] = [];
+  const isEmulatorMode = process.env.NEXT_PUBLIC_USE_EMULATORS === 'true';
+
+  // --- PLATFORM_API_KEY (production only) ---
+  // Browser requests use Firebase token auth; server-to-server calls
+  // (server actions, cron, queue workers) use X-Api-Key. In emulator mode
+  // browser auth suffices for most flows, so we skip this check.
+  if (!isEmulatorMode) {
+    const apiKey = process.env.PLATFORM_API_KEY;
+    if (typeof apiKey !== 'string' || apiKey.length === 0) {
+      errors.push(
+        'PLATFORM_API_KEY is not set. Required for API authentication (middleware X-Api-Key check).',
+      );
+    }
+  }
+
+  // --- SECRETS_ENCRYPTION_KEY (production only) ---
+  if (!isEmulatorMode) {
+    const secretsKey = process.env.SECRETS_ENCRYPTION_KEY;
+    if (typeof secretsKey !== 'string' || secretsKey.length === 0) {
+      errors.push(
+        'SECRETS_ENCRYPTION_KEY is not set. '
+        + 'Set it to a 64-character hex string (see .env.example or run scripts/bootstrap-server.py).',
+      );
+    } else if (!/^[0-9a-fA-F]{64}$/.test(secretsKey)) {
+      errors.push(
+        `SECRETS_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes). Got ${secretsKey.length} character(s).`,
+      );
+    }
+  }
+
+  // --- GOOGLE_APPLICATION_CREDENTIALS (production only) ---
+  if (!isEmulatorMode) {
+    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (typeof credPath !== 'string' || credPath.length === 0) {
+      errors.push(
+        'GOOGLE_APPLICATION_CREDENTIALS is not set. '
+        + 'Point it to your Firebase service account JSON file (e.g. /run/secrets/firebase-sa.json).',
+      );
+    } else if (!existsSync(credPath)) {
+      errors.push(
+        `GOOGLE_APPLICATION_CREDENTIALS points to "${credPath}" but the file does not exist.`,
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    const divider = '─'.repeat(60);
+    const header = `\n${divider}\n  FATAL: Missing or invalid environment variables\n${divider}`;
+    const body = errors.map((e, i) => `  ${i + 1}. ${e}`).join('\n');
+    const footer = `${divider}\n  The server cannot start. Fix the above and restart.\n${divider}\n`;
+
+    console.error(`${header}\n\n${body}\n\n${footer}`);
+    process.exit(1);
+  }
+}
+
+export function register(): void {
+  // Only validate on the server runtime (not edge, not build-time).
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    validateEnv();
+  }
+}

--- a/packages/platform-ui/src/instrumentation.ts
+++ b/packages/platform-ui/src/instrumentation.ts
@@ -1,17 +1,3 @@
-import { existsSync } from 'fs';
-
-/**
- * Validate critical environment variables at Next.js server startup.
- *
- * Runs once via the Next.js instrumentation hook so the process fails fast
- * with a clear error listing ALL missing/invalid vars — instead of starting
- * successfully and then 500-ing on the first API request.
- *
- * In emulator mode (`NEXT_PUBLIC_USE_EMULATORS=true`), only `PLATFORM_API_KEY`
- * is checked because Firebase Admin SDK auto-connects to local emulators
- * without credentials and secrets encryption is not exercised in dev.
- */
-
 function validateEnv(): void {
   const errors: string[] = [];
   const isEmulatorMode = process.env.NEXT_PUBLIC_USE_EMULATORS === 'true';
@@ -52,7 +38,7 @@ function validateEnv(): void {
         'GOOGLE_APPLICATION_CREDENTIALS is not set. '
         + 'Point it to your Firebase service account JSON file (e.g. /run/secrets/firebase-sa.json).',
       );
-    } else if (!existsSync(credPath)) {
+    } else if (!require('fs').existsSync(credPath)) {
       errors.push(
         `GOOGLE_APPLICATION_CREDENTIALS points to "${credPath}" but the file does not exist.`,
       );


### PR DESCRIPTION
## Summary
- Adds Next.js instrumentation hook that validates critical env vars (`SECRETS_ENCRYPTION_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`, `PLATFORM_API_KEY`) at server startup
- Process exits immediately with clear numbered error list instead of silently 500-ing on every API request
- All checks skipped in emulator mode (`NEXT_PUBLIC_USE_EMULATORS=true`)

## Context
On phuse.mediforce.ai, missing `SECRETS_ENCRYPTION_KEY` and `firebase-sa.json` caused the server to start fine but return 500 on every API call. Took SSH + docker logs to diagnose. This prevents that class of issue.

## Test plan
- [ ] Verify dev server still starts with `NEXT_PUBLIC_USE_EMULATORS=true` (no crash)
- [ ] Verify production build fails fast when env vars are missing
- [ ] E2E tests unaffected (emulator mode skips checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)