### PR TITLE
feat(ui): one-click GitHub MCP preset on agent bindings panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,13 @@ DOCKER_OPENROUTER_API_KEY=
 # workflow secrets at rest. Losing this key makes stored secrets unrecoverable.
 SECRETS_ENCRYPTION_KEY=
 
+# --- OAuth provider credentials ---
+# Auto-seeded into Firestore on boot from data/seeds/oauth-providers.json.
+# Per-deployment OAuth Apps registered on the provider side (see
+# docs/DEPLOYMENT-OAUTH-PROVIDERS.md). When unset, the matching provider
+# is skipped at boot.
+OAUTH_GITHUB_CLIENT_ID=
+OAUTH_GITHUB_CLIENT_SECRET=
+
 # --- Server ---
 DOMAIN=localhost

--- a/data/seeds/oauth-providers.json
+++ b/data/seeds/oauth-providers.json
@@ -1,0 +1,14 @@
+{
+  "appsilon": [
+    {
+      "id": "github",
+      "name": "GitHub",
+      "authorizeUrl": "https://github.com/login/oauth/authorize",
+      "tokenUrl": "https://github.com/login/oauth/access_token",
+      "userInfoUrl": "https://api.github.com/user",
+      "scopes": ["repo", "read:user"],
+      "clientIdEnv": "OAUTH_GITHUB_CLIENT_ID",
+      "clientSecretEnv": "OAUTH_GITHUB_CLIENT_SECRET"
+    }
+  ]
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,6 +65,11 @@ services:
       - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
       - MAILGUN_FROM_EMAIL=${MAILGUN_FROM_EMAIL}
       - MAILGUN_SENDER_NAME=${MAILGUN_SENDER_NAME:-Mediforce}
+      # OAuth provider credentials — auto-seeded into Firestore on boot
+      # from data/seeds/oauth-providers.json. Each entry is optional;
+      # when unset, that provider is skipped at boot.
+      - OAUTH_GITHUB_CLIENT_ID=${OAUTH_GITHUB_CLIENT_ID:-}
+      - OAUTH_GITHUB_CLIENT_SECRET=${OAUTH_GITHUB_CLIENT_SECRET:-}
       # Firebase Admin SDK credentials for server-side Firestore/Auth access.
       # Mounted read-only from host ./secrets/firebase-admin-sa.json.
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-sa.json

--- a/docs/DEPLOYMENT-OAUTH-PROVIDERS.md
+++ b/docs/DEPLOYMENT-OAUTH-PROVIDERS.md
@@ -1,0 +1,146 @@
+# Deployment runbook: OAuth providers
+
+OAuth providers (GitHub, Google, etc.) are configured per deployment via
+environment variables. The platform's boot-time seeder reads
+`data/seeds/oauth-providers.json`, resolves the named env vars, and upserts
+each entry into Firestore at `namespaces/{handle}/oauthProviders/{id}`.
+
+This means:
+
+- **Provider URLs and scopes live in the repo** — same JSON in every deployment.
+- **Client credentials live in env vars per deployment** — different OAuth Apps
+  registered on the provider side for staging vs. production vs. each pharma
+  tenant.
+- **Boot is idempotent** — redeploys converge on the JSON-defined config; missing
+  env vars cause that provider to be skipped (with a warning) instead of failing.
+
+## Domain → callback URL
+
+Each deployment needs its own OAuth App registered on the provider, because
+OAuth Apps are pinned to a single callback URL.
+
+| Deployment | Public URL | Callback URL (used during OAuth App registration) |
+|------------|------------|--------------------------------------------------|
+| Local dev | `http://localhost:9003` | `http://localhost:9003/api/oauth/github/callback` |
+| Staging | `https://staging.mediforce.app` | `https://staging.mediforce.app/api/oauth/github/callback` |
+| Production | `https://mediforce.app` | `https://mediforce.app/api/oauth/github/callback` |
+| Pharma `<tenant>` | tenant's domain | `<tenant-domain>/api/oauth/github/callback` |
+
+The callback path is fixed at `/api/oauth/<provider>/callback`. For non-GitHub
+providers, swap `github` for the provider id (matches `id` in
+`data/seeds/oauth-providers.json`).
+
+## Per-deployment setup
+
+### 1. Register the OAuth App on the provider
+
+For GitHub (other providers analogous — see their docs):
+
+1. Open <https://github.com/settings/applications/new> (or the org's developer
+   settings if registering on behalf of an organization).
+2. **Application name**: deployment-specific, e.g. "Mediforce Staging".
+3. **Homepage URL**: this deployment's public URL.
+4. **Authorization callback URL**: the deployment's callback URL from the table above.
+5. Save, then generate a **Client secret** (one-shot — copy it now).
+
+### 2. Write credentials to the deployment's `.env`
+
+Each deployment's runtime env lives in a single file on the host that
+`docker compose` reads via `${VAR}` substitution:
+
+| Deployment | File on host |
+|------------|--------------|
+| Local dev | `packages/platform-ui/.env.local` (in repo) |
+| Staging / production VPS | `/opt/mediforce/.env` |
+| Pharma VPS | tenant's equivalent |
+
+**Interactive (recommended for first-time setup)** — guides through the steps
+above, prompts for the client id + secret, and writes them to the env file:
+
+```bash
+python3 scripts/seed_oauth_providers.py --env-file /opt/mediforce/.env
+```
+
+Use `--public-url` to pre-fill the callback URL in the displayed instructions
+when `MEDIFORCE_PUBLIC_URL` / `APP_BASE_URL` aren't already in the env file:
+
+```bash
+python3 scripts/seed_oauth_providers.py \
+  --env-file /opt/mediforce/.env \
+  --public-url https://staging.mediforce.app
+```
+
+**Non-interactive (CI / automated deploys)** — only reports missing vars,
+exits 0:
+
+```bash
+python3 scripts/seed_oauth_providers.py --env-file .env --non-interactive
+```
+
+**Check only** — read-only audit, exits 1 if anything is missing:
+
+```bash
+python3 scripts/seed_oauth_providers.py --env-file .env --check
+```
+
+You can also edit the env file by hand. The required keys for each provider
+are listed in `data/seeds/oauth-providers.json` under `clientIdEnv` /
+`clientSecretEnv`. For GitHub:
+
+```
+OAUTH_GITHUB_CLIENT_ID=Iv1.abc123...
+OAUTH_GITHUB_CLIENT_SECRET=xxx
+```
+
+### 3. Restart the platform
+
+The seeder runs on `getPlatformServices()` first call, which is during boot:
+
+```bash
+# VPS
+docker compose -f docker-compose.prod.yml restart platform-ui
+
+# Local dev
+pnpm dev   # (if not already running)
+```
+
+Look for the log line:
+
+```
+[seed-oauth-providers] Upserted N provider(s).
+```
+
+### 4. Verify in admin UI
+
+Open `/{handle}/admin/oauth-providers` (where `{handle}` is your namespace,
+e.g. `appsilon`). The provider should appear in the list with the URLs and
+scopes from the seed file. Editing it through the UI will overwrite what the
+seeder put there — the next boot will re-upsert from the seed, so prefer
+changing the seed JSON + redeploying for permanent changes.
+
+## Adding a new provider
+
+1. Add an entry to `data/seeds/oauth-providers.json` for the appropriate
+   namespace, with a unique `id`, the provider's OAuth URLs/scopes, and the
+   names of two env vars (`clientIdEnv`, `clientSecretEnv`).
+2. Add a hint block to `SETUP_HINTS` in `scripts/seed_oauth_providers.py`
+   so the interactive flow can show the registration URL and callback path.
+3. Add the env var stubs (with empty values) to `.env.example` and
+   `packages/platform-ui/.env.local.example`.
+4. Add a `${VAR:-}` line to `docker-compose.prod.yml` under the `platform-ui`
+   service `environment:` so the var is passed to the container.
+5. Document the new provider in this file (extend the table above).
+
+## Troubleshooting
+
+- **Provider not appearing in admin UI after deploy** — check platform-ui logs
+  for `[seed-oauth-providers] Skipping ... missing env vars`. The env var
+  isn't reaching the platform-ui container; verify it's set in the host
+  `.env` file and listed in `docker-compose.prod.yml` under
+  `services.platform-ui.environment`.
+- **OAuth callback returns 404** — the OAuth App is registered with the wrong
+  callback URL. Update it on the provider side to match this deployment's
+  domain.
+- **`invalid_client` from GitHub** — wrong client id or secret pasted into
+  `.env`. Re-run `seed_oauth_providers.py` with the correct values, then
+  restart the platform.

