### PR TITLE
fix(ui): batch bulk cancel/archive and preserve selection

### DIFF
--- a/packages/platform-ui/src/app/actions/processes.ts
+++ b/packages/platform-ui/src/app/actions/processes.ts
@@ -173,6 +173,108 @@ export async function archiveProcessRun(
   }
 }
 
+export interface BulkOperationResult {
+  succeeded: string[];
+  failed: Array<{ id: string; error: string }>;
+}
+
+export async function bulkCancelProcessRuns(
+  instanceIds: string[],
+): Promise<BulkOperationResult> {
+  const { instanceRepo, auditRepo } = getPlatformServices();
+  const now = new Date().toISOString();
+  const succeeded: string[] = [];
+  const failed: Array<{ id: string; error: string }> = [];
+
+  const instances = await Promise.all(
+    instanceIds.map((id) => instanceRepo.getById(id)),
+  );
+
+  await Promise.all(
+    instances.map(async (instance, index) => {
+      const id = instanceIds[index];
+      if (!instance) {
+        failed.push({ id, error: 'Run not found' });
+        return;
+      }
+      if (instance.status !== 'running' && instance.status !== 'paused') {
+        failed.push({ id, error: `Cannot cancel a ${instance.status} run` });
+        return;
+      }
+      await instanceRepo.update(id, {
+        status: 'failed',
+        error: 'Cancelled by user',
+        updatedAt: now,
+      });
+      await auditRepo.append({
+        actorId: 'user',
+        actorType: 'user',
+        actorRole: 'operator',
+        action: 'instance.cancelled',
+        description: `Run cancelled by operator (was ${instance.status}${instance.currentStepId ? ` at step '${instance.currentStepId}'` : ''})`,
+        timestamp: now,
+        inputSnapshot: { previousStatus: instance.status, currentStepId: instance.currentStepId },
+        outputSnapshot: { status: 'failed', error: 'Cancelled by user' },
+        basis: 'User-initiated bulk cancel via UI',
+        entityType: 'processInstance',
+        entityId: id,
+        processInstanceId: id,
+        processDefinitionVersion: instance.definitionVersion,
+      });
+      succeeded.push(id);
+    }),
+  );
+
+  return { succeeded, failed };
+}
+
+export async function bulkArchiveProcessRuns(
+  instanceIds: string[],
+): Promise<BulkOperationResult> {
+  const { instanceRepo, auditRepo } = getPlatformServices();
+  const now = new Date().toISOString();
+  const succeeded: string[] = [];
+  const failed: Array<{ id: string; error: string }> = [];
+
+  const instances = await Promise.all(
+    instanceIds.map((id) => instanceRepo.getById(id)),
+  );
+
+  await Promise.all(
+    instances.map(async (instance, index) => {
+      const id = instanceIds[index];
+      if (!instance) {
+        failed.push({ id, error: 'Run not found' });
+        return;
+      }
+      const { displayStatus } = getWorkflowStatus(instance);
+      if (displayStatus === 'in_progress' || displayStatus === 'waiting_for_human') {
+        failed.push({ id, error: 'Cannot archive an active run' });
+        return;
+      }
+      await instanceRepo.update(id, { archived: true, updatedAt: now });
+      await auditRepo.append({
+        actorId: 'user',
+        actorType: 'user',
+        actorRole: 'operator',
+        action: 'instance.archived',
+        description: 'Run archived by operator',
+        timestamp: now,
+        inputSnapshot: { previousArchived: instance.archived ?? false },
+        outputSnapshot: { archived: true },
+        basis: 'User-initiated bulk archive via UI',
+        entityType: 'processInstance',
+        entityId: id,
+        processInstanceId: id,
+        processDefinitionVersion: instance.definitionVersion,
+      });
+      succeeded.push(id);
+    }),
+  );
+
+  return { succeeded, failed };
+}
+
 export async function cancelProcessRun(
   instanceId: string,
 ): Promise<{ success: boolean; error?: string }> {

--- a/packages/platform-ui/src/app/actions/processes.ts
+++ b/packages/platform-ui/src/app/actions/processes.ts
@@ -178,101 +178,127 @@ export interface BulkOperationResult {
   failed: Array<{ id: string; error: string }>;
 }
 
+const BULK_LIMIT = 100;
+
 export async function bulkCancelProcessRuns(
   instanceIds: string[],
 ): Promise<BulkOperationResult> {
-  const { instanceRepo, auditRepo } = getPlatformServices();
-  const now = new Date().toISOString();
-  const succeeded: string[] = [];
-  const failed: Array<{ id: string; error: string }> = [];
+  if (instanceIds.length > BULK_LIMIT) {
+    return { succeeded: [], failed: [{ id: '', error: `Bulk limit exceeded (max ${BULK_LIMIT})` }] };
+  }
+  try {
+    const { instanceRepo, auditRepo } = getPlatformServices();
+    const now = new Date().toISOString();
+    const succeeded: string[] = [];
+    const failed: Array<{ id: string; error: string }> = [];
 
-  const instances = await Promise.all(
-    instanceIds.map((id) => instanceRepo.getById(id)),
-  );
+    const instances = await Promise.all(
+      instanceIds.map((id) => instanceRepo.getById(id)),
+    );
 
-  await Promise.all(
-    instances.map(async (instance, index) => {
-      const id = instanceIds[index];
-      if (!instance) {
-        failed.push({ id, error: 'Run not found' });
-        return;
-      }
-      if (instance.status !== 'running' && instance.status !== 'paused') {
-        failed.push({ id, error: `Cannot cancel a ${instance.status} run` });
-        return;
-      }
-      await instanceRepo.update(id, {
-        status: 'failed',
-        error: 'Cancelled by user',
-        updatedAt: now,
-      });
-      await auditRepo.append({
-        actorId: 'user',
-        actorType: 'user',
-        actorRole: 'operator',
-        action: 'instance.cancelled',
-        description: `Run cancelled by operator (was ${instance.status}${instance.currentStepId ? ` at step '${instance.currentStepId}'` : ''})`,
-        timestamp: now,
-        inputSnapshot: { previousStatus: instance.status, currentStepId: instance.currentStepId },
-        outputSnapshot: { status: 'failed', error: 'Cancelled by user' },
-        basis: 'User-initiated bulk cancel via UI',
-        entityType: 'processInstance',
-        entityId: id,
-        processInstanceId: id,
-        processDefinitionVersion: instance.definitionVersion,
-      });
-      succeeded.push(id);
-    }),
-  );
+    await Promise.all(
+      instances.map(async (instance, index) => {
+        const id = instanceIds[index];
+        if (!instance) {
+          failed.push({ id, error: 'Run not found' });
+          return;
+        }
+        if (instance.status !== 'running' && instance.status !== 'paused') {
+          failed.push({ id, error: `Cannot cancel a ${instance.status} run` });
+          return;
+        }
+        await Promise.all([
+          instanceRepo.update(id, {
+            status: 'failed',
+            error: 'Cancelled by user',
+            updatedAt: now,
+          }),
+          auditRepo.append({
+            actorId: 'user',
+            actorType: 'user',
+            actorRole: 'operator',
+            action: 'instance.cancelled',
+            description: `Run cancelled by operator (was ${instance.status}${instance.currentStepId ? ` at step '${instance.currentStepId}'` : ''})`,
+            timestamp: now,
+            inputSnapshot: { previousStatus: instance.status, currentStepId: instance.currentStepId },
+            outputSnapshot: { status: 'failed', error: 'Cancelled by user' },
+            basis: 'User-initiated bulk cancel via UI',
+            entityType: 'processInstance',
+            entityId: id,
+            processInstanceId: id,
+            processDefinitionVersion: instance.definitionVersion,
+          }),
+        ]);
+        succeeded.push(id);
+      }),
+    );
 
-  return { succeeded, failed };
+    return { succeeded, failed };
+  } catch (err) {
+    return {
+      succeeded: [],
+      failed: [{ id: '', error: err instanceof Error ? err.message : 'Unknown error' }],
+    };
+  }
 }
 
 export async function bulkArchiveProcessRuns(
   instanceIds: string[],
 ): Promise<BulkOperationResult> {
-  const { instanceRepo, auditRepo } = getPlatformServices();
-  const now = new Date().toISOString();
-  const succeeded: string[] = [];
-  const failed: Array<{ id: string; error: string }> = [];
+  if (instanceIds.length > BULK_LIMIT) {
+    return { succeeded: [], failed: [{ id: '', error: `Bulk limit exceeded (max ${BULK_LIMIT})` }] };
+  }
+  try {
+    const { instanceRepo, auditRepo } = getPlatformServices();
+    const now = new Date().toISOString();
+    const succeeded: string[] = [];
+    const failed: Array<{ id: string; error: string }> = [];
 
-  const instances = await Promise.all(
-    instanceIds.map((id) => instanceRepo.getById(id)),
-  );
+    const instances = await Promise.all(
+      instanceIds.map((id) => instanceRepo.getById(id)),
+    );
 
-  await Promise.all(
-    instances.map(async (instance, index) => {
-      const id = instanceIds[index];
-      if (!instance) {
-        failed.push({ id, error: 'Run not found' });
-        return;
-      }
-      const { displayStatus } = getWorkflowStatus(instance);
-      if (displayStatus === 'in_progress' || displayStatus === 'waiting_for_human') {
-        failed.push({ id, error: 'Cannot archive an active run' });
-        return;
-      }
-      await instanceRepo.update(id, { archived: true, updatedAt: now });
-      await auditRepo.append({
-        actorId: 'user',
-        actorType: 'user',
-        actorRole: 'operator',
-        action: 'instance.archived',
-        description: 'Run archived by operator',
-        timestamp: now,
-        inputSnapshot: { previousArchived: instance.archived ?? false },
-        outputSnapshot: { archived: true },
-        basis: 'User-initiated bulk archive via UI',
-        entityType: 'processInstance',
-        entityId: id,
-        processInstanceId: id,
-        processDefinitionVersion: instance.definitionVersion,
-      });
-      succeeded.push(id);
-    }),
-  );
+    await Promise.all(
+      instances.map(async (instance, index) => {
+        const id = instanceIds[index];
+        if (!instance) {
+          failed.push({ id, error: 'Run not found' });
+          return;
+        }
+        const { displayStatus } = getWorkflowStatus(instance);
+        if (displayStatus === 'in_progress' || displayStatus === 'waiting_for_human') {
+          failed.push({ id, error: 'Cannot archive an active run' });
+          return;
+        }
+        await Promise.all([
+          instanceRepo.update(id, { archived: true, updatedAt: now }),
+          auditRepo.append({
+            actorId: 'user',
+            actorType: 'user',
+            actorRole: 'operator',
+            action: 'instance.archived',
+            description: 'Run archived by operator',
+            timestamp: now,
+            inputSnapshot: { previousArchived: instance.archived ?? false },
+            outputSnapshot: { archived: true },
+            basis: 'User-initiated bulk archive via UI',
+            entityType: 'processInstance',
+            entityId: id,
+            processInstanceId: id,
+            processDefinitionVersion: instance.definitionVersion,
+          }),
+        ]);
+        succeeded.push(id);
+      }),
+    );
 
-  return { succeeded, failed };
+    return { succeeded, failed };
+  } catch (err) {
+    return {
+      succeeded: [],
+      failed: [{ id: '', error: err instanceof Error ? err.message : 'Unknown error' }],
+    };
+  }
 }
 
 export async function cancelProcessRun(

--- a/packages/platform-ui/src/components/processes/runs-table.tsx
+++ b/packages/platform-ui/src/components/processes/runs-table.tsx
@@ -10,7 +10,9 @@ import { useUserDisplayNames } from '@/hooks/use-users';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
 import { routes } from '@/lib/routes';
 import { archiveProcessRun, bulkCancelProcessRuns, bulkArchiveProcessRuns } from '@/app/actions/processes';
+import type { BulkOperationResult } from '@/app/actions/processes';
 import { getWorkflowStatus } from '@/lib/workflow-status';
+import { useToast } from '@/components/command-palette/toast-provider';
 
 interface RunsTableProps {
   runs: ProcessInstance[];
@@ -43,6 +45,7 @@ export function RunsTable({
   activeTaskByInstance,
 }: RunsTableProps) {
   const handle = useHandleFromPath();
+  const { toast } = useToast();
   const userNames = useUserDisplayNames();
   const [archivingIds, setArchivingIds] = React.useState<Set<string>>(new Set());
   const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
@@ -106,15 +109,27 @@ export function RunsTable({
   const cancellableSelected = runs.filter((r) => selectedIds.has(r.id) && isCancellable(r));
   const archivableSelected = runs.filter((r) => selectedIds.has(r.id) && isArchivable(r));
 
+  function reportBulkResult(result: BulkOperationResult, action: string) {
+    if (result.failed.length > 0) {
+      toast({
+        title: `${result.failed.length} run(s) failed to ${action}`,
+        description: result.failed.map((f) => f.error).join('; '),
+        variant: 'error',
+      });
+    }
+  }
+
   async function handleBulkCancel() {
     setBulkCancelling(true);
-    await bulkCancelProcessRuns(cancellableSelected.map((r) => r.id));
+    const result = await bulkCancelProcessRuns(cancellableSelected.map((r) => r.id));
+    reportBulkResult(result, 'cancel');
     setBulkCancelling(false);
   }
 
   async function handleBulkArchive() {
     setBulkArchiving(true);
-    await bulkArchiveProcessRuns(archivableSelected.map((r) => r.id));
+    const result = await bulkArchiveProcessRuns(archivableSelected.map((r) => r.id));
+    reportBulkResult(result, 'archive');
     setBulkArchiving(false);
   }
 

--- a/packages/platform-ui/src/components/processes/runs-table.tsx
+++ b/packages/platform-ui/src/components/processes/runs-table.tsx
@@ -9,7 +9,7 @@ import { ProcessStatusBadge } from './process-status-badge';
 import { useUserDisplayNames } from '@/hooks/use-users';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
 import { routes } from '@/lib/routes';
-import { archiveProcessRun, cancelProcessRun } from '@/app/actions/processes';
+import { archiveProcessRun, bulkCancelProcessRuns, bulkArchiveProcessRuns } from '@/app/actions/processes';
 import { getWorkflowStatus } from '@/lib/workflow-status';
 
 interface RunsTableProps {
@@ -108,16 +108,14 @@ export function RunsTable({
 
   async function handleBulkCancel() {
     setBulkCancelling(true);
-    await Promise.allSettled(cancellableSelected.map((r) => cancelProcessRun(r.id)));
+    await bulkCancelProcessRuns(cancellableSelected.map((r) => r.id));
     setBulkCancelling(false);
-    setSelectedIds(new Set());
   }
 
   async function handleBulkArchive() {
     setBulkArchiving(true);
-    await Promise.allSettled(archivableSelected.map((r) => archiveProcessRun(r.id, true)));
+    await bulkArchiveProcessRuns(archivableSelected.map((r) => r.id));
     setBulkArchiving(false);
-    setSelectedIds(new Set());
   }
 
   const effectiveRunHref = runHref ?? ((run: ProcessInstance) =>


### PR DESCRIPTION
## Summary

- **Batch server actions**: Bulk cancel/archive now sends a single server action (`bulkCancelProcessRuns` / `bulkArchiveProcessRuns`) instead of N individual calls. All Firestore reads, updates, and audit entries run in parallel server-side.
- **Selection preserved**: Selection no longer clears after bulk operations. The existing `useEffect` auto-prunes IDs when runs leave the list (e.g., archived runs filtered out). Users can chain cancel → archive without re-selecting.

## Test plan

- [x] Unit tests pass (1966 green)
- [x] Typecheck clean (no new errors)
- [ ] Manual: select 5+ runs → bulk cancel → verify all cancel in one shot, selection persists
- [ ] Manual: select cancelled runs → bulk archive → verify instant, selection auto-prunes as rows disappear
- [ ] Verify single-run archive button still works (unchanged `archiveProcessRun`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)