### PR TITLE
feat(ui): one-click GitHub MCP preset on agent bindings panel

### DIFF
--- a/packages/platform-ui/e2e/journeys/github-mcp-preset.journey.ts
+++ b/packages/platform-ui/e2e/journeys/github-mcp-preset.journey.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '../helpers/test-fixtures';
+import { TEST_ORG_HANDLE } from '../helpers/constants';
+import { setupRecording, click, showStep, showResult, endRecording } from '../helpers/recording';
+
+/**
+ * Journey — GitHub MCP preset
+ *
+ * One-click "Add GitHub MCP" preset on the agent MCP bindings panel pre-fills
+ * an HTTP binding pointing at `https://api.githubcopilot.com/mcp/` with OAuth
+ * auth. The preset references a provider id of `github`, which doesn't exist
+ * in the e2e seed (we only seed `github-mock`); the test verifies the pre-fill
+ * is correct, then switches the provider to `github-mock` to complete a real
+ * save against the local mock OAuth server. Binding is cleaned up at the end
+ * so the test is rerunnable.
+ */
+
+test.describe('GitHub MCP preset journey', () => {
+  test('one-click "Add GitHub MCP" pre-fills HTTP + OAuth binding', async ({ page }, testInfo) => {
+    await setupRecording(page, 'github-mcp-preset', testInfo);
+
+    await page.goto(`/${TEST_ORG_HANDLE}/agents/definitions/claude-code-agent`);
+    await expect(page.getByText(/edit this ai agent/i)).toBeVisible({ timeout: 30_000 });
+
+    const mcpHeading = page.getByRole('heading', { name: /mcp servers/i });
+    await expect(mcpHeading).toBeVisible();
+    await showStep(page);
+
+    // ── Click "Add GitHub MCP" preset ────────────────────────────────────
+    await click(page, page.getByRole('button', { name: /add github mcp/i }));
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /add github mcp server/i })).toBeVisible();
+
+    // Pre-fills — server name, transport, URL, OAuth auth mode
+    await expect(page.getByLabel(/server name/i)).toHaveValue('github');
+    await expect(page.getByRole('radio', { name: /^http$/i })).toBeChecked();
+    await expect(page.getByLabel(/^url$/i)).toHaveValue('https://api.githubcopilot.com/mcp/');
+    await expect(page.getByRole('radio', { name: /^oauth$/i })).toBeChecked();
+    await showStep(page);
+
+    // ── Switch provider to the e2e mock and save ─────────────────────────
+    // The preset references provider id `github` (real GitHub). The e2e env
+    // only has `github-mock` seeded for OAuth flow testing, so swap before
+    // saving.
+    await page.getByLabel(/oauth provider/i).selectOption({ label: 'GitHub (mock)' });
+
+    await click(page, page.getByRole('button', { name: /^save$|create binding/i }).last());
+    await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 });
+
+    // Binding row appears
+    await expect(page.getByText('github').first()).toBeVisible();
+    await expect(page.getByText(/http/i).first()).toBeVisible();
+    await showResult(page);
+
+    // ── Cleanup so the test is rerunnable ────────────────────────────────
+    await click(page, page.getByRole('button', { name: 'Remove github' }));
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await click(page, page.getByRole('button', { name: /^(delete|confirm|remove)/i }).last());
+
+    await endRecording(page);
+  });
+});

