### PR TITLE
feat(ui): OpenRouter credits pre-flight check on Start Run

### DIFF
--- a/packages/platform-ui/src/app/(app)/layout.tsx
+++ b/packages/platform-ui/src/app/(app)/layout.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/contexts/auth-context';
 import { AppShell } from '@/components/app-shell';
 import { CommandPaletteProvider } from '@/components/command-palette';
 import { DockerImagesProvider } from '@/contexts/docker-images-context';
+import { OpenRouterCreditsProvider } from '@/contexts/openrouter-credits-context';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const { firebaseUser, loading, mustChangePassword } = useAuth();
@@ -35,9 +36,11 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <DockerImagesProvider>
-      <CommandPaletteProvider>
-        <AppShell>{children}</AppShell>
-      </CommandPaletteProvider>
+      <OpenRouterCreditsProvider>
+        <CommandPaletteProvider>
+          <AppShell>{children}</AppShell>
+        </CommandPaletteProvider>
+      </OpenRouterCreditsProvider>
     </DockerImagesProvider>
   );
 }

--- a/packages/platform-ui/src/app/api/system/openrouter-credits/route.ts
+++ b/packages/platform-ui/src/app/api/system/openrouter-credits/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+
+export interface OpenRouterCreditsResponse {
+  available: boolean;
+  limit: number;
+  usage: number;
+  remaining: number;
+  error?: string;
+}
+
+export async function GET(): Promise<NextResponse<OpenRouterCreditsResponse>> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({
+      available: false,
+      limit: 0,
+      usage: 0,
+      remaining: 0,
+      error: 'OPENROUTER_API_KEY not configured',
+    });
+  }
+
+  try {
+    const res = await fetch('https://openrouter.ai/api/v1/auth/key', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+      return NextResponse.json({
+        available: false,
+        limit: 0,
+        usage: 0,
+        remaining: 0,
+        error: `OpenRouter returned ${res.status}`,
+      });
+    }
+
+    const { data } = await res.json() as { data: { limit: number; usage: number; limit_remaining: number } };
+
+    return NextResponse.json({
+      available: true,
+      limit: data.limit,
+      usage: data.usage,
+      remaining: data.limit_remaining,
+    });
+  } catch (err: unknown) {
+    return NextResponse.json({
+      available: false,
+      limit: 0,
+      usage: 0,
+      remaining: 0,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    });
+  }
+}

--- a/packages/platform-ui/src/components/processes/start-run-button.tsx
+++ b/packages/platform-ui/src/components/processes/start-run-button.tsx
@@ -68,9 +68,12 @@ export function StartRunButton({
       dockerImages,
       dockerAvailable,
       secretKeys,
-      openRouterCredits: openRouterCredits.isLoading ? undefined : openRouterCredits,
+      openRouterCredits: openRouterCredits.isLoading ? undefined : {
+        available: openRouterCredits.available,
+        remaining: openRouterCredits.remaining,
+      },
     });
-  }, [effectiveDefinition, dockerImages, dockerAvailable, secretKeys, openRouterCredits]);
+  }, [effectiveDefinition, dockerImages, dockerAvailable, secretKeys, openRouterCredits.isLoading, openRouterCredits.available, openRouterCredits.remaining]);
 
   const preflightLoading = dockerLoading || secretKeysLoading || openRouterCredits.isLoading;
   const hasWarnings = warnings.length > 0;
