### PR TITLE
feat(cli): add secret set/list/delete commands

### DIFF
--- a/packages/cli/src/__tests__/secret-delete.test.ts
+++ b/packages/cli/src/__tests__/secret-delete.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { secretDeleteCommand } from '../commands/secret-delete.js';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BASE_ENV = { MEDIFORCE_API_KEY: 'k' };
+const BASE_ARGV = ['--workflow', 'wf-1', '--namespace', 'ns-1', '--key', 'OLD_KEY'];
+
+describe('secret delete command', () => {
+  it('prints help on --help and exits 0', async () => {
+    const output = captureOutput();
+    const code = await secretDeleteCommand({
+      argv: ['--help'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/Usage: mediforce secret delete/);
+  });
+
+  it('deletes secret and prints confirmation', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ ok: true }),
+    );
+    const output = captureOutput();
+    const code = await secretDeleteCommand({
+      argv: [...BASE_ARGV, '--base-url', 'http://test:9000'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/Secret "OLD_KEY" deleted/);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toContain('namespace=ns-1');
+    expect(url).toContain('workflow=wf-1');
+    expect(url).toContain('key=OLD_KEY');
+    expect(init?.method).toBe('DELETE');
+  });
+
+  it('emits JSON on success when --json set', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: true }));
+    const output = captureOutput();
+    const code = await secretDeleteCommand({
+      argv: [...BASE_ARGV, '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(JSON.parse(output.stdoutLines.join('\n'))).toEqual({ ok: true });
+  });
+
+  it('exits 2 when required flags missing', async () => {
+    const output = captureOutput();
+    const code = await secretDeleteCommand({
+      argv: ['--workflow', 'wf-1', '--namespace', 'ns-1'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/--key are required/);
+  });
+
+  it('exits 1 on API error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Not found' }, 404),
+    );
+    const output = captureOutput();
+    const code = await secretDeleteCommand({
+      argv: [...BASE_ARGV, '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed = JSON.parse(output.stdoutLines.join('\n')) as { status: number };
+    expect(parsed.status).toBe(404);
+  });
+
+  it('exits 2 when API key missing', async () => {
+    const output = captureOutput();
+    const code = await secretDeleteCommand({
+      argv: BASE_ARGV,
+      env: {},
+      output,
+    });
+    expect(code).toBe(2);
+  });
+});

--- a/packages/cli/src/__tests__/secret-list.test.ts
+++ b/packages/cli/src/__tests__/secret-list.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { secretListCommand } from '../commands/secret-list.js';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BASE_ENV = { MEDIFORCE_API_KEY: 'k' };
+const BASE_ARGV = ['--workflow', 'wf-1', '--namespace', 'ns-1'];
+
+describe('secret list command', () => {
+  it('prints help on --help and exits 0', async () => {
+    const output = captureOutput();
+    const code = await secretListCommand({
+      argv: ['--help'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/Usage: mediforce secret list/);
+  });
+
+  it('lists secret keys in human-readable format', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ keys: ['API_TOKEN', 'DB_PASSWORD'] }),
+    );
+    const output = captureOutput();
+    const code = await secretListCommand({
+      argv: [...BASE_ARGV, '--base-url', 'http://test:9000'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    const text = output.stdoutLines.join('\n');
+    expect(text).toMatch(/API_TOKEN/);
+    expect(text).toMatch(/DB_PASSWORD/);
+    expect(text).toMatch(/2/);
+  });
+
+  it('emits JSON when --json set', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ keys: ['KEY_A'] }),
+    );
+    const output = captureOutput();
+    const code = await secretListCommand({
+      argv: [...BASE_ARGV, '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(JSON.parse(output.stdoutLines.join('\n'))).toEqual({ keys: ['KEY_A'] });
+  });
+
+  it('prints empty message when no secrets', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ keys: [] }));
+    const output = captureOutput();
+    const code = await secretListCommand({
+      argv: BASE_ARGV,
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/No secrets configured/);
+  });
+
+  it('exits 2 when required flags missing', async () => {
+    const output = captureOutput();
+    const code = await secretListCommand({
+      argv: ['--workflow', 'wf-1'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(2);
+  });
+
+  it('exits 1 on API error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Unauthorized' }, 401),
+    );
+    const output = captureOutput();
+    const code = await secretListCommand({
+      argv: [...BASE_ARGV, '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed = JSON.parse(output.stdoutLines.join('\n')) as { status: number };
+    expect(parsed.status).toBe(401);
+  });
+
+  it('verifies fetch URL contains correct query params', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ keys: [] }),
+    );
+    const output = captureOutput();
+    await secretListCommand({
+      argv: [...BASE_ARGV, '--base-url', 'http://test:9000'],
+      env: BASE_ENV,
+      output,
+    });
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain('namespace=ns-1');
+    expect(url).toContain('workflow=wf-1');
+  });
+});

