### PR TITLE
feat: per-step cost estimation for agent runs

### DIFF
--- a/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
@@ -184,6 +184,44 @@ describe('ClaudeCodeAgentPlugin', () => {
     });
   });
 
+  describe('parseAgentOutput', () => {
+    it('[DATA] extracts last result event from stream-json', () => {
+      const resultEvent = JSON.stringify({
+        type: 'result', subtype: 'success',
+        result: JSON.stringify({ output_file: '/output/result.json' }),
+        usage: { input_tokens: 5000, output_tokens: 1200 },
+      });
+      const stdout = [
+        JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'working...' }] } }),
+        resultEvent,
+      ].join('\n');
+
+      const result = plugin.parseAgentOutput(stdout);
+      const parsed = JSON.parse(result);
+      expect(parsed.type).toBe('result');
+      expect(parsed.usage).toEqual({ input_tokens: 5000, output_tokens: 1200 });
+    });
+
+    it('[DATA] preserves usage field for token extraction', () => {
+      const resultEvent = JSON.stringify({
+        type: 'result', subtype: 'success',
+        result: 'plain text response',
+        usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 30 },
+      });
+
+      const result = plugin.parseAgentOutput(resultEvent);
+      const parsed = JSON.parse(result);
+      expect(parsed.usage.input_tokens).toBe(100);
+      expect(parsed.usage.output_tokens).toBe(50);
+    });
+
+    it('[DATA] returns empty for non-result events only', () => {
+      const stdout = JSON.stringify({ type: 'assistant', message: { content: [] } });
+      const result = plugin.parseAgentOutput(stdout);
+      expect(result).toBe('');
+    });
+  });
+
   describe('run', () => {
     it('[DATA] emits status event before spawning CLI', async () => {
       const context = buildMockContext();

--- a/packages/agent-runtime/src/plugins/__tests__/opencode-agent-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/opencode-agent-plugin.test.ts
@@ -201,6 +201,28 @@ describe('OpenCodeAgentPlugin', () => {
       const result = plugin.parseAgentOutput('');
       expect(result).toBe('');
     });
+
+    it('[DATA] accumulates token usage from step_finish events', () => {
+      const agentResponse = JSON.stringify({ output_file: '/output/result.json', summary: 'Done' });
+      const stdout = [
+        JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1000, output: 500 }, cost: 0.01 } }),
+        JSON.stringify({ type: 'step_finish', part: { tokens: { input: 2000, output: 800 }, cost: 0.02 } }),
+        openCodeJsonOutput(agentResponse),
+      ].join('\n');
+
+      const result = plugin.parseAgentOutput(stdout);
+      const parsed = JSON.parse(result);
+      expect(parsed.usage).toEqual({ input_tokens: 3000, output_tokens: 1300 });
+    });
+
+    it('[DATA] omits usage when no step_finish events have tokens', () => {
+      const agentResponse = JSON.stringify({ output_file: '/output/result.json', summary: 'Done' });
+      const stdout = openCodeJsonOutput(agentResponse);
+
+      const result = plugin.parseAgentOutput(stdout);
+      const parsed = JSON.parse(result);
+      expect(parsed.usage).toBeUndefined();
+    });
   });
 
   describe('prepareOutputDir', () => {

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -894,12 +894,26 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         ? parsedResult.confidence_rationale
         : undefined;
 
-      const tokenUsage = parsedResult.tokenUsage !== null
+      let tokenUsage: { inputTokens: number; outputTokens: number } | undefined;
+
+      // First: check if agent reported tokenUsage in its result
+      if (parsedResult.tokenUsage !== null
         && typeof parsedResult.tokenUsage === 'object'
         && typeof (parsedResult.tokenUsage as Record<string, unknown>).inputTokens === 'number'
-        && typeof (parsedResult.tokenUsage as Record<string, unknown>).outputTokens === 'number'
-        ? parsedResult.tokenUsage as { inputTokens: number; outputTokens: number }
-        : undefined;
+        && typeof (parsedResult.tokenUsage as Record<string, unknown>).outputTokens === 'number') {
+        tokenUsage = parsedResult.tokenUsage as { inputTokens: number; outputTokens: number };
+      }
+
+      // Second: check stream event for CLI-reported usage (Claude Code stream-json)
+      if (!tokenUsage) {
+        try {
+          const rawEvent = JSON.parse(spawnResult.cliOutput) as Record<string, unknown>;
+          const usage = rawEvent.usage as Record<string, number> | undefined;
+          if (usage && typeof usage.input_tokens === 'number' && typeof usage.output_tokens === 'number') {
+            tokenUsage = { inputTokens: usage.input_tokens, outputTokens: usage.output_tokens };
+          }
+        } catch { /* cliOutput not parseable as single JSON — skip */ }
+      }
 
       // Strip envelope-level fields from result to avoid duplication in UI
       const { confidence: _c, confidence_rationale: _cr, tokenUsage: _tu, ...cleanResult } = parsedResult;

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -904,7 +904,8 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         tokenUsage = parsedResult.tokenUsage as { inputTokens: number; outputTokens: number };
       }
 
-      // Second: check stream event for CLI-reported usage (Claude Code stream-json)
+      // Second: check stream event for CLI-reported usage (e.g. Claude Code stream-json result event)
+      // parseAgentOutput() returns a single JSON object for the final result event.
       if (!tokenUsage) {
         try {
           const rawEvent = JSON.parse(spawnResult.cliOutput) as Record<string, unknown>;
@@ -912,7 +913,11 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
           if (usage && typeof usage.input_tokens === 'number' && typeof usage.output_tokens === 'number') {
             tokenUsage = { inputTokens: usage.input_tokens, outputTokens: usage.output_tokens };
           }
-        } catch { /* cliOutput not parseable as single JSON — skip */ }
+        } catch {
+          agentLog('cost.tokenExtraction', 'could not extract token usage from CLI output', {
+            stepId, instanceId, cliOutputLength: spawnResult.cliOutput.length,
+          });
+        }
       }
 
       // Strip envelope-level fields from result to avoid duplication in UI

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -894,8 +894,15 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         ? parsedResult.confidence_rationale
         : undefined;
 