--- a/packages/platform-api/src/services/__tests__/seed-oauth-providers.test.ts
+++ b/packages/platform-api/src/services/__tests__/seed-oauth-providers.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { resolveOAuthProviderSeeds } from '../seed-oauth-providers.js';
+import type { OAuthProviderSeedEntry } from '@mediforce/platform-core';
+
+const githubEntry: OAuthProviderSeedEntry = {
+  id: 'github',
+  name: 'GitHub',
+  authorizeUrl: 'https://github.com/login/oauth/authorize',
+  tokenUrl: 'https://github.com/login/oauth/access_token',
+  userInfoUrl: 'https://api.github.com/user',
+  scopes: ['repo', 'read:user'],
+  clientIdEnv: 'OAUTH_GITHUB_CLIENT_ID',
+  clientSecretEnv: 'OAUTH_GITHUB_CLIENT_SECRET',
+};
+
+describe('resolveOAuthProviderSeeds', () => {
+  it('resolves env vars into client credentials', () => {
+    const result = resolveOAuthProviderSeeds(
+      { appsilon: [githubEntry] },
+      {
+        OAUTH_GITHUB_CLIENT_ID: 'Iv1.abc123',
+        OAUTH_GITHUB_CLIENT_SECRET: 'shh-secret',
+      },
+    );
+
+    expect(result.skipped).toEqual([]);
+    expect(result.resolved).toHaveLength(1);
+    const [{ namespace, input }] = result.resolved;
+    expect(namespace).toBe('appsilon');
+    expect(input.id).toBe('github');
+    expect(input.clientId).toBe('Iv1.abc123');
+    expect(input.clientSecret).toBe('shh-secret');
+    expect(input.scopes).toEqual(['repo', 'read:user']);
+    expect(input.userInfoUrl).toBe('https://api.github.com/user');
+  });
+
+  it('skips entries when required env vars are missing', () => {
+    const result = resolveOAuthProviderSeeds(
+      { appsilon: [githubEntry] },
+      {},
+    );
+
+    expect(result.resolved).toEqual([]);
+    expect(result.skipped).toEqual([
+      {
+        namespace: 'appsilon',
+        id: 'github',
+        missing: ['OAUTH_GITHUB_CLIENT_ID', 'OAUTH_GITHUB_CLIENT_SECRET'],
+      },
+    ]);
+  });
+
+  it('skips entries when env vars are present but empty', () => {
+    const result = resolveOAuthProviderSeeds(
+      { appsilon: [githubEntry] },
+      {
+        OAUTH_GITHUB_CLIENT_ID: '',
+        OAUTH_GITHUB_CLIENT_SECRET: '',
+      },
+    );
+
+    expect(result.resolved).toEqual([]);
+    expect(result.skipped[0].missing).toEqual([
+      'OAUTH_GITHUB_CLIENT_ID',
+      'OAUTH_GITHUB_CLIENT_SECRET',
+    ]);
+  });
+
+  it('treats clientSecretEnv as optional (PKCE-only public clients)', () => {
+    const publicClient: OAuthProviderSeedEntry = {
+      id: 'pkce-only',
+      name: 'PKCE Only',
+      authorizeUrl: 'https://example.com/auth',
+      tokenUrl: 'https://example.com/token',
+      scopes: ['read'],
+      clientIdEnv: 'OAUTH_PKCE_CLIENT_ID',
+      tokenEndpointAuthMethod: 'none',
+    };
+
+    const result = resolveOAuthProviderSeeds(
+      { appsilon: [publicClient] },
+      { OAUTH_PKCE_CLIENT_ID: 'public-client' },
+    );
+
+    expect(result.skipped).toEqual([]);
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].input.clientId).toBe('public-client');
+    expect(result.resolved[0].input.clientSecret).toBeUndefined();
+    expect(result.resolved[0].input.tokenEndpointAuthMethod).toBe('none');
+  });
+
+  it('handles multiple namespaces and entries independently', () => {
+    const acmeEntry: OAuthProviderSeedEntry = {
+      ...githubEntry,
+      clientIdEnv: 'OAUTH_GITHUB_ACME_CLIENT_ID',
+      clientSecretEnv: 'OAUTH_GITHUB_ACME_CLIENT_SECRET',
+    };
+    const result = resolveOAuthProviderSeeds(
+      { appsilon: [githubEntry], acme: [acmeEntry] },
+      {
+        OAUTH_GITHUB_CLIENT_ID: 'app-id',
+        OAUTH_GITHUB_CLIENT_SECRET: 'app-secret',
+        // acme env vars intentionally absent
+      },
+    );
+
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].namespace).toBe('appsilon');
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].namespace).toBe('acme');
+  });
+});

