### PR TITLE
feat(landing-zone): 5-class deterministic validator router

### DIFF
--- a/apps/landing-zone/plugins/landing-zone/skills/data-validator/SKILL.md
+++ b/apps/landing-zone/plugins/landing-zone/skills/data-validator/SKILL.md
@@ -1,27 +1,27 @@
 ---
 name: data-validator
-description: "Interpret CDISC CORE rules engine output for a single SFTP delivery, classify the delivery as clean, has-findings, or escalate, and render a self-contained HTML report for a human reviewer. Use this skill when the prior step (validate-script) has produced findings or has failed and the task is to triage what happened and present it to an operator. Triggers: 'interpret validation', 'classify findings', 'review CDISC CORE output', 'validation report for human review', 'landing zone interpret'. This skill is the agent half of the validate -> human-review handoff."
+description: "Render a self-contained HTML report for a CDISC CORE validation delivery. The 5-class classification (clean / minor-fix / recovery / escalate / chaos) is computed deterministically by the prior validate-script step — this skill reads it from input.json and presents it. Use this skill when the prior step has produced findings or has failed and the task is to render the report a human reviewer (or downstream auto-route) will read. Triggers: 'interpret validation', 'render validation report', 'review CDISC CORE output', 'validation report for human review', 'landing zone interpret'. This skill is the agent half of the validate -> human-review handoff."
 ---
 
 # Data Validator
 
 ## Purpose
 
-Read the output of a deterministic CDISC CORE validation step and turn it into:
+Read the output of a deterministic CDISC CORE validation step plus its already-computed 5-class classification, and turn them into:
 
-1. A short machine-readable verdict (`/output/result.json`)
-2. A self-contained HTML report (`/output/presentation.html`) that renders inline in the human reviewer's task UI
+1. A short machine-readable verdict (`/output/result.json`) — echoing the deterministic classification.
+2. A self-contained HTML report (`/output/presentation.html`) that renders inline in the human reviewer's task UI.
 
-The validation script (`validate-script` step) is the source of truth for facts. This skill does **not** re-run the rules engine and does **not** invent findings — it interprets, classifies, and presents what the script already produced.
+The validation script (`validate-script` step) is the source of truth for facts **and** for classification. This skill does **not** re-run the rules engine, does **not** classify, and does **not** invent findings. It reads the verdict, presents the data clearly, and stays out of the loop.
 
 ## When to use
 
 This skill runs as the `interpret-validation` agent step in the landing-zone workflow. It receives:
 
-- Findings from CDISC CORE (rule-level issues across the SDTM domains in a delivery), **or**
-- A script-failure signal if the validation harness itself crashed
+- The CORE engine output (`Issue_Summary` rows + per-dataset details), and
+- A deterministic `classification` already assigned by `validate-script` via the Python router (`router_rules.py`).
 
-The downstream `human-review` step reads the HTML report this skill writes; the human picks accept or reject.
+The downstream `human-review` step (or, for `clean` / `escalate` / `chaos`, an automated transition that bypasses the human) reads the HTML report this skill writes.
 
 ## Inputs
 
@@ -31,107 +31,99 @@ The container has two read paths:
   ```json
   {
     "scriptStatus": "ok" | "failed",
-    "deliveryId": "string",
-    "deliveryDir": "/workspace/incoming/<deliveryId>",
-    "findings": [...],
+    "deliveryDir": "incoming/<deliveryId>",
+    "findingsPath": "findings.json" | null,
     "findingsCount": <integer>,
+    "summary_data": { "datasetSummary": [...], "topRules": [...], ... },
+    "classification": "clean" | "minor-fix" | "recovery" | "escalate" | "chaos",
+    "classificationReason": "1-2 sentence text",
+    "scriptFailedFlag": true | false,
+    "summary": "1-2 sentence verdict (alias of classificationReason)",
     "error": "string (only when scriptStatus=failed)",
     "traceback": "string (only when scriptStatus=failed)"
   }
   ```
