### PR TITLE
test(e2e): de-flake agent-mcp-oauth journey

### DIFF
--- a/docs/E2E-STRATEGY.md
+++ b/docs/E2E-STRATEGY.md
@@ -20,6 +20,22 @@ Tests run with `fullyParallel: true`. This is safe because:
 
 When adding a new test that **changes state**, create a new dedicated entry in `seed-data.ts` with a unique ID. Document which test owns it with a comment. Never mutate an instance that read-only tests depend on.
 
+## Retry-Safe State Cleanup
+
+`auth-setup.ts` runs **once per CI invocation**, not once per test. Playwright retries (`retries: 2` on CI) re-run the failing test against the **same Firestore state** the previous attempt left behind. If a test creates or mutates state that survives in Firestore — and the assertion that catches the change comes after the mutation — every retry will see the post-mutation state and fail in a way that looks unrelated to the original cause.
+
+This is a fixture leak across retries. It surfaces as: first run fails for the real reason, retries time out on a setup precondition because the state is no longer pristine.
+
+**Rule:** any journey that writes to Firestore beyond what `auth-setup.ts` seeded must explicitly clean that state at the *start* of the test. Use the `deleteDocument` / `clearEmulators` helpers from `e2e/helpers/emulator.ts`. Do this even when the happy path of the test would clean up at the end — retries don't reach the end.
+
+Examples of state that needs explicit reset at test start:
+
+- OAuth tokens written by callback handlers (`agentOAuthTokens/*`)
+- Documents the test inserts via the UI (uploads, new agents, new bindings)
+- Anything else not present in `auth-setup.ts` seed
+
+Rule of thumb: if the test's first assertion would fail when run twice in a row against the same emulator, it has a fixture leak. Fix it with an explicit reset at the top, not by tightening selectors or bumping timeouts.
+
 ## Test Types
 
 | Type | Location | Purpose |

--- a/packages/platform-ui/e2e/helpers/emulator.ts
+++ b/packages/platform-ui/e2e/helpers/emulator.ts
@@ -137,6 +137,22 @@ export async function patchDocumentFields(
   }
 }
 
