### PR TITLE
fix(infra): verbose error messages for all workflow run failure paths

### DIFF
--- a/packages/core-actions/src/handlers/http.ts
+++ b/packages/core-actions/src/handlers/http.ts
@@ -57,8 +57,17 @@ export const httpActionHandler: HttpActionHandler = async (config, ctx) => {
     const rootMessage = cause instanceof Error ? cause.message : String(cause);
     const underlyingDetail =
       cause instanceof Error && cause.cause instanceof Error ? ` (${cause.cause.message})` : '';
+    // Strip query string — it may contain interpolated secret values (e.g. ?key=${secrets.API_KEY}).
+    const safeUrl = (() => {
+      try {
+        const u = new URL(resolvedConfig.url);
+        return `${u.origin}${u.pathname}`;
+      } catch {
+        return resolvedConfig.url;
+      }
+    })();
     throw new Error(
-      `HTTP request failed: ${resolvedConfig.method} ${resolvedConfig.url} — ${rootMessage}${underlyingDetail}`,
+      `HTTP request failed: ${resolvedConfig.method} ${safeUrl} — ${rootMessage}${underlyingDetail}`,
     );
   }
   const text = await response.text();

--- a/packages/core-actions/src/handlers/http.ts
+++ b/packages/core-actions/src/handlers/http.ts
@@ -50,7 +50,17 @@ export const httpActionHandler: HttpActionHandler = async (config, ctx) => {
     }
   }
 
-  const response = await fetch(resolvedConfig.url, init);
+  let response: Response;
+  try {
+    response = await fetch(resolvedConfig.url, init);
+  } catch (cause) {
+    const rootMessage = cause instanceof Error ? cause.message : String(cause);
+    const underlyingDetail =
+      cause instanceof Error && cause.cause instanceof Error ? ` (${cause.cause.message})` : '';
+    throw new Error(
+      `HTTP request failed: ${resolvedConfig.method} ${resolvedConfig.url} — ${rootMessage}${underlyingDetail}`,
+    );
+  }
   const text = await response.text();
   let json: unknown = null;
   if (text.length > 0) {

--- a/packages/platform-infra/src/crypto/secrets-cipher.ts
+++ b/packages/platform-infra/src/crypto/secrets-cipher.ts
@@ -76,6 +76,7 @@ export function decrypt(encoded: string): string {
       `Decryption auth-tag verification failed (${rootMessage}). ` +
         'Most likely cause: SECRETS_ENCRYPTION_KEY was rotated or differs between environments — ' +
         'secrets stored with the old key cannot be decrypted with the current key.',
+      { cause },
     );
   }
 }

--- a/packages/platform-infra/src/crypto/secrets-cipher.ts
+++ b/packages/platform-infra/src/crypto/secrets-cipher.ts
@@ -64,9 +64,18 @@ export function decrypt(encoded: string): string {
     authTagLength: AUTH_TAG_LENGTH,
   });
   decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
-  const decrypted = Buffer.concat([
-    decipher.update(Buffer.from(ciphertextHex, 'hex')),
-    decipher.final(),
-  ]);
-  return decrypted.toString('utf8');
+  try {
+    const decrypted = Buffer.concat([
+      decipher.update(Buffer.from(ciphertextHex, 'hex')),
+      decipher.final(),
+    ]);
+    return decrypted.toString('utf8');
+  } catch (cause) {
+    const rootMessage = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(
+      `Decryption auth-tag verification failed (${rootMessage}). ` +
+        'Most likely cause: SECRETS_ENCRYPTION_KEY was rotated or differs between environments — ' +
+        'secrets stored with the old key cannot be decrypted with the current key.',
+    );
+  }
 }

--- a/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
+++ b/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
@@ -29,7 +29,7 @@ export class FirestoreWorkflowSecretsRepository {
         result[key] = decrypt(value);
       } catch (cause) {
         const rootMessage = cause instanceof Error ? cause.message : String(cause);
-        throw new Error(`Failed to decrypt workflow secret '${key}': ${rootMessage}`);
+        throw new Error(`Failed to decrypt workflow secret '${key}': ${rootMessage}`, { cause });
       }
     }
     return result;