--- a/packages/cli/src/__tests__/secret-set.test.ts
+++ b/packages/cli/src/__tests__/secret-set.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { secretSetCommand } from '../commands/secret-set.js';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BASE_ENV = { MEDIFORCE_API_KEY: 'k' };
+const BASE_ARGV = ['--workflow', 'wf-1', '--namespace', 'ns-1', '--key', 'TOKEN'];
+
+describe('secret set command', () => {
+  it('prints help on --help and exits 0', async () => {
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: ['--help'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/Usage: mediforce secret set/);
+  });
+
+  it('sets secret via --value flag', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ ok: true }),
+    );
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: [...BASE_ARGV, '--value', 'secret-val', '--base-url', 'http://test:9000'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines.join('\n')).toMatch(/Secret "TOKEN" set/);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toContain('/api/workflow-secrets');
+    expect(url).toContain('namespace=ns-1');
+    expect(url).toContain('workflow=wf-1');
+    expect(init?.method).toBe('PUT');
+    const body = JSON.parse(init?.body as string) as { key: string; value: string };
+    expect(body).toEqual({ key: 'TOKEN', value: 'secret-val' });
+  });
+
+  it('sets secret via --stdin', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: true }));
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: [...BASE_ARGV, '--stdin'],
+      env: BASE_ENV,
+      output,
+      stdin: async () => 'piped-value',
+    });
+    expect(code).toBe(0);
+    const body = JSON.parse(
+      (vi.mocked(globalThis.fetch).mock.calls[0]![1]?.body as string),
+    ) as { value: string };
+    expect(body.value).toBe('piped-value');
+  });
+
+  it('exits 2 when --value and --stdin both missing', async () => {
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: BASE_ARGV,
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/--value or --stdin/);
+  });
+
+  it('exits 2 when --value and --stdin both present', async () => {
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: [...BASE_ARGV, '--value', 'x', '--stdin'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/Cannot use both/);
+  });
+
+  it('exits 1 when stdin is empty', async () => {
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: [...BASE_ARGV, '--stdin'],
+      env: BASE_ENV,
+      output,
+      stdin: async () => '',
+    });
+    expect(code).toBe(1);
+    expect(output.stderrLines.join('\n')).toMatch(/stdin was empty/);
+  });
+
+  it('exits 2 when required flags missing', async () => {
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: ['--value', 'x'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(2);
+  });
+
+  it('exits 1 on API error and prints status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Forbidden' }, 403),
+    );
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: [...BASE_ARGV, '--value', 'x', '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed = JSON.parse(output.stdoutLines.join('\n')) as { status: number };
+    expect(parsed.status).toBe(403);
+  });
+
+  it('exits 2 when API key missing', async () => {
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: [...BASE_ARGV, '--value', 'x'],
+      env: {},
+      output,
+    });
+    expect(code).toBe(2);
+  });
+
+  it('emits JSON on success when --json set', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: true }));
+    const output = captureOutput();
+    const code = await secretSetCommand({
+      argv: [...BASE_ARGV, '--value', 'x', '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(JSON.parse(output.stdoutLines.join('\n'))).toEqual({ ok: true });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,6 +32,9 @@ import { agentGetCommand } from './commands/agent-get.js';
 import { modelListCommand } from './commands/model-list.js';
 import { modelGetCommand } from './commands/model-get.js';
 import { modelSyncCommand } from './commands/model-sync.js';
+import { secretSetCommand } from './commands/secret-set.js';
+import { secretListCommand } from './commands/secret-list.js';
+import { secretDeleteCommand } from './commands/secret-delete.js';
 import { consoleOutput, type OutputSink } from './output.js';
 
 export interface RunCliInput {
@@ -52,6 +55,9 @@ Commands:
   model list                                         List models in registry
   model get <id>                                     Fetch a model from registry
   model sync                                         Sync models from OpenRouter
+  secret set --workflow <name> --namespace <ns> --key <key>  Set a secret
+  secret list --workflow <name> --namespace <ns>     List secret keys
+  secret delete --workflow <name> --namespace <ns> --key <key>  Delete a secret
   run list                                           List recent runs
   run start --workflow <name>                        Start a new run (manual trigger)
   run get <runId>                                    Fetch a single run's status
@@ -103,6 +109,16 @@ Subcommands:
   sync                Sync models from OpenRouter
 
 Run \`mediforce model <subcommand> --help\` for subcommand-specific flags.
+`;
+
+const SECRET_HELP = `Usage: mediforce secret <subcommand> [options]
+
+Subcommands:
+  set --workflow <name> --namespace <ns> --key <key>     Set a secret
+  list --workflow <name> --namespace <ns>                List secret key names
+  delete --workflow <name> --namespace <ns> --key <key>  Delete a secret
+
+Run \`mediforce secret <subcommand> --help\` for subcommand-specific flags.
 `;
 
 const RUN_HELP = `Usage: mediforce run <subcommand> [options]
@@ -163,6 +179,12 @@ export async function runCli(input: RunCliInput): Promise<number> {
     output.stderr(MODEL_HELP);
     return 2;
   }
+  if (command === 'secret' && subcommand === undefined) {
+    output.stderr('mediforce secret: missing subcommand');
+    output.stderr('');
+    output.stderr(SECRET_HELP);
+    return 2;
+  }
   if (command === 'system' && subcommand === undefined) {
     output.stderr('mediforce system: missing subcommand');
     output.stderr('');
@@ -205,6 +227,15 @@ export async function runCli(input: RunCliInput): Promise<number> {
   }
   if (command === 'run' && subcommand === 'start') {
     return runStartCommand({ argv: rest, env: input.env, output });
+  }
+  if (command === 'secret' && subcommand === 'set') {
+    return secretSetCommand({ argv: rest, env: input.env, output });
+  }
+  if (command === 'secret' && subcommand === 'list') {
+    return secretListCommand({ argv: rest, env: input.env, output });
+  }
+  if (command === 'secret' && subcommand === 'delete') {
+    return secretDeleteCommand({ argv: rest, env: input.env, output });
   }
   if (command === 'system' && subcommand === 'status') {
     return systemStatusCommand({ argv: rest, env: input.env, output });

--- a/packages/cli/src/commands/secret-delete.ts
+++ b/packages/cli/src/commands/secret-delete.ts
@@ -1,0 +1,102 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce secret delete --workflow <name> --namespace <ns> --key <key> [options]
+
+Delete a single secret from a workflow.
+
+Required flags:
+  --workflow <name>    Workflow name
+  --namespace <ns>    Namespace handle
+  --key <key>         Secret key name to delete
+
+Optional flags:
+  --base-url <url>    API base URL (default: http://localhost:9003)
+  --json              Emit JSON instead of human-readable output
+  --help, -h          Show this help text
+`;
+
+const DELETE_OPTIONS = {
+  workflow: { type: 'string' },
+  namespace: { type: 'string' },
+  key: { type: 'string' },
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function secretDeleteCommand(input: CommandInput): Promise<number> {
+  let flags: {
+    workflow?: string;
+    namespace?: string;
+    key?: string;
+    'base-url'?: string;
+    json?: boolean;
+    help?: boolean;
+  };
+  try {
+    const parsed = parseArgs({
+      args: input.argv,
+      options: DELETE_OPTIONS,
+      strict: true,
+      allowPositionals: false,
+    });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce secret delete: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+  const jsonMode = flags.json === true;
+
+  if (flags.help === true) {
+    input.output.stdout(HELP);
+    return 0;
+  }
+
+  if (!flags.workflow || !flags.namespace || !flags.key) {
+    printError(input.output, { error: '--workflow, --namespace, and --key are required' }, jsonMode);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    await mediforce.secrets.delete({
+      namespace: flags.namespace,
+      workflow: flags.workflow,
+      key: flags.key,
+    });
+    if (jsonMode) {
+      printJson(input.output, { ok: true });
+    } else {
+      input.output.stdout(`Secret "${flags.key}" deleted from workflow "${flags.workflow}" in namespace "${flags.namespace}".`);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
+    } else {
+      printError(input.output, { error: String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/secret-list.ts
+++ b/packages/cli/src/commands/secret-list.ts
@@ -1,0 +1,105 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce secret list --workflow <name> --namespace <ns> [options]
+
+List secret key names for a workflow. Values are never shown.
+
+Required flags:
+  --workflow <name>    Workflow name
+  --namespace <ns>    Namespace handle
+
+Optional flags:
+  --base-url <url>    API base URL (default: http://localhost:9003)
+  --json              Emit JSON instead of human-readable output
+  --help, -h          Show this help text
+`;
+
+const LIST_OPTIONS = {
+  workflow: { type: 'string' },
+  namespace: { type: 'string' },
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function secretListCommand(input: CommandInput): Promise<number> {
+  let flags: {
+    workflow?: string;
+    namespace?: string;
+    'base-url'?: string;
+    json?: boolean;
+    help?: boolean;
+  };
+  try {
+    const parsed = parseArgs({
+      args: input.argv,
+      options: LIST_OPTIONS,
+      strict: true,
+      allowPositionals: false,
+    });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce secret list: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+  const jsonMode = flags.json === true;
+
+  if (flags.help === true) {
+    input.output.stdout(HELP);
+    return 0;
+  }
+
+  if (!flags.workflow || !flags.namespace) {
+    printError(input.output, { error: '--workflow and --namespace are required' }, jsonMode);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    const result = await mediforce.secrets.list({
+      namespace: flags.namespace,
+      workflow: flags.workflow,
+    });
+    if (jsonMode) {
+      printJson(input.output, result);
+      return 0;
+    }
+    if (result.keys.length === 0) {
+      input.output.stdout(`No secrets configured for workflow "${flags.workflow}" in namespace "${flags.namespace}".`);
+      return 0;
+    }
+    input.output.stdout(`Secrets for "${flags.workflow}" (${String(result.keys.length)}):\n`);
+    for (const key of result.keys) {
+      input.output.stdout(`  ${key}`);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
+    } else {
+      printError(input.output, { error: String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/secret-set.ts
+++ b/packages/cli/src/commands/secret-set.ts
@@ -1,0 +1,148 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+  stdin?: () => Promise<string>;
+}
+
+const HELP = `Usage: mediforce secret set --workflow <name> --namespace <ns> --key <key> [options]
+
+Set a single secret for a workflow. The value is encrypted at rest.
+
+Required flags:
+  --workflow <name>    Workflow name
+  --namespace <ns>    Namespace handle
+  --key <key>         Secret key name
+
+Value source (exactly one required):
+  --value <val>       Secret value (visible in shell history — prefer --stdin)
+  --stdin             Read value from stdin (pipe-friendly, no shell history)
+
+Optional flags:
+  --base-url <url>    API base URL (default: http://localhost:9003)
+  --json              Emit JSON instead of human-readable output
+  --help, -h          Show this help text
+
+Examples:
+  mediforce secret set --workflow my-wf --namespace my-ns --key API_TOKEN --value sk-abc
+  echo "sk-abc" | mediforce secret set --workflow my-wf --namespace my-ns --key API_TOKEN --stdin
+`;
+
+const SET_OPTIONS = {
+  workflow: { type: 'string' },
+  namespace: { type: 'string' },
+  key: { type: 'string' },
+  value: { type: 'string' },
+  stdin: { type: 'boolean' },
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+function readStdinDefault(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on('data', (chunk) => chunks.push(chunk));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8').trim()));
+    process.stdin.on('error', reject);
+  });
+}
+
+export async function secretSetCommand(input: CommandInput): Promise<number> {
+  let flags: {
+    workflow?: string;
+    namespace?: string;
+    key?: string;
+    value?: string;
+    stdin?: boolean;
+    'base-url'?: string;
+    json?: boolean;
+    help?: boolean;
+  };
+  try {
+    const parsed = parseArgs({
+      args: input.argv,
+      options: SET_OPTIONS,
+      strict: true,
+      allowPositionals: false,
+    });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce secret set: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+  const jsonMode = flags.json === true;
+
+  if (flags.help === true) {
+    input.output.stdout(HELP);
+    return 0;
+  }
+
+  if (!flags.workflow || !flags.namespace || !flags.key) {
+    printError(input.output, { error: '--workflow, --namespace, and --key are required' }, jsonMode);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  const hasValue = typeof flags.value === 'string' && flags.value.length > 0;
+  const hasStdin = flags.stdin === true;
+  if (!hasValue && !hasStdin) {
+    printError(input.output, { error: 'Provide --value or --stdin' }, jsonMode);
+    return 2;
+  }
+  if (hasValue && hasStdin) {
+    printError(input.output, { error: 'Cannot use both --value and --stdin' }, jsonMode);
+    return 2;
+  }
+
+  let secretValue: string;
+  if (hasStdin) {
+    const readStdin = input.stdin ?? readStdinDefault;
+    secretValue = await readStdin();
+    if (secretValue.length === 0) {
+      printError(input.output, { error: 'stdin was empty — no value to set' }, jsonMode);
+      return 1;
+    }
+  } else {
+    secretValue = flags.value!;
+  }
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    await mediforce.secrets.set({
+      namespace: flags.namespace,
+      workflow: flags.workflow,
+      key: flags.key,
+      value: secretValue,
+    });
+    if (jsonMode) {
+      printJson(input.output, { ok: true });
+    } else {
+      input.output.stdout(`Secret "${flags.key}" set for workflow "${flags.workflow}" in namespace "${flags.namespace}".`);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
+    } else {
+      printError(input.output, { error: String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -21,6 +21,12 @@ import {
   ListAgentsOutputSchema,
   GetAgentInputSchema,
   GetAgentOutputSchema,
+  SetSecretInputSchema,
+  SetSecretOutputSchema,
+  ListSecretKeysInputSchema,
+  ListSecretKeysOutputSchema,
+  DeleteSecretInputSchema,
+  DeleteSecretOutputSchema,
   type ListTasksInput,
   type ListTasksOutput,
   type RegisterWorkflowInput,
@@ -44,6 +50,12 @@ import {
   type ListAgentsOutput,
   type GetAgentInput,
   type GetAgentOutput,
+  type SetSecretInput,
+  type SetSecretOutput,
+  type ListSecretKeysInput,
+  type ListSecretKeysOutput,
+  type DeleteSecretInput,
+  type DeleteSecretOutput,
   ListModelsInputSchema,
   ListModelsOutputSchema,
   GetModelInputSchema,
@@ -141,6 +153,12 @@ export class Mediforce {
     list: (input?: ListModelsInput) => Promise<ListModelsOutput>;
     get: (input: GetModelInput) => Promise<GetModelOutput>;
     sync: () => Promise<SyncModelsOutput>;
+  };
+
+  readonly secrets: {
+    set: (input: SetSecretInput) => Promise<SetSecretOutput>;
+    list: (input: ListSecretKeysInput) => Promise<ListSecretKeysOutput>;
+    delete: (input: DeleteSecretInput) => Promise<DeleteSecretOutput>;
   };
 
   readonly system: {
@@ -335,6 +353,38 @@ export class Mediforce {
         });
         const body = await parseJsonOrThrow(res, 'mediforce.runs.start');
         return StartRunOutputSchema.parse(body);
+      },
+    };
+
+    this.secrets = {
+      set: async (input) => {
+        const validated = SetSecretInputSchema.parse(input);
+        const qs = toSearchParams({ namespace: validated.namespace, workflow: validated.workflow });
+        const res = await this.request(`/api/workflow-secrets${qs}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: validated.key, value: validated.value }),
+        });
+        const body = await parseJsonOrThrow(res, 'mediforce.secrets.set');
+        return SetSecretOutputSchema.parse(body);
+      },
+      list: async (input) => {
+        const validated = ListSecretKeysInputSchema.parse(input);
+        const qs = toSearchParams({ namespace: validated.namespace, workflow: validated.workflow });
+        const res = await this.request(`/api/workflow-secrets${qs}`);
+        const body = await parseJsonOrThrow(res, 'mediforce.secrets.list');
+        return ListSecretKeysOutputSchema.parse(body);
+      },
+      delete: async (input) => {
+        const validated = DeleteSecretInputSchema.parse(input);
+        const qs = toSearchParams({
+          namespace: validated.namespace,
+          workflow: validated.workflow,
+          key: validated.key,
+        });
+        const res = await this.request(`/api/workflow-secrets${qs}`, { method: 'DELETE' });
+        const body = await parseJsonOrThrow(res, 'mediforce.secrets.delete');
+        return DeleteSecretOutputSchema.parse(body);
       },
     };
 

--- a/packages/platform-api/src/contract/__tests__/secrets.test.ts
+++ b/packages/platform-api/src/contract/__tests__/secrets.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SetSecretInputSchema,
+  ListSecretKeysInputSchema,
+  ListSecretKeysOutputSchema,
+  DeleteSecretInputSchema,
+  SetSecretOutputSchema,
+  DeleteSecretOutputSchema,
+  SECRET_VALUE_MAX_BYTES,
+} from '../secrets.js';
+
+describe('SetSecretInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = SetSecretInputSchema.safeParse({
+      namespace: 'my-ns',
+      workflow: 'my-wf',
+      key: 'API_KEY',
+      value: 'sk-abc123',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty namespace', () => {
+    const result = SetSecretInputSchema.safeParse({
+      namespace: '',
+      workflow: 'wf',
+      key: 'K',
+      value: 'V',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty key', () => {
+    const result = SetSecretInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+      key: '',
+      value: 'V',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty value', () => {
+    const result = SetSecretInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+      key: 'K',
+      value: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects key longer than 256 chars', () => {
+    const result = SetSecretInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+      key: 'X'.repeat(257),
+      value: 'V',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects value exceeding max bytes', () => {
+    const result = SetSecretInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+      key: 'K',
+      value: 'X'.repeat(SECRET_VALUE_MAX_BYTES + 1),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts value at exactly max bytes', () => {
+    const result = SetSecretInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+      key: 'K',
+      value: 'X'.repeat(SECRET_VALUE_MAX_BYTES),
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('ListSecretKeysInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = ListSecretKeysInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing workflow', () => {
+    const result = ListSecretKeysInputSchema.safeParse({ namespace: 'ns' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ListSecretKeysOutputSchema', () => {
+  it('accepts empty keys array', () => {
+    const result = ListSecretKeysOutputSchema.safeParse({ keys: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts populated keys array', () => {
+    const result = ListSecretKeysOutputSchema.safeParse({ keys: ['A', 'B', 'C'] });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('DeleteSecretInputSchema', () => {
+  it('accepts valid input', () => {
+    const result = DeleteSecretInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+      key: 'SECRET_KEY',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing key', () => {
+    const result = DeleteSecretInputSchema.safeParse({
+      namespace: 'ns',
+      workflow: 'wf',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('SetSecretOutputSchema', () => {
+  it('accepts { ok: true }', () => {
+    expect(SetSecretOutputSchema.safeParse({ ok: true }).success).toBe(true);
+  });
+
+  it('rejects { ok: false }', () => {
+    expect(SetSecretOutputSchema.safeParse({ ok: false }).success).toBe(false);
+  });
+});
+
+describe('DeleteSecretOutputSchema', () => {
+  it('accepts { ok: true }', () => {
+    expect(DeleteSecretOutputSchema.safeParse({ ok: true }).success).toBe(true);
+  });
+});

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -82,3 +82,18 @@ export {
   type UpdateRankingsOutput,
   type GetMetaOutput,
 } from './models.js';
+
+export {
+  SetSecretInputSchema,
+  SetSecretOutputSchema,
+  ListSecretKeysInputSchema,
+  ListSecretKeysOutputSchema,
+  DeleteSecretInputSchema,
+  DeleteSecretOutputSchema,
+  type SetSecretInput,
+  type SetSecretOutput,
+  type ListSecretKeysInput,
+  type ListSecretKeysOutput,
+  type DeleteSecretInput,
+  type DeleteSecretOutput,
+} from './secrets.js';

--- a/packages/platform-api/src/contract/secrets.ts
+++ b/packages/platform-api/src/contract/secrets.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const SetSecretInputSchema = z.object({
+  namespace: z.string().min(1),
+  workflow: z.string().min(1),
+  key: z.string().min(1),
+  value: z.string().min(1),
+});
+
+export const ListSecretKeysInputSchema = z.object({
+  namespace: z.string().min(1),
+  workflow: z.string().min(1),
+});
+
+export const ListSecretKeysOutputSchema = z.object({
+  keys: z.array(z.string()),
+});
+
+export const DeleteSecretInputSchema = z.object({
+  namespace: z.string().min(1),
+  workflow: z.string().min(1),
+  key: z.string().min(1),
+});
+
+export const DeleteSecretOutputSchema = z.object({
+  ok: z.literal(true),
+});
+
+export const SetSecretOutputSchema = z.object({
+  ok: z.literal(true),
+});
+
+export type SetSecretInput = z.infer<typeof SetSecretInputSchema>;
+export type SetSecretOutput = z.infer<typeof SetSecretOutputSchema>;
+export type ListSecretKeysInput = z.infer<typeof ListSecretKeysInputSchema>;
+export type ListSecretKeysOutput = z.infer<typeof ListSecretKeysOutputSchema>;
+export type DeleteSecretInput = z.infer<typeof DeleteSecretInputSchema>;
+export type DeleteSecretOutput = z.infer<typeof DeleteSecretOutputSchema>;

--- a/packages/platform-api/src/contract/secrets.ts
+++ b/packages/platform-api/src/contract/secrets.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
 
+export const SECRET_VALUE_MAX_BYTES = 65_536;
+
 export const SetSecretInputSchema = z.object({
   namespace: z.string().min(1),
   workflow: z.string().min(1),
-  key: z.string().min(1),
-  value: z.string().min(1),
+  key: z.string().min(1).max(256),
+  value: z.string().min(1).max(SECRET_VALUE_MAX_BYTES),
 });
 
 export const ListSecretKeysInputSchema = z.object({

--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -12,6 +12,7 @@ import {
   FirestoreOAuthProviderRepository,
   FirestoreAgentOAuthTokenRepository,
   FirestoreModelRegistryRepository,
+  FirestoreWorkflowSecretsRepository,
   getAdminFirestore,
   validateSecretsKey,
   createMailgunSender,
@@ -70,6 +71,7 @@ export interface PlatformServices {
   oauthProviderRepo: FirestoreOAuthProviderRepository;
   agentOAuthTokenRepo: FirestoreAgentOAuthTokenRepository;
   modelRegistryRepo: FirestoreModelRegistryRepository;
+  secretsRepo: FirestoreWorkflowSecretsRepository;
 }
 
 export function getPlatformServices(): PlatformServices {
@@ -94,6 +96,7 @@ export function getPlatformServices(): PlatformServices {
   const oauthProviderRepo = new FirestoreOAuthProviderRepository(db);
   const agentOAuthTokenRepo = new FirestoreAgentOAuthTokenRepository(db);
   const modelRegistryRepo = new FirestoreModelRegistryRepository(db);
+  const secretsRepo = new FirestoreWorkflowSecretsRepository(db);
   const eventLog = new FirestoreAgentEventLog(db);
 
   const pluginRegistry = new PluginRegistry();
@@ -202,6 +205,7 @@ export function getPlatformServices(): PlatformServices {
     oauthProviderRepo,
     agentOAuthTokenRepo,
     modelRegistryRepo,
+    secretsRepo,
   };
 
   if (!seedingStarted) {

--- a/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
+++ b/packages/platform-infra/src/firestore/workflow-secrets-repository.ts
@@ -78,4 +78,47 @@ export class FirestoreWorkflowSecretsRepository {
   async deleteSecrets(namespace: string, workflowName: string): Promise<void> {
     await this.docRef(namespace, workflowName).delete();
   }
+
+  async upsertSecret(namespace: string, workflowName: string, key: string, value: string): Promise<void> {
+    const ref = this.docRef(namespace, workflowName);
+    await this.db.runTransaction(async (tx) => {
+      const snapshot = await tx.get(ref);
+      const existing: Record<string, string> = {};
+      if (snapshot.exists) {
+        const data = snapshot.data();
+        if (data?.secrets && typeof data.secrets === 'object') {
+          const parsed = WorkflowSecretsSchema.parse(data);
+          Object.assign(existing, this.decryptSecrets(parsed.secrets));
+        }
+      }
+      existing[key] = value;
+      const doc: WorkflowSecrets = {
+        workflowName,
+        namespace,
+        secrets: this.encryptSecrets(existing),
+        updatedAt: new Date().toISOString(),
+      };
+      tx.set(ref, doc);
+    });
+  }
+
+  async deleteSecret(namespace: string, workflowName: string, key: string): Promise<void> {
+    const ref = this.docRef(namespace, workflowName);
+    await this.db.runTransaction(async (tx) => {
+      const snapshot = await tx.get(ref);
+      if (!snapshot.exists) return;
+      const data = snapshot.data();
+      if (!data?.secrets || typeof data.secrets !== 'object') return;
+      const parsed = WorkflowSecretsSchema.parse(data);
+      const existing = this.decryptSecrets(parsed.secrets);
+      delete existing[key];
+      const doc: WorkflowSecrets = {
+        workflowName,
+        namespace,
+        secrets: this.encryptSecrets(existing),
+        updatedAt: new Date().toISOString(),
+      };
+      tx.set(ref, doc);
+    });
+  }
 }

--- a/packages/platform-ui/src/app/api/workflow-secrets/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-secrets/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+import {
+  getAdminFirestore,
+  FirestoreWorkflowSecretsRepository,
+} from '@mediforce/platform-infra';
+import { getPlatformServices } from '@/lib/platform-services';
+import { getCallerNamespaces } from '../workflow-definitions/auth.js';
+
+function getSecretsRepo() {
+  getPlatformServices();
+  return new FirestoreWorkflowSecretsRepository(getAdminFirestore());
+}
+
+/**
+ * GET /api/workflow-secrets?namespace=x&workflow=y
+ *
+ * Returns secret key names only (never values).
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  const { namespaceRepo } = getPlatformServices();
+  const callerNs = await getCallerNamespaces(request, namespaceRepo);
+  if (callerNs instanceof NextResponse) return callerNs;
+
+  const url = new URL(request.url);
+  const namespace = url.searchParams.get('namespace');
+  const workflow = url.searchParams.get('workflow');
+  if (!namespace || !workflow) {
+    return NextResponse.json(
+      { error: 'Missing required query parameters: namespace, workflow' },
+      { status: 400 },
+    );
+  }
+
+  if (callerNs !== null && !callerNs.has(namespace)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const keys = await getSecretsRepo().getSecretKeys(namespace, workflow);
+  return NextResponse.json({ keys });
+}
+
+/**
+ * PUT /api/workflow-secrets?namespace=x&workflow=y
+ *
+ * Body: { "key": "SECRET_NAME", "value": "secret-value" }
+ *
+ * Upserts a single secret key. Existing secrets for the workflow are preserved.
+ */
+export async function PUT(request: Request): Promise<NextResponse> {
+  const { namespaceRepo } = getPlatformServices();
+  const callerNs = await getCallerNamespaces(request, namespaceRepo);
+  if (callerNs instanceof NextResponse) return callerNs;
+
+  const url = new URL(request.url);
+  const namespace = url.searchParams.get('namespace');
+  const workflow = url.searchParams.get('workflow');
+  if (!namespace || !workflow) {
+    return NextResponse.json(
+      { error: 'Missing required query parameters: namespace, workflow' },
+      { status: 400 },
+    );
+  }
+
+  if (callerNs !== null && !callerNs.has(namespace)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    typeof (body as Record<string, unknown>).key !== 'string' ||
+    typeof (body as Record<string, unknown>).value !== 'string'
+  ) {
+    return NextResponse.json(
+      { error: 'Body must contain "key" (string) and "value" (string)' },
+      { status: 400 },
+    );
+  }
+
+  const { key, value } = body as { key: string; value: string };
+  if (key.length === 0 || value.length === 0) {
+    return NextResponse.json(
+      { error: 'Both "key" and "value" must be non-empty strings' },
+      { status: 400 },
+    );
+  }
+
+  const repo = getSecretsRepo();
+  const existing = await repo.getSecrets(namespace, workflow);
+  existing[key] = value;
+  await repo.setSecrets(namespace, workflow, existing);
+
+  return NextResponse.json({ ok: true });
+}
+
+/**
+ * DELETE /api/workflow-secrets?namespace=x&workflow=y&key=SECRET_NAME
+ *
+ * Removes a single secret key.
+ */
+export async function DELETE(request: Request): Promise<NextResponse> {
+  const { namespaceRepo } = getPlatformServices();
+  const callerNs = await getCallerNamespaces(request, namespaceRepo);
+  if (callerNs instanceof NextResponse) return callerNs;
+
+  const url = new URL(request.url);
+  const namespace = url.searchParams.get('namespace');
+  const workflow = url.searchParams.get('workflow');
+  const key = url.searchParams.get('key');
+  if (!namespace || !workflow || !key) {
+    return NextResponse.json(
+      { error: 'Missing required query parameters: namespace, workflow, key' },
+      { status: 400 },
+    );
+  }
+
+  if (callerNs !== null && !callerNs.has(namespace)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const repo = getSecretsRepo();
+  const existing = await repo.getSecrets(namespace, workflow);
+  delete existing[key];
+  await repo.setSecrets(namespace, workflow, existing);
+
+  return NextResponse.json({ ok: true });
+}

--- a/packages/platform-ui/src/app/api/workflow-secrets/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-secrets/route.ts
@@ -1,15 +1,11 @@
 import { NextResponse } from 'next/server';
 import {
-  getAdminFirestore,
-  FirestoreWorkflowSecretsRepository,
-} from '@mediforce/platform-infra';
+  SetSecretInputSchema,
+  ListSecretKeysInputSchema,
+  DeleteSecretInputSchema,
+} from '@mediforce/platform-api/contract';
 import { getPlatformServices } from '@/lib/platform-services';
 import { getCallerNamespaces } from '../workflow-definitions/auth.js';
-
-function getSecretsRepo() {
-  getPlatformServices();
-  return new FirestoreWorkflowSecretsRepository(getAdminFirestore());
-}
 
 /**
  * GET /api/workflow-secrets?namespace=x&workflow=y
@@ -17,25 +13,28 @@ function getSecretsRepo() {
  * Returns secret key names only (never values).
  */
 export async function GET(request: Request): Promise<NextResponse> {
-  const { namespaceRepo } = getPlatformServices();
+  const { namespaceRepo, secretsRepo } = getPlatformServices();
   const callerNs = await getCallerNamespaces(request, namespaceRepo);
   if (callerNs instanceof NextResponse) return callerNs;
 
   const url = new URL(request.url);
-  const namespace = url.searchParams.get('namespace');
-  const workflow = url.searchParams.get('workflow');
-  if (!namespace || !workflow) {
+  const parsed = ListSecretKeysInputSchema.safeParse({
+    namespace: url.searchParams.get('namespace') ?? undefined,
+    workflow: url.searchParams.get('workflow') ?? undefined,
+  });
+  if (!parsed.success) {
     return NextResponse.json(
-      { error: 'Missing required query parameters: namespace, workflow' },
+      { error: parsed.error.issues.map((i) => i.message).join('; ') },
       { status: 400 },
     );
   }
 
+  const { namespace, workflow } = parsed.data;
   if (callerNs !== null && !callerNs.has(namespace)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const keys = await getSecretsRepo().getSecretKeys(namespace, workflow);
+  const keys = await secretsRepo.getSecretKeys(namespace, workflow);
   return NextResponse.json({ keys });
 }
 
@@ -44,27 +43,14 @@ export async function GET(request: Request): Promise<NextResponse> {
  *
  * Body: { "key": "SECRET_NAME", "value": "secret-value" }
  *
- * Upserts a single secret key. Existing secrets for the workflow are preserved.
+ * Upserts a single secret key atomically. Existing secrets are preserved.
  */
 export async function PUT(request: Request): Promise<NextResponse> {
-  const { namespaceRepo } = getPlatformServices();
+  const { namespaceRepo, secretsRepo } = getPlatformServices();
   const callerNs = await getCallerNamespaces(request, namespaceRepo);
   if (callerNs instanceof NextResponse) return callerNs;
 
   const url = new URL(request.url);
-  const namespace = url.searchParams.get('namespace');
-  const workflow = url.searchParams.get('workflow');
-  if (!namespace || !workflow) {
-    return NextResponse.json(
-      { error: 'Missing required query parameters: namespace, workflow' },
-      { status: 400 },
-    );
-  }
-
-  if (callerNs !== null && !callerNs.has(namespace)) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
   let body: unknown;
   try {
     body = await request.json();
@@ -72,63 +58,55 @@ export async function PUT(request: Request): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  if (
-    typeof body !== 'object' ||
-    body === null ||
-    typeof (body as Record<string, unknown>).key !== 'string' ||
-    typeof (body as Record<string, unknown>).value !== 'string'
-  ) {
+  const parsed = SetSecretInputSchema.safeParse({
+    namespace: url.searchParams.get('namespace') ?? undefined,
+    workflow: url.searchParams.get('workflow') ?? undefined,
+    ...(typeof body === 'object' && body !== null ? body : {}),
+  });
+  if (!parsed.success) {
     return NextResponse.json(
-      { error: 'Body must contain "key" (string) and "value" (string)' },
+      { error: parsed.error.issues.map((i) => i.message).join('; ') },
       { status: 400 },
     );
   }
 
-  const { key, value } = body as { key: string; value: string };
-  if (key.length === 0 || value.length === 0) {
-    return NextResponse.json(
-      { error: 'Both "key" and "value" must be non-empty strings' },
-      { status: 400 },
-    );
+  const { namespace, workflow, key, value } = parsed.data;
+  if (callerNs !== null && !callerNs.has(namespace)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const repo = getSecretsRepo();
-  const existing = await repo.getSecrets(namespace, workflow);
-  existing[key] = value;
-  await repo.setSecrets(namespace, workflow, existing);
-
+  await secretsRepo.upsertSecret(namespace, workflow, key, value);
   return NextResponse.json({ ok: true });
 }
 
 /**
  * DELETE /api/workflow-secrets?namespace=x&workflow=y&key=SECRET_NAME
  *
- * Removes a single secret key.
+ * Removes a single secret key atomically.
  */
 export async function DELETE(request: Request): Promise<NextResponse> {
-  const { namespaceRepo } = getPlatformServices();
+  const { namespaceRepo, secretsRepo } = getPlatformServices();
   const callerNs = await getCallerNamespaces(request, namespaceRepo);
   if (callerNs instanceof NextResponse) return callerNs;
 
   const url = new URL(request.url);
-  const namespace = url.searchParams.get('namespace');
-  const workflow = url.searchParams.get('workflow');
-  const key = url.searchParams.get('key');
-  if (!namespace || !workflow || !key) {
+  const parsed = DeleteSecretInputSchema.safeParse({
+    namespace: url.searchParams.get('namespace') ?? undefined,
+    workflow: url.searchParams.get('workflow') ?? undefined,
+    key: url.searchParams.get('key') ?? undefined,
+  });
+  if (!parsed.success) {
     return NextResponse.json(
-      { error: 'Missing required query parameters: namespace, workflow, key' },
+      { error: parsed.error.issues.map((i) => i.message).join('; ') },
       { status: 400 },
     );
   }
 
+  const { namespace, workflow, key } = parsed.data;
   if (callerNs !== null && !callerNs.has(namespace)) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  const repo = getSecretsRepo();
-  const existing = await repo.getSecrets(namespace, workflow);
-  delete existing[key];
-  await repo.setSecrets(namespace, workflow, existing);
-
+  await secretsRepo.deleteSecret(namespace, workflow, key);
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary

- Adds `mediforce secret set|list|delete` CLI commands for managing workflow secrets
- New API route `PUT/GET/DELETE /api/workflow-secrets` with namespace-scoped auth
- Extends `Mediforce` client with `.secrets` namespace
- Supports `--stdin` flag for pipe-friendly usage (avoids secrets in shell history)

## Usage

```bash
# Set a secret
mediforce secret set --workflow my-wf --namespace my-ns --key API_TOKEN --value sk-abc

# Pipe-friendly (no shell history)
echo "sk-abc" | mediforce secret set --workflow my-wf --namespace my-ns --key API_TOKEN --stdin

# List keys (values never exposed)
mediforce secret list --workflow my-wf --namespace my-ns

# Delete
mediforce secret delete --workflow my-wf --namespace my-ns --key API_TOKEN
```

## Layers

| Layer | File |
|-------|------|
| Contract | `packages/platform-api/src/contract/secrets.ts` |
| API route | `packages/platform-ui/src/app/api/workflow-secrets/route.ts` |
| Client | `packages/platform-api/src/client/index.ts` (`.secrets` namespace) |
| CLI | `packages/cli/src/commands/secret-{set,list,delete}.ts` |

## Test plan

- [ ] Unit tests for CLI commands (mock fetch)
- [ ] Contract test for API route
- [ ] Manual: `pnpm exec mediforce secret set --workflow test --namespace personal --key FOO --value bar`
- [ ] Manual: verify `--stdin` reads from pipe
- [ ] Verify existing secrets in UI still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)