+/** Delete a single Firestore document by its full path
+ *  (e.g. `namespaces/test/agentOAuthTokens/oauth-test-agent__github-mcp`).
+ *  Returns true if the doc was deleted, false if it didn't exist. */
+export async function deleteDocument(docPath: string): Promise<boolean> {
+  const basePath = `${FIRESTORE_EMULATOR}/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
+  const res = await fetch(`${basePath}/${docPath}`, {
+    method: 'DELETE',
+    headers: EMULATOR_ADMIN_HEADERS,
+  });
+  if (res.status === 404) return false;
+  if (!res.ok) {
+    throw new Error(`Failed to delete ${docPath}: ${await res.text()}`);
+  }
+  return true;
+}
+
 export async function seedSubcollection(
   parentCollection: string,
   parentId: string,

--- a/packages/platform-ui/e2e/helpers/emulator.ts
+++ b/packages/platform-ui/e2e/helpers/emulator.ts
@@ -139,18 +139,21 @@ export async function patchDocumentFields(
 
 /** Delete a single Firestore document by its full path
  *  (e.g. `namespaces/test/agentOAuthTokens/oauth-test-agent__github-mcp`).
- *  Returns true if the doc was deleted, false if it didn't exist. */
-export async function deleteDocument(docPath: string): Promise<boolean> {
+ *  Each path segment is URL-encoded so segments containing `#`, `?`, spaces,
+ *  or other URL-special characters route correctly. Missing docs are a
+ *  no-op — callers can use this for idempotent cleanup. */
+export async function deleteDocument(docPath: string): Promise<void> {
   const basePath = `${FIRESTORE_EMULATOR}/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
-  const res = await fetch(`${basePath}/${docPath}`, {
+  const encodedPath = docPath.split('/').map(encodeURIComponent).join('/');
+  const res = await fetch(`${basePath}/${encodedPath}`, {
     method: 'DELETE',
     headers: EMULATOR_ADMIN_HEADERS,
+    signal: AbortSignal.timeout(5000),
   });
-  if (res.status === 404) return false;
+  if (res.status === 404) return;
   if (!res.ok) {
     throw new Error(`Failed to delete ${docPath}: ${await res.text()}`);
   }
-  return true;
 }
 
 export async function seedSubcollection(

--- a/packages/platform-ui/e2e/journeys/agent-mcp-oauth.journey.ts
+++ b/packages/platform-ui/e2e/journeys/agent-mcp-oauth.journey.ts
@@ -1,6 +1,12 @@
 import { test, expect } from '../helpers/test-fixtures';
 import { TEST_ORG_HANDLE } from '../helpers/constants';
+import { deleteDocument } from '../helpers/emulator';
 import { setupRecording, click, showStep, showResult, endRecording } from '../helpers/recording';
+
+const OAUTH_AGENT_ID = 'oauth-test-agent';
+const OAUTH_SERVER_NAME = 'github-mcp';
+const OAUTH_TOKEN_DOC_PATH =
+  `namespaces/${TEST_ORG_HANDLE}/agentOAuthTokens/${OAUTH_AGENT_ID}__${OAUTH_SERVER_NAME}`;
 
 /**
  * Journey 4 — Agent MCP OAuth (Step 5)
@@ -34,25 +40,39 @@ test.describe('Agent MCP OAuth Journey', () => {
   test('connect, disconnect, reconnect, revoke via mock provider', async ({ page }, testInfo) => {
     await setupRecording(page, 'agent-mcp-oauth', testInfo);
 
+    // Playwright re-runs the full test on retry, but `auth-setup` runs once
+    // globally — so a token written by an earlier failed attempt would still
+    // be in Firestore here. That makes the binding row render "Connected as
+    // @mock-user" before any user action, with no Connect button to click.
+    // Delete any leftover token via the emulator REST API to make this
+    // journey idempotent across retries.
+    await deleteDocument(OAUTH_TOKEN_DOC_PATH);
+
     // ── Admin view: provider is listed ───────────────────────────────────
     await page.goto(`/${TEST_ORG_HANDLE}/admin/oauth-providers`);
     await expect(page.getByRole('heading', { name: /oauth providers/i })).toBeVisible({
       timeout: 30_000,
     });
     // The seeded `github-mock` provider should be in the list. It renders
-    // with doc id as code and display name beside it.
-    await expect(page.getByText('github-mock').first()).toBeVisible();
+    // with doc id as code and display name beside it. Cold compile + data
+    // fetch on first hit can exceed Playwright's 5s default — give it room.
+    await expect(page.getByText('github-mock').first()).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText(/github \(mock\)/i).first()).toBeVisible();
     await showStep(page);
 
     // ── Open the fixture agent with the pre-bound OAuth binding ──────────
-    await page.goto(`/${TEST_ORG_HANDLE}/agents/definitions/oauth-test-agent`);
+    await page.goto(`/${TEST_ORG_HANDLE}/agents/definitions/${OAUTH_AGENT_ID}`);
     await expect(page.getByText(/edit this ai agent/i)).toBeVisible({ timeout: 15_000 });
 
     const mcpHeading = page.getByRole('heading', { name: /mcp servers/i });
     await expect(mcpHeading).toBeVisible();
     // The seeded binding name is `github-mcp`.
-    await expect(page.getByText('github-mcp').first()).toBeVisible();
+    await expect(page.getByText(OAUTH_SERVER_NAME).first()).toBeVisible();
+    // Wait for OAuthConnectionStatus to finish its initial token-list fetch
+    // before clicking Connect — otherwise the click locator races against
+    // the "Checking connection…" placeholder. The "Not connected" label
+    // proves listAgentOAuthTokens resolved with no token (clean state).
+    await expect(page.getByText(/not connected/i).first()).toBeVisible({ timeout: 15_000 });
     await showStep(page);
 
     // ── Connect ───────────────────────────────────────────────────────────
@@ -62,14 +82,24 @@ test.describe('Agent MCP OAuth Journey', () => {
     // which 302s to the agent page with `?connected=github-mcp`.
     await click(page, page.getByRole('button', { name: /^connect$/i }).first());
     await page.waitForURL(/\?connected=github-mcp/, { timeout: 20_000 });
+    // After the hard navigation back, the OAuthConnectionStatus component
+    // re-mounts in `loading` state and refetches the token list. Wait for
+    // the loading placeholder to clear before asserting on the connected
+    // label, otherwise a slow refetch (cold route compile, contended
+    // emulator) eats the 10s window.
+    await expect(page.getByText(/checking connection/i)).toHaveCount(0, { timeout: 15_000 });
     await expect(page.getByText(/connected as @mock-user|connected: @mock-user|@mock-user/i).first()).toBeVisible({
-      timeout: 10_000,
+      timeout: 15_000,
     });
     await showStep(page);
 
     // ── Disconnect (local only) ──────────────────────────────────────────
     await click(page, page.getByRole('button', { name: /^disconnect$/i }).first());
-    // UI either re-renders immediately or after a server round-trip.
+    // UI either re-renders immediately or after a server round-trip. Wait
+    // for the loading placeholder triggered by `refresh()` to clear before
+    // asserting on the post-disconnect state.
+    await expect(page.getByText(/checking connection/i)).toHaveCount(0, { timeout: 15_000 });
+    await expect(page.getByText(/not connected/i).first()).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole('button', { name: /^connect$/i }).first()).toBeVisible({
       timeout: 10_000,
     });
@@ -79,7 +109,8 @@ test.describe('Agent MCP OAuth Journey', () => {
     // ── Reconnect ────────────────────────────────────────────────────────
     await click(page, page.getByRole('button', { name: /^connect$/i }).first());
     await page.waitForURL(/\?connected=github-mcp/, { timeout: 20_000 });
-    await expect(page.getByText(/@mock-user/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/checking connection/i)).toHaveCount(0, { timeout: 15_000 });
+    await expect(page.getByText(/@mock-user/i).first()).toBeVisible({ timeout: 15_000 });
     await showStep(page);
 
     // ── Revoke (local + provider) ────────────────────────────────────────
@@ -90,6 +121,7 @@ test.describe('Agent MCP OAuth Journey', () => {
     await expect(page.getByRole('dialog')).toBeVisible();
     await click(page, page.getByRole('button', { name: /^(revoke|confirm)$/i }).last());
 
+    await expect(page.getByText(/checking connection/i)).toHaveCount(0, { timeout: 15_000 });
     await expect(page.getByRole('button', { name: /^connect$/i }).first()).toBeVisible({
       timeout: 10_000,
     });


### PR DESCRIPTION
## Summary

Closes #340. Three independent root causes producing ~30% flake — none of them quieted by retry, all addressed at the test layer.

### Root causes

1. **Retry stale state.** Playwright re-runs the full test on retry, but `auth-setup` runs once globally. A token written by a failed initial attempt stays in Firestore, so on retry the binding row mounts as "Connected as @mock-user" with no Connect button. Every retry then hits `locator.click(/^connect$/i)` 30s timeout.
2. **Cold-compile race after OAuth callback redirect.** `waitForURL(/\?connected=github-mcp/)` matches as soon as the URL lands, but the React tree has just hard-navigated. `OAuthConnectionStatus` re-mounts in `loading` state ("Checking connection…") and only swaps to "Connected as @mock-user" once `listAgentOAuthTokens` resolves. On a cold first-hit compile of `/api/agents/[id]/oauth` the 10s assertion window expired before the fetch completed.
3. **Tight default timeout on admin oauth-providers list.** The heading had a 30s wait but `getByText('github-mock')` relied on Playwright's 5s default. A cold compile occasionally exceeded that — caused the line-44 failure observed in local repro run 6.

Confirmed via local repro: 7/10 fails reproducing every assertion in the issue + the line-44 cold-page case. Backend (mock OAuth) always succeeded — `/authorize` → `/token` → `/userinfo` always logged.

### Fixes

- New `deleteDocument` helper in `e2e/helpers/emulator.ts` (Firestore emulator REST `DELETE`). Journey starts by deleting any leftover `agentOAuthTokens/oauth-test-agent__github-mcp` doc so retries start from a clean state.
- After every state flip (initial Connect, Disconnect, Reconnect, Revoke), wait for `"Checking connection…"` to clear before asserting on the next UI state. This bounds each assertion on the actual fetch completion instead of racing it.
- Add an explicit `"Not connected"` wait before the first Connect click — proves the initial token-list fetch has resolved before the click, preventing the same cold-compile race on first entry.
- Bump the `github-mock` list assertion to 15s.

No retry-quieting: the fixes target the real races (stale Firestore state across retries, racing the loading placeholder), not just longer timeouts.

## E2E

- Updated: `e2e/journeys/agent-mcp-oauth.journey.ts`
- User flow verified: full Connect / Disconnect / Reconnect / Revoke cycle.
- Not covered: real OAuth providers (deliberate — uses the in-process mock server).

## Test plan

- [ ] `pnpm typecheck` ✓
- [ ] CI e2e-tests passes 5x consecutively
- [ ] No retries used by the failing test in the CI report