--- a/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
+++ b/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
@@ -25,7 +25,12 @@ export class FirestoreWorkflowSecretsRepository {
   private decryptSecrets(encrypted: Record<string, string>): Record<string, string> {
     const result: Record<string, string> = {};
     for (const [key, value] of Object.entries(encrypted)) {
-      result[key] = decrypt(value);
+      try {
+        result[key] = decrypt(value);
+      } catch (cause) {
+        const rootMessage = cause instanceof Error ? cause.message : String(cause);
+        throw new Error(`Failed to decrypt workflow secret '${key}': ${rootMessage}`);
+      }
     }
     return result;
   }

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -480,7 +480,7 @@ export async function POST(
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
 
-    console.error(`[auto-runner] Unhandled error for instance '${instanceId}': ${message}`);
+    console.error(`[auto-runner] Unhandled error for instance '${instanceId}':`, err);
 
     // Attempt to mark instance as failed and write audit event
     try {

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -18,6 +18,7 @@ export async function POST(
   const { instanceRepo, processRepo, auditRepo } = getPlatformServices();
   let stepsExecuted = 0;
   let definitionVersion = 'unknown';
+  let lastActiveStepId: string | null = null;
 
   try {
     const body = (await req.json().catch(() => ({}))) as RunProcessBody;
@@ -115,6 +116,8 @@ export async function POST(
         if (!instance) break;
         if (instance.status !== 'running') break;
         if (instance.currentStepId === null) break;
+
+        lastActiveStepId = instance.currentStepId;
 
         if (isStuckLoop(instance.currentStepId, loopTracker)) {
           console.error(`[auto-runner] Safety guard: step '${instance.currentStepId}' looped ${MAX_SAME_STEP_ITERATIONS} times — aborting instance ${instanceId}`);
@@ -386,8 +389,9 @@ export async function POST(
             stepsExecuted++;
             continue;
           } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            console.error(`[auto-runner] Action step '${currentStep.id}' failed: ${message}`);
+            const rootMessage = err instanceof Error ? err.message : String(err);
+            const message = `Step '${currentStep.id}' (action: ${currentStep.action.kind}) failed: ${rootMessage}`;
+            console.error(`[auto-runner] Action step '${currentStep.id}' failed:`, err);
             await instanceRepo.updateStepExecution(instanceId, executionId, {
               status: 'failed',
               completedAt: new Date().toISOString(),
@@ -478,7 +482,9 @@ export async function POST(
       stepsExecuted,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
+    const rootMessage = err instanceof Error ? err.message : 'Unknown error';
+    const stepContext = lastActiveStepId !== null ? ` (crashed while processing step '${lastActiveStepId}')` : '';
+    const message = `${rootMessage}${stepContext}`;
 
     console.error(`[auto-runner] Unhandled error for instance '${instanceId}':`, err);
 

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -193,6 +193,18 @@ export async function executeAgentStep(
     });
   }
 
+  // When the agent crashes (fallbackReason='error'), surface the error on the
+  // run overview by writing it to processInstance.error. Without this the error
+  // is only visible on the step detail page.
+  const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
+  if (isFailed && runResult.errorMessage) {
+    const failLabel = runResult.fallbackReason === 'timeout' ? 'timed out' : 'failed';
+    await instanceRepo.update(instanceId, {
+      error: `Agent step '${stepId}' ${failLabel}: ${runResult.errorMessage}`,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
   // Persist output to instance.variables so subsequent steps can read it
   const agentOutput = envelope?.result ?? null;
   if (agentOutput !== null) {

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -197,12 +197,15 @@ export async function executeAgentStep(
   // run overview by writing it to processInstance.error. Without this the error
   // is only visible on the step detail page.
   const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
-  if (isFailed && runResult.errorMessage) {
+  if (isFailed) {
     const failLabel = runResult.fallbackReason === 'timeout' ? 'timed out' : 'failed';
-    await instanceRepo.update(instanceId, {
-      error: `Agent step '${stepId}' ${failLabel}: ${runResult.errorMessage}`,
-      updatedAt: new Date().toISOString(),
-    });
+    const errorDetail = runResult.errorMessage ?? (runResult.fallbackReason === 'timeout' ? 'agent execution timed out' : null);
+    if (errorDetail !== null) {
+      await instanceRepo.update(instanceId, {
+        error: `Agent step '${stepId}' ${failLabel}: ${errorDetail}`,
+        updatedAt: new Date().toISOString(),
+      });
+    }
   }
 
   // Persist output to instance.variables so subsequent steps can read it

--- a/packages/platform-ui/src/lib/workflow-status.ts
+++ b/packages/platform-ui/src/lib/workflow-status.ts
@@ -54,7 +54,7 @@ export function getWorkflowStatus(instance: {
       case 'cowork_in_progress':
         return { displayStatus: 'waiting_for_human', reason: 'Cowork session in progress', rawReason: pauseReason, isRetryable: false, hasDedicatedBanner: false };
       case 'agent_escalated':
-        return { displayStatus: 'waiting_for_human', reason: 'Agent escalated to human review', rawReason: pauseReason, isRetryable: true, hasDedicatedBanner: false };
+        return { displayStatus: 'waiting_for_human', reason: error !== null ? `Agent failed: ${error}` : 'Agent escalated to human review', rawReason: pauseReason, isRetryable: true, hasDedicatedBanner: false };
       case 'agent_paused':
         return { displayStatus: 'waiting_for_human', reason: 'Agent requested human review', rawReason: pauseReason, isRetryable: true, hasDedicatedBanner: false };
       case 'missing_env':


### PR DESCRIPTION
## Motivation

Every error that ends up in `processInstance.error` is shown verbatim in the run detail UI. Previously most errors were raw Node.js / Firestore messages with no context — users (and admins without SSH access) couldn't tell which step failed, what kind of failure it was, or what to do about it.

## What changed

### Decryption failures (`platform-infra`)
`decrypt()` threw the raw AES-256-GCM error with no context.

**Before:** `Unsupported state or unable to authenticate data`

**After:** `Failed to decrypt workflow secret 'MY_API_KEY': Decryption auth-tag verification failed (Unsupported state or unable to authenticate data). Most likely cause: SECRETS_ENCRYPTION_KEY was rotated or differs between environments — secrets stored with the old key cannot be decrypted with the current key.`

### HTTP action transport failures (`core-actions`)
**Before:** `fetch failed`

**After:** `HTTP request failed: POST https://api.example.com/endpoint — fetch failed (ECONNREFUSED)`

Query string is stripped from the URL to avoid leaking interpolated secret values (e.g. `?key=${secrets.API_KEY}`).

### Action step failures (`run/route.ts`)
**Before:** `Connection refused`

**After:** `Step 'fetch-patient-data' (action: http) failed: Connection refused`

### Unhandled crashes in the run loop (`run/route.ts`)
**Before:** `DEADLINE_EXCEEDED: Deadline exceeded`

**After:** `DEADLINE_EXCEEDED: Deadline exceeded (crashed while processing step 'validate-record')`

### Agent step errors invisible on run overview (`execute-agent-step.ts`)
Agent crash / timeout errors were written to `stepExecution.error` only — requiring a click-through to the step detail page. The run overview showed the generic "Agent escalated to human review" with no details.

Now `processInstance.error` is also written when an agent fails or times out, so the error appears directly on the run overview. Timeout errors get the fallback message "agent execution timed out" when no error string is available.

### Agent escalated banner now shows the error (`workflow-status.ts`)
For `pauseReason='agent_escalated'`, the amber banner now shows the actual error text from `instance.error` when available, instead of the hardcoded generic message.

## E2E
- No visible UI change beyond the error text itself — displayed by the existing red/amber banner in the run detail view
- Not covered by E2E (would require deliberately triggering each failure mode mid-test)
- All 93 platform-infra unit tests pass; no new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)