### PR TITLE
feat(container-worker): add HTTP info service for Docker host visibility

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,6 +82,8 @@ services:
       dockerfile: packages/container-worker/Dockerfile.worker
     restart: unless-stopped
     mem_limit: ${AGENT_WORKER_MEM_LIMIT:-1280m}
+    expose:
+      - "3001"
     environment:
       - REDIS_URL=redis://redis:6379
     volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -86,6 +86,7 @@ services:
       - "3001"
     environment:
       - REDIS_URL=redis://redis:6379
+      - WORKER_HTTP_PORT=3001
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -28,5 +28,7 @@ services:
       - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
 
   container-worker:
+    expose:
+      - "3001"
     environment:
       - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     build:
       context: .
       dockerfile: packages/container-worker/Dockerfile.worker
+    expose:
+      - "3001"
     environment:
       - REDIS_URL=redis://redis:6379
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - "3001"
     environment:
       - REDIS_URL=redis://redis:6379
+      - WORKER_HTTP_PORT=3001
     volumes:
       # Worker needs Docker socket to spawn containers
       - /var/run/docker.sock:/var/run/docker.sock

--- a/packages/container-worker/src/__tests__/docker-info.test.ts
+++ b/packages/container-worker/src/__tests__/docker-info.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { listImages, getDiskUsage } from '../docker-info.js';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+const mockExecSync = vi.mocked(execSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listImages', () => {
+  it('parses docker images NDJSON output', () => {
+    mockExecSync.mockReturnValue(Buffer.from(
+      [
+        JSON.stringify({ Repository: 'mediforce/agent', Tag: 'latest', ID: 'abc123', Size: '1.2GB', CreatedSince: '2 days ago' }),
+        JSON.stringify({ Repository: 'node', Tag: '20-slim', ID: 'def456', Size: '200MB', CreatedSince: '3 weeks ago' }),
+      ].join('\n'),
+    ));
+
+    const result = listImages();
+
+    expect(result).toEqual([
+      { repository: 'mediforce/agent', tag: 'latest', id: 'abc123', size: '1.2GB', created: '2 days ago' },
+      { repository: 'node', tag: '20-slim', id: 'def456', size: '200MB', created: '3 weeks ago' },
+    ]);
+    expect(mockExecSync).toHaveBeenCalledWith("docker images --format '{{json .}}'", { stdio: 'pipe' });
+  });
+
+  it('returns empty array when no images', () => {
+    mockExecSync.mockReturnValue(Buffer.from(''));
+    expect(listImages()).toEqual([]);
+  });
+});
+
+describe('getDiskUsage', () => {
+  it('parses docker system df NDJSON output', () => {
+    mockExecSync.mockReturnValue(Buffer.from(
+      [
+        JSON.stringify({ Type: 'Images', TotalCount: '15', Active: '5', Size: '4.2GB' }),
+        JSON.stringify({ Type: 'Containers', TotalCount: '8', Active: '3', Size: '500MB' }),
+        JSON.stringify({ Type: 'Local Volumes', TotalCount: '2', Active: '1', Size: '100MB' }),
+        JSON.stringify({ Type: 'Build Cache', TotalCount: '20', Active: '0', Size: '1.5GB' }),
+      ].join('\n'),
+    ));
+
+    const result = getDiskUsage();
+
+    expect(result).toEqual({
+      images: { totalCount: 15, size: '4.2GB' },
+      containers: { totalCount: 8, active: 3, size: '500MB' },
+      buildCache: { size: '1.5GB' },
+    });
+  });
+
+  it('defaults to zero when type missing', () => {
+    mockExecSync.mockReturnValue(Buffer.from(
+      JSON.stringify({ Type: 'Images', TotalCount: '5', Size: '2GB' }),
+    ));
+
+    const result = getDiskUsage();
+
+    expect(result.containers).toEqual({ totalCount: 0, active: 0, size: '0B' });
+    expect(result.buildCache).toEqual({ size: '0B' });
+  });
+});

