### PR TITLE
refactor(oauth): export publicOrigin from app-base-url, remove local copies

### DIFF
--- a/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/oauth-discover/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/oauth-discover/route.ts
@@ -12,7 +12,7 @@ import {
   type CreateOAuthProviderInput,
 } from '@mediforce/platform-core';
 import { getPlatformServices } from '@/lib/platform-services';
-import { getConfiguredAppBaseUrl } from '@/lib/app-base-url';
+import { publicOrigin } from '@/lib/app-base-url';
 
 interface DiscoverBody {
   /** Namespace to scope the resulting provider doc. Required because
@@ -221,9 +221,7 @@ function existingHeaderValueTemplate(
 }
 
 function buildCallbackUrl(request: Request, providerSlug: string): string {
-  // Public origin — see lib/app-base-url for why request.url isn't trusted.
-  const origin = getConfiguredAppBaseUrl() ?? new URL(request.url).origin;
-  return `${origin}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
+  return `${publicOrigin(request)}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
 }
 
 function buildDisplayName(issuerUrl: string, serverName: string): string {

--- a/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/oauth-discover/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/oauth-discover/route.ts
@@ -220,7 +220,6 @@ function existingHeaderValueTemplate(
   return undefined;
 }
 
-
 function buildDisplayName(issuerUrl: string, serverName: string): string {
   const host = new URL(issuerUrl).hostname;
   return `${serverName} (${host})`;

--- a/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/oauth-discover/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/oauth-discover/route.ts
@@ -12,7 +12,7 @@ import {
   type CreateOAuthProviderInput,
 } from '@mediforce/platform-core';
 import { getPlatformServices } from '@/lib/platform-services';
-import { publicOrigin } from '@/lib/app-base-url';
+import { buildOAuthCallbackUrl } from '@/lib/app-base-url';
 
 interface DiscoverBody {
   /** Namespace to scope the resulting provider doc. Required because
@@ -95,7 +95,7 @@ export async function POST(
     );
   }
 
-  const redirectUri = buildCallbackUrl(request, existingProviderSlug(binding, authServer.issuer));
+  const redirectUri = buildOAuthCallbackUrl(request, existingProviderSlug(binding, authServer.issuer));
   const providerSlug = existingProviderSlug(binding, authServer.issuer);
   const authMethod = pickAuthMethod(authServer.token_endpoint_auth_methods_supported);
   const scopes = chooseScopes(resourceMetadata.scopes_supported, authServer.scopes_supported);
@@ -220,9 +220,6 @@ function existingHeaderValueTemplate(
   return undefined;
 }
 
-function buildCallbackUrl(request: Request, providerSlug: string): string {
-  return `${publicOrigin(request)}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
-}
 
 function buildDisplayName(issuerUrl: string, serverName: string): string {
   const host = new URL(issuerUrl).hostname;

--- a/packages/platform-ui/src/app/api/agents/[id]/oauth/[provider]/start/route.ts
+++ b/packages/platform-ui/src/app/api/agents/[id]/oauth/[provider]/start/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { signState, generateNonce, generatePkcePair } from '@mediforce/agent-runtime';
 import { getPlatformServices } from '@/lib/platform-services';
 import { getOAuthStateSecret } from '@/lib/oauth-state-secret';
-import { publicOrigin } from '@/lib/app-base-url';
+import { buildOAuthCallbackUrl } from '@/lib/app-base-url';
 import {
   requireFirebaseUid,
   requireNamespaceFromQuery,
@@ -14,9 +14,6 @@ const StartBodySchema = z.object({
   serverName: z.string().min(1),
 });
 
-function buildCallbackUrl(request: Request, providerSlug: string): string {
-  return `${publicOrigin(request)}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
-}
 
 function buildAuthorizeUrl(params: {
   base: string;
@@ -139,7 +136,7 @@ export async function POST(
     base: provider.authorizeUrl,
     clientId: provider.clientId,
     scopes: provider.scopes,
-    redirectUri: buildCallbackUrl(request, providerSlug),
+    redirectUri: buildOAuthCallbackUrl(request, providerSlug),
     state,
     codeChallenge: pkce.codeChallenge,
   });

--- a/packages/platform-ui/src/app/api/agents/[id]/oauth/[provider]/start/route.ts
+++ b/packages/platform-ui/src/app/api/agents/[id]/oauth/[provider]/start/route.ts
@@ -14,7 +14,6 @@ const StartBodySchema = z.object({
   serverName: z.string().min(1),
 });
 
-
 function buildAuthorizeUrl(params: {
   base: string;
   clientId: string;

--- a/packages/platform-ui/src/app/api/agents/[id]/oauth/[provider]/start/route.ts
+++ b/packages/platform-ui/src/app/api/agents/[id]/oauth/[provider]/start/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { signState, generateNonce, generatePkcePair } from '@mediforce/agent-runtime';
 import { getPlatformServices } from '@/lib/platform-services';
 import { getOAuthStateSecret } from '@/lib/oauth-state-secret';
-import { getConfiguredAppBaseUrl } from '@/lib/app-base-url';
+import { publicOrigin } from '@/lib/app-base-url';
 import {
   requireFirebaseUid,
   requireNamespaceFromQuery,
@@ -15,10 +15,7 @@ const StartBodySchema = z.object({
 });
 
 function buildCallbackUrl(request: Request, providerSlug: string): string {
-  // Origin comes from the configured base URL — request.url is wrong behind
-  // Docker/reverse proxy. See lib/app-base-url for the why.
-  const origin = getConfiguredAppBaseUrl() ?? new URL(request.url).origin;
-  return `${origin}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
+  return `${publicOrigin(request)}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
 }
 
 function buildAuthorizeUrl(params: {

--- a/packages/platform-ui/src/app/api/oauth/[provider]/callback/route.ts
+++ b/packages/platform-ui/src/app/api/oauth/[provider]/callback/route.ts
@@ -28,7 +28,6 @@ interface ProviderUserInfo {
   accountLogin: string;
 }
 
-
 function redirectSuccess(request: Request, state: OAuthStatePayload): NextResponse {
   const origin = publicOrigin(request);
   const destination = `${origin}/${encodeURIComponent(state.namespace)}/agents/definitions/${encodeURIComponent(state.agentId)}?connected=${encodeURIComponent(state.serverName)}`;

--- a/packages/platform-ui/src/app/api/oauth/[provider]/callback/route.ts
+++ b/packages/platform-ui/src/app/api/oauth/[provider]/callback/route.ts
@@ -3,7 +3,7 @@ import { verifyState, type OAuthStatePayload } from '@mediforce/agent-runtime';
 import type { AgentOAuthToken, OAuthProviderConfig } from '@mediforce/platform-core';
 import { getPlatformServices } from '@/lib/platform-services';
 import { getOAuthStateSecret } from '@/lib/oauth-state-secret';
-import { getConfiguredAppBaseUrl } from '@/lib/app-base-url';
+import { publicOrigin } from '@/lib/app-base-url';
 
 /** Platform-owned callback for the OAuth authorization-code flow. Provider
  *  redirects here after consent. No user session (external origin), so the
@@ -26,13 +26,6 @@ interface TokenExchangeResponse {
 interface ProviderUserInfo {
   providerUserId: string;
   accountLogin: string;
-}
-
-// Public origin for absolute URLs we emit — see lib/app-base-url for why we
-// don't trust request.url. Falls back to request.url.origin only on local
-// dev where APP_BASE_URL / NEXT_PUBLIC_APP_URL are unset.
-function publicOrigin(request: Request): string {
-  return getConfiguredAppBaseUrl() ?? new URL(request.url).origin;
 }
 
 function buildSelfCallbackUrl(request: Request, providerSlug: string): string {

--- a/packages/platform-ui/src/app/api/oauth/[provider]/callback/route.ts
+++ b/packages/platform-ui/src/app/api/oauth/[provider]/callback/route.ts
@@ -3,7 +3,7 @@ import { verifyState, type OAuthStatePayload } from '@mediforce/agent-runtime';
 import type { AgentOAuthToken, OAuthProviderConfig } from '@mediforce/platform-core';
 import { getPlatformServices } from '@/lib/platform-services';
 import { getOAuthStateSecret } from '@/lib/oauth-state-secret';
-import { publicOrigin } from '@/lib/app-base-url';
+import { buildOAuthCallbackUrl, publicOrigin } from '@/lib/app-base-url';
 
 /** Platform-owned callback for the OAuth authorization-code flow. Provider
  *  redirects here after consent. No user session (external origin), so the
@@ -28,9 +28,6 @@ interface ProviderUserInfo {
   accountLogin: string;
 }
 
-function buildSelfCallbackUrl(request: Request, providerSlug: string): string {
-  return `${publicOrigin(request)}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
-}
 
 function redirectSuccess(request: Request, state: OAuthStatePayload): NextResponse {
   const origin = publicOrigin(request);
@@ -185,7 +182,7 @@ export async function GET(
   const exchange = await exchangeCode({
     provider,
     code,
-    redirectUri: buildSelfCallbackUrl(request, providerSlug),
+    redirectUri: buildOAuthCallbackUrl(request, providerSlug),
     codeVerifier: state.codeVerifier,
   });
   if (exchange === null) {

--- a/packages/platform-ui/src/lib/__tests__/app-base-url.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/app-base-url.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getAppBaseUrl, getConfiguredAppBaseUrl } from '../app-base-url';
+import { getAppBaseUrl, getConfiguredAppBaseUrl, publicOrigin, buildOAuthCallbackUrl } from '../app-base-url';
 
 describe('getConfiguredAppBaseUrl', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -79,5 +79,59 @@ describe('getAppBaseUrl (with localhost fallback)', () => {
   it('falls back to localhost with custom PORT', () => {
     process.env.PORT = '9003';
     expect(getAppBaseUrl()).toBe('http://localhost:9003');
+  });
+});
+
+describe('publicOrigin', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  const dockerRequest = new Request('http://e195cf41c355:3000/api/oauth/github/callback');
+  const localRequest = new Request('http://localhost:9003/api/oauth/github/callback');
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.APP_BASE_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns env URL when set', () => {
+    process.env.APP_BASE_URL = 'https://staging.mediforce.ai';
+    expect(publicOrigin(dockerRequest)).toBe('https://staging.mediforce.ai');
+  });
+
+  it('falls back to request.url.origin when no env var set', () => {
+    expect(publicOrigin(localRequest)).toBe('http://localhost:9003');
+  });
+});
+
+describe('buildOAuthCallbackUrl', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  const request = new Request('http://localhost:9003/any');
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env.APP_BASE_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('builds canonical callback URL from env origin', () => {
+    process.env.APP_BASE_URL = 'https://staging.mediforce.ai';
+    expect(buildOAuthCallbackUrl(request, 'github')).toBe(
+      'https://staging.mediforce.ai/api/oauth/github/callback',
+    );
+  });
+
+  it('encodes provider slug', () => {
+    process.env.APP_BASE_URL = 'https://staging.mediforce.ai';
+    expect(buildOAuthCallbackUrl(request, 'my provider')).toBe(
+      'https://staging.mediforce.ai/api/oauth/my%20provider/callback',
+    );
   });
 });

--- a/packages/platform-ui/src/lib/app-base-url.ts
+++ b/packages/platform-ui/src/lib/app-base-url.ts
@@ -41,3 +41,11 @@ export function getConfiguredAppBaseUrl(): string | undefined {
 export function getAppBaseUrl(): string {
   return getConfiguredAppBaseUrl() ?? `http://localhost:${process.env.PORT ?? '3000'}`;
 }
+
+/** Public origin for absolute URLs the server emits to real clients — OAuth
+ *  `redirect_uri`, post-callback redirects. Prefers the env-configured base
+ *  URL; falls back to `request.url.origin` only on local dev where neither
+ *  env var is set and there is no proxy hop. */
+export function publicOrigin(request: Request): string {
+  return getConfiguredAppBaseUrl() ?? new URL(request.url).origin;
+}

--- a/packages/platform-ui/src/lib/app-base-url.ts
+++ b/packages/platform-ui/src/lib/app-base-url.ts
@@ -49,3 +49,10 @@ export function getAppBaseUrl(): string {
 export function publicOrigin(request: Request): string {
   return getConfiguredAppBaseUrl() ?? new URL(request.url).origin;
 }
+
+/** Canonical OAuth callback URL for a given provider slug. All three OAuth
+ *  route handlers (start, callback, oauth-discover) must send the provider
+ *  to the same URL — centralised here so they can't drift. */
+export function buildOAuthCallbackUrl(request: Request, providerSlug: string): string {
+  return `${publicOrigin(request)}/api/oauth/${encodeURIComponent(providerSlug)}/callback`;
+}

--- a/packages/platform-ui/src/lib/app-base-url.ts
+++ b/packages/platform-ui/src/lib/app-base-url.ts
@@ -45,7 +45,11 @@ export function getAppBaseUrl(): string {
 /** Public origin for absolute URLs the server emits to real clients — OAuth
  *  `redirect_uri`, post-callback redirects. Prefers the env-configured base
  *  URL; falls back to `request.url.origin` only on local dev where neither
- *  env var is set and there is no proxy hop. */
+ *  env var is set and there is no proxy hop.
+ *
+ *  The `request.url` fallback assumes Next.js always supplies a valid URL,
+ *  which holds in practice — malformed request URLs are rejected by Node's
+ *  HTTP parser before they reach a route handler. */
 export function publicOrigin(request: Request): string {
   return getConfiguredAppBaseUrl() ?? new URL(request.url).origin;
 }


### PR DESCRIPTION
Follow-up to #326.

Three route files each had a local copy of `getConfiguredAppBaseUrl() ?? new URL(request.url).origin` — one wrapped in a local function, two inlined. Exports `publicOrigin(request)` from `app-base-url.ts` and replaces all three.

No behaviour change.