### PR TITLE
fix(ui): redirect /[handle]/workflows to workspace home

### DIFF
--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+
+export default async function WorkflowsIndexPage({ params }: { params: Promise<{ handle: string }> }) {
+  const { handle } = await params;
+  redirect(`/${handle}`);
+}


### PR DESCRIPTION
## Summary
- `/{handle}/workflows` returned 404 (e.g. `https://staging.mediforce.ai/appsilon/workflows`).
- Cause: route folder had only sub-routes (`new`, `[name]`) — no index `page.tsx`.
- Workflow catalog actually lives at `/{handle}`. Added a server-side redirect so the natural URL works.

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Manual: visit `/appsilon/workflows` on staging after deploy → lands on `/appsilon`