### PR TITLE
feat(oauth): one-click GitHub App preset in admin provider form

### DIFF
--- a/packages/platform-core/src/schemas/__tests__/oauth-provider.test.ts
+++ b/packages/platform-core/src/schemas/__tests__/oauth-provider.test.ts
@@ -117,11 +117,17 @@ describe('UpdateOAuthProviderInputSchema', () => {
 });
 
 describe('OAUTH_PROVIDER_PRESETS', () => {
-  it('github preset has the canonical endpoints', () => {
+  it('github preset uses the GitHub App installation URL pattern', () => {
+    // Placeholder slug — admin form rewrites this from a "GitHub App slug" field.
     expect(OAUTH_PROVIDER_PRESETS.github.authorizeUrl).toBe(
-      'https://github.com/login/oauth/authorize',
+      'https://github.com/apps/your-app-slug/installations/new',
     );
-    expect(OAUTH_PROVIDER_PRESETS.github.scopes).toContain('repo');
+    expect(OAUTH_PROVIDER_PRESETS.github.tokenUrl).toBe(
+      'https://github.com/login/oauth/access_token',
+    );
+    // GitHub Apps ignore OAuth scopes (permissions come from install) — only
+    // userInfo-related scope is needed.
+    expect(OAUTH_PROVIDER_PRESETS.github.scopes).toContain('read:user');
   });
 
   it('google preset has the token + revoke endpoints', () => {

--- a/packages/platform-core/src/schemas/oauth-provider.ts
+++ b/packages/platform-core/src/schemas/oauth-provider.ts
@@ -82,16 +82,30 @@ export type UpdateOAuthProviderInput = z.infer<typeof UpdateOAuthProviderInputSc
 
 /** Built-in provider presets. UI exposes these as "Add GitHub" / "Add Google"
  *  buttons that pre-fill the admin form. Admin still supplies clientId +
- *  clientSecret for their own OAuth App. */
+ *  clientSecret for their own OAuth App.
+ *
+ *  GitHub preset is shaped for the **GitHub App** user-server OAuth flow
+ *  (not classic OAuth Apps, not app-level JWT). The admin form synthesises
+ *  the final `authorizeUrl` from the App's slug — `installations/new` is the
+ *  install-then-authorize path, so users granting access install the App on
+ *  the right account/org in one step. Permissions come from the App's
+ *  installation, so the requested OAuth `scopes` stay minimal. */
 export const OAUTH_PROVIDER_PRESETS = {
   github: {
     id: 'github',
     name: 'GitHub',
-    authorizeUrl: 'https://github.com/login/oauth/authorize',
+    // Placeholder — the form's "GitHub App slug" field overwrites this on type.
+    // The literal "your-app-slug" passes z.string().url() but is blocked by
+    // a custom check at submit time.
+    authorizeUrl: 'https://github.com/apps/your-app-slug/installations/new',
     tokenUrl: 'https://github.com/login/oauth/access_token',
     revokeUrl: undefined,
     userInfoUrl: 'https://api.github.com/user',
-    scopes: ['repo', 'read:user'],
+    // GitHub Apps ignore the `scope` parameter on user OAuth — repo / write
+    // permissions come from the App's installation. Keep `read:user` so the
+    // userInfo call works for displaying the connected GitHub account.
+    scopes: ['read:user'],
+    iconUrl: 'https://github.githubassets.com/favicons/favicon.svg',
   },
   google: {
     id: 'google',

--- a/packages/platform-ui/src/app/(app)/[handle]/admin/oauth-providers/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/admin/oauth-providers/page.tsx
@@ -199,7 +199,7 @@ export default function AdminOAuthProvidersPage() {
               className="inline-flex items-center gap-1.5 rounded-md border bg-card px-3 py-2 text-sm font-medium hover:bg-muted transition-colors"
             >
               <KeyRound className="h-3.5 w-3.5" />
-              Add GitHub
+              Add GitHub App
             </button>
             <button
               type="button"

--- a/packages/platform-ui/src/components/admin/oauth-providers/__tests__/provider-form.test.tsx
+++ b/packages/platform-ui/src/components/admin/oauth-providers/__tests__/provider-form.test.tsx
@@ -5,6 +5,10 @@ import type { OAuthProviderConfig } from '@mediforce/platform-core';
 
 import { ProviderForm } from '../provider-form';
 
+async function openAdvanced(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+  await user.click(screen.getByRole('button', { name: /Advanced/i }));
+}
+
 function makeProvider(overrides: Partial<OAuthProviderConfig> = {}): OAuthProviderConfig {
   return {
     id: 'github',
@@ -36,7 +40,8 @@ describe('ProviderForm', () => {
     expect(screen.getByRole('button', { name: /^Create$/i })).toBeInTheDocument();
   });
 
-  it('pre-fills GitHub preset fields', () => {
+  it('pre-fills GitHub App preset fields (advanced section reveals URLs/scopes)', async () => {
+    const user = userEvent.setup();
     render(
       <ProviderForm
         provider={null}
@@ -47,8 +52,16 @@ describe('ProviderForm', () => {
 
     expect((screen.getByLabelText(/^Id$/i) as HTMLInputElement).value).toBe('github');
     expect((screen.getByLabelText(/^Name$/i) as HTMLInputElement).value).toBe('GitHub');
+
+    // URL/scope inputs are hidden until the advanced section is opened
+    expect(screen.queryByLabelText(/^Authorize URL$/i)).toBeNull();
+
+    await openAdvanced(user);
+
+    // GitHub App preset starts with a placeholder authorize URL — the slug
+    // field rewrites it on type.
     expect((screen.getByLabelText(/^Authorize URL$/i) as HTMLInputElement).value).toBe(
-      'https://github.com/login/oauth/authorize',
+      'https://github.com/apps/your-app-slug/installations/new',
     );
     expect((screen.getByLabelText(/^Token URL$/i) as HTMLInputElement).value).toBe(
       'https://github.com/login/oauth/access_token',
@@ -56,10 +69,65 @@ describe('ProviderForm', () => {
     expect((screen.getByLabelText(/^User info URL$/i) as HTMLInputElement).value).toBe(
       'https://api.github.com/user',
     );
-    expect((screen.getByLabelText(/^Scopes$/i) as HTMLTextAreaElement).value).toBe('repo read:user');
+    expect((screen.getByLabelText(/^Scopes$/i) as HTMLTextAreaElement).value).toBe('read:user');
   });
 
-  it('pre-fills Google preset fields including revokeUrl', () => {
+  it('renders the GitHub App setup guide and slug field for github preset', () => {
+    render(
+      <ProviderForm
+        provider={null}
+        preset="github"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Setting up a GitHub App/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^GitHub App slug$/i)).toBeInTheDocument();
+  });
+
+  it('synthesises Authorize URL from the GitHub App slug as the admin types', async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderForm
+        provider={null}
+        preset="github"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^GitHub App slug$/i), 'mediforce-staging');
+
+    await openAdvanced(user);
+
+    expect((screen.getByLabelText(/^Authorize URL$/i) as HTMLInputElement).value).toBe(
+      'https://github.com/apps/mediforce-staging/installations/new',
+    );
+  });
+
+  it('blocks submit when the App slug placeholder is left untouched', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <ProviderForm
+        provider={null}
+        preset="github"
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^Client id$/i), 'cid');
+    await user.type(screen.getByLabelText(/^Client secret$/i), 'csecret');
+    await user.click(screen.getByRole('button', { name: /^Create$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fill in your GitHub App slug/i)).toBeInTheDocument();
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('pre-fills Google preset fields including revokeUrl', async () => {
+    const user = userEvent.setup();
     render(
       <ProviderForm
         provider={null}
@@ -70,12 +138,69 @@ describe('ProviderForm', () => {
 
     expect((screen.getByLabelText(/^Id$/i) as HTMLInputElement).value).toBe('google');
     expect((screen.getByLabelText(/^Name$/i) as HTMLInputElement).value).toBe('Google');
+
+    await openAdvanced(user);
+
     expect((screen.getByLabelText(/^Revoke URL$/i) as HTMLInputElement).value).toBe(
       'https://oauth2.googleapis.com/revoke',
     );
     expect((screen.getByLabelText(/^Scopes$/i) as HTMLTextAreaElement).value).toBe(
       'openid email profile',
     );
+  });
+
+  it('hides advanced section by default in preset mode and shows it on demand', async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderForm
+        provider={null}
+        preset="github"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    // Visible from the start
+    expect(screen.getByLabelText(/^Id$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Client id$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Client secret$/i)).toBeInTheDocument();
+
+    // Hidden behind the toggle
+    expect(screen.queryByLabelText(/^Authorize URL$/i)).toBeNull();
+    expect(screen.queryByLabelText(/^Token URL$/i)).toBeNull();
+    expect(screen.queryByLabelText(/^Scopes$/i)).toBeNull();
+
+    const toggle = screen.getByRole('button', { name: /Advanced/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    await user.click(toggle);
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByLabelText(/^Authorize URL$/i)).toBeInTheDocument();
+  });
+
+  it('opens advanced section by default for custom create and edit modes', () => {
+    const { unmount } = render(
+      <ProviderForm
+        provider={null}
+        preset={null}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    // Custom create — advanced open
+    expect(screen.getByLabelText(/^Authorize URL$/i)).toBeInTheDocument();
+    unmount();
+
+    // Edit mode (provider set, preset null) — advanced open
+    render(
+      <ProviderForm
+        provider={makeProvider({ id: 'acme', name: 'Acme' })}
+        preset={null}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/^Authorize URL$/i)).toBeInTheDocument();
   });
 
   it('pre-fills edit form from existing provider', () => {
@@ -106,7 +231,7 @@ describe('ProviderForm', () => {
     expect(screen.getByRole('button', { name: /^Save$/i })).toBeInTheDocument();
   });
 
-  it('submits payload with tokenized scopes on create', async () => {
+  it('submits a GitHub App preset payload with synthesised authorizeUrl', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockResolvedValue(undefined);
 
@@ -120,6 +245,7 @@ describe('ProviderForm', () => {
 
     await user.type(screen.getByLabelText(/^Client id$/i), 'test-client-id');
     await user.type(screen.getByLabelText(/^Client secret$/i), 'test-secret');
+    await user.type(screen.getByLabelText(/^GitHub App slug$/i), 'mediforce-prod');
     await user.click(screen.getByRole('button', { name: /^Create$/i }));
 
     await waitFor(() => {
@@ -131,10 +257,13 @@ describe('ProviderForm', () => {
     expect(payload.name).toBe('GitHub');
     expect(payload.clientId).toBe('test-client-id');
     expect(payload.clientSecret).toBe('test-secret');
-    expect(payload.authorizeUrl).toBe('https://github.com/login/oauth/authorize');
-    expect(payload.scopes).toEqual(['repo', 'read:user']);
+    expect(payload.authorizeUrl).toBe(
+      'https://github.com/apps/mediforce-prod/installations/new',
+    );
+    expect(payload.scopes).toEqual(['read:user']);
     expect(payload.revokeUrl).toBeUndefined();
-    expect(payload.iconUrl).toBeUndefined();
+    expect(payload.iconUrl).toBe('https://github.githubassets.com/favicons/favicon.svg');
+    expect(payload.appSlug).toBeUndefined();
   });
 
   it('submits payload with revokeUrl and iconUrl when provided', async () => {
@@ -200,6 +329,8 @@ describe('ProviderForm', () => {
       />,
     );
 
+    await user.type(screen.getByLabelText(/^GitHub App slug$/i), 'demo-app');
+    await openAdvanced(user);
     const scopesTextarea = screen.getByLabelText(/^Scopes$/i);
     await user.clear(scopesTextarea);
     await user.type(scopesTextarea, 'repo,read:user org:read');
@@ -250,7 +381,10 @@ describe('ProviderForm', () => {
       />,
     );
 
-    // Clear scopes to trigger min-length failure
+    // Clear scopes to trigger min-length failure (slug filled to isolate the
+    // scope-validation path from the App-slug placeholder check).
+    await user.type(screen.getByLabelText(/^GitHub App slug$/i), 'demo-app');
+    await openAdvanced(user);
     const scopesTextarea = screen.getByLabelText(/^Scopes$/i);
     await user.clear(scopesTextarea);
 

--- a/packages/platform-ui/src/components/admin/oauth-providers/provider-form.tsx
+++ b/packages/platform-ui/src/components/admin/oauth-providers/provider-form.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Trash2 } from 'lucide-react';
+import { ChevronDown, ChevronRight, ExternalLink, Trash2 } from 'lucide-react';
 import type { OAuthProviderConfig } from '@mediforce/platform-core';
 import { OAUTH_PROVIDER_PRESETS } from '@mediforce/platform-core';
 import { cn } from '@/lib/utils';
 
 const idPattern = /^[a-z0-9][a-z0-9-]*$/;
+const githubAppSlugPattern = /^[a-z0-9][a-z0-9-]*$/;
+
+function authorizeUrlFromGithubAppSlug(slug: string): string {
+  return `https://github.com/apps/${slug}/installations/new`;
+}
 
 const FormSchema = z.object({
   id: z
@@ -19,12 +24,27 @@ const FormSchema = z.object({
   name: z.string().min(1, 'Required'),
   clientId: z.string().min(1, 'Required'),
   clientSecret: z.string().min(1, 'Required'),
+  // Convenience input for the GitHub preset — synthesises authorizeUrl on
+  // change. Not part of the persisted payload. Optional at the schema level
+  // so non-GitHub presets parse cleanly; required-when-github is enforced in
+  // a superRefine below.
+  appSlug: z.string().optional(),
   authorizeUrl: z.string().url('Must be a valid URL'),
   tokenUrl: z.string().url('Must be a valid URL'),
   userInfoUrl: z.string().url('Must be a valid URL'),
   revokeUrl: z.string().url('Must be a valid URL').optional().or(z.literal('')),
   scopes: z.string().min(1, 'At least one scope is required'),
   iconUrl: z.string().url('Must be a valid URL').optional().or(z.literal('')),
+}).superRefine((values, ctx) => {
+  // Catch the placeholder slipping through when admin ignores the App slug
+  // field. authorizeUrl passes z.string().url() but is functionally broken.
+  if (values.authorizeUrl.includes('your-app-slug')) {
+    ctx.addIssue({
+      path: ['appSlug'],
+      code: z.ZodIssueCode.custom,
+      message: 'Fill in your GitHub App slug to set the Authorize URL.',
+    });
+  }
 });
 
 type ProviderFormValues = z.infer<typeof FormSchema>;
@@ -47,6 +67,7 @@ function emptyValues(): ProviderFormValues {
     name: '',
     clientId: '',
     clientSecret: '',
+    appSlug: '',
     authorizeUrl: '',
     tokenUrl: '',
     userInfoUrl: '',
@@ -63,12 +84,13 @@ function valuesFromPreset(preset: PresetKey): ProviderFormValues {
     name: template.name,
     clientId: '',
     clientSecret: '',
+    appSlug: '',
     authorizeUrl: template.authorizeUrl,
     tokenUrl: template.tokenUrl,
     userInfoUrl: template.userInfoUrl,
     revokeUrl: template.revokeUrl ?? '',
     scopes: template.scopes.join(' '),
-    iconUrl: '',
+    iconUrl: 'iconUrl' in template ? (template.iconUrl ?? '') : '',
   };
 }
 
@@ -78,6 +100,7 @@ function valuesFromProvider(provider: OAuthProviderConfig): ProviderFormValues {
     name: provider.name,
     clientId: provider.clientId,
     clientSecret: provider.clientSecret ?? '',
+    appSlug: '',
     authorizeUrl: provider.authorizeUrl,
     tokenUrl: provider.tokenUrl,
     userInfoUrl: provider.userInfoUrl ?? '',
@@ -136,6 +159,35 @@ export function ProviderForm({
     mode: 'onSubmit',
   });
 
+  // Pre-fillable fields (URLs, scopes, icon) live behind an "Advanced" toggle
+  // for preset flows so the visible form is just id/name/clientId/clientSecret.
+  // Custom-create and edit modes open it by default since the admin is there
+  // specifically to set or review those values.
+  const [advancedOpen, setAdvancedOpen] = useState(preset === null);
+
+  // GitHub preset gets its own callback URL hint (one URL per provider id —
+  // each GitHub App registers its own callback) and a slug field that
+  // synthesises authorizeUrl as the admin types.
+  const isGithubPreset = preset === 'github' && !isEditing;
+  const idValue = form.watch('id');
+  const appSlugValue = form.watch('appSlug') ?? '';
+  const callbackUrl = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    const slug = idValue !== '' ? idValue : 'github';
+    return `${window.location.origin}/api/oauth/${slug}/callback`;
+  }, [idValue]);
+
+  useEffect(() => {
+    if (!isGithubPreset) return;
+    const slug = appSlugValue.trim();
+    if (slug === '') return;
+    if (!githubAppSlugPattern.test(slug)) return;
+    form.setValue('authorizeUrl', authorizeUrlFromGithubAppSlug(slug), {
+      shouldValidate: false,
+      shouldDirty: true,
+    });
+  }, [appSlugValue, isGithubPreset, form]);
+
   const handleSubmit = form.handleSubmit(async (values) => {
     const tokens = tokenizeScopes(values.scopes);
     if (tokens.length === 0) {
@@ -150,6 +202,10 @@ export function ProviderForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+      {isGithubPreset && (
+        <GithubAppSetupGuide callbackUrl={callbackUrl} providerId={idValue} />
+      )}
+
       <div className="grid gap-4 md:grid-cols-2">
         <Field label="Id" error={form.formState.errors.id?.message}>
           <input
@@ -197,77 +253,114 @@ export function ProviderForm({
         </Field>
       </div>
 
-      <Field label="Authorize URL" error={form.formState.errors.authorizeUrl?.message}>
-        <input
-          id="provider-authorize-url"
-          {...form.register('authorizeUrl')}
-          placeholder="https://github.com/login/oauth/authorize"
-          className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
-          autoComplete="off"
-        />
-      </Field>
+      {isGithubPreset && (
+        <Field
+          label="GitHub App slug"
+          hint="From github.com/apps/<slug> — the URL of your installed App."
+          error={form.formState.errors.appSlug?.message}
+        >
+          <input
+            id="provider-app-slug"
+            {...form.register('appSlug')}
+            placeholder="my-org-mediforce"
+            className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+            autoComplete="off"
+          />
+        </Field>
+      )}
 
-      <Field label="Token URL" error={form.formState.errors.tokenUrl?.message}>
-        <input
-          id="provider-token-url"
-          {...form.register('tokenUrl')}
-          placeholder="https://github.com/login/oauth/access_token"
-          className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
-          autoComplete="off"
-        />
-      </Field>
+      <div className="flex flex-col gap-4 rounded-md border bg-muted/20 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => setAdvancedOpen((open) => !open)}
+          aria-expanded={advancedOpen}
+          aria-controls="provider-advanced"
+          className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {advancedOpen ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+          Advanced — endpoints, scopes, icon
+        </button>
 
-      <Field label="User info URL" error={form.formState.errors.userInfoUrl?.message}>
-        <input
-          id="provider-userinfo-url"
-          {...form.register('userInfoUrl')}
-          placeholder="https://api.github.com/user"
-          className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
-          autoComplete="off"
-        />
-      </Field>
+        {advancedOpen && (
+          <div id="provider-advanced" className="flex flex-col gap-4">
+            <Field label="Authorize URL" error={form.formState.errors.authorizeUrl?.message}>
+              <input
+                id="provider-authorize-url"
+                {...form.register('authorizeUrl')}
+                placeholder="https://github.com/login/oauth/authorize"
+                className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+                autoComplete="off"
+              />
+            </Field>
 
-      <Field
-        label="Revoke URL"
-        hint="Optional. When present, 'Revoke' in the agent UI POSTs here after deleting the local token."
-        error={form.formState.errors.revokeUrl?.message}
-      >
-        <input
-          id="provider-revoke-url"
-          {...form.register('revokeUrl')}
-          placeholder="https://oauth2.googleapis.com/revoke"
-          className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
-          autoComplete="off"
-        />
-      </Field>
+            <Field label="Token URL" error={form.formState.errors.tokenUrl?.message}>
+              <input
+                id="provider-token-url"
+                {...form.register('tokenUrl')}
+                placeholder="https://github.com/login/oauth/access_token"
+                className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+                autoComplete="off"
+              />
+            </Field>
 
-      <Field
-        label="Scopes"
-        hint="Space-separated (or one per line). Sent verbatim to the provider at authorize time."
-        error={form.formState.errors.scopes?.message}
-      >
-        <textarea
-          id="provider-scopes"
-          {...form.register('scopes')}
-          rows={2}
-          placeholder="repo read:user"
-          className="resize-none rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
-        />
-      </Field>
+            <Field label="User info URL" error={form.formState.errors.userInfoUrl?.message}>
+              <input
+                id="provider-userinfo-url"
+                {...form.register('userInfoUrl')}
+                placeholder="https://api.github.com/user"
+                className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+                autoComplete="off"
+              />
+            </Field>
 
-      <Field
-        label="Icon URL"
-        hint="Optional. Shown in provider dropdown on agent binding form."
-        error={form.formState.errors.iconUrl?.message}
-      >
-        <input
-          id="provider-icon-url"
-          {...form.register('iconUrl')}
-          placeholder="https://cdn.example.com/github.svg"
-          className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
-          autoComplete="off"
-        />
-      </Field>
+            <Field
+              label="Revoke URL"
+              hint="Optional. When present, 'Revoke' in the agent UI POSTs here after deleting the local token."
+              error={form.formState.errors.revokeUrl?.message}
+            >
+              <input
+                id="provider-revoke-url"
+                {...form.register('revokeUrl')}
+                placeholder="https://oauth2.googleapis.com/revoke"
+                className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+                autoComplete="off"
+              />
+            </Field>
+
+            <Field
+              label="Scopes"
+              hint="Space-separated (or one per line). Sent verbatim to the provider at authorize time."
+              error={form.formState.errors.scopes?.message}
+            >
+              <textarea
+                id="provider-scopes"
+                {...form.register('scopes')}
+                rows={2}
+                placeholder="repo read:user"
+                className="resize-none rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+              />
+            </Field>
+
+            <Field
+              label="Icon URL"
+              hint="Optional. Shown in provider dropdown on agent binding form."
+              error={form.formState.errors.iconUrl?.message}
+            >
+              <input
+                id="provider-icon-url"
+                {...form.register('iconUrl')}
+                placeholder="https://cdn.example.com/github.svg"
+                className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+                autoComplete="off"
+              />
+            </Field>
+          </div>
+        )}
+      </div>
 
       {submitError !== undefined && submitError !== null && (
         <div className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -319,6 +412,66 @@ function Field({
       </label>
       {hint !== undefined && <span className="text-xs text-muted-foreground">{hint}</span>}
       {error !== undefined && <span className="text-xs text-destructive">{error}</span>}
+    </div>
+  );
+}
+
+/** Inline runbook for the GitHub App setup. We default to the App flow (not
+ *  classic OAuth Apps) because Apps offer install-scoped, fine-grained
+ *  permissions per repo/org — the right shape for agents that open PRs. */
+function GithubAppSetupGuide({
+  callbackUrl,
+  providerId,
+}: {
+  callbackUrl: string;
+  providerId: string;
+}) {
+  const callbackPlaceholder = callbackUrl !== ''
+    ? callbackUrl
+    : `<deployment>/api/oauth/${providerId !== '' ? providerId : 'github'}/callback`;
+
+  return (
+    <div className="rounded-md border bg-muted/40 px-4 py-3 text-xs">
+      <p className="mb-2 text-sm font-medium text-foreground">Setting up a GitHub App</p>
+      <ol className="list-decimal space-y-1.5 pl-5 text-muted-foreground">
+        <li>
+          Open{' '}
+          <a
+            href="https://github.com/settings/apps/new"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 font-mono text-foreground underline underline-offset-2"
+          >
+            github.com/settings/apps/new
+            <ExternalLink className="h-3 w-3" />
+          </a>{' '}
+          (or your org's developer settings to install at org scope).
+        </li>
+        <li>
+          <span className="font-medium text-foreground">Callback URL:</span>{' '}
+          <code className="rounded bg-background px-1 py-0.5 font-mono">
+            {callbackPlaceholder}
+          </code>{' '}
+          — derived from the <span className="font-mono">Id</span> field above; change Id to bind
+          a different App.
+        </li>
+        <li>
+          Disable webhook (we don't consume events).{' '}
+          <span className="font-medium text-foreground">Permissions:</span> Contents (Read &amp;
+          write), Pull requests (Read &amp; write), Metadata (Read).
+        </li>
+        <li>Save, then generate a client secret on the App page.</li>
+        <li>Install the App on your account / org and grant access to the repos the agent will touch.</li>
+        <li>
+          Copy the App slug from the install URL (
+          <code className="rounded bg-background px-1 py-0.5 font-mono">
+            github.com/apps/&lt;slug&gt;
+          </code>
+          ) and paste it into <span className="font-medium text-foreground">GitHub App slug</span>{' '}
+          below — that builds the Authorize URL.
+        </li>
+        <li>Paste the App's client id and the secret you generated, then Create.</li>
+      </ol>
     </div>
   );
 }


### PR DESCRIPTION
One-click setup for GitHub OAuth in the admin form, shaped around **GitHub Apps** (user-server OAuth flow) — not classic OAuth Apps, not app-level JWT. Apps offer install-scoped, fine-grained per-repo permissions, which is the right shape for agents that read code and open PRs.

When the admin clicks **Add GitHub App**:

- Inline setup runbook lists the registration steps on github.com, with the deployment-specific callback URL rendered live from the provider `Id` field (changing Id rebinds to a different App).
- **GitHub App slug** input synthesises the Authorize URL on type — `github.com/apps/<slug>/installations/new`, the install-then-authorize flow. A submit-time check rejects the placeholder if the admin saves without filling it.
- The form's **Advanced** section (URLs, scopes, icon URL) stays collapsed by default; only `id` / `name` / `clientId` / `clientSecret` + the slug field are visible up-front. Custom-create and edit modes still open Advanced by default.

## Multiple GitHub Apps per namespace

Each provider id maps to its own callback URL pattern (`/api/oauth/<id>/callback`), so a namespace can hold many GitHub providers (`github`, `github-readonly`, `github-writer`, …) — each tied to a separate registered App with distinct repo permissions. Bindings on the agent side reference a specific provider id.

## Changes

- `provider-form.tsx` — Advanced collapse, GitHub App setup guide, slug field that synthesises Authorize URL, submit-time placeholder check.
- `OAUTH_PROVIDER_PRESETS.github` — installation-URL pattern, scope trimmed to `read:user` (Apps ignore OAuth scopes; permissions come from install), GitHub favicon as `iconUrl`.
- Admin page button label `Add GitHub` → `Add GitHub App`.
- Tests cover preset rendering, slug → URL synthesis, placeholder rejection, advanced toggle visibility, and the existing payload paths.

## Context

- #302 — GitHub MCP for Vedhav demo.
- Unblocks #319 — its binding preset references provider id `github`, so the admin first sets up the provider here ("Add GitHub App" → 2-minute runbook → save), then uses the binding preset to wire it to an agent.

## Test plan

- [ ] CI passes
- [ ] Open `/{handle}/admin/oauth-providers` → click **Add GitHub App** → setup guide visible, callback URL reflects `Id` field
- [ ] Type App slug → reveal Advanced → Authorize URL is `github.com/apps/<slug>/installations/new`
- [ ] Save without slug → submit blocked with "Fill in your GitHub App slug…"
- [ ] End-to-end with a real GitHub App: register App, install, paste credentials, save, run agent, confirm OAuth connect works
- [ ] Click **Add custom** → Advanced section open by default, no setup guide