@@ -320,7 +323,7 @@ function WarningGroup({ title, warnings }: { title: string; warnings: PreflightW
             <div className="flex items-start gap-2">
               <span className="text-amber-500 shrink-0 mt-0.5">•</span>
               <div>
-                <p className="font-mono font-medium">{w.message}</p>
+                <p className="font-mono font-medium">{w.message || w.resource}</p>
                 <p className="text-muted-foreground mt-0.5">Used by: {formatStepList(w.stepNames)}</p>
                 <p className="text-muted-foreground/70 mt-0.5">{w.hint}</p>
               </div>

--- a/packages/platform-ui/src/components/processes/start-run-button.tsx
+++ b/packages/platform-ui/src/components/processes/start-run-button.tsx
@@ -12,6 +12,7 @@ import { getWorkflowSecretKeys } from '@/app/actions/workflow-secrets';
 import { VersionLabel } from '@/components/ui/version-label';
 import { cn } from '@/lib/utils';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
+import { useOpenRouterCredits } from '@/hooks/use-openrouter-credits';
 import { runPreflightChecks, type PreflightWarning } from '@/lib/preflight-checks';
 
 interface StartRunButtonProps {
@@ -34,6 +35,7 @@ export function StartRunButton({
   const { firebaseUser } = useAuth();
   const { definitions, effectiveVersion: hookEffectiveVersion } = useWorkflowDefinitions(workflowName);
   const { images: dockerImages, isAvailable: dockerAvailable, isLoading: dockerLoading } = useDockerImages();
+  const openRouterCredits = useOpenRouterCredits();
   const [starting, setStarting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
@@ -66,10 +68,11 @@ export function StartRunButton({
       dockerImages,
       dockerAvailable,
       secretKeys,
+      openRouterCredits: openRouterCredits.isLoading ? undefined : openRouterCredits,
     });
-  }, [effectiveDefinition, dockerImages, dockerAvailable, secretKeys]);
+  }, [effectiveDefinition, dockerImages, dockerAvailable, secretKeys, openRouterCredits]);
 
-  const preflightLoading = dockerLoading || secretKeysLoading;
+  const preflightLoading = dockerLoading || secretKeysLoading || openRouterCredits.isLoading;
   const hasWarnings = warnings.length > 0;
   const missingSecretKeys = warnings.filter((w) => w.category === 'missing-secret').map((w) => w.resource);
 
@@ -173,6 +176,10 @@ export function StartRunButton({
             <WarningGroup
               title="Missing secrets"
               warnings={warnings.filter((w) => w.category === 'missing-secret')}
+            />
+            <WarningGroup
+              title="LLM credits"
+              warnings={warnings.filter((w) => w.category === 'low-credits')}
             />
           </div>
 
@@ -313,7 +320,7 @@ function WarningGroup({ title, warnings }: { title: string; warnings: PreflightW
             <div className="flex items-start gap-2">
               <span className="text-amber-500 shrink-0 mt-0.5">•</span>
               <div>
-                <p className="font-mono font-medium">{w.resource}</p>
+                <p className="font-mono font-medium">{w.message}</p>
                 <p className="text-muted-foreground mt-0.5">Used by: {formatStepList(w.stepNames)}</p>
                 <p className="text-muted-foreground/70 mt-0.5">{w.hint}</p>
               </div>

--- a/packages/platform-ui/src/contexts/openrouter-credits-context.tsx
+++ b/packages/platform-ui/src/contexts/openrouter-credits-context.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef, type ReactNode } from 'react';
 import { apiFetch } from '@/lib/api-fetch';
 import type { OpenRouterCreditsResponse } from '@/app/api/system/openrouter-credits/route';
 
@@ -25,14 +25,20 @@ const OpenRouterCreditsContext = createContext<OpenRouterCreditsState>({
   refresh: () => {},
 });
 
+/**
+ * Lazy provider — does NOT fetch on mount. Call `useOpenRouterCredits()`
+ * from a component that needs it; the first consumer triggers the fetch.
+ * Subsequent consumers share the cached result. Auto-refreshes every 2min
+ * once activated.
+ */
 export function OpenRouterCreditsProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<Omit<OpenRouterCreditsState, 'refresh'>>({
-    available: false,
-    remaining: 0,
-    limit: 0,
-    usage: 0,
-    isLoading: true,
-  });
+  const [available, setAvailable] = useState(false);
+  const [remaining, setRemaining] = useState(0);
+  const [limit, setLimit] = useState(0);
+  const [usage, setUsage] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+  const [activated, setActivated] = useState(false);
   const cancelledRef = useRef(false);
 
   const fetchCredits = useCallback(async () => {
@@ -41,35 +47,57 @@ export function OpenRouterCreditsProvider({ children }: { children: ReactNode })
       if (!res.ok || cancelledRef.current) return;
       const data = await res.json() as OpenRouterCreditsResponse;
       if (cancelledRef.current) return;
-      setState({
-        available: data.available,
-        remaining: data.remaining,
-        limit: data.limit,
-        usage: data.usage,
-        isLoading: false,
-        error: data.error,
-      });
+      setAvailable(data.available);
+      setRemaining(data.remaining);
+      setLimit(data.limit);
+      setUsage(data.usage);
+      setIsLoading(false);
+      setError(data.error);
     } catch {
       if (!cancelledRef.current) {
-        setState((prev) => ({ ...prev, isLoading: false, error: 'Failed to fetch credits' }));
+        setIsLoading(false);
+        setError('Failed to fetch credits');
       }
     }
   }, []);
 
   useEffect(() => {
+    if (!activated) return;
     cancelledRef.current = false;
     fetchCredits();
     const interval = setInterval(fetchCredits, REFRESH_INTERVAL_MS);
     return () => { cancelledRef.current = true; clearInterval(interval); };
-  }, [fetchCredits]);
+  }, [activated, fetchCredits]);
+
+  const activate = useCallback(() => setActivated(true), []);
+
+  const value = useMemo<OpenRouterCreditsState>(() => ({
+    available,
+    remaining,
+    limit,
+    usage,
+    isLoading,
+    error,
+    refresh: fetchCredits,
+  }), [available, remaining, limit, usage, isLoading, error, fetchCredits]);
 
   return (
-    <OpenRouterCreditsContext.Provider value={{ ...state, refresh: fetchCredits }}>
-      {children}
-    </OpenRouterCreditsContext.Provider>
+    <ActivateContext.Provider value={activate}>
+      <OpenRouterCreditsContext.Provider value={value}>
+        {children}
+      </OpenRouterCreditsContext.Provider>
+    </ActivateContext.Provider>
   );
 }
 
+const ActivateContext = createContext<() => void>(() => {});
+
+/**
+ * Returns OpenRouter credits state. Lazily triggers the first fetch —
+ * no network call until a component actually uses this hook.
+ */
 export function useOpenRouterCredits(): OpenRouterCreditsState {
+  const activate = useContext(ActivateContext);
+  useEffect(() => { activate(); }, [activate]);
   return useContext(OpenRouterCreditsContext);
 }

--- a/packages/platform-ui/src/contexts/openrouter-credits-context.tsx
+++ b/packages/platform-ui/src/contexts/openrouter-credits-context.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
+import { apiFetch } from '@/lib/api-fetch';
+import type { OpenRouterCreditsResponse } from '@/app/api/system/openrouter-credits/route';
+
+export interface OpenRouterCreditsState {
+  available: boolean;
+  remaining: number;
+  limit: number;
+  usage: number;
+  isLoading: boolean;
+  error?: string;
+  refresh: () => void;
+}
+
+const REFRESH_INTERVAL_MS = 120_000;
+
+const OpenRouterCreditsContext = createContext<OpenRouterCreditsState>({
+  available: false,
+  remaining: 0,
+  limit: 0,
+  usage: 0,
+  isLoading: true,
+  refresh: () => {},
+});
+
+export function OpenRouterCreditsProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<Omit<OpenRouterCreditsState, 'refresh'>>({
+    available: false,
+    remaining: 0,
+    limit: 0,
+    usage: 0,
+    isLoading: true,
+  });
+  const cancelledRef = useRef(false);
+
+  const fetchCredits = useCallback(async () => {
+    try {
+      const res = await apiFetch('/api/system/openrouter-credits');
+      if (!res.ok || cancelledRef.current) return;
+      const data = await res.json() as OpenRouterCreditsResponse;
+      if (cancelledRef.current) return;
+      setState({
+        available: data.available,
+        remaining: data.remaining,
+        limit: data.limit,
+        usage: data.usage,
+        isLoading: false,
+        error: data.error,
+      });
+    } catch {
+      if (!cancelledRef.current) {
+        setState((prev) => ({ ...prev, isLoading: false, error: 'Failed to fetch credits' }));
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    fetchCredits();
+    const interval = setInterval(fetchCredits, REFRESH_INTERVAL_MS);
+    return () => { cancelledRef.current = true; clearInterval(interval); };
+  }, [fetchCredits]);
+
+  return (
+    <OpenRouterCreditsContext.Provider value={{ ...state, refresh: fetchCredits }}>
+      {children}
+    </OpenRouterCreditsContext.Provider>
+  );
+}
+
+export function useOpenRouterCredits(): OpenRouterCreditsState {
+  return useContext(OpenRouterCreditsContext);
+}

--- a/packages/platform-ui/src/hooks/use-openrouter-credits.ts
+++ b/packages/platform-ui/src/hooks/use-openrouter-credits.ts
@@ -1,0 +1,3 @@
+'use client';
+
+export { useOpenRouterCredits } from '@/contexts/openrouter-credits-context';

--- a/packages/platform-ui/src/lib/preflight-checks.ts
+++ b/packages/platform-ui/src/lib/preflight-checks.ts
@@ -2,7 +2,7 @@ import type { DockerImageInfo } from '@mediforce/platform-api/contract';
 import type { WorkflowDefinition } from '@mediforce/platform-core';
 
 export interface PreflightWarning {
-  category: 'missing-image' | 'missing-secret';
+  category: 'missing-image' | 'missing-secret' | 'low-credits';
   resource: string;
   stepNames: string[];
   message: string;
@@ -11,12 +11,20 @@ export interface PreflightWarning {
 
 const TEMPLATE_RE = /^\{\{(?:[A-Z]+:)?([A-Za-z0-9_-]+)\}\}$/;
 
+export interface OpenRouterCreditsInfo {
+  available: boolean;
+  remaining: number;
+}
+
+const LOW_CREDITS_THRESHOLD = 0.5;
+
 export function runPreflightChecks(
   definition: WorkflowDefinition,
   options: {
     dockerImages?: DockerImageInfo[];
     dockerAvailable: boolean;
     secretKeys?: string[];
+    openRouterCredits?: OpenRouterCreditsInfo;
   },
 ): PreflightWarning[] {
   const imageMap = new Map<string, string[]>();
@@ -75,6 +83,24 @@ export function runPreflightChecks(
       message: `Secret '${key}' not configured (referenced as ${envVar})`,
       hint: 'Add this secret in the Secrets panel for this workflow.',
     });
+  }
+
+  if (options.openRouterCredits?.available && options.openRouterCredits.remaining <= LOW_CREDITS_THRESHOLD) {
+    const agentSteps = definition.steps
+      .filter((s) => s.executor === 'agent')
+      .map((s) => s.name);
+    if (agentSteps.length > 0) {
+      const remaining = options.openRouterCredits.remaining;
+      warnings.push({
+        category: 'low-credits',
+        resource: 'OPENROUTER_API_KEY',
+        stepNames: agentSteps,
+        message: remaining <= 0
+          ? 'OpenRouter credits exhausted ($0.00 remaining)'
+          : `OpenRouter credits low ($${remaining.toFixed(2)} remaining)`,
+        hint: 'Top up credits at https://openrouter.ai/settings/credits or the run will fail.',
+      });
+    }
   }
 
   return warnings;


### PR DESCRIPTION
## Summary

- Adds pre-flight warning when OpenRouter credits are exhausted or low (≤$0.50)
- Shows in the same "Before you start" dialog alongside missing images and secrets
- Prevents starting runs that will silently fail on LLM API calls

## Changes

- **API route** `/api/system/openrouter-credits` — proxies `GET https://openrouter.ai/api/v1/auth/key`
- **Context** `OpenRouterCreditsProvider` — single fetch shared across all components, 2min auto-refresh
- **Preflight** — new `low-credits` category in `runPreflightChecks()`
- **Dialog** — `WarningGroup` now shows descriptive `message` instead of raw resource name

## Test plan

- [x] Unit tests pass (171 files green)
- [x] Verified on localhost: dialog shows "OpenRouter credits exhausted ($0.00 remaining)" with hint to top up
- [ ] Verify warning disappears after credits are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)