### PR TITLE
ci(deploy-staging): add concurrency + skip cache prune by default

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -10,15 +10,17 @@ echo "==> Pulling latest code"
 git fetch origin
 git checkout "$DEPLOY_SHA"
 
-echo "==> Pruning Docker build cache (keeping tagged images)"
-docker builder prune -af 2>/dev/null || true
-docker image prune -f 2>/dev/null || true
-
-# Early warning if the Docker data volume is filling up
+# Only prune when the Docker data volume is actually filling up — unconditional
+# `builder prune -af` evicts the layer cache and forces every agent image to rebuild
+# from scratch on each deploy, which is the main cause of staging deploy timeouts.
 DOCKER_ROOT=$(docker info -f '{{.DockerRootDir}}' 2>/dev/null || echo /var/lib/docker)
 USE_PCT=$(df --output=pcent "$DOCKER_ROOT" | tail -1 | tr -dc '0-9')
 if [ -n "$USE_PCT" ] && [ "$USE_PCT" -gt 80 ]; then
-  echo "WARN: docker volume at ${USE_PCT}% (${DOCKER_ROOT}) — GC cap may need lowering" >&2
+  echo "==> Docker volume at ${USE_PCT}% (${DOCKER_ROOT}) — pruning build cache"
+  docker builder prune -af 2>/dev/null || true
+  docker image prune -f 2>/dev/null || true
+else
+  echo "==> Docker volume at ${USE_PCT:-?}% — skipping prune to keep layer cache"
 fi
 
 export NEXT_PUBLIC_GIT_SHA=$(git rev-parse --short HEAD)


### PR DESCRIPTION
## Summary

Two cheap fixes for #330 (staging deploys hit 15min timeout when three pushes queue back-to-back).

- **Concurrency group** on `Deploy to Staging` — newer pushes cancel older in-flight runs instead of queueing on the VPS Docker daemon.
- **Gate the build-cache prune behind disk pressure** — only prune when Docker data volume >80% full. Daemon-level BuildKit GC cap (`defaultKeepStorage=20GB` set in `bootstrap-server.py`) remains the steady-state guarantee.

## Why the prune change is safe

The unconditional `docker builder prune -af` was added intentionally by @filipstachura in [207d2545](https://github.com/Appsilon/mediforce/commit/207d2545) (Apr 23) after a real ENOSPC incident — at that point `deploy-staging.sh` only rebuilt **one** image (platform-ui via compose), so wiping the layer cache was cheap.

A week later, [9092da40](https://github.com/Appsilon/mediforce/commit/9092da40) (Apr 30) added a `rebuild-docker-images.sh` call to the same script — six more agent image builds (`golden-image`, `mediforce-node`, `protocol-to-tfl`, `tealflow`, `community-digest`, `landing-zone`). The prune wasn't revisited. From that point on, every deploy paid full cold-build cost on six images, which is what hits the 15min timeout in #330.

Two defenses against ENOSPC remain in place after this change:
1. Daemon-level BuildKit GC at 20GB cap (auto-enforced regardless of deploy script)
2. Prune still fires when the volume actually reaches 80% — the warning condition that already existed but wasn't acted on

Together these would have prevented the pile-up on PR #326. SHA-tagging / path-filtering the agent image rebuild itself is a follow-up — see #330 for the full plan.

## Test plan

- [ ] Merge to `main`, confirm next staging deploy completes well under 15min
- [ ] Push two commits to `main` in quick succession; older `Deploy to Staging` run shows as cancelled, only the latest runs to completion
- [ ] On staging VPS, verify `docker images` retains agent images between deploys (cache survives)
- [ ] Force the >80% branch (e.g. fill the volume in a test env) and confirm prune still fires when it should

Closes #330 partially (mitigations 1+5 from the issue). Items 2/3/4 (SHA tags, path filters, separate workflow) tracked separately.