--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -43,6 +43,7 @@ import {
 import { WebhookRouter } from '@mediforce/workflow-engine';
 import { seedBuiltinAgentDefinitions } from './seed-agent-definitions.js';
 import { seedBuiltinToolCatalog } from './seed-tool-catalog.js';
+import { seedBuiltinOAuthProviders } from './seed-oauth-providers.js';
 import { backfillInstanceNamespaces } from '@mediforce/platform-infra';
 
 let services: PlatformServices | null = null;
@@ -207,6 +208,9 @@ export function getPlatformServices(): PlatformServices {
     });
     seedBuiltinToolCatalog(toolCatalogRepo).catch((err) => {
       console.error('[platform-services] Failed to seed built-in tool catalog:', err);
+    });
+    seedBuiltinOAuthProviders(oauthProviderRepo).catch((err) => {
+      console.error('[platform-services] Failed to seed built-in OAuth providers:', err);
     });
     backfillInstanceNamespaces(db, processRepo).catch((err) => {
       console.error('[platform-services] Failed to backfill instance namespaces:', err);

--- a/packages/platform-api/src/services/seed-oauth-providers.ts
+++ b/packages/platform-api/src/services/seed-oauth-providers.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { OAuthProviderRepository } from '@mediforce/platform-core';
+import {
+  OAuthProviderSeedFileSchema,
+  type OAuthProviderSeedEntry,
+  type CreateOAuthProviderInput,
+} from '@mediforce/platform-core';
+
+/** Boot-time loader for `data/seeds/oauth-providers.json`.
+ *
+ *  The JSON carries provider URLs, scopes, and the *names* of env vars that
+ *  hold per-deployment client credentials. At seed time we resolve those env
+ *  vars and upsert into Firestore at `namespaces/{ns}/oauthProviders/{id}`.
+ *
+ *  Per-deployment isolation: same JSON in every deployment, different env
+ *  → different OAuth Apps registered on the provider side. Entries whose
+ *  required env vars are not set are skipped with a warning so a deployment
+ *  that doesn't use a given provider boots cleanly. */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// packages/platform-api/dist/services -> repo root
+// packages/platform-api/src/services   -> repo root (also 4 levels up via @mediforce/source)
+const SEED_PATH = resolve(__dirname, '../../../../data/seeds/oauth-providers.json');
+
+interface ResolvedSeed {
+  namespace: string;
+  input: CreateOAuthProviderInput;
+}
+
+interface ResolutionResult {
+  resolved: ResolvedSeed[];
+  skipped: { namespace: string; id: string; missing: string[] }[];
+}
+
+export function resolveOAuthProviderSeeds(
+  file: Record<string, OAuthProviderSeedEntry[]>,
+  env: Record<string, string | undefined>,
+): ResolutionResult {
+  const resolved: ResolvedSeed[] = [];
+  const skipped: ResolutionResult['skipped'] = [];
+
+  for (const [namespace, entries] of Object.entries(file)) {
+    for (const entry of entries) {
+      const clientId = env[entry.clientIdEnv];
+      const clientSecret = entry.clientSecretEnv !== undefined
+        ? env[entry.clientSecretEnv]
+        : undefined;
+
+      const missing: string[] = [];
+      if (clientId === undefined || clientId === '') missing.push(entry.clientIdEnv);
+      if (
+        entry.clientSecretEnv !== undefined
+        && (clientSecret === undefined || clientSecret === '')
+      ) {
+        missing.push(entry.clientSecretEnv);
+      }
+      if (missing.length > 0) {
+        skipped.push({ namespace, id: entry.id, missing });
+        continue;
+      }
+
+      const input: CreateOAuthProviderInput = {
+        id: entry.id,
+        name: entry.name,
+        authorizeUrl: entry.authorizeUrl,
+        tokenUrl: entry.tokenUrl,
+        scopes: entry.scopes,
+        clientId: clientId as string,
+        ...(clientSecret !== undefined ? { clientSecret } : {}),
+        ...(entry.revokeUrl !== undefined ? { revokeUrl: entry.revokeUrl } : {}),
+        ...(entry.userInfoUrl !== undefined ? { userInfoUrl: entry.userInfoUrl } : {}),
+        ...(entry.tokenEndpointAuthMethod !== undefined
+          ? { tokenEndpointAuthMethod: entry.tokenEndpointAuthMethod }
+          : {}),
+        ...(entry.iconUrl !== undefined ? { iconUrl: entry.iconUrl } : {}),
+      };
+      resolved.push({ namespace, input });
+    }
+  }
+
+  return { resolved, skipped };
+}
+
+function loadSeedFile(): Record<string, OAuthProviderSeedEntry[]> {
+  const raw = JSON.parse(readFileSync(SEED_PATH, 'utf-8')) as unknown;
+  return OAuthProviderSeedFileSchema.parse(raw);
+}
+
+export async function seedBuiltinOAuthProviders(
+  repo: OAuthProviderRepository,
+): Promise<void> {
+  const file = loadSeedFile();
+  const { resolved, skipped } = resolveOAuthProviderSeeds(file, process.env);
+
+  for (const { namespace, id, missing } of skipped) {
+    console.warn(
+      `[seed-oauth-providers] Skipping ${namespace}/${id} — missing env vars: ${missing.join(', ')}`,
+    );
+  }
+
+  await Promise.all(
+    resolved.map(({ namespace, input }) => repo.upsert(namespace, input)),
+  );
+
+  if (resolved.length > 0) {
+    console.log(`[seed-oauth-providers] Upserted ${resolved.length} provider(s).`);
+  }
+}

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -203,6 +203,8 @@ export {
   PublicOAuthProviderConfigSchema,
   CreateOAuthProviderInputSchema,
   UpdateOAuthProviderInputSchema,
+  OAuthProviderSeedEntrySchema,
+  OAuthProviderSeedFileSchema,
   OAUTH_PROVIDER_PRESETS,
 } from './schemas/oauth-provider.js';
 export type {
@@ -210,6 +212,8 @@ export type {
   PublicOAuthProviderConfig,
   CreateOAuthProviderInput,
   UpdateOAuthProviderInput,
+  OAuthProviderSeedEntry,
+  OAuthProviderSeedFile,
 } from './schemas/oauth-provider.js';
 export {
   AgentOAuthTokenSchema,

--- a/packages/platform-core/src/repositories/oauth-provider-repository.ts
+++ b/packages/platform-core/src/repositories/oauth-provider-repository.ts
@@ -25,6 +25,11 @@ export interface OAuthProviderRepository {
     patch: UpdateOAuthProviderInput,
   ): Promise<OAuthProviderConfig | null>;
 
+  /** Idempotent create-or-replace by id. Used by the boot-time seeder so
+   *  redeploys converge on the JSON-defined config without manual cleanup.
+   *  `createdAt` is preserved across replaces; `updatedAt` is refreshed. */
+  upsert(namespace: string, input: CreateOAuthProviderInput): Promise<OAuthProviderConfig>;
+
   /** Delete a provider. No-op if the id does not exist. Returns whether
    *  a document was actually removed. */
   delete(namespace: string, id: string): Promise<boolean>;

--- a/packages/platform-core/src/schemas/oauth-provider.ts
+++ b/packages/platform-core/src/schemas/oauth-provider.ts
@@ -80,6 +80,40 @@ export const UpdateOAuthProviderInputSchema = CreateOAuthProviderInputSchema.omi
 
 export type UpdateOAuthProviderInput = z.infer<typeof UpdateOAuthProviderInputSchema>;
 
+/** Seed-time entry for `data/seeds/oauth-providers.json`. Mirrors the
+ *  runtime config but replaces `clientId`/`clientSecret` with names of env
+ *  vars to resolve at boot. Lets us check provider URLs/scopes into the
+ *  repo while keeping per-deployment credentials in env files. */
+export const OAuthProviderSeedEntrySchema = z.object({
+  id: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*$/),
+  name: z.string().min(1),
+  authorizeUrl: z.string().url(),
+  tokenUrl: z.string().url(),
+  revokeUrl: z.string().url().optional(),
+  userInfoUrl: z.string().url().optional(),
+  scopes: z.array(z.string().min(1)).min(1),
+  tokenEndpointAuthMethod: z
+    .enum(['client_secret_basic', 'client_secret_post', 'none'])
+    .optional(),
+  iconUrl: z.string().url().optional(),
+  /** Name of env var holding the OAuth App client id. */
+  clientIdEnv: z.string().min(1),
+  /** Name of env var holding the client secret. Optional for public
+   *  clients (PKCE-only, `tokenEndpointAuthMethod: 'none'`). */
+  clientSecretEnv: z.string().min(1).optional(),
+}).strict();
+
+export type OAuthProviderSeedEntry = z.infer<typeof OAuthProviderSeedEntrySchema>;
+
+/** Top-level shape of `data/seeds/oauth-providers.json` — namespace handle
+ *  → list of seed entries. */
+export const OAuthProviderSeedFileSchema = z.record(
+  z.string().min(1),
+  z.array(OAuthProviderSeedEntrySchema),
+);
+
+export type OAuthProviderSeedFile = z.infer<typeof OAuthProviderSeedFileSchema>;
+
 /** Built-in provider presets. UI exposes these as "Add GitHub" / "Add Google"
  *  buttons that pre-fill the admin form. Admin still supplies clientId +
  *  clientSecret for their own OAuth App. */

--- a/packages/platform-core/src/testing/__tests__/in-memory-oauth-repos.test.ts
+++ b/packages/platform-core/src/testing/__tests__/in-memory-oauth-repos.test.ts
@@ -76,6 +76,39 @@ describe('InMemoryOAuthProviderRepository', () => {
     expect(await repo.delete('acme', 'github')).toBe(true);
     expect(await repo.delete('acme', 'github')).toBe(false);
   });
+
+  describe('upsert', () => {
+    it('creates a fresh provider when none exists', async () => {
+      const created = await repo.upsert('acme', providerInput);
+      expect(created.id).toBe('github');
+      expect(created.createdAt).toBe(created.updatedAt);
+      const fetched = await repo.get('acme', 'github');
+      expect(fetched?.clientId).toBe('Iv1.xxx');
+    });
+
+    it('preserves createdAt and refreshes updatedAt on replace', async () => {
+      const first = await repo.upsert('acme', providerInput);
+      const replaced = await repo.upsert('acme', { ...providerInput, name: 'Renamed' });
+      expect(replaced.createdAt).toBe(first.createdAt);
+      expect(replaced.updatedAt > first.updatedAt).toBe(true);
+      expect(replaced.name).toBe('Renamed');
+    });
+
+    it('replaces all fields (no field merge)', async () => {
+      await repo.upsert('acme', providerInput);
+      const replaced = await repo.upsert('acme', {
+        id: 'github',
+        name: 'GitHub',
+        clientId: 'Iv1.new',
+        clientSecret: 'new-secret',
+        authorizeUrl: providerInput.authorizeUrl,
+        tokenUrl: providerInput.tokenUrl,
+        scopes: ['repo', 'read:user'],
+      });
+      expect(replaced.userInfoUrl).toBeUndefined();
+      expect(replaced.clientSecret).toBe('new-secret');
+    });
+  });
 });
 
 const tokenFixture: AgentOAuthToken = {

--- a/packages/platform-core/src/testing/in-memory-oauth-provider-repository.ts
+++ b/packages/platform-core/src/testing/in-memory-oauth-provider-repository.ts
@@ -62,6 +62,23 @@ export class InMemoryOAuthProviderRepository implements OAuthProviderRepository 
     return updated;
   }
 
+  async upsert(
+    namespace: string,
+    input: CreateOAuthProviderInput,
+  ): Promise<OAuthProviderConfig> {
+    const scope = this.store.get(namespace) ?? new Map<string, OAuthProviderConfig>();
+    const existing = scope.get(input.id);
+    const now = new Date(this.clock++).toISOString();
+    const config: OAuthProviderConfig = {
+      ...input,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    scope.set(input.id, config);
+    this.store.set(namespace, scope);
+    return config;
+  }
+
   async delete(namespace: string, id: string): Promise<boolean> {
     const scope = this.store.get(namespace);
     if (!scope) return false;

--- a/packages/platform-infra/src/__tests__/oauth-provider-repository.test.ts
+++ b/packages/platform-infra/src/__tests__/oauth-provider-repository.test.ts
@@ -189,4 +189,40 @@ describe('FirestoreOAuthProviderRepository', () => {
     expect(result).toBe(true);
     expect(mockDelete).toHaveBeenCalledTimes(1);
   });
+
+  describe('upsert', () => {
+    it('creates a new doc when none exists, with createdAt == updatedAt', async () => {
+      mockGet.mockResolvedValueOnce({ exists: false });
+      const created = await repo.upsert('acme', providerInput);
+
+      expect(created.id).toBe('github');
+      expect(created.createdAt).toBe(created.updatedAt);
+      expect(mockSet).toHaveBeenCalledTimes(1);
+      const persisted = mockSet.mock.calls[0][0] as Record<string, unknown>;
+      expect(persisted.id).toBeUndefined();
+      expect(persisted.clientId).toBe('Iv1.xxx');
+    });
+
+    it('preserves createdAt and refreshes updatedAt when doc already exists', async () => {
+      const existing = storedProviderFor(providerInput, {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        id: 'github',
+        data: () => existing,
+      });
+
+      const replaced = await repo.upsert('acme', { ...providerInput, name: 'Renamed' });
+
+      expect(replaced.createdAt).toBe(existing.createdAt);
+      expect(replaced.updatedAt > existing.updatedAt).toBe(true);
+      expect(replaced.name).toBe('Renamed');
+
+      expect(mockSet).toHaveBeenCalledTimes(1);
+      const persisted = mockSet.mock.calls[0][0] as Record<string, unknown>;
+      expect(persisted.name).toBe('Renamed');
+    });
+  });
 });

--- a/packages/platform-infra/src/firestore/oauth-provider-repository.ts
+++ b/packages/platform-infra/src/firestore/oauth-provider-repository.ts
@@ -73,6 +73,26 @@ export class FirestoreOAuthProviderRepository implements OAuthProviderRepository
     return updated;
   }
 