--- a/packages/platform-ui/src/components/agents/__tests__/agent-mcp-binding-form.test.tsx
+++ b/packages/platform-ui/src/components/agents/__tests__/agent-mcp-binding-form.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { OAuthProviderConfig } from '@mediforce/platform-core';
+
+const githubProvider: OAuthProviderConfig = {
+  id: 'github',
+  name: 'GitHub',
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  authorizeUrl: 'https://github.com/login/oauth/authorize',
+  tokenUrl: 'https://github.com/login/oauth/access_token',
+  userInfoUrl: 'https://api.github.com/user',
+  scopes: ['repo', 'read:user'],
+  createdAt: '2026-04-23T10:00:00.000Z',
+  updatedAt: '2026-04-23T10:00:00.000Z',
+};
+
+vi.mock('@/lib/oauth-admin-client', () => ({
+  listOAuthProviders: vi.fn(async () => [githubProvider]),
+}));
+
+import { AgentMcpBindingForm } from '../agent-mcp-binding-form';
+
+describe('AgentMcpBindingForm — github-mcp preset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-fills name, transport, URL, and OAuth provider for GitHub MCP preset', async () => {
+    render(
+      <AgentMcpBindingForm
+        existing={null}
+        existingNames={[]}
+        catalogEntries={[]}
+        agentId="agent-1"
+        namespace="appsilon"
+        preset="github-mcp"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Server name input — selected by its placeholder which is unique on the form
+    const nameInput = screen.getByPlaceholderText('filesystem') as HTMLInputElement;
+    expect(nameInput.value).toBe('github');
+
+    // HTTP transport selected by preset (selected by value to avoid label-text collisions)
+    const transportRadios = screen.getAllByRole('radio');
+    const httpRadio = transportRadios.find(
+      (r) => (r as HTMLInputElement).value === 'http',
+    ) as HTMLInputElement;
+    expect(httpRadio.checked).toBe(true);
+
+    const urlInput = screen.getByPlaceholderText(/api.example.com\/mcp/i) as HTMLInputElement;
+    expect(urlInput.value).toBe('https://api.githubcopilot.com/mcp/');
+
+    // OAuth auth mode selected
+    const oauthAuthRadio = transportRadios.find(
+      (r) => (r as HTMLInputElement).value === 'oauth',
+    ) as HTMLInputElement;
+    expect(oauthAuthRadio.checked).toBe(true);
+
+    // Wait for providers to load and verify github is selected
+    await waitFor(() => {
+      const providerSelect = screen.getByLabelText(/OAuth provider/i) as HTMLSelectElement;
+      expect(providerSelect.value).toBe('github');
+    });
+  });
+
+  it('submits a github-mcp preset binding with HTTP + OAuth (provider=github)', async () => {
+    const onSubmit = vi.fn(async () => {});
+    const user = userEvent.setup();
+
+    render(
+      <AgentMcpBindingForm
+        existing={null}
+        existingNames={[]}
+        catalogEntries={[]}
+        agentId="agent-1"
+        namespace="appsilon"
+        preset="github-mcp"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Wait for the OAuth provider list to load before submitting,
+    // otherwise the selected provider value is empty.
+    await waitFor(() => {
+      const providerSelect = screen.getByLabelText(/OAuth provider/i) as HTMLSelectElement;
+      expect(providerSelect.value).toBe('github');
+    });
+
+    await user.click(screen.getByRole('button', { name: /Create binding/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const [name, binding] = onSubmit.mock.calls[0];
+    expect(name).toBe('github');
+    expect(binding).toEqual({
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      auth: {
+        type: 'oauth',
+        provider: 'github',
+        headerName: 'Authorization',
+        headerValueTemplate: 'Bearer {token}',
+      },
+    });
+  });
+
+  it('lets the user switch to PAT (static headers) instead of OAuth', async () => {
+    const onSubmit = vi.fn(async () => {});
+    const user = userEvent.setup();
+
+    render(
+      <AgentMcpBindingForm
+        existing={null}
+        existingNames={[]}
+        catalogEntries={[]}
+        agentId="agent-1"
+        namespace="appsilon"
+        preset="github-mcp"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Switch from OAuth → static headers (PAT path). Pick the radio by value
+    // since "OAuth" / "Static headers" labels can collide with other text.
+    const allRadios = screen.getAllByRole('radio');
+    const headersRadio = allRadios.find(
+      (r) => (r as HTMLInputElement).value === 'headers',
+    ) as HTMLInputElement;
+    await user.click(headersRadio);
+
+    // Add a header carrying the GITHUB_TOKEN secret template.
+    // userEvent treats { as keyboard syntax; doubled-up braces produce a literal {.
+    await user.click(screen.getByRole('button', { name: /Add header/i }));
+    await user.type(screen.getByLabelText(/Header key 1/i), 'Authorization');
+    // user-event treats { as keyboard syntax; doubled-up `{{` produces a literal `{`.
+    // `}` has no escape semantics, so type it once for each `}` we want.
+    await user.type(
+      screen.getByLabelText(/Header value 1/i),
+      'Bearer {{{{SECRET:GITHUB_TOKEN}}',
+    );
+
+    await user.click(screen.getByRole('button', { name: /Create binding/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const [name, binding] = onSubmit.mock.calls[0];
+    expect(name).toBe('github');
+    expect(binding).toEqual({
+      type: 'http',
+      url: 'https://api.githubcopilot.com/mcp/',
+      auth: {
+        type: 'headers',
+        headers: { Authorization: 'Bearer {{SECRET:GITHUB_TOKEN}}' },
+      },
+    });
+  });
+});

--- a/packages/platform-ui/src/components/agents/agent-mcp-binding-form.tsx
+++ b/packages/platform-ui/src/components/agents/agent-mcp-binding-form.tsx
@@ -15,6 +15,35 @@ import { listOAuthProviders } from '@/lib/oauth-admin-client';
 
 const nameRegex = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
 
+/** Built-in form presets surfaced as one-click "Add X MCP" buttons.
+ *  Pre-fills name + transport + transport-specific defaults so the user
+ *  only needs to click Save (or tweak as needed). */
+export type McpBindingPreset = 'github-mcp';
+
+interface HttpPresetDefaults {
+  url: string;
+  authMode: 'oauth' | 'headers';
+  oauthProvider?: string;
+}
+
+interface PresetDefaults {
+  name: string;
+  transport: 'stdio' | 'http';
+  http?: HttpPresetDefaults;
+}
+
+const PRESET_DEFAULTS: Record<McpBindingPreset, PresetDefaults> = {
+  'github-mcp': {
+    name: 'github',
+    transport: 'http',
+    http: {
+      url: 'https://api.githubcopilot.com/mcp/',
+      authMode: 'oauth',
+      oauthProvider: 'github',
+    },
+  },
+};
+
 const StdioFormSchema = z.object({
   catalogId: z.string().min(1, 'Choose a catalog entry'),
   allowedTools: z.array(z.object({ value: z.string() })),
@@ -71,6 +100,8 @@ interface AgentMcpBindingFormProps {
   catalogEntries: ToolCatalogEntry[];
   agentId: string;
   namespace: string;
+  /** Optional preset that pre-fills the form for one-click MCP setup. */
+  preset?: McpBindingPreset;
   onSubmit: (name: string, binding: AgentMcpBinding) => Promise<void>;
   onCancel: () => void;
 }
@@ -81,13 +112,17 @@ export function AgentMcpBindingForm({
   catalogEntries,
   agentId,
   namespace,
+  preset,
   onSubmit,
   onCancel,
 }: AgentMcpBindingFormProps) {
   const isEdit = existing !== null;
-  const [name, setName] = useState(existing?.name ?? '');
+  const presetDefaults = preset !== undefined ? PRESET_DEFAULTS[preset] : null;
+  const [name, setName] = useState(existing?.name ?? presetDefaults?.name ?? '');
   const [nameError, setNameError] = useState<string | null>(null);
-  const [transport, setTransport] = useState<'stdio' | 'http'>(existing?.binding.type ?? 'stdio');
+  const [transport, setTransport] = useState<'stdio' | 'http'>(
+    existing?.binding.type ?? presetDefaults?.transport ?? 'stdio',
+  );
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   function validateName(value: string): string | null {
@@ -174,6 +209,7 @@ export function AgentMcpBindingForm({
         <HttpFields
           key="http-fields"
           initial={existing?.binding.type === 'http' ? existing.binding : null}
+          presetHttp={presetDefaults?.http ?? null}
           agentId={agentId}
           namespace={namespace}
           existingServerName={existing?.name ?? null}
@@ -281,6 +317,7 @@ function StdioFields({
 
 function HttpFields({
   initial,
+  presetHttp,
   agentId,
   namespace,
   existingServerName,
@@ -290,6 +327,7 @@ function HttpFields({
   submitLabel,
 }: {
   initial: Extract<AgentMcpBinding, { type: 'http' }> | null;
+  presetHttp: HttpPresetDefaults | null;
   agentId: string;
   namespace: string;
   existingServerName: string | null;
@@ -306,17 +344,21 @@ function HttpFields({
   const initialAuthMode: 'none' | 'headers' | 'oauth' = useMemo(() => {
     if (initial?.auth?.type === 'oauth') return 'oauth';
     if (initial?.auth?.type === 'headers') return 'headers';
+    if (presetHttp !== null) return presetHttp.authMode;
     return 'none';
-  }, [initial]);
+  }, [initial, presetHttp]);
 
   const form = useForm<HttpFormValues>({
     resolver: zodResolver(HttpFormSchema),
     defaultValues: {
-      url: initial?.url ?? '',
+      url: initial?.url ?? presetHttp?.url ?? '',
       allowedTools: (initial?.allowedTools ?? []).map((value) => ({ value })),
       authMode: initialAuthMode,
       headers: initialHeaders,
-      oauthProvider: initial?.auth?.type === 'oauth' ? initial.auth.provider : '',
+      oauthProvider:
+        initial?.auth?.type === 'oauth'
+          ? initial.auth.provider
+          : presetHttp?.oauthProvider ?? '',
       oauthHeaderName:
         initial?.auth?.type === 'oauth' ? initial.auth.headerName : 'Authorization',
       oauthHeaderValueTemplate:
@@ -347,6 +389,20 @@ function HttpFields({
       cancelled = true;
     };
   }, [namespace]);
+
+  // Re-sync the provider <select> with the form value once providers load.
+  // The defaultValue path is initialized synchronously, but the matching
+  // <option> only renders after the async fetch — without this, presets
+  // and edit-mode bindings show an empty selection until the user touches
+  // the dropdown.
+  useEffect(() => {
+    if (providers.length === 0) return;
+    const target = form.getValues('oauthProvider');
+    if (target === undefined || target === '') return;
+    if (providers.some((p) => p.id === target)) {
+      form.setValue('oauthProvider', target, { shouldDirty: false });
+    }
+  }, [providers, form]);
 
   const selectedProvider = useMemo(
     () => providers.find((p) => p.id === oauthProviderId) ?? null,

--- a/packages/platform-ui/src/components/agents/agent-mcp-section.tsx
+++ b/packages/platform-ui/src/components/agents/agent-mcp-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as Dialog from '@radix-ui/react-dialog';
-import { AlertTriangle, Pencil, Plus, Server, Trash2, X } from 'lucide-react';
+import { AlertTriangle, GitBranch, Pencil, Plus, Server, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AgentMcpBinding, AgentMcpBindingMap, ToolCatalogEntry } from '@mediforce/platform-core';
 import {
@@ -20,7 +20,7 @@ interface AgentMcpSectionProps {
 
 type DialogState =
   | { kind: 'closed' }
-  | { kind: 'create' }
+  | { kind: 'create'; preset?: 'github-mcp' }
   | { kind: 'edit'; name: string; binding: AgentMcpBinding };
 
 export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
@@ -88,14 +88,24 @@ export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
           <Server className="h-4 w-4 text-muted-foreground" />
           <h2 className="text-sm font-semibold">MCP Servers</h2>
         </div>
-        <button
-          type="button"
-          onClick={() => setDialog({ kind: 'create' })}
-          className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
-        >
-          <Plus className="h-3 w-3" />
-          Add server
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setDialog({ kind: 'create', preset: 'github-mcp' })}
+            className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+          >
+            <GitBranch className="h-3 w-3" />
+            Add GitHub MCP
+          </button>
+          <button
+            type="button"
+            onClick={() => setDialog({ kind: 'create' })}
+            className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+          >
+            <Plus className="h-3 w-3" />
+            Add server
+          </button>
+        </div>
       </header>
 
       <p className="text-xs text-muted-foreground">
@@ -153,6 +163,8 @@ export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
                   <>
                     Edit binding <span className="font-mono">{dialog.name}</span>
                   </>
+                ) : dialog.kind === 'create' && dialog.preset === 'github-mcp' ? (
+                  'Add GitHub MCP server'
                 ) : (
                   'Add MCP server'
                 )}
@@ -166,12 +178,17 @@ export function AgentMcpSection({ agentId, handle }: AgentMcpSectionProps) {
             <div className="overflow-y-auto px-5 py-4">
               {dialog.kind !== 'closed' && (
                 <AgentMcpBindingForm
-                  key={dialog.kind === 'edit' ? `edit:${dialog.name}` : 'create'}
+                  key={
+                    dialog.kind === 'edit'
+                      ? `edit:${dialog.name}`
+                      : dialog.preset ?? 'create'
+                  }
                   existing={dialog.kind === 'edit' ? { name: dialog.name, binding: dialog.binding } : null}
                   existingNames={existingNames}
                   catalogEntries={catalog}
                   agentId={agentId}
                   namespace={handle}
+                  preset={dialog.kind === 'create' ? dialog.preset : undefined}
                   onSubmit={handleSubmit}
                   onCancel={() => setDialog({ kind: 'closed' })}
                 />


### PR DESCRIPTION
## Summary

Replaces #319, dropping the abandoned config-as-code seeding commit. What survives: the **UI preset** for agent MCP bindings + a side fix.

Adds an **\"Add GitHub MCP\"** button next to **\"Add server\"** on the agent MCP servers section. One click opens the binding dialog pre-filled with:
- server name: \`github\`
- transport: HTTP
- URL: \`https://api.githubcopilot.com/mcp/\`
- auth mode: OAuth (provider: \`github\`)

The provider id \`github\` lines up with the GitHub App provider configured via #318 (admin OAuth providers form). User just clicks Save, then **Connect** on the binding row to run the OAuth user-to-server install + authorize flow.

## Side fix

\`HttpFields\`: re-sync the OAuth provider \`<select>\` with the form value once providers load. Without it, the \`defaultValue\` path was effectively wiped on initial render because the matching \`<option>\` only renders after the async \`listOAuthProviders\` fetch — affected both the new preset and edit-mode bindings.

## Tests

- 3 unit tests (testing-library): preset pre-fill, OAuth submission payload, switch-to-PAT (static headers) submission payload
- E2E journey \`github-mcp-preset.journey.ts\`: clicks the preset button, asserts pre-fill, swaps OAuth provider to e2e-seeded \`github-mock\`, saves, cleans up

## Stacked on #318

Base = \`feat/oauth-provider-seeding\` (= #318). #318 reshapes the GitHub provider preset around the GitHub App user-to-server flow; this PR consumes the same provider id from the agent binding side. Merge #318 first.

## Closes

Replaces #319 (closed). Drops the unused \`config-as-code\` commit (\`705975e2\`) — that approach was abandoned in favour of manual admin UI configuration on staging.