--- a/packages/container-worker/src/__tests__/docker-info.test.ts
+++ b/packages/container-worker/src/__tests__/docker-info.test.ts
@@ -2,52 +2,54 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { listImages, getDiskUsage } from '../docker-info.js';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFile: vi.fn(),
 }));
 
-import { execSync } from 'node:child_process';
-const mockExecSync = vi.mocked(execSync);
+vi.mock('node:util', () => ({
+  promisify: (fn: unknown) => fn,
+}));
+
+import { execFile } from 'node:child_process';
+const mockExecFile = vi.mocked(execFile);
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe('listImages', () => {
-  it('parses docker images NDJSON output', () => {
-    mockExecSync.mockReturnValue(Buffer.from(
-      [
-        JSON.stringify({ Repository: 'mediforce/agent', Tag: 'latest', ID: 'abc123', Size: '1.2GB', CreatedSince: '2 days ago' }),
-        JSON.stringify({ Repository: 'node', Tag: '20-slim', ID: 'def456', Size: '200MB', CreatedSince: '3 weeks ago' }),
-      ].join('\n'),
-    ));
+  it('parses docker images NDJSON output', async () => {
+    const stdout = [
+      JSON.stringify({ Repository: 'mediforce/agent', Tag: 'latest', ID: 'abc123', Size: '1.2GB', CreatedSince: '2 days ago' }),
+      JSON.stringify({ Repository: 'node', Tag: '20-slim', ID: 'def456', Size: '200MB', CreatedSince: '3 weeks ago' }),
+    ].join('\n');
+    (mockExecFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout, stderr: '' });
 
-    const result = listImages();
+    const result = await listImages();
 
     expect(result).toEqual([
       { repository: 'mediforce/agent', tag: 'latest', id: 'abc123', size: '1.2GB', created: '2 days ago' },
       { repository: 'node', tag: '20-slim', id: 'def456', size: '200MB', created: '3 weeks ago' },
     ]);
-    expect(mockExecSync).toHaveBeenCalledWith("docker images --format '{{json .}}'", { stdio: 'pipe' });
+    expect(mockExecFile).toHaveBeenCalledWith('docker', ['images', '--format', '{{json .}}']);
   });
 
-  it('returns empty array when no images', () => {
-    mockExecSync.mockReturnValue(Buffer.from(''));
-    expect(listImages()).toEqual([]);
+  it('returns empty array when no images', async () => {
+    (mockExecFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout: '', stderr: '' });
+    expect(await listImages()).toEqual([]);
   });
 });
 
 describe('getDiskUsage', () => {
-  it('parses docker system df NDJSON output', () => {
-    mockExecSync.mockReturnValue(Buffer.from(
-      [
-        JSON.stringify({ Type: 'Images', TotalCount: '15', Active: '5', Size: '4.2GB' }),
-        JSON.stringify({ Type: 'Containers', TotalCount: '8', Active: '3', Size: '500MB' }),
-        JSON.stringify({ Type: 'Local Volumes', TotalCount: '2', Active: '1', Size: '100MB' }),
-        JSON.stringify({ Type: 'Build Cache', TotalCount: '20', Active: '0', Size: '1.5GB' }),
-      ].join('\n'),
-    ));
+  it('parses docker system df NDJSON output', async () => {
+    const stdout = [
+      JSON.stringify({ Type: 'Images', TotalCount: '15', Active: '5', Size: '4.2GB' }),
+      JSON.stringify({ Type: 'Containers', TotalCount: '8', Active: '3', Size: '500MB' }),
+      JSON.stringify({ Type: 'Local Volumes', TotalCount: '2', Active: '1', Size: '100MB' }),
+      JSON.stringify({ Type: 'Build Cache', TotalCount: '20', Active: '0', Size: '1.5GB' }),
+    ].join('\n');
+    (mockExecFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout, stderr: '' });
 
-    const result = getDiskUsage();
+    const result = await getDiskUsage();
 
     expect(result).toEqual({
       images: { totalCount: 15, size: '4.2GB' },
@@ -56,12 +58,11 @@ describe('getDiskUsage', () => {
     });
   });
 
-  it('defaults to zero when type missing', () => {
-    mockExecSync.mockReturnValue(Buffer.from(
-      JSON.stringify({ Type: 'Images', TotalCount: '5', Size: '2GB' }),
-    ));
+  it('defaults to zero when type missing', async () => {
+    const stdout = JSON.stringify({ Type: 'Images', TotalCount: '5', Size: '2GB' });
+    (mockExecFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ stdout, stderr: '' });
 
-    const result = getDiskUsage();
+    const result = await getDiskUsage();
 
     expect(result.containers).toEqual({ totalCount: 0, active: 0, size: '0B' });
     expect(result.buildCache).toEqual({ size: '0B' });

--- a/packages/container-worker/src/__tests__/http-server.test.ts
+++ b/packages/container-worker/src/__tests__/http-server.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+
+vi.mock('../docker-info.js', () => ({
+  listImages: vi.fn(),
+  getDiskUsage: vi.fn(),
+}));
+
+import { listImages, getDiskUsage } from '../docker-info.js';
+const mockListImages = vi.mocked(listImages);
+const mockGetDiskUsage = vi.mocked(getDiskUsage);
+
+let server: Server | null = null;
+
+async function getServer(): Promise<{ server: Server; port: number }> {
+  process.env.WORKER_HTTP_PORT = '0';
+  const { startHttpServer } = await import('../http-server.js');
+  const srv = startHttpServer();
+  await new Promise<void>((resolve) => srv.once('listening', resolve));
+  const addr = srv.address();
+  const port = typeof addr === 'object' && addr !== null ? addr.port : 0;
+  server = srv;
+  return { server: srv, port };
+}
+
+afterEach(() => {
+  if (server) {
+    server.close();
+    server = null;
+  }
+  vi.resetModules();
+});
+
+describe('HTTP info server', () => {
+  it('GET /health returns ok', async () => {
+    const { port } = await getServer();
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+
+  it('GET /images returns image list', async () => {
+    const images = [{ repository: 'test', tag: 'latest', id: 'abc', size: '100MB', created: '1 day ago' }];
+    mockListImages.mockReturnValue(images);
+
+    const { port } = await getServer();
+    const res = await fetch(`http://localhost:${port}/images`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(images);
+  });
+
+  it('GET /disk returns disk usage', async () => {
+    const disk = {
+      images: { totalCount: 5, size: '2GB' },
+      containers: { totalCount: 2, active: 1, size: '100MB' },
+      buildCache: { size: '500MB' },
+    };
+    mockGetDiskUsage.mockReturnValue(disk);
+
+    const { port } = await getServer();
+    const res = await fetch(`http://localhost:${port}/disk`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(disk);
+  });
+
+  it('returns 404 for unknown routes', async () => {
+    const { port } = await getServer();
+    const res = await fetch(`http://localhost:${port}/unknown`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 405 for non-GET methods', async () => {
+    const { port } = await getServer();
+    const res = await fetch(`http://localhost:${port}/health`, { method: 'POST' });
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 500 when docker command fails', async () => {
+    mockListImages.mockImplementation(() => { throw new Error('docker not found'); });
+
+    const { port } = await getServer();
+    const res = await fetch(`http://localhost:${port}/images`);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'docker not found' });
+  });
+});

--- a/packages/container-worker/src/__tests__/http-server.test.ts
+++ b/packages/container-worker/src/__tests__/http-server.test.ts
@@ -41,7 +41,7 @@ describe('HTTP info server', () => {
 
   it('GET /images returns image list', async () => {
     const images = [{ repository: 'test', tag: 'latest', id: 'abc', size: '100MB', created: '1 day ago' }];
-    mockListImages.mockReturnValue(images);
+    mockListImages.mockResolvedValue(images);
 
     const { port } = await getServer();
     const res = await fetch(`http://localhost:${port}/images`);
@@ -55,7 +55,7 @@ describe('HTTP info server', () => {
       containers: { totalCount: 2, active: 1, size: '100MB' },
       buildCache: { size: '500MB' },
     };
-    mockGetDiskUsage.mockReturnValue(disk);
+    mockGetDiskUsage.mockResolvedValue(disk);
 
     const { port } = await getServer();
     const res = await fetch(`http://localhost:${port}/disk`);
@@ -76,7 +76,7 @@ describe('HTTP info server', () => {
   });
 
   it('returns 500 when docker command fails', async () => {
-    mockListImages.mockImplementation(() => { throw new Error('docker not found'); });
+    mockListImages.mockRejectedValue(new Error('docker not found'));
 
     const { port } = await getServer();
     const res = await fetch(`http://localhost:${port}/images`);

--- a/packages/container-worker/src/docker-info.ts
+++ b/packages/container-worker/src/docker-info.ts
@@ -1,26 +1,25 @@
-import { execSync } from 'node:child_process';
-import { z } from 'zod';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
-export const DockerImageSchema = z.object({
-  repository: z.string(),
-  tag: z.string(),
-  id: z.string(),
-  size: z.string(),
-  created: z.string(),
-});
+const execFileAsync = promisify(execFile);
 
-export type DockerImage = z.infer<typeof DockerImageSchema>;
+export interface DockerImage {
+  repository: string;
+  tag: string;
+  id: string;
+  size: string;
+  created: string;
+}
 
-export const DockerDiskUsageSchema = z.object({
-  images: z.object({ totalCount: z.number(), size: z.string() }),
-  containers: z.object({ totalCount: z.number(), active: z.number(), size: z.string() }),
-  buildCache: z.object({ size: z.string() }),
-});
+export interface DockerDiskUsage {
+  images: { totalCount: number; size: string };
+  containers: { totalCount: number; active: number; size: string };
+  buildCache: { size: string };
+}
 
-export type DockerDiskUsage = z.infer<typeof DockerDiskUsageSchema>;
-
-export function listImages(): DockerImage[] {
-  const raw = execSync("docker images --format '{{json .}}'", { stdio: 'pipe' }).toString().trim();
+export async function listImages(): Promise<DockerImage[]> {
+  const { stdout } = await execFileAsync('docker', ['images', '--format', '{{json .}}']);
+  const raw = stdout.trim();
   if (raw.length === 0) return [];
 
   return raw.split('\n').map((line) => {
@@ -35,9 +34,9 @@ export function listImages(): DockerImage[] {
   });
 }
 
-export function getDiskUsage(): DockerDiskUsage {
-  const raw = execSync("docker system df --format '{{json .}}'", { stdio: 'pipe' }).toString().trim();
-  const rows = raw.split('\n').map((line) => JSON.parse(line));
+export async function getDiskUsage(): Promise<DockerDiskUsage> {
+  const { stdout } = await execFileAsync('docker', ['system', 'df', '--format', '{{json .}}']);
+  const rows = stdout.trim().split('\n').map((line) => JSON.parse(line));
 
   const find = (type: string) => rows.find((r) => r.Type === type);
 

--- a/packages/container-worker/src/docker-info.ts
+++ b/packages/container-worker/src/docker-info.ts
@@ -1,0 +1,62 @@
+import { execSync } from 'node:child_process';
+import { z } from 'zod';
+
+export const DockerImageSchema = z.object({
+  repository: z.string(),
+  tag: z.string(),
+  id: z.string(),
+  size: z.string(),
+  created: z.string(),
+});
+
+export type DockerImage = z.infer<typeof DockerImageSchema>;
+
+export const DockerDiskUsageSchema = z.object({
+  images: z.object({ totalCount: z.number(), size: z.string() }),
+  containers: z.object({ totalCount: z.number(), active: z.number(), size: z.string() }),
+  buildCache: z.object({ size: z.string() }),
+});
+
+export type DockerDiskUsage = z.infer<typeof DockerDiskUsageSchema>;
+
+export function listImages(): DockerImage[] {
+  const raw = execSync("docker images --format '{{json .}}'", { stdio: 'pipe' }).toString().trim();
+  if (raw.length === 0) return [];
+
+  return raw.split('\n').map((line) => {
+    const parsed = JSON.parse(line);
+    return {
+      repository: parsed.Repository,
+      tag: parsed.Tag,
+      id: parsed.ID,
+      size: parsed.Size,
+      created: parsed.CreatedSince,
+    };
+  });
+}
+
+export function getDiskUsage(): DockerDiskUsage {
+  const raw = execSync("docker system df --format '{{json .}}'", { stdio: 'pipe' }).toString().trim();
+  const rows = raw.split('\n').map((line) => JSON.parse(line));
+
+  const find = (type: string) => rows.find((r) => r.Type === type);
+
+  const images = find('Images');
+  const containers = find('Containers');
+  const buildCache = find('Build Cache');
+
+  return {
+    images: {
+      totalCount: Number(images?.TotalCount ?? 0),
+      size: images?.Size ?? '0B',
+    },
+    containers: {
+      totalCount: Number(containers?.TotalCount ?? 0),
+      active: Number(containers?.Active ?? 0),
+      size: containers?.Size ?? '0B',
+    },
+    buildCache: {
+      size: buildCache?.Size ?? '0B',
+    },
+  };
+}

--- a/packages/container-worker/src/http-server.ts
+++ b/packages/container-worker/src/http-server.ts
@@ -11,7 +11,7 @@ function jsonResponse(res: import('node:http').ServerResponse, status: number, b
 }
 
 export function startHttpServer(): Server {
-  const server = createServer((req, res) => {
+  const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', `http://localhost:${WORKER_HTTP_PORT}`);
 
     if (req.method !== 'GET') {
@@ -26,7 +26,7 @@ export function startHttpServer(): Server {
 
     if (url.pathname === '/images') {
       try {
-        const images = listImages();
+        const images = await listImages();
         jsonResponse(res, 200, images);
       } catch (err) {
         jsonResponse(res, 500, { error: err instanceof Error ? err.message : String(err) });
@@ -36,7 +36,7 @@ export function startHttpServer(): Server {
 
     if (url.pathname === '/disk') {
       try {
-        const disk = getDiskUsage();
+        const disk = await getDiskUsage();
         jsonResponse(res, 200, disk);
       } catch (err) {
         jsonResponse(res, 500, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/container-worker/src/http-server.ts
+++ b/packages/container-worker/src/http-server.ts
@@ -1,0 +1,55 @@
+import { createServer, type Server } from 'node:http';
+import { listImages, getDiskUsage } from './docker-info.js';
+
+const WORKER_HTTP_PORT = process.env.WORKER_HTTP_PORT !== undefined
+  ? Number(process.env.WORKER_HTTP_PORT)
+  : 3001;
+
+function jsonResponse(res: import('node:http').ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+export function startHttpServer(): Server {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://localhost:${WORKER_HTTP_PORT}`);
+
+    if (req.method !== 'GET') {
+      jsonResponse(res, 405, { error: 'Method not allowed' });
+      return;
+    }
+
+    if (url.pathname === '/health') {
+      jsonResponse(res, 200, { status: 'ok' });
+      return;
+    }
+
+    if (url.pathname === '/images') {
+      try {
+        const images = listImages();
+        jsonResponse(res, 200, images);
+      } catch (err) {
+        jsonResponse(res, 500, { error: err instanceof Error ? err.message : String(err) });
+      }
+      return;
+    }
+
+    if (url.pathname === '/disk') {
+      try {
+        const disk = getDiskUsage();
+        jsonResponse(res, 200, disk);
+      } catch (err) {
+        jsonResponse(res, 500, { error: err instanceof Error ? err.message : String(err) });
+      }
+      return;
+    }
+
+    jsonResponse(res, 404, { error: 'Not found' });
+  });
+
+  server.listen(WORKER_HTTP_PORT, () => {
+    console.log(`[worker] HTTP info server listening on port ${WORKER_HTTP_PORT}`);
+  });
+
+  return server;
+}

--- a/packages/container-worker/src/worker-entry.ts
+++ b/packages/container-worker/src/worker-entry.ts
@@ -12,6 +12,7 @@ import { getRedisConnection } from './connection.js';
 import { QUEUE_NAME, DockerJobDataSchema } from './schemas.js';
 import type { DockerJobResult } from './schemas.js';
 import { ensureImage } from './docker-image-builder.js';
+import { startHttpServer } from './http-server.js';
 
 /**
  * If inputFiles are provided (remote caller), create a local temp dir,
@@ -191,6 +192,8 @@ const worker = new Worker(
   },
 );
 
+const httpServer = startHttpServer();
+
 worker.on('ready', () => {
   console.log(`[worker] Ready — listening on queue '${QUEUE_NAME}'`);
 });
@@ -203,6 +206,7 @@ worker.on('failed', (job, error) => {
 for (const sig of ['SIGINT', 'SIGTERM'] as const) {
   process.on(sig, async () => {
     console.log(`[worker] ${sig} received — shutting down`);
+    httpServer.close();
     await worker.close();
     process.exit(0);
   });

--- a/packages/container-worker/vitest.config.ts
+++ b/packages/container-worker/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    conditions: ['@mediforce/source'],
+  },
+});

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -22,6 +22,15 @@ export {
 } from './workflows.js';
 
 export {
+  DockerImageInfoSchema,
+  DockerDiskInfoSchema,
+  DockerInfoResponseSchema,
+  type DockerImageInfo,
+  type DockerDiskInfo,
+  type DockerInfoResponse,
+} from './system.js';
+
+export {
   GetRunInputSchema,
   GetRunOutputSchema,
   StartRunInputSchema,

--- a/packages/platform-api/src/contract/system.ts
+++ b/packages/platform-api/src/contract/system.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const DockerImageInfoSchema = z.object({
+  repository: z.string(),
+  tag: z.string(),
+  id: z.string(),
+  size: z.string(),
+  created: z.string(),
+});
+
+export const DockerDiskInfoSchema = z.object({
+  images: z.object({ totalCount: z.number(), size: z.string() }),
+  containers: z.object({ totalCount: z.number(), active: z.number(), size: z.string() }),
+  buildCache: z.object({ size: z.string() }),
+});
+
+export const DockerInfoResponseSchema = z.discriminatedUnion('available', [
+  z.object({
+    available: z.literal(true),
+    images: z.array(DockerImageInfoSchema),
+    disk: DockerDiskInfoSchema,
+  }),
+  z.object({
+    available: z.literal(false),
+  }),
+]);
+
+export type DockerImageInfo = z.infer<typeof DockerImageInfoSchema>;
+export type DockerDiskInfo = z.infer<typeof DockerDiskInfoSchema>;
+export type DockerInfoResponse = z.infer<typeof DockerInfoResponseSchema>;

--- a/packages/platform-ui/src/app/api/system/docker-info/route.ts
+++ b/packages/platform-ui/src/app/api/system/docker-info/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import type { DockerInfoResponse } from '@mediforce/platform-api/contract';
+
+const CONTAINER_WORKER_URL = process.env.CONTAINER_WORKER_URL ?? 'http://container-worker:3001';
+
+export async function GET(): Promise<NextResponse<DockerInfoResponse>> {
+  try {
+    const [imagesRes, diskRes] = await Promise.all([
+      fetch(`${CONTAINER_WORKER_URL}/images`),
+      fetch(`${CONTAINER_WORKER_URL}/disk`),
+    ]);
+
+    if (!imagesRes.ok || !diskRes.ok) {
+      return NextResponse.json({ available: false } as const);
+    }
+
+    const images = await imagesRes.json();
+    const disk = await diskRes.json();
+
+    return NextResponse.json({ available: true, images, disk } as const);
+  } catch {
+    return NextResponse.json({ available: false } as const);
+  }
+}

--- a/packages/platform-ui/src/app/api/system/docker-info/route.ts
+++ b/packages/platform-ui/src/app/api/system/docker-info/route.ts
@@ -1,9 +1,25 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { DockerImageInfoSchema, DockerDiskInfoSchema } from '@mediforce/platform-api/contract';
 import type { DockerInfoResponse } from '@mediforce/platform-api/contract';
+import { z } from 'zod';
 
 const CONTAINER_WORKER_URL = process.env.CONTAINER_WORKER_URL ?? 'http://container-worker:3001';
 
-export async function GET(): Promise<NextResponse<DockerInfoResponse>> {
+function hasAdminApiKey(req: NextRequest): boolean {
+  const adminKey = process.env.PLATFORM_ADMIN_API_KEY;
+  if (typeof adminKey !== 'string' || adminKey === '') return false;
+  const provided = req.headers.get('X-Api-Key');
+  return provided === adminKey;
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse<DockerInfoResponse | { error: string }>> {
+  if (!hasAdminApiKey(req)) {
+    return NextResponse.json(
+      { error: 'Forbidden — admin API key required' },
+      { status: 403 },
+    );
+  }
+
   try {
     const [imagesRes, diskRes] = await Promise.all([
       fetch(`${CONTAINER_WORKER_URL}/images`),
@@ -14,10 +30,17 @@ export async function GET(): Promise<NextResponse<DockerInfoResponse>> {
       return NextResponse.json({ available: false } as const);
     }
 
-    const images = await imagesRes.json();
-    const disk = await diskRes.json();
+    const imagesRaw = await imagesRes.json();
+    const diskRaw = await diskRes.json();
 
-    return NextResponse.json({ available: true, images, disk } as const);
+    const imagesParsed = z.array(DockerImageInfoSchema).safeParse(imagesRaw);
+    const diskParsed = DockerDiskInfoSchema.safeParse(diskRaw);
+
+    if (!imagesParsed.success || !diskParsed.success) {
+      return NextResponse.json({ available: false } as const);
+    }
+
+    return NextResponse.json({ available: true, images: imagesParsed.data, disk: diskParsed.data } as const);
   } catch {
     return NextResponse.json({ available: false } as const);
   }


### PR DESCRIPTION
## Summary

- Add lightweight HTTP server to container-worker exposing `/health`, `/images`, `/disk` endpoints — shells out to Docker CLI, zero new dependencies
- Add proxy route at `/api/system/docker-info` in platform-ui that merges both responses, gracefully returns `{ available: false }` when worker unreachable
- Add Zod contract schemas in `platform-api/contract/system.ts` for typed response shape
- Expose port 3001 in all three docker-compose files (internal only, not through Caddy)

## Details

**container-worker** (`packages/container-worker/`)
- `docker-info.ts` — `listImages()` parses `docker images --format '{{json .}}'` NDJSON; `getDiskUsage()` parses `docker system df --format '{{json .}}'`
- `http-server.ts` — bare `node:http`, port from `WORKER_HTTP_PORT` env (default 3001)
- `worker-entry.ts` — starts HTTP server alongside BullMQ worker, included in SIGINT/SIGTERM graceful shutdown

**platform-ui** (`packages/platform-ui/`)
- `GET /api/system/docker-info` — fetches `/images` + `/disk` from container-worker, base URL from `CONTAINER_WORKER_URL` env (default `http://container-worker:3001`)

## Test plan

- [x] Unit tests for `docker-info.ts` — mock `execSync`, verify NDJSON parse + empty output + missing types (4 tests)
- [x] Unit tests for `http-server.ts` — real HTTP to ephemeral port, all routes + error handling (6 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 1893 tests pass (159 files)
- [ ] Manual: deploy to staging, verify `curl http://container-worker:3001/health` from platform-ui container
- [ ] Manual: verify `/api/system/docker-info` returns images + disk when worker running, `{ available: false }` when not

🤖 Generated with [Claude Code](https://claude.com/claude-code)