### PR TITLE
feat(agent-runtime): inject AgentDefinition systemPrompt + skills into agent prompt

### DIFF
--- a/packages/agent-runtime/src/interfaces/agent-plugin.ts
+++ b/packages/agent-runtime/src/interfaces/agent-plugin.ts
@@ -92,6 +92,11 @@ export interface WorkflowAgentContext {
    *  config is `{ type: 'oauth', ... }`. Consumed by writeMcpConfig to
    *  synthesize the Authorization header at spawn time. */
   oauthTokens?: Record<string, ResolvedOAuthBinding>;
+  /** Pre-assembled prompt sections from the AgentDefinition referenced by
+   *  step.agentId: the agent's systemPrompt + resolved skill file contents.
+   *  Populated by platform-ui's executeAgentStep (downloads from Storage).
+   *  Injected into buildPrompt() after the workflow preamble. */
+  agentIdentityPrompt?: string;
 }
 
 // EmitFn: platform assigns id and sequence — plugin provides type, payload, timestamp

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -1003,7 +1003,12 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
       parts.push(this.context.workflowDefinition.preamble);
     }
 
-    // 1. Skill prompt from SKILL.md
+    // 0b. Agent identity + skills from AgentDefinition (resolved by platform-ui)
+    if (isWorkflowAgentContext(this.context) && this.context.agentIdentityPrompt) {
+      parts.push(this.context.agentIdentityPrompt);
+    }
+
+    // 1. Skill prompt from SKILL.md (step-level override — takes precedence over agent skills)
     if (this.agentConfig.skill && this.agentConfig.skillsDir) {
       const skillContent = await this.readSkillFile(
         this.resolveSkillsDir(this.agentConfig.skillsDir, resolveProjectPath),

--- a/packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx
@@ -103,9 +103,31 @@ export default function EditAgentPage({ params }: { params: Promise<{ id: string
   const activeModel = FOUNDATION_MODELS.find((m) => m.id === selectedModelId);
   const canSave = name.trim().length > 0 && selectedModelId !== '' && !saving;
 
+  const MAX_SKILL_FILES = 100;
+  const MAX_SKILL_FILE_BYTES = 100 * 1024;
+  const [skillFileErrors, setSkillFileErrors] = useState<string[]>([]);
+
   function addSkillFiles(incoming: FileList | File[]) {
     const files = Array.from(incoming);
-    setNewSkillFiles((prev) => [...prev, ...files]);
+    const errors: string[] = [];
+    const totalAfter = existingSkillPaths.length + newSkillFiles.length + files.length;
+    if (totalAfter > MAX_SKILL_FILES) {
+      errors.push(`Maximum ${MAX_SKILL_FILES} skill files allowed.`);
+      setSkillFileErrors(errors);
+      return;
+    }
+    const accepted: File[] = [];
+    for (const file of files) {
+      if (file.size > MAX_SKILL_FILE_BYTES) {
+        errors.push(`"${file.name}" exceeds 100 KB — split into smaller files or reduce content.`);
+      } else {
+        accepted.push(file);
+      }
+    }
+    setSkillFileErrors(errors);
+    if (accepted.length > 0) {
+      setNewSkillFiles((prev) => [...prev, ...accepted]);
+    }
   }
 
   function handleSkillDrop(event: React.DragEvent<HTMLDivElement>) {
@@ -337,13 +359,21 @@ export default function EditAgentPage({ params }: { params: Promise<{ id: string
                 ref={fileInputRef}
                 type="file"
                 multiple
-                accept=".yaml,.yml,.json,.md,.txt"
+                accept=".yaml,.yml,.json,.md,.txt,.xlsx,.xls,.csv"
                 onChange={(e) => {
                   if (e.target.files) { addSkillFiles(e.target.files); e.target.value = ''; }
                 }}
                 className="hidden"
               />
             </div>
+
+            {skillFileErrors.length > 0 && (
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2">
+                {skillFileErrors.map((err, i) => (
+                  <p key={i} className="text-xs text-destructive">{err}</p>
+                ))}
+              </div>
+            )}
 
             {(existingSkillPaths.length > 0 || newSkillFiles.length > 0) && (
               <ul className="space-y-1.5">

--- a/packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx
@@ -103,7 +103,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ id: string
   const activeModel = FOUNDATION_MODELS.find((m) => m.id === selectedModelId);
   const canSave = name.trim().length > 0 && selectedModelId !== '' && !saving;
 
-  const MAX_SKILL_FILES = 100;
+  const MAX_SKILL_FILES = 10;
   const MAX_SKILL_FILE_BYTES = 100 * 1024;
   const [skillFileErrors, setSkillFileErrors] = useState<string[]>([]);
 
@@ -359,7 +359,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ id: string
                 ref={fileInputRef}
                 type="file"
                 multiple
-                accept=".yaml,.yml,.json,.md,.txt,.xlsx,.xls,.csv"
+                accept=".yaml,.yml,.json,.md,.txt,.csv"
                 onChange={(e) => {
                   if (e.target.files) { addSkillFiles(e.target.files); e.target.value = ''; }
                 }}

--- a/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
@@ -116,6 +116,10 @@ vi.mock('@/app/actions/workflow-secrets', () => ({
   getWorkflowSecretsForRuntime: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('@/lib/resolve-agent-identity', () => ({
+  resolveAgentIdentityPrompt: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Import after mock setup
 import { executeAgentStep } from '../execute-agent-step';
 

--- a/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
@@ -117,7 +117,7 @@ vi.mock('@/app/actions/workflow-secrets', () => ({
 }));
 
 vi.mock('@/lib/resolve-agent-identity', () => ({
-  resolveAgentIdentityPrompt: vi.fn().mockResolvedValue(undefined),
+  resolveAgentIdentity: vi.fn().mockResolvedValue({ prompt: undefined, warnings: [] }),
 }));
 
 // Import after mock setup

--- a/packages/platform-ui/src/lib/__tests__/resolve-agent-identity.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/resolve-agent-identity.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AgentDefinition, AgentDefinitionRepository } from '@mediforce/platform-core';
+
+const mockDownload = vi.fn();
+const mockGetMetadata = vi.fn();
+const mockFile = vi.fn(() => ({ download: mockDownload, getMetadata: mockGetMetadata }));
+const mockBucket = vi.fn(() => ({ file: mockFile }));
+
+vi.mock('firebase-admin/storage', () => ({
+  getStorage: () => ({ bucket: mockBucket }),
+}));
+
+import {
+  resolveAgentIdentity,
+  resolveAgentIdentityPrompt,
+  downloadSkillFiles,
+  MAX_SKILL_FILE_BYTES,
+} from '../resolve-agent-identity';
+
+function makeAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    iconName: 'Bot',
+    description: 'test',
+    foundationModel: 'anthropic/claude-sonnet-4',
+    systemPrompt: '',
+    inputDescription: '',
+    outputDescription: '',
+    skillFileNames: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeRepo(agent: AgentDefinition | null): AgentDefinitionRepository {
+  return {
+    getById: vi.fn().mockResolvedValue(agent),
+    create: vi.fn(),
+    upsert: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+describe('resolveAgentIdentity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test-bucket';
+    mockGetMetadata.mockResolvedValue([{ size: 100 }]);
+  });
+
+  it('returns undefined when agent not found', async () => {
+    const repo = makeRepo(null);
+    const result = await resolveAgentIdentity('missing', repo);
+    expect(result.prompt).toBeUndefined();
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('returns undefined when agent has no systemPrompt and no skills', async () => {
+    const repo = makeRepo(makeAgent({ systemPrompt: '', skillFileNames: [] }));
+    const result = await resolveAgentIdentity('agent-1', repo);
+    expect(result.prompt).toBeUndefined();
+  });
+
+  it('returns systemPrompt only when no skills', async () => {
+    const repo = makeRepo(makeAgent({ systemPrompt: 'You are a CDISC expert.', skillFileNames: [] }));
+    const result = await resolveAgentIdentity('agent-1', repo);
+    expect(result.prompt).toContain('## Agent Identity');
+    expect(result.prompt).toContain('You are a CDISC expert.');
+    expect(result.prompt).not.toContain('## Skills');
+  });
+
+  it('returns skills only when no systemPrompt', async () => {
+    mockDownload.mockResolvedValue([Buffer.from('Skill content here')]);
+    const repo = makeRepo(makeAgent({ systemPrompt: '', skillFileNames: ['skills/a.md'] }));
+    const result = await resolveAgentIdentity('agent-1', repo);
+    expect(result.prompt).not.toContain('## Agent Identity');
+    expect(result.prompt).toContain('## Skills');
+    expect(result.prompt).toContain('Skill content here');
+  });
+
+  it('returns both systemPrompt and skills', async () => {
+    mockDownload.mockResolvedValue([Buffer.from('SDTM rules knowledge')]);
+    const repo = makeRepo(makeAgent({
+      systemPrompt: 'You author CDISC rules.',
+      skillFileNames: ['skills/rules.md'],
+    }));
+    const result = await resolveAgentIdentity('agent-1', repo);
+    expect(result.prompt).toContain('## Agent Identity');
+    expect(result.prompt).toContain('You author CDISC rules.');
+    expect(result.prompt).toContain('## Skills');
+    expect(result.prompt).toContain('SDTM rules knowledge');
+  });
+
+  it('returns warning when download fails (partial success)', async () => {
+    mockDownload
+      .mockResolvedValueOnce([Buffer.from('Good skill')])
+      .mockRejectedValueOnce(new Error('404 Not Found'));
+    mockGetMetadata
+      .mockResolvedValueOnce([{ size: 50 }])
+      .mockResolvedValueOnce([{ size: 50 }]);
+    const repo = makeRepo(makeAgent({
+      skillFileNames: ['skills/good.md', 'skills/missing.md'],
+    }));
+    const result = await resolveAgentIdentity('agent-1', repo);
+    expect(result.prompt).toContain('Good skill');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].path).toBe('skills/missing.md');
+    expect(result.warnings[0].reason).toContain('404 Not Found');
+  });
+
+  it('resolveAgentIdentityPrompt returns just the prompt string', async () => {
+    mockDownload.mockResolvedValue([Buffer.from('skill')]);
+    const repo = makeRepo(makeAgent({ systemPrompt: 'Hello', skillFileNames: ['s.md'] }));
+    const prompt = await resolveAgentIdentityPrompt('agent-1', repo);
+    expect(prompt).toContain('Hello');
+    expect(prompt).toContain('skill');
+  });
+});
+
+describe('downloadSkillFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET = 'test-bucket';
+    mockGetMetadata.mockResolvedValue([{ size: 100 }]);
+  });
+
+  it('returns warnings for all files when bucket env not set', async () => {
+    delete process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+    const result = await downloadSkillFiles(['a.md', 'b.md']);
+    expect(result.contents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0].reason).toContain('NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET');
+  });
+
+  it('downloads files in parallel', async () => {
+    let concurrency = 0;
+    let maxConcurrency = 0;
+    mockDownload.mockImplementation(async () => {
+      concurrency++;
+      maxConcurrency = Math.max(maxConcurrency, concurrency);
+      await new Promise((r) => setTimeout(r, 10));
+      concurrency--;
+      return [Buffer.from('content')];
+    });
+    const result = await downloadSkillFiles(['a.md', 'b.md', 'c.md']);
+    expect(result.contents).toHaveLength(3);
+    expect(maxConcurrency).toBeGreaterThan(1);
+  });
+
+  it('rejects files exceeding size limit', async () => {
+    mockGetMetadata.mockResolvedValue([{ size: MAX_SKILL_FILE_BYTES + 1 }]);
+    const result = await downloadSkillFiles(['big.md']);
+    expect(result.contents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].reason).toContain('exceeds');
+    expect(result.warnings[0].reason).toContain('100KB');
+  });
+
+  it('skips empty files', async () => {
+    mockDownload.mockResolvedValue([Buffer.from('   ')]);
+    const result = await downloadSkillFiles(['empty.md']);
+    expect(result.contents).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -21,7 +21,7 @@ import type {
   WorkflowStep,
 } from '@mediforce/platform-core';
 import { getWorkflowSecretsForRuntime } from '../app/actions/workflow-secrets';
-import { resolveAgentIdentityPrompt } from './resolve-agent-identity';
+import { resolveAgentIdentity } from './resolve-agent-identity';
 
 export interface WorkflowAgentStepResult {
   instanceId: string;
@@ -141,10 +141,15 @@ export async function executeAgentStep(
 
   // Resolve agent identity prompt (systemPrompt + skill file contents) from
   // the AgentDefinition. Returns undefined when step has no agentId or agent
-  // has no systemPrompt/skills.
-  const agentIdentityPrompt = workflowStep.agentId !== undefined
-    ? await resolveAgentIdentityPrompt(workflowStep.agentId, agentDefinitionRepo)
-    : undefined;
+  // has no systemPrompt/skills. Warnings logged for visibility.
+  let agentIdentityPrompt: string | undefined;
+  if (workflowStep.agentId !== undefined) {
+    const identity = await resolveAgentIdentity(workflowStep.agentId, agentDefinitionRepo);
+    agentIdentityPrompt = identity.prompt;
+    for (const w of identity.warnings) {
+      console.warn(`[agent-identity] step=${stepId} skill="${w.path}": ${w.reason}`);
+    }
+  }
 
   const workflowAgentContext: WorkflowAgentContext = {
     stepId,

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -21,6 +21,7 @@ import type {
   WorkflowStep,
 } from '@mediforce/platform-core';
 import { getWorkflowSecretsForRuntime } from '../app/actions/workflow-secrets';
+import { resolveAgentIdentityPrompt } from './resolve-agent-identity';
 
 export interface WorkflowAgentStepResult {
   instanceId: string;
@@ -138,6 +139,13 @@ export async function executeAgentStep(
       })
     : undefined;
 
+  // Resolve agent identity prompt (systemPrompt + skill file contents) from
+  // the AgentDefinition. Returns undefined when step has no agentId or agent
+  // has no systemPrompt/skills.
+  const agentIdentityPrompt = workflowStep.agentId !== undefined
+    ? await resolveAgentIdentityPrompt(workflowStep.agentId, agentDefinitionRepo)
+    : undefined;
+
   const workflowAgentContext: WorkflowAgentContext = {
     stepId,
     processInstanceId: instanceId,
@@ -153,6 +161,7 @@ export async function executeAgentStep(
       ? { previousRun: instance.previousRun }
       : {}),
     oauthTokens,
+    agentIdentityPrompt,
     getPreviousStepOutputs: async () => {
       const executions = await instanceRepo.getStepExecutions(instanceId);
       const result: Record<string, unknown> = {};

--- a/packages/platform-ui/src/lib/resolve-agent-identity.ts
+++ b/packages/platform-ui/src/lib/resolve-agent-identity.ts
@@ -1,58 +1,109 @@
 import { getStorage } from 'firebase-admin/storage';
-import type { AgentDefinition, AgentDefinitionRepository } from '@mediforce/platform-core';
+import type { AgentDefinitionRepository } from '@mediforce/platform-core';
+
+export const MAX_SKILL_FILE_BYTES = 100 * 1024; // 100 KB
+
+export interface SkillDownloadWarning {
+  path: string;
+  reason: string;
+}
+
+export interface ResolveResult {
+  prompt: string | undefined;
+  warnings: SkillDownloadWarning[];
+}
 
 /**
  * Resolve the agent identity prompt from an AgentDefinition:
  * assembles systemPrompt + downloaded skill file contents into a single string
  * injected into the agent's prompt after the workflow preamble.
  *
- * Returns undefined when the agent has no systemPrompt and no skills.
+ * Returns undefined prompt when the agent has no systemPrompt and no skills.
+ * Returns warnings for any skills that could not be loaded.
  */
 export async function resolveAgentIdentityPrompt(
   agentId: string,
   agentDefinitionRepo: AgentDefinitionRepository,
 ): Promise<string | undefined> {
+  const { prompt } = await resolveAgentIdentity(agentId, agentDefinitionRepo);
+  return prompt;
+}
+
+export async function resolveAgentIdentity(
+  agentId: string,
+  agentDefinitionRepo: AgentDefinitionRepository,
+): Promise<ResolveResult> {
   const agent = await agentDefinitionRepo.getById(agentId);
-  if (!agent) return undefined;
+  if (!agent) return { prompt: undefined, warnings: [] };
 
   const parts: string[] = [];
+  const warnings: SkillDownloadWarning[] = [];
 
   if (agent.systemPrompt) {
     parts.push(`## Agent Identity\n\n${agent.systemPrompt}`);
   }
 
   if (agent.skillFileNames.length > 0) {
-    const skillContents = await downloadSkillFiles(agent.skillFileNames);
-    if (skillContents.length > 0) {
-      parts.push(`## Skills\n\n${skillContents.join('\n\n---\n\n')}`);
+    const { contents, warnings: dlWarnings } = await downloadSkillFiles(agent.skillFileNames);
+    warnings.push(...dlWarnings);
+    if (contents.length > 0) {
+      parts.push(`## Skills\n\n${contents.join('\n\n---\n\n')}`);
     }
   }
 
-  return parts.length > 0 ? parts.join('\n\n') : undefined;
+  return {
+    prompt: parts.length > 0 ? parts.join('\n\n') : undefined,
+    warnings,
+  };
 }
 
-async function downloadSkillFiles(paths: string[]): Promise<string[]> {
+interface DownloadResult {
+  contents: string[];
+  warnings: SkillDownloadWarning[];
+}
+
+export async function downloadSkillFiles(paths: string[]): Promise<DownloadResult> {
   const bucketName = process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
   if (!bucketName) {
-    console.warn('[resolve-agent-identity] NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET not set, skipping skill download');
-    return [];
+    return {
+      contents: [],
+      warnings: paths.map((path) => ({
+        path,
+        reason: 'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET not set — skill files cannot be loaded',
+      })),
+    };
   }
-  const bucket = getStorage().bucket(bucketName);
-  const results: string[] = [];
 
-  for (const storagePath of paths) {
-    try {
+  const bucket = getStorage().bucket(bucketName);
+  const warnings: SkillDownloadWarning[] = [];
+
+  const settled = await Promise.allSettled(
+    paths.map(async (storagePath) => {
       const file = bucket.file(storagePath);
-      const [buffer] = await file.download();
-      const content = buffer.toString('utf-8').trim();
-      if (content.length > 0) {
-        results.push(content);
+      const [metadata] = await file.getMetadata();
+      const size = Number(metadata.size ?? 0);
+      if (size > MAX_SKILL_FILE_BYTES) {
+        throw new Error(
+          `File exceeds ${MAX_SKILL_FILE_BYTES / 1024}KB limit (${Math.round(size / 1024)}KB)`,
+        );
       }
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`[resolve-agent-identity] Failed to download skill file "${storagePath}": ${message}`);
+      const [buffer] = await file.download();
+      return { path: storagePath, content: buffer.toString('utf-8').trim() };
+    }),
+  );
+
+  const contents: string[] = [];
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      if (result.value.content.length > 0) {
+        contents.push(result.value.content);
+      }
+    } else {
+      const failedPath = paths[settled.indexOf(result)];
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      warnings.push({ path: failedPath, reason });
     }
   }
 
-  return results;
+  return { contents, warnings };
 }

--- a/packages/platform-ui/src/lib/resolve-agent-identity.ts
+++ b/packages/platform-ui/src/lib/resolve-agent-identity.ts
@@ -1,0 +1,58 @@
+import { getStorage } from 'firebase-admin/storage';
+import type { AgentDefinition, AgentDefinitionRepository } from '@mediforce/platform-core';
+
+/**
+ * Resolve the agent identity prompt from an AgentDefinition:
+ * assembles systemPrompt + downloaded skill file contents into a single string
+ * injected into the agent's prompt after the workflow preamble.
+ *
+ * Returns undefined when the agent has no systemPrompt and no skills.
+ */
+export async function resolveAgentIdentityPrompt(
+  agentId: string,
+  agentDefinitionRepo: AgentDefinitionRepository,
+): Promise<string | undefined> {
+  const agent = await agentDefinitionRepo.getById(agentId);
+  if (!agent) return undefined;
+
+  const parts: string[] = [];
+
+  if (agent.systemPrompt) {
+    parts.push(`## Agent Identity\n\n${agent.systemPrompt}`);
+  }
+
+  if (agent.skillFileNames.length > 0) {
+    const skillContents = await downloadSkillFiles(agent.skillFileNames);
+    if (skillContents.length > 0) {
+      parts.push(`## Skills\n\n${skillContents.join('\n\n---\n\n')}`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join('\n\n') : undefined;
+}
+
+async function downloadSkillFiles(paths: string[]): Promise<string[]> {
+  const bucketName = process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET;
+  if (!bucketName) {
+    console.warn('[resolve-agent-identity] NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET not set, skipping skill download');
+    return [];
+  }
+  const bucket = getStorage().bucket(bucketName);
+  const results: string[] = [];
+
+  for (const storagePath of paths) {
+    try {
+      const file = bucket.file(storagePath);
+      const [buffer] = await file.download();
+      const content = buffer.toString('utf-8').trim();
+      if (content.length > 0) {
+        results.push(content);
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[resolve-agent-identity] Failed to download skill file "${storagePath}": ${message}`);
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary

- When a workflow step has `agentId`, the runtime now resolves the referenced AgentDefinition's `systemPrompt` and `skillFileNames` from Firebase Storage and injects them into the assembled prompt
- Previously `agentId` only resolved MCP bindings and OAuth tokens — the agent's own knowledge was ignored
- Enables agents created via UI (with uploaded skill files) to bring their identity and skills into workflow execution

## Context

Vedha created two skill-based agents (SDTM Rule Author + SDTMIG Reference) via the staging UI and needs them to work in workflow steps. This wires up the missing connection.

## Changes

- `WorkflowAgentContext` — new optional `agentIdentityPrompt` field
- `buildPrompt()` — injects agent identity after workflow preamble, before step-level skill
- `resolve-agent-identity.ts` — fetches AgentDefinition, downloads skill file contents from Storage, assembles prompt sections
- `execute-agent-step.ts` — calls resolver, passes result into context

## Test plan

- [x] Unit tests pass (171 files, all green)
- [x] Smoke test: workflow with `agentId` → agent receives systemPrompt + skills → responds with domain knowledge
- [x] Verified end-to-end via `mediforce run start` + OpenRouter

🤖 Generated with [Claude Code](https://claude.com/claude-code)