+      const tokenUsage = parsedResult.tokenUsage !== null
+        && typeof parsedResult.tokenUsage === 'object'
+        && typeof (parsedResult.tokenUsage as Record<string, unknown>).inputTokens === 'number'
+        && typeof (parsedResult.tokenUsage as Record<string, unknown>).outputTokens === 'number'
+        ? parsedResult.tokenUsage as { inputTokens: number; outputTokens: number }
+        : undefined;
+
       // Strip envelope-level fields from result to avoid duplication in UI
-      const { confidence: _c, confidence_rationale: _cr, ...cleanResult } = parsedResult;
+      const { confidence: _c, confidence_rationale: _cr, tokenUsage: _tu, ...cleanResult } = parsedResult;
 
       // Persist any deliverable file from the output dir before it gets cleaned up
       const deliverableFile = await this.persistDeliverableFile(
@@ -928,6 +935,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
           ...(spawnResult.gitMetadata ? { gitMetadata: spawnResult.gitMetadata } : {}),
           ...(spawnResult.presentation ? { presentation: spawnResult.presentation } : {}),
           ...(deliverableFile ? { deliverableFile } : {}),
+          ...(tokenUsage ? { tokenUsage } : {}),
         },
         timestamp: new Date().toISOString(),
       });

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -920,6 +920,12 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         }
       }
 
+      if (tokenUsage) {
+        agentLog('cost.tokensExtracted', 'token usage captured', {
+          stepId, instanceId, inputTokens: tokenUsage.inputTokens, outputTokens: tokenUsage.outputTokens,
+        });
+      }
+
       // Strip envelope-level fields from result to avoid duplication in UI
       const { confidence: _c, confidence_rationale: _cr, tokenUsage: _tu, ...cleanResult } = parsedResult;
 