-  May also carry workflow-level fields the engine attached (`variables`, the previous step's full output, etc.).
+  May also carry workflow-level fields the engine attached (`variables`, etc.).
 
-- **`/workspace/findings.json`** — the same findings persisted to the run worktree by `validate-script` for audit. Always read this; if it disagrees with `/output/input.json`, prefer the workspace copy (it is the version that ended up in the run's git history).
+- **`/workspace/findings.json`** — the raw CORE engine output (full `Issue_Summary` + `Issue_Details` + `Conformance_Details`) persisted to the run worktree for audit. Always read this for the per-finding rows that drive the heatmap and top-findings list. If it disagrees with `/output/input.json`, prefer the workspace copy (it is the version that ended up in the run's git history).
 
-Do not assume the structure of an individual finding beyond the fields documented in `references/cdisc-categories.md`. The CORE engine emits a flat array of finding objects; field names of interest typically include `rule_id` (or `core_id`), `domain`, `severity`, `message`, `variable`, and a count or list of affected records. Field names can vary across CORE versions — read defensively and degrade gracefully when an expected field is absent.
+Do not assume the structure of an individual finding beyond the fields documented in `references/cdisc-categories.md`. The CORE engine emits arrays of objects; field names of interest typically include `rule_id` (or `core_id`), `dataset` (the domain), `severity`, `message`, and an issue count. Field names can vary across CORE versions — read defensively and degrade gracefully when an expected field is absent.
 
 ## Workflow
 
 ### Step 1 — Read inputs
 
-Read `/output/input.json` first. Then read `/workspace/findings.json`. If either read fails, treat that as `scriptStatus = failed` even if the JSON in `input.json` claimed otherwise — log what went wrong in `result.summary`.
+Read `/output/input.json` first. Then read `/workspace/findings.json` for the raw engine rows. If either read fails, surface the failure prominently in the HTML and write `result.json` echoing whatever classification the input contained (or `chaos` if input is unreadable). Do not synthesise a classification.
 
-### Step 2 — Branch on scriptStatus
+### Step 2 — Read the deterministic classification
 
-**If `scriptStatus === "failed"`:**
+The classification is **already computed**. Read these fields from `/output/input.json` and use them as-is:
 
-- Set `classification = "escalate"` and `scriptFailedFlag = true`
-- Read the `error` and `traceback` fields. Try to extract a partial signal — common patterns:
-  - `"no domain found"` / empty domain list → CRO uploaded files but none match expected SDTM domains (likely wrong filenames or wrong format)
-  - `"encoding error"` / `"UnicodeDecodeError"` → file is not valid SAS XPORT or has a corrupt header
-  - `"core: command not found"` / `"ModuleNotFoundError: cdisc_rules_engine"` → CORE CLI not available in the container; this is an infrastructure problem, not a CRO problem — flag it clearly
-  - `"FileNotFoundError"` on the delivery dir → SFTP download lost a file between steps
-  - timeout / OOM signals → partial validation; reviewer should retry rather than reject
-- Compose a 1–2 sentence `summary` that names the failure category as plainly as possible. If you cannot identify the category, say so — do not guess.
-- Skip the heatmap and findings list in the HTML; instead surface the error and traceback prominently.
+- `classification` — one of `clean`, `minor-fix`, `recovery`, `escalate`, `chaos`. Echo this verbatim in `result.json`. Do **not** recompute it from the findings.
+- `classificationReason` — 1–2 sentence text explaining which rule fired. Echo this verbatim in `result.summary`.
+- `scriptFailedFlag` — boolean. Echo verbatim in `result.scriptFailedFlag`.
+- `summary` — alias of `classificationReason`. Use whichever is non-empty.
 
-**If `scriptStatus === "ok"`:**
+The five classes are the v0.1 product spec and the only allowed values. The router enforces them. Do not invent new labels and do not "upgrade" a class based on the findings — if the script chose `recovery` for a single critical-structure domain and the findings look bad, still emit `recovery`. Determinism is the point.
 
-- Read `findingsCount`. If `0`, set `classification = "clean"`. If `> 0`, set `classification = "has-findings"`.
-- Optionally upgrade to `escalate` only when the findings indicate the validation itself is unreliable (e.g., a critical Structure-category violation that means CORE could not parse a key file). Be conservative — `has-findings` is the default for non-empty results. The human picks accept-or-reject; the agent's job is to summarise, not to pre-empt the human.
+### Step 3 — Build the heatmap and top-findings rows (presentation only)
 
-The three classifications are the v0.1 minimum and the only allowed values. Future versions will extend this set; do not invent new labels.
+The classification is settled, but the report still needs the visual breakdown. Read `/workspace/findings.json` and build:
 
-### Step 3 — Classify findings (only if scriptStatus=ok and findingsCount>0)
+- **Domain × Category heatmap** — rows = SDTM domains present in `Issue_Summary`, columns = the rule categories from `references/cdisc-categories.md` (Structure / Controlled Terminology / Consistency / FDA Business Rules / PMDA / Other), cells = sum of `issues` per `(domain, category)` pair.
+- **Top findings list** — top 20 rows from `Issue_Summary` sorted by `issues` descending, then by domain. Each row shows: rule code (`rule_id` or `core_id`), domain (`dataset`), severity badge, brief `message` (truncate to ~200 chars).
 
-Read `references/cdisc-categories.md` for the rule-category and severity vocabulary. For each finding, derive:
+Use the prefix-to-category mapping from `references/cdisc-categories.md`. The router uses the same mapping internally; the skill must mirror it for visual consistency.
 
-- **Category** — Structure / Controlled Terminology / Consistency / FDA Business Rules / PMDA. Map by `rule_id` prefix when possible (CORE codes like `SD####`, `CT####`, `AD####`, `CG####`, `FDA####`, `PMDA####`). When a finding has no clear category, place it under "Other" — do not force a guess.
-- **Severity** — Critical / Major / Minor / Warning. Use the severity field on the finding when present. If absent, leave it blank in the report — do not infer severity from `rule_id` alone.
-
-Aggregate to a domain × category heatmap (counts of findings per cell). This drives the HTML heatmap.
-
-### Step 4 — Compose the summary
-
-The `summary` field of `result.json` is the at-a-glance verdict the reviewer sees in the task list before they open the HTML. Two sentences max. Examples:
-
-- `"Clean delivery — 0 findings across 7 expected domains."`
-- `"24 findings across DM, AE, LB. Mostly Controlled Terminology violations in AE; no Critical Structure issues."`
-- `"Validation script crashed: CORE CLI returned 'no domain found'. Likely wrong file format from CRO."`
-- `"Validation script crashed with traceback (UnicodeDecodeError on lb.xpt). File may be corrupt or non-XPORT."`
-
-Be factual. Do not editorialise. The summary is also the explanation the agent gives for its classification.
-
-### Step 5 — Render the HTML report
+### Step 4 — Render the HTML report
 
 Write `/output/presentation.html`. The host iframe loads Tailwind v4 via CDN and exposes the result JSON as `window.__data__`. You can rely on Tailwind utility classes; do not re-import Tailwind.
 
 Required sections, in order:
 
-1. **Status banner** — full-width, top of page.
-   - `scriptStatus = failed`: red background (`bg-red-600 text-white`) with the error message in plain text and a `<details>` block holding the traceback.
-   - `clean`: green (`bg-green-600 text-white`) — "Delivery is clean — no findings."
-   - `has-findings`: amber (`bg-amber-500 text-white`) — "{findingsCount} findings across {domainCount} domains."
+1. **Status banner** — full-width, top of page. Colour and text are driven by `classification`:
 
-2. **Header** — delivery ID, study ID (read from `STUDY_ID` env if available, otherwise from `input.json.variables`), timestamp, total findings count.
+   | Classification | Banner classes              | Banner text                                                                       |
+   |----------------|-----------------------------|-----------------------------------------------------------------------------------|
+   | `clean`        | `bg-green-600 text-white`   | "Delivery is clean — no findings."                                                |
+   | `minor-fix`    | `bg-blue-600 text-white`    | "Minor fixes — terminology drift dominates."                                      |
+   | `recovery`     | `bg-amber-500 text-white`   | "Single-domain critical structure issue — recoverable."                           |
+   | `escalate`     | `bg-red-600 text-white`     | "Multi-domain critical structure failure — cannot ingest."                        |
+   | `chaos`        | `bg-zinc-900 text-white`    | "Validation could not complete (script failure or pervasive structure errors)."   |
 
-3. **Severity heatmap** — only when `scriptStatus = ok` and `findingsCount > 0`. A simple HTML table: rows = SDTM domains present in the findings, columns = the rule categories from `references/cdisc-categories.md`, cells = counts. Empty cells render blank, non-zero cells use a colour scale (light amber for 1–4, deeper amber for 5–19, red for 20+). Add a small legend.
+   Below the headline, render the `classificationReason` (1–2 sentence text from input). When `scriptFailedFlag = true`, also include a `<details>` block holding the traceback.
 
-4. **Top findings list** — only when `scriptStatus = ok`. Show the top 20 findings sorted by severity then domain. For each: rule code, domain, severity badge, brief message. If `findingsCount > 20`, add a footer line "+ N more findings — see /workspace/findings.json for full set."
+2. **Header** — delivery ID (from `deliveryDir` basename), study ID (read from `STUDY_ID` env if available, otherwise from `input.json.variables`), timestamp, total findings count.
 
-5. **Failure detail** — only when `scriptStatus = failed`. The traceback inside a collapsible `<details>`. No heatmap, no findings list.
+3. **Severity heatmap** — only when `findingsCount > 0`. A simple HTML table: rows = SDTM domains present in the findings, columns = the rule categories from `references/cdisc-categories.md`, cells = counts. Empty cells render blank, non-zero cells use a colour scale (light amber for 1–4, deeper amber for 5–19, red for 20+). Add a small legend.
+
+4. **Top findings list** — only when `findingsCount > 0`. Show the top 20 findings sorted by `issues` descending then by domain. For each: rule code, domain, severity badge, brief message. If `findingsCount > 20` (or `Issue_Summary.length > 20`), add a footer line "+ N more findings — see /workspace/findings.json for full set."
+
+5. **Failure detail** — only when `scriptFailedFlag = true`. The traceback inside a collapsible `<details>`. The heatmap and findings list are still rendered when raw findings exist (e.g., script failed mid-run with partial output) — show whatever signal is available without overstating it.
 
 Keep the HTML self-contained. No external scripts. No fetch calls. The iframe is sandboxed; relative URLs do not resolve. Use only Tailwind utility classes — no `<style>` blocks beyond what is strictly necessary for the heatmap colour scale.
 
 The reviewer is a human data manager. Use plain English, no marketing tone. Show counts, codes, domains, messages — not adjectives.
 
-### Step 6 — Write `/output/result.json`
+### Step 5 — Write `/output/result.json`
 
-Exact shape:
+Exact shape — every field is echoed from input, except `htmlReportPath`:
 
 ```json
 {
-  "classification": "clean" | "has-findings" | "escalate",
-  "summary": "1–2 sentence text",
+  "classification": "clean" | "minor-fix" | "recovery" | "escalate" | "chaos",
+  "classificationReason": "echoed from input",
+  "summary": "echoed from input (alias of classificationReason)",
   "htmlReportPath": "/output/presentation.html",
   "scriptFailedFlag": true | false
 }
 ```
 
-`htmlReportPath` is always `/output/presentation.html` when an HTML report was written. Omit the field if (and only if) you somehow could not write the HTML — but in v0.1 always write the HTML, even for the failure path.
+`htmlReportPath` is always `/output/presentation.html` when an HTML report was written. Omit the field if (and only if) you somehow could not write the HTML — but in v0.1 always write the HTML, even for the chaos path.
 
 ## Constraints
 
+- **Do not classify.** The 5-class verdict is computed by the deterministic Python router in `validate-script` and arrives in `input.json`. Echo it; do not recompute it. This is a pharma compliance / reproducibility / cost requirement — LLM output cannot drive automated routing.
 - Do not call out to external services. Do not run `cdisc-rules-engine` yourself — that is the previous step's job.
 - Do not modify `/workspace/findings.json`. It is the audit record.
 - Do not invent findings, severities, or rule codes. If the data does not contain a field, omit the field; do not synthesise.
@@ -140,11 +132,12 @@ Exact shape:
 
 ## Edge cases
 
-- **`findings` is missing or null but `findingsCount > 0`** — treat as `scriptStatus = failed` ("findings count without findings array").
-- **`findings` is a very large array (>1000)** — still write the full count to the heatmap, but truncate the top-findings list to 20 with a "+ N more" footer.
-- **`scriptStatus = ok` but `error` field is set** — surface the error as a note in the HTML alongside the otherwise-successful findings.
-- **No `deliveryId` in input** — fall back to the directory basename of `deliveryDir`. If neither is present, label the delivery `unknown` and add a note in the summary.
+- **`classification` is missing from input** — fall back to `chaos` and surface the missing-classification fact in the banner. This should never happen in production (the Python router always emits one) but treat it as a script-integrity signal if it does.
+- **`/workspace/findings.json` is unreadable** — still render the banner with the input's classification + reason. Skip the heatmap and top-findings sections; note the missing audit file in the failure-detail section.
+- **Raw findings array is very large (>1000 rows)** — still write the full count to the heatmap, but truncate the top-findings list to 20 with a "+ N more" footer.
+- **`scriptStatus = ok` but `error` field is set** — surface the error as a note in the HTML alongside the otherwise-successful findings; the classification still wins the banner.
+- **No `deliveryId` in input** — fall back to the directory basename of `deliveryDir`. If neither is present, label the delivery `unknown` and add a note next to the header.
 
 ## Reference files
 
-- `references/cdisc-categories.md` — CDISC rule categories (Structure / Controlled Terminology / Consistency / FDA Business Rules / PMDA), severity levels (Critical / Major / Minor / Warning), and the rule-code prefix conventions used to map findings into categories. Read this before classification in Step 3.
+- `references/cdisc-categories.md` — CDISC rule categories (Structure / Controlled Terminology / Consistency / FDA Business Rules / PMDA), severity levels (Critical / Major / Minor / Warning), and the rule-code prefix conventions used to map findings into categories. Read this before building the heatmap in Step 3. The same prefix mapping is applied internally by the Python router that assigned the classification.

--- a/apps/landing-zone/scripts/router_rules.py
+++ b/apps/landing-zone/scripts/router_rules.py
@@ -1,0 +1,204 @@
+"""5-class router for CDISC validation findings.
+
+Pure deterministic classification — no LLM, no I/O. Lives next to validate.py
+because pharma compliance / reproducibility / cost reasons preclude letting
+the LLM agent route automated steps. The agent reads the resulting class
+from input.json and renders the report; it does not classify.
+
+## Glossary (CDISC rule prefix → category)
+
+| Prefix     | Category               | Source                     |
+|------------|------------------------|----------------------------|
+| SD0001-49  | Structure (SDTM)       | CDISC Conformance Rules    |
+| SD0050-99  | Controlled Terminology | per-domain CT checks       |
+| AD0001-99  | Structure (ADaM)       | ADaM IG                    |
+| CT####     | Controlled Terminology | CT codelist checks         |
+| CG####     | Consistency General    | cross-record / cross-domain|
+| FDA####    | FDA Business Rules     | FDA submission expectations|
+| PMDA####   | PMDA                   | Japanese regulator         |
+| anything   | Other                  | unrecognised — surface     |
+
+Severity field is read as-is. Missing severity is treated as `Major`
+(conservative default per Q1 of the v0.1 product decisions).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal, TypedDict
+
+
+Classification = Literal["clean", "minor-fix", "recovery", "escalate", "chaos"]
+
+
+class Finding(TypedDict, total=False):
+    rule_id: str
+    core_id: str
+    domain: str
+    severity: str  # Critical / Major / Minor / Warning
+    message: str
+    issues: int
+
+
+@dataclass(frozen=True)
+class RouterThresholds:
+    """Tunable thresholds. Defaults here; future studies/<id>/router-rules.yaml may override."""
+
+    # Min ratio of Controlled-Terminology findings to qualify as minor-fix
+    minor_fix_ct_ratio: float = 0.80
+    # Default expected-domains list for chaos calculation when EXPECTED_DOMAINS
+    # is not supplied by the caller
+    default_expected_domains: tuple[str, ...] = ("DM", "AE", "LB", "EX", "VS", "MH", "CM")
+    # Chaos triggers when Critical-Structure domains exceed this fraction of expected
+    chaos_critical_structure_fraction: float = 0.50
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    classification: Classification
+    reason: str  # 1-2 sentence text that explains which rule fired
+    script_failed_flag: bool
+
+
+def _category_of(finding: Finding) -> str:
+    """Map a finding to one of: Structure / ControlledTerminology / Consistency / FDA / PMDA / Other."""
+    raw = (finding.get("rule_id") or finding.get("core_id") or "").strip().upper()
+    if not raw:
+        return "Other"
+    # Allow numeric range matching for SD prefix
+    if raw.startswith("SD") and len(raw) >= 6:
+        try:
+            num = int(raw[2:6])
+            if 1 <= num <= 49:
+                return "Structure"
+            if 50 <= num <= 99:
+                return "ControlledTerminology"
+        except ValueError:
+            pass
+    if raw.startswith("AD"):
+        return "Structure"
+    if raw.startswith("CT"):
+        return "ControlledTerminology"
+    if raw.startswith("CG"):
+        return "Consistency"
+    if raw.startswith("FDA"):
+        return "FDA"
+    if raw.startswith("PMDA"):
+        return "PMDA"
+    return "Other"
+
+
+def _severity_of(finding: Finding) -> str:
+    raw = (finding.get("severity") or "").strip()
+    if not raw:
+        # Conservative default per Q1 — missing severity treated as Major
+        return "Major"
+    return raw
+
+
+def _critical_structure_domains(findings: Iterable[Finding]) -> set[str]:
+    """Return the set of unique domains with at least one Critical Structure finding."""
+    out: set[str] = set()
+    for finding in findings:
+        if _category_of(finding) != "Structure":
+            continue
+        if _severity_of(finding).lower() != "critical":
+            continue
+        domain = (finding.get("domain") or "").strip().upper()
+        if domain:
+            out.add(domain)
+    return out
+
+
+def classify(
+    *,
+    script_status: str,
+    findings: list[Finding],
+    expected_domains: list[str] | None = None,
+    thresholds: RouterThresholds | None = None,
+) -> ClassificationResult:
+    """Classify a delivery into one of the five v0.1 classes.
+
+    Evaluation order (first match wins):
+      1. scriptStatus=failed → chaos
+      2. Critical Structure findings span > 50% of expected domains → chaos
+      3. Critical Structure findings span >= 2 unique domains → escalate
+      4. Critical Structure findings in exactly 1 unique domain → recovery
+      5. >= 80% of findings are Controlled Terminology → minor-fix
+      6. findingsCount == 0 → clean
+      7. fallback (findings exist, none of the above) → recovery
+
+    The fallback at (7) reflects that an ambiguous has-findings case still
+    surfaces to a human reviewer. It is NOT escalate — only multi-domain
+    critical structure failures bypass the human.
+    """
+    thresholds = thresholds or RouterThresholds()
+    expected = tuple(
+        domain.strip().upper()
+        for domain in (expected_domains or thresholds.default_expected_domains)
+        if domain.strip()
+    )
+    findings_count = len(findings)
+
+    # 1. chaos — script failed
+    if script_status != "ok":
+        return ClassificationResult(
+            "chaos",
+            f"Validation script failed (scriptStatus={script_status!r}); cannot trust findings.",
+            script_failed_flag=True,
+        )
+
+    crit_struct_domains = _critical_structure_domains(findings)
+
+    # 2. chaos — critical structure across > 50% of expected domains
+    if expected and len(crit_struct_domains) > thresholds.chaos_critical_structure_fraction * len(expected):
+        return ClassificationResult(
+            "chaos",
+            f"Critical Structure findings in {len(crit_struct_domains)} of {len(expected)} expected domains "
+            f"({len(crit_struct_domains)}/{len(expected)} > {thresholds.chaos_critical_structure_fraction:.0%}).",
+            script_failed_flag=False,
+        )
+
+    # 3. escalate — critical structure in >= 2 unique domains
+    if len(crit_struct_domains) >= 2:
+        return ClassificationResult(
+            "escalate",
+            f"Critical Structure findings in {len(crit_struct_domains)} unique domains "
+            f"({', '.join(sorted(crit_struct_domains))}); no recovery path.",
+            script_failed_flag=False,
+        )
+
+    # 4. recovery — critical structure in exactly 1 unique domain
+    if len(crit_struct_domains) == 1:
+        domain = next(iter(crit_struct_domains))
+        return ClassificationResult(
+            "recovery",
+            f"Critical Structure findings in single domain {domain}; other domains parseable.",
+            script_failed_flag=False,
+        )
+
+    # 5. minor-fix — >= 80% findings are Controlled Terminology
+    if findings_count > 0:
+        ct_count = sum(1 for finding in findings if _category_of(finding) == "ControlledTerminology")
+        ratio = ct_count / findings_count
+        if ratio >= thresholds.minor_fix_ct_ratio:
+            return ClassificationResult(
+                "minor-fix",
+                f"{ct_count}/{findings_count} findings ({ratio:.0%}) are Controlled Terminology; pattern looks fixable.",
+                script_failed_flag=False,
+            )
+
+    # 6. clean — no findings
+    if findings_count == 0:
+        return ClassificationResult(
+            "clean",
+            "No findings — delivery passes all CDISC CORE rules.",
+            script_failed_flag=False,
+        )
+
+    # 7. fallback — has findings but no specific pattern
+    return ClassificationResult(
+        "recovery",
+        f"{findings_count} findings without a clear pattern; surfacing to human reviewer.",
+        script_failed_flag=False,
+    )

--- a/apps/landing-zone/scripts/test_router.py
+++ b/apps/landing-zone/scripts/test_router.py
@@ -1,0 +1,171 @@
+"""Tests for the deterministic 5-class router (router_rules.py).
+
+Covers the 11 cases from the v0.1 router spec test plan:
+  1.  empty findings + ok                                        → clean
+  2.  4 CT + 1 Major Structure (boundary 4/5 = 80%)              → minor-fix
+  3.  3 CT + 2 Major Structure (60%)                             → NOT minor-fix
+  4.  1 critical Structure DM + 5 Minor AE                       → recovery
+  5.  critical Structure DM + critical Structure AE              → escalate
+  6.  scriptStatus=failed                                        → chaos
+  7.  critical Structure in 4/7 expected domains                 → chaos
+  8.  crit Struct dom1 + crit Struct dom2 (default expected)     → escalate
+  9.  findingsCount=0, scriptStatus=ok                           → clean (alias of 1)
+  10. 1 CT only (boundary L1=1, 1/1=100%)                        → minor-fix
+  11. missing severity field                                     → treated as Major
+
+Run from repo root:
+  python3 -m unittest apps/landing-zone/scripts/test_router.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from router_rules import Finding, classify  # noqa: E402
+
+
+def make_finding(
+    *,
+    rule_id: str = "",
+    core_id: str = "",
+    domain: str = "",
+    severity: str = "",
+    message: str = "",
+    issues: int = 1,
+) -> Finding:
+    """Build a Finding TypedDict, only including non-empty keys."""
+    out: Finding = {}
+    if rule_id:
+        out["rule_id"] = rule_id
+    if core_id:
+        out["core_id"] = core_id
+    if domain:
+        out["domain"] = domain
+    if severity:
+        out["severity"] = severity
+    if message:
+        out["message"] = message
+    out["issues"] = issues
+    return out
+
+
+class TestRouterClassification(unittest.TestCase):
+    def test_01_empty_findings_ok_is_clean(self) -> None:
+        result = classify(script_status="ok", findings=[])
+        self.assertEqual(result.classification, "clean")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_02_four_ct_one_major_structure_is_minor_fix(self) -> None:
+        # 4 CT + 1 Major Structure → CT ratio = 4/5 = 80% boundary → minor-fix
+        findings: list[Finding] = [
+            make_finding(rule_id="CT0001", domain="DM", severity="Minor"),
+            make_finding(rule_id="CT0002", domain="AE", severity="Minor"),
+            make_finding(rule_id="CT0003", domain="LB", severity="Minor"),
+            make_finding(rule_id="CT0004", domain="VS", severity="Minor"),
+            make_finding(rule_id="SD0001", domain="DM", severity="Major"),
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertEqual(result.classification, "minor-fix")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_03_three_ct_two_major_structure_is_not_minor_fix(self) -> None:
+        # 3 CT + 2 Major Structure → CT ratio = 3/5 = 60% < 80% → NOT minor-fix
+        # No critical Structure → not recovery/escalate/chaos. Fallback → recovery.
+        findings: list[Finding] = [
+            make_finding(rule_id="CT0001", domain="DM", severity="Minor"),
+            make_finding(rule_id="CT0002", domain="AE", severity="Minor"),
+            make_finding(rule_id="CT0003", domain="LB", severity="Minor"),
+            make_finding(rule_id="SD0001", domain="DM", severity="Major"),
+            make_finding(rule_id="SD0002", domain="AE", severity="Major"),
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertNotEqual(result.classification, "minor-fix")
+        self.assertEqual(result.classification, "recovery")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_04_one_critical_structure_dm_plus_minor_ae_is_recovery(self) -> None:
+        findings: list[Finding] = [
+            make_finding(rule_id="SD0001", domain="DM", severity="Critical"),
+            make_finding(rule_id="CT0010", domain="AE", severity="Minor"),
+            make_finding(rule_id="CT0011", domain="AE", severity="Minor"),
+            make_finding(rule_id="CT0012", domain="AE", severity="Minor"),
+            make_finding(rule_id="CT0013", domain="AE", severity="Minor"),
+            make_finding(rule_id="CT0014", domain="AE", severity="Minor"),
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertEqual(result.classification, "recovery")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_05_critical_structure_dm_and_ae_is_escalate(self) -> None:
+        findings: list[Finding] = [
+            make_finding(rule_id="SD0001", domain="DM", severity="Critical"),
+            make_finding(rule_id="SD0002", domain="AE", severity="Critical"),
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertEqual(result.classification, "escalate")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_06_script_status_failed_is_chaos(self) -> None:
+        result = classify(script_status="failed", findings=[])
+        self.assertEqual(result.classification, "chaos")
+        self.assertTrue(result.script_failed_flag)
+
+    def test_07_critical_structure_in_four_of_seven_expected_is_chaos(self) -> None:
+        # 4 / 7 = 57% > 50% → chaos via fraction trigger
+        findings: list[Finding] = [
+            make_finding(rule_id="SD0001", domain="DM", severity="Critical"),
+            make_finding(rule_id="SD0002", domain="AE", severity="Critical"),
+            make_finding(rule_id="SD0003", domain="LB", severity="Critical"),
+            make_finding(rule_id="SD0004", domain="EX", severity="Critical"),
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertEqual(result.classification, "chaos")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_08_crit_struct_two_domains_default_expected_is_escalate(self) -> None:
+        # Default expected = 7 domains; 2 critical-structure domains is 2/7 = 29%,
+        # below the 50% chaos threshold → falls through to escalate.
+        findings: list[Finding] = [
+            make_finding(rule_id="SD0001", domain="DM", severity="Critical"),
+            make_finding(rule_id="SD0002", domain="AE", severity="Critical"),
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertEqual(result.classification, "escalate")
+        self.assertNotEqual(result.classification, "recovery")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_09_findings_count_zero_status_ok_is_clean(self) -> None:
+        result = classify(script_status="ok", findings=[])
+        self.assertEqual(result.classification, "clean")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_10_single_ct_finding_is_minor_fix(self) -> None:
+        # 1 CT total, 1/1 = 100% >= 80% → minor-fix
+        findings: list[Finding] = [
+            make_finding(rule_id="CT0001", domain="DM", severity="Minor"),
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertEqual(result.classification, "minor-fix")
+        self.assertFalse(result.script_failed_flag)
+
+    def test_11_missing_severity_is_treated_as_major(self) -> None:
+        # A Structure finding with no severity field. The conservative default
+        # is Major, NOT Critical, so it must NOT trigger recovery/escalate/chaos.
+        # With one such finding the classifier should fall through:
+        #   crit_struct_domains is empty (severity defaulted to Major, not Critical)
+        #   1 finding, 0 CT → ratio 0% < 80% → not minor-fix
+        #   findingsCount > 0 → fallback recovery
+        findings: list[Finding] = [
+            make_finding(rule_id="SD0001", domain="DM"),  # no severity
+        ]
+        result = classify(script_status="ok", findings=findings)
+        self.assertEqual(result.classification, "recovery")
+        self.assertFalse(result.script_failed_flag)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/landing-zone/scripts/validate.py
+++ b/apps/landing-zone/scripts/validate.py
@@ -4,26 +4,33 @@ Reads the most recent delivery dropped into /workspace/incoming/ by sftp-poll,
 runs the CDISC CORE rules engine against it, and writes structured findings to
 both /workspace (audit trail via run worktree commit) and /output (engine I/O).
 
-The script catches its own exceptions and ALWAYS exits 0. The next step
-(interpret-validation, an LLM agent) reads `scriptStatus` from the result and
-adapts: on `ok` it summarizes findings; on `failed` it surfaces the failure
-prominently to the human reviewer and attempts to extract any partial signal.
+The script catches its own exceptions and ALWAYS exits 0. After running the
+engine (whether it succeeded or failed) the script calls the deterministic
+router (router_rules.classify) to compute a 5-class verdict. The interpret
+step (an LLM agent) reads the classification from input.json and renders the
+HTML report — it does not classify itself.
 
 Inputs:
   /workspace/incoming/{deliveryId}/*.xpt — files downloaded by sftp-poll
   env: VALIDATION_STANDARD (sdtm/adam), VALIDATION_IG_VERSION (e.g. 3.4)
+  env: EXPECTED_DOMAINS — comma-separated list driving chaos threshold
 
 Outputs:
   /output/result.json:
     {
-      "scriptStatus": "ok" | "failed",
-      "deliveryDir":  "incoming/d-..." or null,
-      "findings":     {...} | null,         # raw CORE engine output
-      "findingsCount": int,                 # zero on failure
-      "error":        str (on failure),
-      "traceback":    str (on failure)
+      "scriptStatus":         "ok" | "failed",
+      "deliveryDir":          "incoming/d-..." or null,
+      "findingsPath":         "findings.json" or null,
+      "findingsCount":        int,                 # zero on failure
+      "summary_data":         {...},               # per-finding summary
+      "classification":       "clean|minor-fix|recovery|escalate|chaos",
+      "classificationReason": "1-2 sentence text",
+      "scriptFailedFlag":     bool,
+      "summary":              "1-2 sentence verdict (alias of classificationReason)",
+      "error":                str (on failure),
+      "traceback":            str (on failure)
     }
-  /workspace/findings.json — same content as result.json (audit trail)
+  /workspace/findings.json — raw CORE engine output (audit trail)
 """
 
 from __future__ import annotations
@@ -35,6 +42,9 @@ import sys
 import traceback
 from pathlib import Path
 from typing import Any
+
+import router_rules
+from router_rules import ClassificationResult, Finding
 
 OUTPUT = Path("/output")
 WORKSPACE = Path("/workspace")
@@ -170,6 +180,54 @@ def count_findings(findings: dict[str, Any] | None) -> int:
     return 0
 
 
+def build_router_findings(findings: dict[str, Any] | None) -> list[Finding]:
+    """Map CORE Issue_Summary rows to Finding TypedDicts the router can read.
+
+    Each Issue_Summary row represents a unique rule-finding (one rule fired
+    against one dataset). We do NOT flatten Issue_Details into per-row
+    findings — the router operates on rule-level uniqueness, not row-level
+    repetition.
+    """
+    if not isinstance(findings, dict):
+        return []
+    summary = findings.get("Issue_Summary")
+    if not isinstance(summary, list):
+        return []
+    out: list[Finding] = []
+    for entry in summary:
+        if not isinstance(entry, dict):
+            continue
+        finding: Finding = {}
+        rule_id = entry.get("rule_id") or entry.get("core_id")
+        if isinstance(rule_id, str) and rule_id:
+            finding["rule_id"] = rule_id
+        core_id = entry.get("core_id")
+        if isinstance(core_id, str) and core_id:
+            finding["core_id"] = core_id
+        dataset = entry.get("dataset")
+        if isinstance(dataset, str) and dataset:
+            finding["domain"] = dataset
+        severity = entry.get("severity")
+        if isinstance(severity, str) and severity:
+            finding["severity"] = severity
+        message = entry.get("message")
+        if isinstance(message, str) and message:
+            finding["message"] = message
+        issues = entry.get("issues")
+        if isinstance(issues, int):
+            finding["issues"] = issues
+        out.append(finding)
+    return out
+
+
+def parse_expected_domains() -> list[str] | None:
+    """Read EXPECTED_DOMAINS env var as comma-separated list. Empty → None."""
+    raw = os.environ.get("EXPECTED_DOMAINS", "").strip()
+    if not raw:
+        return None
+    return [token.strip() for token in raw.split(",") if token.strip()]
+
+
 def summarise_findings(findings: dict[str, Any] | None) -> dict[str, Any]:
     """Compact summary suitable for the step output envelope.
 
@@ -215,14 +273,33 @@ def summarise_findings(findings: dict[str, Any] | None) -> dict[str, Any]:
     }
 
 
+def classify_payload(
+    *,
+    script_status: str,
+    findings: dict[str, Any] | None,
+) -> ClassificationResult:
+    """Run the deterministic router against the engine output."""
+    return router_rules.classify(
+        script_status=script_status,
+        findings=build_router_findings(findings),
+        expected_domains=parse_expected_domains(),
+    )
+
+
 def main() -> None:
     delivery = find_latest_delivery()
     if delivery is None:
+        verdict = classify_payload(script_status="failed", findings=None)
         write_result({
             "scriptStatus": "failed",
             "deliveryDir": None,
+            "findingsPath": None,
             "findingsCount": 0,
-            "summary": None,
+            "summary_data": None,
+            "classification": verdict.classification,
+            "classificationReason": verdict.reason,
+            "scriptFailedFlag": verdict.script_failed_flag,
+            "summary": verdict.reason,
             "error": "No delivery directory found in /workspace/incoming",
             "traceback": "",
         })
@@ -234,25 +311,38 @@ def main() -> None:
     try:
         findings = run_cdisc_core(delivery, findings_path)
         write_findings(findings)
+        verdict = classify_payload(script_status="ok", findings=findings)
         write_result({
             "scriptStatus": "ok",
             "deliveryDir": delivery_rel,
             "findingsPath": "findings.json",
             "findingsCount": count_findings(findings),
-            "summary": summarise_findings(findings),
+            "summary_data": summarise_findings(findings),
+            "classification": verdict.classification,
+            "classificationReason": verdict.reason,
+            "scriptFailedFlag": verdict.script_failed_flag,
+            "summary": verdict.reason,
         })
-        print(f"validate: ok, {count_findings(findings)} finding(s)", file=sys.stderr)
+        print(
+            f"validate: ok, {count_findings(findings)} finding(s) → {verdict.classification}",
+            file=sys.stderr,
+        )
     except Exception as error:
+        verdict = classify_payload(script_status="failed", findings=None)
         write_result({
             "scriptStatus": "failed",
             "deliveryDir": delivery_rel,
             "findingsPath": None,
             "findingsCount": 0,
-            "summary": None,
+            "summary_data": None,
+            "classification": verdict.classification,
+            "classificationReason": verdict.reason,
+            "scriptFailedFlag": verdict.script_failed_flag,
+            "summary": verdict.reason,
             "error": f"{type(error).__name__}: {error}",
             "traceback": traceback.format_exc(),
         })
-        print(f"validate: FAILED — {error}", file=sys.stderr)
+        print(f"validate: FAILED — {error} → {verdict.classification}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/apps/landing-zone/src/__tests__/workflow-definition.test.ts
+++ b/apps/landing-zone/src/__tests__/workflow-definition.test.ts
@@ -144,7 +144,7 @@ describe('landing-zone-CDISCPILOT01.wd.json', () => {
     expect(result.data.workspace?.remoteAuth).toBe('GITHUB_TOKEN');
   });
 
-  it('interpret-validation has 5 outgoing classification transitions', () => {
+  it('interpret-validation has 5 classification transitions + an else fallback', () => {
     const result = loadDefinition();
     expect(result.success).toBe(true);
     if (!result.success) return;
@@ -152,18 +152,29 @@ describe('landing-zone-CDISCPILOT01.wd.json', () => {
     const interpretTransitions = result.data.transitions.filter(
       (transition) => transition.from === 'interpret-validation',
     );
-    expect(interpretTransitions).toHaveLength(5);
+    expect(interpretTransitions).toHaveLength(6);
 
     const allowedTargets = new Set(['accept-delivery', 'human-review', 'draft-rejection-note']);
     for (const transition of interpretTransitions) {
       expect(transition.when).toBeDefined();
-      expect(transition.when).toContain('output.classification');
       expect(allowedTargets.has(transition.to)).toBe(true);
+    }
+
+    const classificationTransitions = interpretTransitions.filter(
+      (transition) => transition.when !== 'else',
+    );
+    const elseTransitions = interpretTransitions.filter(
+      (transition) => transition.when === 'else',
+    );
+
+    expect(classificationTransitions).toHaveLength(5);
+    for (const transition of classificationTransitions) {
+      expect(transition.when).toContain('output.classification');
     }
 
     const expectedClasses = ['clean', 'minor-fix', 'recovery', 'escalate', 'chaos'];
     for (const className of expectedClasses) {
-      const matching = interpretTransitions.filter((transition) =>
+      const matching = classificationTransitions.filter((transition) =>
         transition.when?.includes(`"${className}"`),
       );
       expect(
@@ -173,7 +184,7 @@ describe('landing-zone-CDISCPILOT01.wd.json', () => {
     }
 
     const targetByClass = new Map<string, string>();
-    for (const transition of interpretTransitions) {
+    for (const transition of classificationTransitions) {
       const matched = expectedClasses.find((className) =>
         transition.when?.includes(`"${className}"`),
       );
@@ -184,6 +195,9 @@ describe('landing-zone-CDISCPILOT01.wd.json', () => {
     expect(targetByClass.get('recovery')).toBe('human-review');
     expect(targetByClass.get('escalate')).toBe('draft-rejection-note');
     expect(targetByClass.get('chaos')).toBe('draft-rejection-note');
+
+    expect(elseTransitions).toHaveLength(1);
+    expect(elseTransitions[0].to).toBe('human-review');
   });
 
   it('human-review verdicts unchanged (approve/revise routes preserved)', () => {

--- a/apps/landing-zone/src/__tests__/workflow-definition.test.ts
+++ b/apps/landing-zone/src/__tests__/workflow-definition.test.ts
@@ -143,4 +143,59 @@ describe('landing-zone-CDISCPILOT01.wd.json', () => {
     expect(result.data.workspace?.remote).toBe('Appsilon/mediforce-landing-zone-study-demo');
     expect(result.data.workspace?.remoteAuth).toBe('GITHUB_TOKEN');
   });
+
+  it('interpret-validation has 5 outgoing classification transitions', () => {
+    const result = loadDefinition();
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const interpretTransitions = result.data.transitions.filter(
+      (transition) => transition.from === 'interpret-validation',
+    );
+    expect(interpretTransitions).toHaveLength(5);
+
+    const allowedTargets = new Set(['accept-delivery', 'human-review', 'draft-rejection-note']);
+    for (const transition of interpretTransitions) {
+      expect(transition.when).toBeDefined();
+      expect(transition.when).toContain('output.classification');
+      expect(allowedTargets.has(transition.to)).toBe(true);
+    }
+
+    const expectedClasses = ['clean', 'minor-fix', 'recovery', 'escalate', 'chaos'];
+    for (const className of expectedClasses) {
+      const matching = interpretTransitions.filter((transition) =>
+        transition.when?.includes(`"${className}"`),
+      );
+      expect(
+        matching.length,
+        `expected exactly one transition matching class "${className}"`,
+      ).toBe(1);
+    }
+
+    const targetByClass = new Map<string, string>();
+    for (const transition of interpretTransitions) {
+      const matched = expectedClasses.find((className) =>
+        transition.when?.includes(`"${className}"`),
+      );
+      if (matched) targetByClass.set(matched, transition.to);
+    }
+    expect(targetByClass.get('clean')).toBe('accept-delivery');
+    expect(targetByClass.get('minor-fix')).toBe('human-review');
+    expect(targetByClass.get('recovery')).toBe('human-review');
+    expect(targetByClass.get('escalate')).toBe('draft-rejection-note');
+    expect(targetByClass.get('chaos')).toBe('draft-rejection-note');
+  });
+
+  it('human-review verdicts unchanged (approve/revise routes preserved)', () => {
+    const result = loadDefinition();
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const humanReview = result.data.steps.find((step) => step.id === 'human-review');
+    expect(humanReview).toBeDefined();
+    expect(humanReview?.verdicts).toEqual({
+      approve: { target: 'accept-delivery' },
+      revise: { target: 'draft-rejection-note' },
+    });
+  });
 });

--- a/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
+++ b/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
@@ -148,6 +148,7 @@
     { "from": "interpret-validation", "to": "human-review", "when": "output.classification == \"recovery\"" },
     { "from": "interpret-validation", "to": "draft-rejection-note", "when": "output.classification == \"escalate\"" },
     { "from": "interpret-validation", "to": "draft-rejection-note", "when": "output.classification == \"chaos\"" },
+    { "from": "interpret-validation", "to": "human-review", "when": "else" },
     { "from": "accept-delivery", "to": "accepted" },
     { "from": "draft-rejection-note", "to": "rejected-with-note" }
   ]

--- a/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
+++ b/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
@@ -143,7 +143,11 @@
     { "from": "sftp-poll", "to": "no-deliveries", "when": "output.newFiles.length == 0" },
     { "from": "sftp-poll", "to": "validate-script", "when": "output.newFiles.length > 0" },
     { "from": "validate-script", "to": "interpret-validation" },
-    { "from": "interpret-validation", "to": "human-review" },
+    { "from": "interpret-validation", "to": "accept-delivery", "when": "output.classification == \"clean\"" },
+    { "from": "interpret-validation", "to": "human-review", "when": "output.classification == \"minor-fix\"" },
+    { "from": "interpret-validation", "to": "human-review", "when": "output.classification == \"recovery\"" },
+    { "from": "interpret-validation", "to": "draft-rejection-note", "when": "output.classification == \"escalate\"" },
+    { "from": "interpret-validation", "to": "draft-rejection-note", "when": "output.classification == \"chaos\"" },
     { "from": "accept-delivery", "to": "accepted" },
     { "from": "draft-rejection-note", "to": "rejected-with-note" }
   ]

--- a/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
+++ b/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
@@ -71,7 +71,7 @@
       "executor": "agent",
       "plugin": "claude-code-agent",
       "autonomyLevel": "L2",
-      "description": "Read findings + scriptStatus. Classify (clean / has-findings / escalate). Render HTML report for human review. On scriptStatus=failed, surface the failure prominently and attempt to extract any partial signal.",
+      "description": "Read deterministic classification (clean / minor-fix / recovery / escalate / chaos) from validate-script output and render an HTML report. Does not classify — the rules engine + router_rules.py decide the class. Surfaces script-failure path (chaos) prominently with traceback when present.",
       "agent": {
         "skill": "data-validator",
         "skillsDir": "apps/landing-zone/plugins/landing-zone/skills",


### PR DESCRIPTION
## Summary

- Move CDISC validation classification from the LLM agent into a deterministic Python module (`router_rules.py`) — required for pharma compliance (auditable, reproducible) and to enable autonomous routing on `clean` / `escalate` / `chaos` paths.
- Extends the v0.1 vocabulary from 3 classes (`clean` / `has-findings` / `escalate`) to 5: `clean`, `minor-fix`, `recovery`, `escalate`, `chaos` — each with explicit firing rules and routing target.
- `interpret-validation` agent now reads the classification from input.json and renders the report; it never recomputes the class.

## Routing change

| Class | Rule | New target | Skip human? |
|---|---|---|---|
| `clean` | `findingsCount === 0` and script ok | `accept-delivery` | yes (L4) |
| `minor-fix` | ≥80% of findings are Controlled Terminology | `human-review` | no |
| `recovery` | Critical Structure findings in exactly 1 unique domain | `human-review` | no |
| `escalate` | Critical Structure findings in ≥2 unique domains | `draft-rejection-note` | yes (L4) |
| `chaos` | `scriptStatus=failed` OR Critical Structure in >50% of expected domains | `draft-rejection-note` | yes (L4) |

Evaluation order: chaos → escalate → recovery → minor-fix → clean. Has-findings without a clear pattern falls back to `recovery` (surfaces to human).

`human-review` verdicts unchanged (`approve` → `accept-delivery`, `revise` → `draft-rejection-note`).

## Files changed

- `apps/landing-zone/scripts/router_rules.py` (new) — `RouterThresholds` dataclass, `classify()` function, glossary docstring with CDISC prefix → category mapping
- `apps/landing-zone/scripts/test_router.py` (new) — 11 stdlib unittest cases covering the spec
- `apps/landing-zone/scripts/validate.py` — emit `classification`, `classificationReason`, `summary`, `scriptFailedFlag`; rename per-finding summary to `summary_data`
- `apps/landing-zone/plugins/landing-zone/skills/data-validator/SKILL.md` — drop classification logic, expand banner colour scheme to 5 classes, document the new result.json shape
- `apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json` — 5 conditional transitions from `interpret-validation` based on `output.classification`
- `apps/landing-zone/src/__tests__/workflow-definition.test.ts` — assert the 5-transition graph + unchanged `human-review` verdicts

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1884 passed / 1 skipped
- [x] `npx vitest run apps/landing-zone/src/__tests__/workflow-definition.test.ts` — 12 passed
- [x] `python3 -m unittest apps/landing-zone/scripts/test_router.py -v` — 11 passed
- [ ] Smoke test: re-upload to staging SFTP, observe pipeline auto-route on `clean` and `escalate` paths

## E2E

This change does not touch `packages/platform-ui/src/` or any package the platform-ui consumes at runtime — landing-zone is a workflow definition app loaded by the engine via JSON. No platform-ui E2E run required by the AGENTS.md rules.

The end-to-end smoke test for routing behaviour is the staging-SFTP pipeline run (last item in Test plan), planned post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)