### PR TITLE
fix(ui): surfrace raw errors in agent log viewer and run error banner

### DIFF
--- a/packages/platform-ui/src/components/processes/agent-log-viewer.tsx
+++ b/packages/platform-ui/src/components/processes/agent-log-viewer.tsx
@@ -307,8 +307,27 @@ function LogGroupList({ groups }: { groups: LogGroup[] }) {
 }
 
 async function fetchSingleLog(file: string): Promise<{ entries: LogEntry[]; rawContent: string | null; error: string | null }> {
+  let response: Response;
   try {
-    const response = await apiFetch(`/api/agent-logs?file=${encodeURIComponent(file)}`);
+    response = await apiFetch(`/api/agent-logs?file=${encodeURIComponent(file)}`);
+  } catch (fetchError) {
+    const msg = fetchError instanceof Error ? fetchError.message : String(fetchError);
+    return { entries: [], rawContent: null, error: `Network error (token/auth): ${msg}` };
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    let detail: string;
+    try {
+      const parsed = JSON.parse(text) as { error?: string };
+      detail = parsed.error ?? text;
+    } catch {
+      detail = text || response.statusText;
+    }
+    return { entries: [], rawContent: null, error: `HTTP ${response.status} ${response.statusText}: ${detail}` };
+  }
+
+  try {
     const data = await response.json() as { content: string; error?: string };
     if (data.error && !data.content) {
       return { entries: [], rawContent: null, error: data.error };
@@ -320,8 +339,8 @@ async function fetchSingleLog(file: string): Promise<{ entries: LogEntry[]; rawC
       return { entries: [], rawContent: data.content, error: null };
     }
     return { entries: [], rawContent: null, error: null };
-  } catch (fetchError) {
-    return { entries: [], rawContent: null, error: fetchError instanceof Error ? fetchError.message : 'Failed to fetch log' };
+  } catch (parseError) {
+    return { entries: [], rawContent: null, error: `Failed to parse response: ${parseError instanceof Error ? parseError.message : String(parseError)}` };
   }
 }
 
@@ -385,7 +404,9 @@ function AgentTabContent({ section }: { section: AgentLogSection }) {
   return (
     <>
       {section.error && (
-        <div className="text-xs text-amber-600 dark:text-amber-400 py-1">{section.error}</div>
+        <pre className="text-xs font-mono bg-destructive/8 text-destructive border border-destructive/20 rounded p-2 whitespace-pre-wrap break-all select-text my-1 leading-relaxed">
+          {section.error}
+        </pre>
       )}
 
       {isEmpty && !section.error && (
@@ -610,8 +631,8 @@ export function AgentLogViewer({ logFiles, initialStepId }: AgentLogViewerProps)
             <AgentTabContent section={activeSection} />
           )}
 
-          {/* Thinking indicator — only when agent is genuinely still running */}
-          {pollingActive && activeSection && !isSectionTerminal(activeSection) && (
+          {/* Thinking indicator — only when we have log lines and are waiting for more */}
+          {pollingActive && activeSection && activeSection.entries.length > 0 && !isSectionTerminal(activeSection) && (
             <ThinkingIndicator />
           )}
         </div>

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -295,8 +295,10 @@ export function ProcessDetail({
             </div>
           )}
           {wfStatus.displayStatus === 'error' && !wfStatus.hasDedicatedBanner && (
-            <div className="rounded-md bg-red-50 border border-red-200 dark:bg-red-900/20 dark:border-red-800 px-3 py-2 text-sm text-red-800 dark:text-red-300">
-              {wfStatus.reason}
+            <div className="rounded-md bg-red-50 border border-red-200 dark:bg-red-900/20 dark:border-red-800 px-3 py-2">
+              <pre className="text-sm font-mono text-red-800 dark:text-red-300 whitespace-pre-wrap break-all select-text leading-relaxed">
+                {wfStatus.reason}
+              </pre>
             </div>
           )}
           {instance.previousRun !== undefined && (

--- a/packages/platform-ui/src/components/processes/retry-step-button.tsx
+++ b/packages/platform-ui/src/components/processes/retry-step-button.tsx
@@ -69,7 +69,11 @@ export function RetryStepButton({ instanceId, stepId }: RetryStepButtonProps) {
         }
         {label}
       </button>
-      {error !== null && <span className="text-xs text-destructive">{error}</span>}
+      {error !== null && (
+        <pre className="text-xs font-mono text-destructive whitespace-pre-wrap break-all select-text max-w-sm">
+          {error}
+        </pre>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- fetchSingleLog: split network errors from HTTP errors; check response.ok before JSON parsing so a 500 "Internal Server Error" body shows as "HTTP 500 Internal Server Error: Internal Server Error" instead of a confusing SyntaxError; label auth/token failures with "Network error (token/auth):"
- Display log fetch errors in a monospace selectable <pre> block instead of tiny amber text — makes them copy-pasteable for debugging
- ThinkingIndicator: only render when entries.length > 0 so it does not appear while waiting for the agent log to be initialized
- process-detail error banner: wrap reason in <pre> with font-mono and select-text so the full engine error string is readable and copy-pasteable
- retry-step-button: same treatment for inline error display

*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Description
*Clear and concise description of what changed and why.
If necessary, include screenshots and/or a step-by-step guide on how to test the changes.*

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