--- a/packages/agent-runtime/src/plugins/opencode-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/opencode-agent-plugin.ts
@@ -225,6 +225,8 @@ export class OpenCodeAgentPlugin extends BaseContainerAgentPlugin {
     const lines = rawStdout.trim().split('\n');
     const textParts: string[] = [];
     const errors: string[] = [];
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
 
     for (const line of lines) {
       const trimmed = line.trim();
@@ -233,12 +235,17 @@ export class OpenCodeAgentPlugin extends BaseContainerAgentPlugin {
       try {
         const event = JSON.parse(trimmed) as {
           type?: string;
-          part?: { type?: string; text?: string };
+          part?: { type?: string; text?: string; cost?: number; tokens?: { input?: number; output?: number } };
           error?: { name?: string; data?: { message?: string } };
         };
 
         if (event.type === 'text' && typeof event.part?.text === 'string') {
           textParts.push(event.part.text);
+        }
+
+        if (event.type === 'step_finish' && event.part?.tokens) {
+          totalInputTokens += event.part.tokens.input ?? 0;
+          totalOutputTokens += event.part.tokens.output ?? 0;
         }
 
         if (event.type === 'error' && event.error?.data?.message) {
@@ -253,6 +260,10 @@ export class OpenCodeAgentPlugin extends BaseContainerAgentPlugin {
       return '';
     }
 
+    const usage = (totalInputTokens > 0 || totalOutputTokens > 0)
+      ? { input_tokens: totalInputTokens, output_tokens: totalOutputTokens }
+      : undefined;
+
     // Find the contract JSON in text parts (scan from last to first).
     // The contract is: {"output_file": "...", "summary": "..."}
     // The model may wrap it in narration text, so extract just the JSON object.
@@ -262,17 +273,17 @@ export class OpenCodeAgentPlugin extends BaseContainerAgentPlugin {
         // Extract the JSON object from the text (model may add preamble/postamble)
         const jsonMatch = part.match(/\{[^{}]*"output_file"[^{}]*\}/);
         const contractJson = jsonMatch ? jsonMatch[0] : part;
-        return JSON.stringify({ result: contractJson });
+        return JSON.stringify({ result: contractJson, ...(usage ? { usage } : {}) });
       }
     }
 
     // Fallback: use the last text part (most likely the final response)
     if (textParts.length > 0) {
-      return JSON.stringify({ result: textParts[textParts.length - 1] });
+      return JSON.stringify({ result: textParts[textParts.length - 1], ...(usage ? { usage } : {}) });
     }
 
     // Only errors
-    return JSON.stringify({ result: errors.map((e) => `[OpenCode error] ${e}`).join('\n') });
+    return JSON.stringify({ result: errors.map((e) => `[OpenCode error] ${e}`).join('\n'), ...(usage ? { usage } : {}) });
   }
 
   protected override async prepareOutputDir(outputDir: string): Promise<void> {

--- a/packages/cli/src/commands/run-get.ts
+++ b/packages/cli/src/commands/run-get.ts
@@ -104,6 +104,10 @@ export async function runGetCommand(input: CommandInput): Promise<number> {
         `  url:           ${config.baseUrl}/${result.definitionNamespace}/workflows/${encodeURIComponent(result.definitionName)}/runs/${result.runId}`,
       );
     }
+    if (result.totalCostUsd != null) {
+      const isTerminal = result.status === 'completed' || result.status === 'failed';
+      input.output.stdout(`  cost:          $${result.totalCostUsd.toFixed(4)}${isTerminal ? '' : '+'}`);
+    }
     if (result.finalOutput !== null && result.finalOutput !== undefined) {
       input.output.stdout(`  finalOutput:   ${JSON.stringify(result.finalOutput)}`);
     }

--- a/packages/cli/src/commands/run-list.ts
+++ b/packages/cli/src/commands/run-list.ts
@@ -119,8 +119,12 @@ export async function runListCommand(input: CommandInput): Promise<number> {
     for (const run of result.runs) {
       const icon = STATUS_ICONS[run.status] ?? '?';
       const age = formatAge(run.createdAt);
+      const isTerminal = run.status === 'completed' || run.status === 'failed';
+      const costLabel = run.totalCostUsd != null
+        ? `  $${run.totalCostUsd.toFixed(4)}${isTerminal ? '' : '+'}`
+        : '';
       input.output.stdout(
-        `${icon} ${run.status.padEnd(10)} ${run.runId}  ${run.definitionName} v${run.definitionVersion}  ${age}`,
+        `${icon} ${run.status.padEnd(10)} ${run.runId}  ${run.definitionName} v${run.definitionVersion}${costLabel}  ${age}`,
       );
       if (run.currentStepId !== null) {
         input.output.stdout(`  step: ${run.currentStepId}`);

--- a/packages/platform-api/src/contract/runs.ts
+++ b/packages/platform-api/src/contract/runs.ts
@@ -26,6 +26,7 @@ export const GetRunOutputSchema = z.object({
    *  Nullable when the definition has been deleted; optional for older
    *  servers that don't include the field. */
   definitionNamespace: z.string().min(1).nullable().optional(),
+  totalCostUsd: z.number().optional(),
 });
 
 export type GetRunInput = z.infer<typeof GetRunInputSchema>;
@@ -75,6 +76,7 @@ export const ListRunsOutputSchema = z.object({
       createdAt: z.string().datetime(),
       updatedAt: z.string().datetime(),
       createdBy: z.string().min(1),
+      totalCostUsd: z.number().optional(),
     }),
   ),
 });

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -29,6 +29,7 @@ export {
   AnnotationSchema,
   AgentOutputEnvelopeSchema,
   GitMetadataSchema,
+  TokenUsageSchema,
   AgentEventSchema,
   AgentRunStatusSchema,
   AgentRunSchema,
@@ -113,6 +114,7 @@ export type {
   Annotation,
   AgentOutputEnvelope,
   GitMetadata,
+  TokenUsage,
   AgentEvent,
   AgentRunStatus,
   AgentRun,
@@ -306,3 +308,4 @@ export type { HandoffTypeRegistration } from './collaboration/index.js';
 // Utils (zero-dep helpers shared across runtime + worker)
 export { createLineStreamReader } from './utils/line-stream.js';
 export type { LineStreamReader } from './utils/line-stream.js';
+export { calculateEstimatedCost } from './utils/cost.js';

--- a/packages/platform-core/src/schemas/agent-output-envelope.ts
+++ b/packages/platform-core/src/schemas/agent-output-envelope.ts
@@ -13,6 +13,11 @@ export const GitMetadataSchema = z.object({
   repoUrl: z.string(),
 });
 
+export const TokenUsageSchema = z.object({
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+});
+
 export const AgentOutputEnvelopeSchema = z.object({
   confidence: z.number().min(0).max(1),
   confidence_rationale: z.string().optional(),
@@ -25,8 +30,10 @@ export const AgentOutputEnvelopeSchema = z.object({
   gitMetadata: GitMetadataSchema.nullable().optional(), // container execution git output
   presentation: z.string().nullable().optional(), // optional HTML view for human reviewers
   deliverableFile: z.string().nullable().optional(), // persisted deliverable file path
+  tokenUsage: TokenUsageSchema.optional(),
 });
 
 export type Annotation = z.infer<typeof AnnotationSchema>;
 export type GitMetadata = z.infer<typeof GitMetadataSchema>;
+export type TokenUsage = z.infer<typeof TokenUsageSchema>;
 export type AgentOutputEnvelope = z.infer<typeof AgentOutputEnvelopeSchema>;

--- a/packages/platform-core/src/schemas/index.ts
+++ b/packages/platform-core/src/schemas/index.ts
@@ -72,8 +72,10 @@ export {
   AnnotationSchema,
   GitMetadataSchema,
   AgentOutputEnvelopeSchema,
+  TokenUsageSchema,
   type Annotation,
   type GitMetadata,
+  type TokenUsage,
   type AgentOutputEnvelope,
 } from './agent-output-envelope.js';
 

--- a/packages/platform-core/src/schemas/process-instance.ts
+++ b/packages/platform-core/src/schemas/process-instance.ts
@@ -52,6 +52,7 @@ export const ProcessInstanceSchema = z.object({
   previousRun: z.record(z.string(), z.unknown()).optional(),
   /** ID of the ProcessInstance whose outputs populated `previousRun`. */
   previousRunSourceId: z.string().optional(),
+  totalCostUsd: z.number().optional(),
 });
 
 export type InstanceStatus = z.infer<typeof InstanceStatusSchema>;

--- a/packages/platform-core/src/schemas/step-execution.ts
+++ b/packages/platform-core/src/schemas/step-execution.ts
@@ -36,8 +36,8 @@ export const AgentOutputSnapshotSchema = z.object({
     repoUrl: z.string(),
   }).nullable(),
   deliverableFile: z.string().nullable().optional(),
-  tokenUsage: TokenUsageSchema.nullable().optional(),
-  estimatedCostUsd: z.number().nullable().optional(),
+  tokenUsage: TokenUsageSchema.optional(),
+  estimatedCostUsd: z.number().optional(),
 });
 
 export const StepExecutionSchema = z.object({

--- a/packages/platform-core/src/schemas/step-execution.ts
+++ b/packages/platform-core/src/schemas/step-execution.ts
@@ -35,6 +35,11 @@ export const AgentOutputSnapshotSchema = z.object({
     repoUrl: z.string(),
   }).nullable(),
   deliverableFile: z.string().nullable().optional(),
+  tokenUsage: z.object({
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+  }).nullable().optional(),
+  estimatedCostUsd: z.number().nullable().optional(),
 });
 
 export const StepExecutionSchema = z.object({

--- a/packages/platform-core/src/schemas/step-execution.ts
+++ b/packages/platform-core/src/schemas/step-execution.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { TokenUsageSchema } from './agent-output-envelope.js';
 
 export const StepExecutionStatusSchema = z.enum([
   'pending',
@@ -35,10 +36,7 @@ export const AgentOutputSnapshotSchema = z.object({
     repoUrl: z.string(),
   }).nullable(),
   deliverableFile: z.string().nullable().optional(),
-  tokenUsage: z.object({
-    inputTokens: z.number(),
-    outputTokens: z.number(),
-  }).nullable().optional(),
+  tokenUsage: TokenUsageSchema.nullable().optional(),
   estimatedCostUsd: z.number().nullable().optional(),
 });
 

--- a/packages/platform-core/src/types/index.ts
+++ b/packages/platform-core/src/types/index.ts
@@ -42,6 +42,7 @@ export type {
 export type {
   Annotation,
   GitMetadata,
+  TokenUsage,
   AgentOutputEnvelope,
 } from '../schemas/agent-output-envelope.js';
 

--- a/packages/platform-core/src/utils/__tests__/cost.test.ts
+++ b/packages/platform-core/src/utils/__tests__/cost.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { calculateEstimatedCost } from '../cost.js';
+
+describe('calculateEstimatedCost', () => {
+  it('multiplies tokens by per-token pricing', () => {
+    const result = calculateEstimatedCost(
+      { inputTokens: 1000, outputTokens: 500 },
+      { input: 0.000003, output: 0.000015 },
+    );
+    // 1000 * 0.000003 + 500 * 0.000015 = 0.003 + 0.0075 = 0.0105
+    expect(result).toBeCloseTo(0.0105);
+  });
+
+  it('returns 0 when tokens are 0', () => {
+    const result = calculateEstimatedCost(
+      { inputTokens: 0, outputTokens: 0 },
+      { input: 0.000003, output: 0.000015 },
+    );
+    expect(result).toBe(0);
+  });
+
+  it('handles large token counts', () => {
+    const result = calculateEstimatedCost(
+      { inputTokens: 100_000, outputTokens: 50_000 },
+      { input: 0.000003, output: 0.000015 },
+    );
+    // 100000 * 0.000003 + 50000 * 0.000015 = 0.3 + 0.75 = 1.05
+    expect(result).toBeCloseTo(1.05);
+  });
+});

--- a/packages/platform-core/src/utils/cost.ts
+++ b/packages/platform-core/src/utils/cost.ts
@@ -1,0 +1,6 @@
+export function calculateEstimatedCost(
+  tokenUsage: { inputTokens: number; outputTokens: number },
+  pricing: { input: number; output: number },
+): number {
+  return tokenUsage.inputTokens * pricing.input + tokenUsage.outputTokens * pricing.output;
+}

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
@@ -307,7 +307,7 @@ function AgentMetadataSection({ agentOutput }: { agentOutput: NonNullable<StepEx
             <span>{formatDuration(agentOutput.duration_ms)}</span>
           </div>
         )}
-        {agentOutput.estimatedCostUsd !== null && agentOutput.estimatedCostUsd !== undefined && (
+        {agentOutput.estimatedCostUsd != null && (
           <div className="flex items-center gap-1.5">
             <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
             <span className="text-muted-foreground">Cost:</span>

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
@@ -4,12 +4,12 @@ import { useParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { ArrowLeft, CheckCircle2, Clock, XCircle, Circle, Pause, Bot, User, ExternalLink, FileText, GitBranch, Gauge, ChevronDown, ChevronRight, MessageSquare } from 'lucide-react';
+import { ArrowLeft, CheckCircle2, Clock, XCircle, Circle, Pause, Bot, User, ExternalLink, FileText, GitBranch, Gauge, ChevronDown, ChevronRight, MessageSquare, DollarSign } from 'lucide-react';
 import type { StepExecution, Step, AgentEvent } from '@mediforce/platform-core';
 import { useProcessInstance, useSubcollection } from '@/hooks/use-process-instances';
 import { useProcessDefinitionVersions } from '@/hooks/use-process-definitions';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
-import { formatDuration, formatStepName } from '@/lib/format';
+import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
 
 function StatusIcon({ status }: { status: string }) {
   switch (status) {
@@ -305,6 +305,20 @@ function AgentMetadataSection({ agentOutput }: { agentOutput: NonNullable<StepEx
           <div className="flex items-center gap-1.5">
             <Clock className="h-3.5 w-3.5 text-muted-foreground" />
             <span>{formatDuration(agentOutput.duration_ms)}</span>
+          </div>
+        )}
+        {agentOutput.estimatedCostUsd !== null && agentOutput.estimatedCostUsd !== undefined && (
+          <div className="flex items-center gap-1.5">
+            <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-muted-foreground">Cost:</span>
+            <span className="font-medium">{formatCostUsd(agentOutput.estimatedCostUsd)}</span>
+          </div>
+        )}
+        {agentOutput.tokenUsage && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span>{agentOutput.tokenUsage.inputTokens.toLocaleString()} in</span>
+            <span>/</span>
+            <span>{agentOutput.tokenUsage.outputTokens.toLocaleString()} out</span>
           </div>
         )}
       </div>

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
@@ -61,6 +61,10 @@ vi.mock('@/app/actions/workflow-secrets', () => ({
   getWorkflowSecretsForRuntime: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('@/app/actions/namespace-secrets', () => ({
+  getNamespaceSecretsForRuntime: vi.fn().mockResolvedValue({}),
+}));
+
 import { POST } from '../route';
 
 // ---- Helpers ----

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -5,6 +5,7 @@ import { executeAgentStep } from '@/lib/execute-agent-step';
 import { flattenResolvedMcpToLegacy, resolveMcpForStep, validateWorkflowEnv } from '@mediforce/agent-runtime';
 import { validateActionSecrets } from '@mediforce/core-actions';
 import { getWorkflowSecretsForRuntime } from '@/app/actions/workflow-secrets';
+import { getNamespaceSecretsForRuntime } from '@/app/actions/namespace-secrets';
 import { isStuckLoop, createLoopTracker, MAX_SAME_STEP_ITERATIONS } from '@/lib/loop-guard';
 
 interface RunProcessBody {
@@ -69,10 +70,11 @@ export async function POST(
     // Pre-flight: validate all env templates are resolvable before executing anything.
     // The decrypted bag is also reused below as the `secrets` source for action
     // interpolation (`${secrets.NAME}` in http urls/headers/body).
-    const workflowSecrets = await getWorkflowSecretsForRuntime(
-      workflowDefinition.namespace,
-      workflowDefinition.name,
-    );
+    const [namespaceSecrets, perWorkflowSecrets] = await Promise.all([
+      getNamespaceSecretsForRuntime(workflowDefinition.namespace),
+      getWorkflowSecretsForRuntime(workflowDefinition.namespace, workflowDefinition.name),
+    ]);
+    const workflowSecrets = { ...namespaceSecrets, ...perWorkflowSecrets };
     {
       const missingEnv = validateWorkflowEnv(workflowDefinition, workflowSecrets);
       const missingActionSecrets = validateActionSecrets(

--- a/packages/platform-ui/src/app/api/runs/[runId]/route.ts
+++ b/packages/platform-ui/src/app/api/runs/[runId]/route.ts
@@ -74,5 +74,6 @@ export async function GET(
     finalOutput,
     definitionName: instance.definitionName,
     definitionNamespace,
+    ...(instance.totalCostUsd != null ? { totalCostUsd: instance.totalCostUsd } : {}),
   });
 }

--- a/packages/platform-ui/src/app/api/runs/route.ts
+++ b/packages/platform-ui/src/app/api/runs/route.ts
@@ -44,6 +44,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       createdAt: inst.createdAt,
       updatedAt: inst.updatedAt,
       createdBy: inst.createdBy,
+      ...(inst.totalCostUsd != null ? { totalCostUsd: inst.totalCostUsd } : {}),
     }));
 
     return NextResponse.json({ runs });

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -21,7 +21,7 @@ import { formatStepName } from '@/components/tasks/task-utils';
 import { MissingEnvBanner } from './missing-env-banner';
 import { AgentEscalatedBanner } from './agent-escalated-banner';
 import { PreviousRunBanner } from './previous-run-banner';
-import { formatDuration } from '@/lib/format';
+import { formatDuration, formatCostUsd } from '@/lib/format';
 import { getWorkflowStatus } from '@/lib/workflow-status';
 
 type AuditEventWithId = AuditEvent & { id: string };
@@ -162,6 +162,21 @@ export function ProcessDetail({
     return end - start;
   }, [instance.createdAt, instance.updatedAt]);
 
+  const totalCostUsd = React.useMemo(() => {
+    if (!stepExecutions || stepExecutions.length === 0) return null;
+    let total = 0;
+    let hasCost = false;
+    for (const exec of stepExecutions) {
+      if (exec.agentOutput?.estimatedCostUsd != null) {
+        total += exec.agentOutput.estimatedCostUsd;
+        hasCost = true;
+      }
+    }
+    return hasCost ? total : null;
+  }, [stepExecutions]);
+
+  const isTerminal = instance.status === 'completed' || instance.status === 'failed';
+
   // Scroll audit log to bottom when events change
   const auditScrollRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
@@ -246,6 +261,9 @@ export function ProcessDetail({
             <span>Created: <span className="text-foreground">{format(new Date(instance.createdAt), 'MMM d, yyyy HH:mm')}</span></span>
             {wfStatus.displayStatus !== 'in_progress' && (
               <span>Duration: <span className="text-foreground">{formatDuration(runDurationMs)}</span></span>
+            )}
+            {totalCostUsd != null && (
+              <span>Cost: <span className={isTerminal ? 'text-foreground' : 'text-amber-600 dark:text-amber-400'}>{formatCostUsd(totalCostUsd)}{isTerminal ? '' : '+'}</span></span>
             )}
             {instance.status === 'completed' && (
               <Link

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -162,6 +162,9 @@ export function ProcessDetail({
     return end - start;
   }, [instance.createdAt, instance.updatedAt]);
 
+  // Computed from step executions (source of truth on detail page).
+  // List views use the denormalized instance.totalCostUsd instead —
+  // the two can briefly diverge after retries until the next step completes.
   const totalCostUsd = React.useMemo(() => {
     if (!stepExecutions || stepExecutions.length === 0) return null;
     let total = 0;

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -8,6 +8,7 @@ import type { ProcessInstance } from '@mediforce/platform-core';
 import { StatusDot } from '@/components/ui/status-dot';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
 import { routes } from '@/lib/routes';
+import { formatCostUsd } from '@/lib/format';
 
 function toHumanLabel(identifier: string): string {
   return identifier
@@ -220,6 +221,11 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
             </span>
           )}
         </>
+      )}
+      {instance.totalCostUsd != null && (
+        <span className="text-[11px] text-muted-foreground tabular-nums shrink-0 text-right">
+          {formatCostUsd(instance.totalCostUsd)}
+        </span>
       )}
       <span className="text-[11px] text-muted-foreground tabular-nums shrink-0 w-[48px] text-right" title={fullTimeAgo}>
         {timeAgo}

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -224,7 +224,7 @@ export function ProcessInstanceRow({ instance, showProcess = false, steps, stepS
       )}
       {instance.totalCostUsd != null && (
         <span className="text-[11px] text-muted-foreground tabular-nums shrink-0 text-right">
-          {formatCostUsd(instance.totalCostUsd)}
+          {formatCostUsd(instance.totalCostUsd)}{instance.status !== 'completed' && instance.status !== 'failed' ? '+' : ''}
         </span>
       )}
       <span className="text-[11px] text-muted-foreground tabular-nums shrink-0 w-[48px] text-right" title={fullTimeAgo}>

--- a/packages/platform-ui/src/components/processes/run-results-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-results-panel.tsx
@@ -91,7 +91,7 @@ export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
               <span>{formatDuration(output.duration_ms)}</span>
             </div>
           )}
-          {output.estimatedCostUsd !== null && output.estimatedCostUsd !== undefined && (
+          {output.estimatedCostUsd != null && (
             <div className="flex items-center gap-1.5">
               <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
               <span className="text-muted-foreground">Cost:</span>

--- a/packages/platform-ui/src/components/processes/run-results-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-results-panel.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import * as React from 'react';
-import { CheckCircle2, ExternalLink, Gauge, GitBranch, Clock, FileText } from 'lucide-react';
+import { CheckCircle2, ExternalLink, Gauge, GitBranch, Clock, FileText, DollarSign } from 'lucide-react';
 import type { StepExecution, AgentOutputSnapshot } from '@mediforce/platform-core';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
-import { formatDuration, formatStepName } from '@/lib/format';
+import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
 
 interface RunResultsPanelProps {
   stepExecutions: StepExecution[];
@@ -89,6 +89,13 @@ export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
               <Clock className="h-3.5 w-3.5 text-muted-foreground" />
               <span className="text-muted-foreground">Duration:</span>
               <span>{formatDuration(output.duration_ms)}</span>
+            </div>
+          )}
+          {output.estimatedCostUsd !== null && output.estimatedCostUsd !== undefined && (
+            <div className="flex items-center gap-1.5">
+              <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-muted-foreground">Cost:</span>
+              <span className="font-medium">{formatCostUsd(output.estimatedCostUsd)}</span>
             </div>
           )}
         </div>

--- a/packages/platform-ui/src/components/processes/runs-table.tsx
+++ b/packages/platform-ui/src/components/processes/runs-table.tsx
@@ -295,7 +295,7 @@ export function RunsTable({
                   ) : <span className="text-muted-foreground">—</span>}
                 </td>
                 <td className="px-4 py-3 text-xs text-muted-foreground tabular-nums">
-                  {run.totalCostUsd != null ? formatCostUsd(run.totalCostUsd) : '—'}
+                  {run.totalCostUsd != null ? `${formatCostUsd(run.totalCostUsd)}${run.status !== 'completed' && run.status !== 'failed' ? '+' : ''}` : '—'}
                 </td>
                 <td className="px-4 py-3 text-xs text-muted-foreground">
                   {formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}

--- a/packages/platform-ui/src/components/processes/runs-table.tsx
+++ b/packages/platform-ui/src/components/processes/runs-table.tsx
@@ -12,6 +12,7 @@ import { routes } from '@/lib/routes';
 import { archiveProcessRun, bulkCancelProcessRuns, bulkArchiveProcessRuns } from '@/app/actions/processes';
 import type { BulkOperationResult } from '@/app/actions/processes';
 import { getWorkflowStatus } from '@/lib/workflow-status';
+import { formatCostUsd } from '@/lib/format';
 import { useToast } from '@/components/command-palette/toast-provider';
 
 interface RunsTableProps {
@@ -144,6 +145,7 @@ export function RunsTable({
     'Status',
     'Started by',
     'Current Step',
+    'Cost',
     'Started',
     '', // per-row archive
     '', // view link
@@ -291,6 +293,9 @@ export function RunsTable({
                       </span>
                     )
                   ) : <span className="text-muted-foreground">—</span>}
+                </td>
+                <td className="px-4 py-3 text-xs text-muted-foreground tabular-nums">
+                  {run.totalCostUsd != null ? formatCostUsd(run.totalCostUsd) : '—'}
                 </td>
                 <td className="px-4 py-3 text-xs text-muted-foreground">
                   {formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -9,7 +9,7 @@ import { AutonomyBadge } from '../agents/autonomy-badge';
 import { RetryStepButton } from './retry-step-button';
 import { cn } from '@/lib/utils';
 import { getWorkflowStatus } from '@/lib/workflow-status';
-import { formatDuration } from '@/lib/format';
+import { formatDuration, formatCostUsd } from '@/lib/format';
 import { useUserDisplayNames } from '@/hooks/use-users';
 
 const SYSTEM_ACTOR_IDS = new Set(['auto-runner', 'api-user', 'system']);
@@ -479,6 +479,14 @@ export function StepStatusPanel({
                         <span className="text-xs text-muted-foreground">
                           {formatDuration(new Date(latestExec.completedAt).getTime() - new Date(latestExec.startedAt).getTime())}
                         </span>
+                        {latestExec.agentOutput?.estimatedCostUsd != null && (
+                          <>
+                            <span className="text-muted-foreground/40">·</span>
+                            <span className="text-xs text-muted-foreground">
+                              {formatCostUsd(latestExec.agentOutput.estimatedCostUsd)}
+                            </span>
+                          </>
+                        )}
                       </>
                     )}
                     <span className="text-muted-foreground/40">·</span>

--- a/packages/platform-ui/src/lib/__tests__/format-cost.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/format-cost.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { formatCostUsd } from '../format';
+
+describe('formatCostUsd', () => {
+  it('shows $0.00 for zero', () => {
+    expect(formatCostUsd(0)).toBe('$0.00');
+  });
+
+  it('shows 4 decimals for tiny costs (< $0.01)', () => {
+    expect(formatCostUsd(0.0034)).toBe('$0.0034');
+    expect(formatCostUsd(0.0001)).toBe('$0.0001');
+  });
+
+  it('shows 3 decimals for sub-dollar costs', () => {
+    expect(formatCostUsd(0.105)).toBe('$0.105');
+    expect(formatCostUsd(0.5)).toBe('$0.500');
+  });
+
+  it('shows 2 decimals for dollar+ costs', () => {
+    expect(formatCostUsd(1.05)).toBe('$1.05');
+    expect(formatCostUsd(12.5)).toBe('$12.50');
+  });
+});

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -13,12 +13,13 @@ import {
   type ResolvedOAuthBinding,
   type WorkflowAgentContext,
 } from '@mediforce/agent-runtime';
-import type {
-  AgentOAuthTokenRepository,
-  OAuthProviderRepository,
-  ResolvedMcpConfig,
-  WorkflowDefinition,
-  WorkflowStep,
+import {
+  calculateEstimatedCost,
+  type AgentOAuthTokenRepository,
+  type OAuthProviderRepository,
+  type ResolvedMcpConfig,
+  type WorkflowDefinition,
+  type WorkflowStep,
 } from '@mediforce/platform-core';
 import { getWorkflowSecretsForRuntime } from '../app/actions/workflow-secrets';
 import { getNamespaceSecretsForRuntime } from '../app/actions/namespace-secrets';
@@ -58,6 +59,7 @@ export async function executeAgentStep(
     toolCatalogRepo,
     oauthProviderRepo,
     agentOAuthTokenRepo,
+    modelRegistryRepo,
   } = getPlatformServices();
 
   const instance = await instanceRepo.getById(instanceId);
@@ -205,6 +207,8 @@ export async function executeAgentStep(
             duration_ms: envelope.duration_ms ?? null,
             gitMetadata: envelope.gitMetadata ?? null,
             deliverableFile: (envelope.deliverableFile as string | undefined) ?? null,
+            tokenUsage: envelope.tokenUsage ?? null,
+            estimatedCostUsd: await estimateCost(envelope, modelRegistryRepo),
           }
         : null,
     });
@@ -539,4 +543,14 @@ async function loadOAuthTokens(
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+async function estimateCost(
+  envelope: { model: string | null; tokenUsage?: { inputTokens: number; outputTokens: number } },
+  modelRegistryRepo: { getById(id: string): Promise<{ pricing: { input: number; output: number } } | null> },
+): Promise<number | null> {
+  if (!envelope.tokenUsage || !envelope.model) return null;
+  const entry = await modelRegistryRepo.getById(envelope.model);
+  if (!entry) return null;
+  return calculateEstimatedCost(envelope.tokenUsage, entry.pricing);
 }

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -188,6 +188,7 @@ export async function executeAgentStep(
 
   // Persist agent output to step execution
   const envelope = runResult.envelope;
+  const costResult = envelope ? await estimateCostField(envelope, modelRegistryRepo) : {};
   if (stepExecutionId) {
     const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
     // L3 + escalated (non-error) routes to human review below, so the execution
@@ -208,7 +209,7 @@ export async function executeAgentStep(
             gitMetadata: envelope.gitMetadata ?? null,
             deliverableFile: (envelope.deliverableFile as string | undefined) ?? null,
             ...(envelope.tokenUsage ? { tokenUsage: envelope.tokenUsage } : {}),
-            ...(await estimateCostField(envelope, modelRegistryRepo)),
+            ...costResult,
           }
         : null,
     });
@@ -229,16 +230,23 @@ export async function executeAgentStep(
     }
   }
 
-  // Persist output to instance.variables so subsequent steps can read it
+  // Persist output to instance.variables so subsequent steps can read it.
+  // Also accumulate totalCostUsd on the instance for list views.
   const agentOutput = envelope?.result ?? null;
-  if (agentOutput !== null) {
+  const stepCost = costResult.estimatedCostUsd;
+  if (agentOutput !== null || stepCost !== undefined) {
     const freshInstance = await instanceRepo.getById(instanceId);
     if (freshInstance) {
       await instanceRepo.update(instanceId, {
-        variables: {
-          ...freshInstance.variables,
-          [stepId]: agentOutput,
-        },
+        ...(agentOutput !== null ? {
+          variables: {
+            ...freshInstance.variables,
+            [stepId]: agentOutput,
+          },
+        } : {}),
+        ...(stepCost !== undefined ? {
+          totalCostUsd: (freshInstance.totalCostUsd ?? 0) + stepCost,
+        } : {}),
       });
     }
   }

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -232,6 +232,9 @@ export async function executeAgentStep(
 
   // Persist output to instance.variables so subsequent steps can read it.
   // Also accumulate totalCostUsd on the instance for list views.
+  // Note: read-then-increment is not atomic, but steps execute sequentially
+  // per instance (auto-runner loop is serial). If parallel branches are
+  // added, switch to Firestore FieldValue.increment().
   const agentOutput = envelope?.result ?? null;
   const stepCost = costResult.estimatedCostUsd;
   if (agentOutput !== null || stepCost !== undefined) {

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -207,8 +207,8 @@ export async function executeAgentStep(
             duration_ms: envelope.duration_ms ?? null,
             gitMetadata: envelope.gitMetadata ?? null,
             deliverableFile: (envelope.deliverableFile as string | undefined) ?? null,
-            tokenUsage: envelope.tokenUsage ?? null,
-            estimatedCostUsd: await estimateCost(envelope, modelRegistryRepo),
+            ...(envelope.tokenUsage ? { tokenUsage: envelope.tokenUsage } : {}),
+            ...(await estimateCostField(envelope, modelRegistryRepo)),
           }
         : null,
     });
@@ -545,12 +545,15 @@ async function loadOAuthTokens(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-async function estimateCost(
+async function estimateCostField(
   envelope: { model: string | null; tokenUsage?: { inputTokens: number; outputTokens: number } },
   modelRegistryRepo: { getById(id: string): Promise<{ pricing: { input: number; output: number } } | null> },
-): Promise<number | null> {
-  if (!envelope.tokenUsage || !envelope.model) return null;
+): Promise<{ estimatedCostUsd: number } | Record<string, never>> {
+  if (!envelope.tokenUsage || !envelope.model) return {};
   const entry = await modelRegistryRepo.getById(envelope.model);
-  if (!entry) return null;
-  return calculateEstimatedCost(envelope.tokenUsage, entry.pricing);
+  if (!entry) {
+    console.warn(`[cost] model "${envelope.model}" not found in registry — cost unavailable`);
+    return {};
+  }
+  return { estimatedCostUsd: calculateEstimatedCost(envelope.tokenUsage, entry.pricing) };
 }

--- a/packages/platform-ui/src/lib/format.ts
+++ b/packages/platform-ui/src/lib/format.ts
@@ -9,6 +9,12 @@ export function formatDuration(ms: number): string {
   return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
 }
 
+export function formatCostUsd(cost: number): string {
+  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  if (cost < 1) return `$${cost.toFixed(3)}`;
+  return `$${cost.toFixed(2)}`;
+}
+
 export function formatStepName(stepId: string): string {
   return stepId
     .replace(/[-_]/g, ' ')

--- a/packages/platform-ui/src/lib/format.ts
+++ b/packages/platform-ui/src/lib/format.ts
@@ -10,6 +10,7 @@ export function formatDuration(ms: number): string {
 }
 
 export function formatCostUsd(cost: number): string {
+  if (cost === 0) return '$0.00';
   if (cost < 0.01) return `$${cost.toFixed(4)}`;
   if (cost < 1) return `$${cost.toFixed(3)}`;
   return `$${cost.toFixed(2)}`;


### PR DESCRIPTION
## Summary

- Add `tokenUsage` (inputTokens/outputTokens) to `AgentOutputEnvelope` and `AgentOutputSnapshot` schemas
- Extract token usage from **Claude Code CLI** (`usage` field in stream-json result event) and **OpenCode CLI** (`step_finish` events with accumulated tokens)
- Calculate `estimatedCostUsd` using ModelRegistry per-token pricing at execution time
- Denormalize `totalCostUsd` on `ProcessInstance` for zero-cost list queries
- Display cost across all views: step detail, run header, step list, namespace cards, runs table
- In-progress runs show `$X.XX+` (amber); terminal runs show `$X.XX`
- Fix: auto-runner secret validation now merges namespace-level secrets (was only checking workflow-level)

## Data flow

```
CLI output (tokens) → plugin extracts → envelope.tokenUsage
  → execute-agent-step calculates cost via ModelRegistry
  → snapshot.estimatedCostUsd + instance.totalCostUsd → UI displays
```

## Cost display locations

| View | What shows |
|------|-----------|
| Step detail page | Cost badge + token counts (in/out) |
| Run header | Total cost with +/final indicator |
| Step list (run page) | Per-step cost after duration |
| Namespace cards | Cost per run row |
| Workflow runs table | Cost column |

## What's NOT in this PR

- Cowork session per-turn cost tracking — separate phase
- Run-level cost backfill for pre-deployment runs — lazy backfill planned
- ScriptContainer cost — N/A, no LLM involved

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 2121/2121 pass
- [x] Unit tests for `calculateEstimatedCost` and `formatCostUsd`
- [x] Manual: triggered community-digest run (OpenCode + DeepSeek), cost visible in all views
- [x] Legacy runs without cost show dash gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)