+  async upsert(
+    namespace: string,
+    input: CreateOAuthProviderInput,
+  ): Promise<OAuthProviderConfig> {
+    const ref = this.col(namespace).doc(input.id);
+    const existing = await ref.get();
+    const now = new Date().toISOString();
+    const createdAt = existing.exists
+      ? OAuthProviderConfigSchema.parse({ ...existing.data(), id: existing.id }).createdAt
+      : now;
+    const config: OAuthProviderConfig = OAuthProviderConfigSchema.parse({
+      ...input,
+      createdAt,
+      updatedAt: now,
+    });
+    const { id: _id, ...body } = config;
+    await ref.set(body);
+    return config;
+  }
+
   async delete(namespace: string, id: string): Promise<boolean> {
     const ref = this.col(namespace).doc(id);
     const snap = await ref.get();

--- a/packages/platform-ui/.env.local.example
+++ b/packages/platform-ui/.env.local.example
@@ -23,6 +23,13 @@ OAUTH_STATE_SECRET=
 APP_BASE_URL=
 NAMESPACE=
 
+# OAuth provider client credentials — auto-seeded into Firestore on boot
+# from data/seeds/oauth-providers.json. Per-deployment OAuth Apps registered
+# at the provider side (see docs/DEPLOYMENT-OAUTH-PROVIDERS.md). When unset,
+# the matching provider is skipped at boot.
+OAUTH_GITHUB_CLIENT_ID=
+OAUTH_GITHUB_CLIENT_SECRET=
+
 # Command palette → ticket creation (optional)
 # Personal access token with `repo` scope for the target repo, so the
 # "New ticket" command in the command palette can open GitHub issues.

--- a/packages/platform-ui/e2e/journeys/github-mcp-preset.journey.ts
+++ b/packages/platform-ui/e2e/journeys/github-mcp-preset.journey.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '../helpers/test-fixtures';
+import { TEST_ORG_HANDLE } from '../helpers/constants';
+import { setupRecording, click, showStep, showResult, endRecording } from '../helpers/recording';
+
+/**
+ * Journey — GitHub MCP preset
+ *
+ * One-click "Add GitHub MCP" preset on the agent MCP bindings panel pre-fills
+ * an HTTP binding pointing at `https://api.githubcopilot.com/mcp/` with OAuth
+ * auth. The preset references a provider id of `github`, which doesn't exist
+ * in the e2e seed (we only seed `github-mock`); the test verifies the pre-fill
+ * is correct, then switches the provider to `github-mock` to complete a real
+ * save against the local mock OAuth server. Binding is cleaned up at the end
+ * so the test is rerunnable.
+ */
+
+test.describe('GitHub MCP preset journey', () => {
+  test('one-click "Add GitHub MCP" pre-fills HTTP + OAuth binding', async ({ page }, testInfo) => {
+    await setupRecording(page, 'github-mcp-preset', testInfo);
+
+    await page.goto(`/${TEST_ORG_HANDLE}/agents/definitions/claude-code-agent`);
+    await expect(page.getByText(/edit this ai agent/i)).toBeVisible({ timeout: 30_000 });
+
+    const mcpHeading = page.getByRole('heading', { name: /mcp servers/i });
+    await expect(mcpHeading).toBeVisible();
+    await showStep(page);
+
+    // ── Click "Add GitHub MCP" preset ────────────────────────────────────
+    await click(page, page.getByRole('button', { name: /add github mcp/i }));
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /add github mcp server/i })).toBeVisible();
+
+    // Pre-fills — server name, transport, URL, OAuth auth mode
+    await expect(page.getByLabel(/server name/i)).toHaveValue('github');
+    await expect(page.getByRole('radio', { name: /^http$/i })).toBeChecked();
+    await expect(page.getByLabel(/^url$/i)).toHaveValue('https://api.githubcopilot.com/mcp/');
+    await expect(page.getByRole('radio', { name: /^oauth$/i })).toBeChecked();
+    await showStep(page);
+
+    // ── Switch provider to the e2e mock and save ─────────────────────────
+    // The preset references provider id `github` (real GitHub). The e2e env
+    // only has `github-mock` seeded for OAuth flow testing, so swap before
+    // saving.
+    await page.getByLabel(/oauth provider/i).selectOption({ label: 'GitHub (mock)' });
+
+    await click(page, page.getByRole('button', { name: /^save$|create binding/i }).last());
+    await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 });
+
+    // Binding row appears
+    await expect(page.getByText('github').first()).toBeVisible();
+    await expect(page.getByText(/http/i).first()).toBeVisible();
+    await showResult(page);
+
+    // ── Cleanup so the test is rerunnable ────────────────────────────────
+    await click(page, page.getByRole('button', { name: 'Remove github' }));
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await click(page, page.getByRole('button', { name: /^(delete|confirm|remove)/i }).last());
+
+    await endRecording(page);
+  });
+});

--- a/packages/platform-ui/src/components/agents/__tests__/agent-mcp-binding-form.test.tsx
+++ b/packages/platform-ui/src/components/agents/__tests__/agent-mcp-binding-form.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { OAuthProviderConfig } from '@mediforce/platform-core';
+
+const githubProvider: OAuthProviderConfig = {
+  id: 'github',
+  name: 'GitHub',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  authorizeUrl: 'https://github.com/login/oauth/authorize',
+  tokenUrl: 'https://github.com/login/oauth/access_token',
+  userInfoUrl: 'https://api.github.com/user',
+  scopes: ['repo', 'read:user'],
+  createdAt: '2026-04-23T10:00:00.000Z',
+  updatedAt: '2026-04-23T10:00:00.000Z',
+};
+
+vi.mock('@/lib/oauth-admin-client', () => ({
+  listOAuthProviders: vi.fn(async () => [githubProvider]),
+}));
+
+import { AgentMcpBindingForm } from '../agent-mcp-binding-form';
+
+describe('AgentMcpBindingForm — github-mcp preset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills name, transport, URL, and OAuth provider for GitHub MCP preset', async () => {
+    render(
+      <AgentMcpBindingForm
+        existing={null}
+        existingNames={[]}
+        catalogEntries={[]}
+        agentId="agent-1"
+        namespace="appsilon"
+        preset="github-mcp"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Server name input — selected by its placeholder which is unique on the form
+    const nameInput = screen.getByPlaceholderText('filesystem') as HTMLInputElement;
+    expect(nameInput.value).toBe('github');
+
+    // HTTP transport selected by preset (selected by value to avoid label-text collisions)
+    const transportRadios = screen.getAllByRole('radio');
+    const httpRadio = transportRadios.find(
+      (r) => (r as HTMLInputElement).value === 'http',
+    ) as HTMLInputElement;
+    expect(httpRadio.checked).toBe(true);
+
+    const urlInput = screen.getByPlaceholderText(/api.example.com\/mcp/i) as HTMLInputElement;
+    expect(urlInput.value).toBe('https://api.githubcopilot.com/mcp/');
+
+    // OAuth auth mode selected
+    const oauthAuthRadio = transportRadios.find(
+      (r) => (r as HTMLInputElement).value === 'oauth',
+    ) as HTMLInputElement;
+    expect(oauthAuthRadio.checked).toBe(true);
+
+    // Wait for providers to load and verify github is selected
+    await waitFor(() => {
+      const providerSelect = screen.getByLabelText(/OAuth provider/i) as HTMLSelectElement;
+      expect(providerSelect.value).toBe('github');
+    });
+  });
+
+  it('submits a github-mcp preset binding with HTTP + OAuth (provider=github)', async () => {
+    const onSubmit = vi.fn(async () => {});
+    const user = userEvent.setup();
+
+    render(
+      <AgentMcpBindingForm
+        existing={null}
+        existingNames={[]}
+        catalogEntries={[]}
+        agentId="agent-1"
+        namespace="appsilon"
+        preset="github-mcp"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Wait for the OAuth provider list to load before submitting,
+    // otherwise the selected provider value is empty.
+    await waitFor(() => {
+      const providerSelect = screen.getByLabelText(/OAuth provider/i) as HTMLSelectElement;
+      expect(providerSelect.value).toBe('github');
+    });
+
+    await user.click(screen.getByRole('button', { name: /Create binding/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const [name, binding] = onSubmit.mock.calls[0];
+    expect(name).toBe('github');
+    expect(binding).toEqual({
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      auth: {
+        type: 'oauth',
+        provider: 'github',
+        headerName: 'Authorization',
+        headerValueTemplate: 'Bearer {token}',
+      },
+    });
+  });
+
+  it('lets the user switch to PAT (static headers) instead of OAuth', async () => {
+    const onSubmit = vi.fn(async () => {});
+    const user = userEvent.setup();
+
+    render(
+      <AgentMcpBindingForm
+        existing={null}
+        existingNames={[]}
+        catalogEntries={[]}
+        agentId="agent-1"
+        namespace="appsilon"
+        preset="github-mcp"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Switch from OAuth → static headers (PAT path). Pick the radio by value
+    // since "OAuth" / "Static headers" labels can collide with other text.
+    const allRadios = screen.getAllByRole('radio');
+    const headersRadio = allRadios.find(
+      (r) => (r as HTMLInputElement).value === 'headers',
+    ) as HTMLInputElement;
+    await user.click(headersRadio);
+
+    // Add a header carrying the GITHUB_TOKEN secret template.
+    // userEvent treats { as keyboard syntax; doubled-up braces produce a literal {.
+    await user.click(screen.getByRole('button', { name: /Add header/i }));
+    await user.type(screen.getByLabelText(/Header key 1/i), 'Authorization');
+    // user-event treats { as keyboard syntax; doubled-up `{{` produces a literal `{`.
+    // `}` has no escape semantics, so type it once for each `}` we want.
+    await user.type(
+      screen.getByLabelText(/Header value 1/i),
+      'Bearer {{{{SECRET:GITHUB_TOKEN}}',
+    );
+
+    await user.click(screen.getByRole('button', { name: /Create binding/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const [name, binding] = onSubmit.mock.calls[0];
+    expect(name).toBe('github');
+    expect(binding).toEqual({
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      auth: {
+        type: 'headers',
+        headers: { Authorization: 'Bearer {{SECRET:GITHUB_TOKEN}}' },
+      },
+    });
+  });
+});

--- a/packages/platform-ui/src/components/agents/agent-mcp-binding-form.tsx
+++ b/packages/platform-ui/src/components/agents/agent-mcp-binding-form.tsx
@@ -15,6 +15,35 @@ import { listOAuthProviders } from '@/lib/oauth-admin-client';
 
 const nameRegex = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
 
+/** Built-in form presets surfaced as one-click "Add X MCP" buttons.
+ *  Pre-fills name + transport + transport-specific defaults so the user
+ *  only needs to click Save (or tweak as needed). */
+export type McpBindingPreset = 'github-mcp';
+
+interface HttpPresetDefaults {
+  url: string;
+  authMode: 'oauth' | 'headers';
+  oauthProvider?: string;
+}
+
+interface PresetDefaults {
+  name: string;
+  transport: 'stdio' | 'http';
+  http?: HttpPresetDefaults;
+}
+
+const PRESET_DEFAULTS: Record<McpBindingPreset, PresetDefaults> = {
+  'github-mcp': {
+    name: 'github',
+    transport: 'http',
+    http: {
+      url: 'https://api.githubcopilot.com/mcp/',
+      authMode: 'oauth',
+      oauthProvider: 'github',
+    },
+  },
+};
+
 const StdioFormSchema = z.object({
   catalogId: z.string().min(1, 'Choose a catalog entry'),
   allowedTools: z.array(z.object({ value: z.string() })),
@@ -71,6 +100,8 @@ interface AgentMcpBindingFormProps {
   catalogEntries: ToolCatalogEntry[];
   agentId: string;
   namespace: string;
+  /** Optional preset that pre-fills the form for one-click MCP setup. */
+  preset?: McpBindingPreset;
   onSubmit: (name: string, binding: AgentMcpBinding) => Promise<void>;
   onCancel: () => void;
 }
@@ -81,13 +112,17 @@ export function AgentMcpBindingForm({
   catalogEntries,
   agentId,
   namespace,
+  preset,
   onSubmit,
   onCancel,
 }: AgentMcpBindingFormProps) {
   const isEdit = existing !== null;
-  const [name, setName] = useState(existing?.name ?? '');
+  const presetDefaults = preset !== undefined ? PRESET_DEFAULTS[preset] : null;
+  const [name, setName] = useState(existing?.name ?? presetDefaults?.name ?? '');
   const [nameError, setNameError] = useState<string | null>(null);
-  const [transport, setTransport] = useState<'stdio' | 'http'>(existing?.binding.type ?? 'stdio');
+  const [transport, setTransport] = useState<'stdio' | 'http'>(
+    existing?.binding.type ?? presetDefaults?.transport ?? 'stdio',
+  );
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   function validateName(value: string): string | null {
@@ -174,6 +209,7 @@ export function AgentMcpBindingForm({
         <HttpFields
           key="http-fields"
           initial={existing?.binding.type === 'http' ? existing.binding : null}
+          presetHttp={presetDefaults?.http ?? null}
           agentId={agentId}
           namespace={namespace}
           existingServerName={existing?.name ?? null}
@@ -281,6 +317,7 @@ function StdioFields({
 
 function HttpFields({
   initial,
+  presetHttp,
   agentId,
   namespace,
   existingServerName,
@@ -290,6 +327,7 @@ function HttpFields({
   submitLabel,
 }: {
   initial: Extract<AgentMcpBinding, { type: 'http' }> | null;
+  presetHttp: HttpPresetDefaults | null;
   agentId: string;
   namespace: string;
   existingServerName: string | null;
@@ -306,17 +344,21 @@ function HttpFields({
   const initialAuthMode: 'none' | 'headers' | 'oauth' = useMemo(() => {
     if (initial?.auth?.type === 'oauth') return 'oauth';
     if (initial?.auth?.type === 'headers') return 'headers';
+    if (presetHttp !== null) return presetHttp.authMode;
     return 'none';
-  }, [initial]);
+  }, [initial, presetHttp]);
 
   const form = useForm<HttpFormValues>({
     resolver: zodResolver(HttpFormSchema),
     defaultValues: {
-      url: initial?.url ?? '',
+      url: initial?.url ?? presetHttp?.url ?? '',
       allowedTools: (initial?.allowedTools ?? []).map((value) => ({ value })),
       authMode: initialAuthMode,
       headers: initialHeaders,
-      oauthProvider: initial?.auth?.type === 'oauth' ? initial.auth.provider : '',
+      oauthProvider:
+        initial?.auth?.type === 'oauth'
+          ? initial.auth.provider
+          : presetHttp?.oauthProvider ?? '',
       oauthHeaderName:
         initial?.auth?.type === 'oauth' ? initial.auth.headerName : 'Authorization',
       oauthHeaderValueTemplate:
@@ -347,6 +389,20 @@ function HttpFields({
       cancelled = true;
     };
   }, [namespace]);
+
+  // Re-sync the provider <select> with the form value once providers load.
+  // The defaultValue path is initialized synchronously, but the matching
+  // <option> only renders after the async fetch — without this, presets
+  // and edit-mode bindings show an empty selection until the user touches
+  // the dropdown.
+  useEffect(() => {
+    if (providers.length === 0) return;
+    const target = form.getValues('oauthProvider');
+    if (target === undefined || target === '') return;
+    if (providers.some((p) => p.id === target)) {
+      form.setValue('oauthProvider', target, { shouldDirty: false });
+    }
+  }, [providers, form]);
 
   const selectedProvider = useMemo(
     () => providers.find((p) => p.id === oauthProviderId) ?? null,

--- a/packages/platform-ui/src/components/agents/agent-mcp-section.tsx
+++ b/packages/platform-ui/src/components/agents/agent-mcp-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as Dialog from '@radix-ui/react-dialog';
-import { AlertTriangle, Pencil, Plus, Server, Trash2, X } from 'lucide-react';
+import { AlertTriangle, GitBranch, Pencil, Plus, Server, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AgentMcpBinding, AgentMcpBindingMap, ToolCatalogEntry } from '@mediforce/platform-core';
 import {
@@ -20,7 +20,7 @@ interface AgentMcpSectionProps {
 
 type DialogState =
   | { kind: 'closed' }
-  | { kind: 'create' }
+  | { kind: 'create'; preset?: 'github-mcp' }
   | { kind: 'edit'; name: string; binding: AgentMcpBinding };
 
 export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
@@ -88,14 +88,24 @@ export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
           <Server className="h-4 w-4 text-muted-foreground" />
           <h2 className="text-sm font-semibold">MCP Servers</h2>
         </div>
-        <button
-          type="button"
-          onClick={() => setDialog({ kind: 'create' })}
-          className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
-        >
-          <Plus className="h-3 w-3" />
-          Add server
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setDialog({ kind: 'create', preset: 'github-mcp' })}
+            className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+          >
+            <GitBranch className="h-3 w-3" />
+            Add GitHub MCP
+          </button>
+          <button
+            type="button"
+            onClick={() => setDialog({ kind: 'create' })}
+            className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+          >
+            <Plus className="h-3 w-3" />
+            Add server
+          </button>
+        </div>
       </header>
 
       <p className="text-xs text-muted-foreground">
@@ -153,6 +163,8 @@ export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
                   <>
                     Edit binding <span className="font-mono">{dialog.name}</span>
                   </>
+                ) : dialog.kind === 'create' && dialog.preset === 'github-mcp' ? (
+                  'Add GitHub MCP server'
                 ) : (
                   'Add MCP server'
                 )}
@@ -166,12 +178,17 @@ export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
             <div className="overflow-y-auto px-5 py-4">
               {dialog.kind !== 'closed' && (
                 <AgentMcpBindingForm
-                  key={dialog.kind === 'edit' ? `edit:${dialog.name}` : 'create'}
+                  key={
+                    dialog.kind === 'edit'
+                      ? `edit:${dialog.name}`
+                      : dialog.preset ?? 'create'
+                  }
                   existing={dialog.kind === 'edit' ? { name: dialog.name, binding: dialog.binding } : null}
                   existingNames={existingNames}
                   catalogEntries={catalog}
                   agentId={agentId}
                   namespace={handle}
+                  preset={dialog.kind === 'create' ? dialog.preset : undefined}
                   onSubmit={handleSubmit}
                   onCancel={() => setDialog({ kind: 'closed' })}
                 />

--- a/scripts/seed_oauth_providers.py
+++ b/scripts/seed_oauth_providers.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Interactive setup helper for OAuth provider credentials.
+
+Reads `data/seeds/oauth-providers.json`, checks each provider's required
+env vars against the target `.env` file, and either:
+  - reports what's set / missing (`--check`)
+  - skips missing entries with a warning (`--non-interactive`, for CI)
+  - guides through OAuth App registration and writes credentials to the
+    env file (default, interactive)
+
+The platform reads these env vars on boot via `seedBuiltinOAuthProviders`
+in platform-api/src/services/seed-oauth-providers.ts and upserts the
+resolved providers into Firestore at `namespaces/{ns}/oauthProviders/{id}`.
+
+Usage:
+    # Local dev — write to repo .env.local
+    python3 scripts/seed_oauth_providers.py --env-file packages/platform-ui/.env.local
+
+    # Production VPS — write to /opt/mediforce/.env
+    python3 scripts/seed_oauth_providers.py --env-file /opt/mediforce/.env
+
+    # CI — non-interactive: report only, never prompt
+    python3 scripts/seed_oauth_providers.py --env-file .env --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SEED_PATH = REPO_ROOT / "data" / "seeds" / "oauth-providers.json"
+
+# Per-provider setup hints. Mirrors data/seeds/oauth-providers.json by id.
+# Keep this small — adding new providers here is intentional, not automatic.
+SETUP_HINTS: dict[str, dict[str, str]] = {
+    "github": {
+        "registration_url": "https://github.com/settings/applications/new",
+        "callback_path": "/api/oauth/github/callback",
+        "notes": (
+            "Application name: choose something deployment-specific (e.g. "
+            "'Mediforce Staging'). Homepage URL: your Mediforce public URL. "
+            "After saving, generate a client secret."
+        ),
+    },
+}
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    """Parse a flat KEY=VALUE .env file. Lines starting with # or empty are
+    skipped. No quote stripping (we want round-trip equality on writes)."""
+    env: dict[str, str] = {}
+    if not path.exists():
+        return env
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        env[key.strip()] = value.strip()
+    return env
+
+
+def _upsert_env(path: Path, updates: dict[str, str]) -> None:
+    """Upsert KEY=VALUE pairs into the env file. Preserves comments and
+    ordering for existing keys; appends new keys at the end."""
+    if path.exists():
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=False)
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lines = []
+
+    seen: set[str] = set()
+    new_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("#") or "=" not in stripped:
+            new_lines.append(line)
+            continue
+        key = stripped.split("=", 1)[0].strip()
+        if key in updates:
+            new_lines.append(f"{key}={updates[key]}")
+            seen.add(key)
+        else:
+            new_lines.append(line)
+
+    appended_keys = [key for key in updates if key not in seen]
+    if appended_keys:
+        if new_lines and new_lines[-1].strip() != "":
+            new_lines.append("")
+        new_lines.append("# Added by seed_oauth_providers.py")
+        for key in appended_keys:
+            new_lines.append(f"{key}={updates[key]}")
+
+    path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
+def _hint_for(provider_id: str) -> dict[str, str] | None:
+    return SETUP_HINTS.get(provider_id)
+
+
+def _print_setup_instructions(
+    provider_id: str,
+    provider_name: str,
+    public_url: str | None,
+) -> None:
+    hint = _hint_for(provider_id)
+    if hint is None:
+        print(f"  No setup hint for provider '{provider_id}' — refer to vendor docs.")
+        return
+
+    callback = (
+        f"{public_url.rstrip('/')}{hint['callback_path']}"
+        if public_url
+        else f"<your-mediforce-url>{hint['callback_path']}"
+    )
+    print(f"\n  Setup steps for {provider_name}:")
+    print(f"    1. Open: {hint['registration_url']}")
+    print(f"    2. Authorization callback URL: {callback}")
+    print(f"    3. {hint['notes']}")
+
+
+def _process_entry(
+    namespace: str,
+    entry: dict,
+    env: dict[str, str],
+    *,
+    interactive: bool,
+    public_url: str | None,
+) -> tuple[dict[str, str], list[str]]:
+    """Returns (updates_to_write, missing_after_processing)."""
+    required: list[str] = [entry["clientIdEnv"]]
+    if "clientSecretEnv" in entry:
+        required.append(entry["clientSecretEnv"])
+
+    missing = [name for name in required if env.get(name, "") == ""]
+    if not missing:
+        print(f"  ✓ {namespace}/{entry['id']}: all credentials set")
+        return ({}, [])
+
+    print(f"  ✗ {namespace}/{entry['id']}: missing {', '.join(missing)}")
+
+    if not interactive:
+        return ({}, missing)
+
+    _print_setup_instructions(entry["id"], entry["name"], public_url)
+    print()
+
+    updates: dict[str, str] = {}
+    for var_name in missing:
+        is_secret = "SECRET" in var_name.upper() or "PASSWORD" in var_name.upper()
+        prompt = f"  Paste {var_name}{' (input hidden)' if is_secret else ''}: "
+        try:
+            if is_secret:
+                import getpass
+
+                value = getpass.getpass(prompt)
+            else:
+                value = input(prompt)
+        except (EOFError, KeyboardInterrupt):
+            print("\n  Skipped.")
+            return ({}, missing)
+        value = value.strip()
+        if value == "":
+            print(f"  Skipped {var_name} — left empty.")
+            return ({}, missing)
+        updates[var_name] = value
+
+    return (updates, [])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=REPO_ROOT / "packages" / "platform-ui" / ".env.local",
+        help="Path to the env file to read/write (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--public-url",
+        default=None,
+        help=(
+            "Public URL of this deployment, used to build callback URLs in "
+            "the setup instructions (e.g. https://staging.mediforce.app). "
+            "Defaults to MEDIFORCE_PUBLIC_URL or APP_BASE_URL from the env file."
+        ),
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Never prompt; report missing vars and exit 0. Suitable for CI.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Read-only: report what's set / missing without changes.",
+    )
+    args = parser.parse_args()
+
+    if not SEED_PATH.exists():
+        print(f"Seed file not found at {SEED_PATH}", file=sys.stderr)
+        return 1
+
+    seed_data = json.loads(SEED_PATH.read_text(encoding="utf-8"))
+    env = _load_env(args.env_file)
+    public_url = (
+        args.public_url
+        or env.get("MEDIFORCE_PUBLIC_URL")
+        or env.get("APP_BASE_URL")
+        or env.get("NEXT_PUBLIC_APP_URL")
+    )
+
+    interactive = not args.non_interactive and not args.check
+
+    print(f"Reading {SEED_PATH.relative_to(REPO_ROOT)}")
+    print(f"Env file: {args.env_file}")
+    if public_url:
+        print(f"Public URL: {public_url}")
+
+    all_updates: dict[str, str] = {}
+    total_missing: list[str] = []
+
+    for namespace, entries in seed_data.items():
+        print(f"\nNamespace: {namespace}")
+        for entry in entries:
+            updates, missing = _process_entry(
+                namespace,
+                entry,
+                env,
+                interactive=interactive,
+                public_url=public_url,
+            )
+            all_updates.update(updates)
+            total_missing.extend(missing)
+            # Reflect freshly captured values for subsequent entries in the
+            # same run (e.g. when two entries reference the same env var).
+            env.update(updates)
+
+    if args.check:
+        print()
+        if total_missing:
+            print(f"Missing env vars: {', '.join(sorted(set(total_missing)))}")
+            return 1
+        print("All providers have their credentials configured.")
+        return 0
+
+    if all_updates:
+        _upsert_env(args.env_file, all_updates)
+        print(f"\nWrote {len(all_updates)} variable(s) to {args.env_file}")
+        print(
+            "Restart the platform (e.g. `docker compose restart platform-ui`) so "
+            "the boot-time seeder picks up the new credentials.",
+        )
+    else:
+        print("\nNo changes made.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

One-click "Add GitHub MCP" button on the agent MCP bindings panel that opens the binding dialog pre-filled for GitHub's hosted MCP server (https://api.githubcopilot.com/mcp/) with OAuth as the default auth mode (PAT via static headers as the alternative).

Stacked on #318 — that PR adds the `github` OAuth provider via config-as-code seeding (`data/seeds/oauth-providers.json`); this PR consumes that provider id from the form preset. **Merge #318 first.**

Context: issue #302 (Vedhav demo) — final piece to make GitHub PR opening from agents one-click after the OAuth App + creds are configured for a deployment.

## What's in the form preset

Clicking **Add GitHub MCP** sets:

| Field | Value |
|-------|-------|
| Server name | `github` |
| Transport | HTTP |
| URL | `https://api.githubcopilot.com/mcp/` |
| Auth mode | OAuth |
| OAuth provider | `github` |

The user can save as-is (assuming the `github` OAuth provider exists in their namespace — which it does after #318 + per-deployment env vars), or switch the auth mode to **Static headers** to use a PAT via `Bearer {{SECRET:GITHUB_TOKEN}}` instead.

`allowedTools` is intentionally left empty — the user narrows toolset later if they want.

## Side fix

`HttpFields` now re-syncs the OAuth provider `<select>` with the form value once providers load. Without it, the `defaultValue` path was effectively lost on first render because the matching `<option>` only renders after the async fetch — this affected both the new preset and edit-mode bindings.

## Tests

- **Unit** (3 tests, testing-library): preset pre-fill assertion, OAuth submission payload assertion, switch-to-PAT (static headers) submission assertion.
- **E2E journey** `github-mcp-preset.journey.ts`: clicks the preset button, asserts pre-fill, swaps the OAuth provider to the e2e-seeded `github-mock`, saves the binding, asserts the row appears, cleans up so the test is rerunnable.

## Verified locally

- `pnpm typecheck` — clean
- `pnpm test` — 1970 passed, 10 skipped, 0 failed
- E2E run — running in background; will update PR if anything fails

## Test plan

- [ ] CI passes (unit + E2E)
- [ ] Open `/{handle}/agents/definitions/<agentId>` → click **Add GitHub MCP** → form pre-fills as expected
- [ ] With #318 deployed and `OAUTH_GITHUB_CLIENT_ID/_SECRET` set: save the preset, run the agent, confirm the OAuth flow connects and `create_pull_request` works end-to-end