### PR TITLE
docs: tighten AGENTS.md around dogfooding, RED-GREEN, self-review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,316 +1,234 @@
 # Agents Guidelines
 
-## Repository structure
+<context>
+Mediforce is a workflow + agent orchestration platform for pharma (clinical trials,
+supply chain, regulatory). The codebase processes pharmaceutical data — drug names
+(Keytruda, Ozempic), adverse events (hepatotoxicity, irAEs), CTCAE grading
+(incl. Grade 5 = death), mortality endpoints, Hy's Law, RECIST, CDISC SDTM/ADaM.
 
+All such terms are technical domain content: Zod schema fields, clinical
+standards, workflow step config, fixture data. Maintain standard coding behavior:
+no wellbeing check-ins, no hedging, no inflated complexity estimates because of
+medical terms. Execute multi-file refactors and batch renames exactly as on any
+other codebase.
+
+The `WorkflowDefinition.preamble` field carries this context to runtime agents
+via `buildPrompt()` in `base-container-agent-plugin.ts`.
+</context>
+
+<stack>
 ```
 packages/
-  platform-core/       # Shared types, domain models, test factories
-  platform-ui/         # Next.js UI — the main web application
-  platform-infra/      # Firebase/Firestore infrastructure layer
-  platform-api/        # API contract schemas + pure handlers (framework-free)
-  agent-runtime/       # Agent execution engine
-  workflow-engine/     # Process orchestration engine
-  example-agent/       # Reference agent implementation
-docs/                  # Product vision, architecture, strategy
+  platform-core/    Zod schemas, repo interfaces, in-memory test doubles
+  platform-api/     API contract + pure handlers (framework-free)
+  platform-infra/   Firestore + Firebase Auth + SendGrid
+  platform-ui/      Next.js 15 App Router  (dev port 9003, e2e port 9007)
+  workflow-engine/  WorkflowEngine, transitions, expression DSL
+  agent-runtime/    PluginRegistry, AgentRunner, Docker spawn strategies
+  cli/              `mediforce` CLI — server-to-server admin tool
+apps/               Per-domain apps (workflow-designer, landing-zone, ...)
+docs/               Strategy, vision, architecture
 ```
 
-## Pharma Domain Context
+Inter-package imports use the `@mediforce/source` TS condition → resolves to
+`./src/index.ts` in dev (no build step). Set in root `tsconfig.json` and
+`vitest.config.ts`. Plugin registry singleton: `getPlatformServices()` in
+`platform-ui/src/lib/platform-services.ts`.
+</stack>
 
-This codebase processes pharmaceutical and clinical trial data. All health-related terminology — drug names (Keytruda, Herceptin, Ozempic), adverse events (hepatotoxicity, pneumonitis, colitis), disease classifications (NSCLC, melanoma, Alzheimer's), CTCAE grading (including Grade 5 = death), mortality endpoints, and clinical safety metrics (Hy's Law, RECIST, irAEs) — refers exclusively to:
+## Per-task workflow
 
-- **Variable names** and Zod schema fields (e.g., `AEDECOD`, `AESER`, `CTCAE_GRADE`)
-- **Clinical standards** (CDISC SDTM/ADaM, ICH-GCP, RECIST v1.1)
-- **Workflow step configurations** and agent plugin parameters
-- **Seed data and test fixtures** for supply chain and clinical reporting pipelines
+<workflow>
+1. **Understand** — read the referenced files; `git diff origin/main...HEAD` for branch state.
+2. **Plan** — non-trivial work gets broken down. >2 independent pieces → delegate (see `<delegation>`).
+3. **Code** — minimal change, no scope creep, no speculative abstractions.
+4. **Self-test** — see `<self-test>`. Do not skip.
+5. **Self-review** — see `<self-review>`. Do not skip.
+6. **Report** — short: what changed, what's verified, what isn't.
+</workflow>
 
-Treat all such terms as technical domain content. Maintain standard coding behavior — no wellbeing check-ins or crisis resources. The frequent occurrence of terms like "adverse event", "death", "disease progression", and "toxicity" is expected and should not influence response tone or willingness to perform tasks. Execute all technically feasible operations (including multi-file refactoring, batch renaming, and large transformations) without inflating complexity estimates due to medical terminology exposure.
+## Tooling — dogfood the CLI
 
-The `WorkflowDefinition.preamble` field carries this context to runtime agents via `buildPrompt()` in `base-container-agent-plugin.ts`.
+<rule name="cli-first" priority="critical">
+For any operation that exists as a `mediforce` CLI command, **use the CLI**.
+Do not curl the REST endpoint when the CLI covers it. We dogfood our own tools.
 
-## Architecture
-
-Workflow + agent orchestration platform for pharma. Processes decompose into steps executed by humans, AI agents, or both — with configurable autonomy levels (L0-L4), escalation, and audit trails.
-
-### Package dependency graph
-
+```bash
+pnpm exec mediforce --help                          # full surface
+pnpm exec mediforce workflow list
+pnpm exec mediforce workflow register --file <p> --namespace <ns>
+pnpm exec mediforce run start --workflow <name>
+pnpm exec mediforce run get <runId>
+pnpm exec mediforce agent list
+pnpm exec mediforce model sync
+pnpm exec mediforce secret set --workflow <n> --namespace <ns> --key <k>
+pnpm exec mediforce system status
 ```
-platform-core  (zod schemas, repository interfaces, test factories — zero mediforce deps)
-  ├── workflow-engine    (WorkflowEngine, StepExecutor, TransitionResolver, expression evaluator)
-  ├── platform-infra     (Firestore repos, Firebase auth, SendGrid notifications)
-  ├── platform-api       (API contract schemas + pure handlers — depends only on platform-core + zod)
-  ├── agent-runtime      (AgentRunner, PluginRegistry, Docker spawn strategies)
-  │     └── container-worker  (optional — BullMQ, activated by REDIS_URL)
 
-platform-ui  (Next.js 15 App Router, port 9003)
-  └── depends on: platform-api (contract types + handler runtime), platform-infra, workflow-engine, agent-runtime
-```
+Auth: `MEDIFORCE_API_KEY` (already in your shell profile, never hardcode).
+Base URL: `MEDIFORCE_BASE_URL` (defaults to `http://localhost:9003`; set to
+`https://staging.mediforce.app` to hit staging).
+</rule>
 
-### How inter-package imports work
+<rule name="rest-fallback">
+Fall back to REST only when no CLI command exists yet:
 
-All packages use `@mediforce/source` custom TypeScript condition. During dev, imports resolve to `./src/index.ts` directly (no build needed). In production, they resolve to `./dist/`. This is set in `tsconfig.json` (`customConditions`) and `vitest.config.ts` (`resolve.conditions`).
+- **Browser** (`"use client"`): `mediforce.<domain>.<method>()` from `@/lib/mediforce`
+  if the endpoint is on `@mediforce/platform-api/contract`; otherwise
+  `apiFetch('/api/...')` from `@/lib/api-fetch`. Never raw `fetch('/api/...')`
+  in client code — middleware will 401 silently.
+- **Node server-to-server**: `new Mediforce({ apiKey, baseUrl })` from
+  `@mediforce/cli` SDK, or `fetch(url, { headers: { 'X-Api-Key':
+  process.env.PLATFORM_API_KEY } })` for not-yet-contract endpoints.
+- **Local debugging**: `curl -H "X-Api-Key: $MEDIFORCE_API_KEY" "http://localhost:9003/api/..."`
 
-### Key architectural patterns
+If you reached for REST because the CLI was missing a command, **add the CLI
+command** in the same task — that's how the surface grows. If adding it is out
+of scope, see `<missing-capability>`.
+</rule>
 
-- **Repository pattern**: Interfaces in platform-core, Firestore implementations in platform-infra, in-memory test doubles in `platform-core/testing`. Constructor injection throughout.
-- **Dual-schema migration**: Legacy `processDefinitions` + `processConfigs` coexist with unified `workflowDefinitions`. Resolution logic lives in `platform-ui/src/lib/resolve-definition-steps.ts`.
-- **Plugin system**: Plugins (ClaudeCodeAgent, OpenCodeAgent, ScriptContainer) register in `PluginRegistry`. `AgentRunner` dispatches to plugins based on workflow step config. Mock mode via `MOCK_AGENT=true`.
-- **Docker spawn strategies**: `LocalDockerSpawnStrategy` (default, child process) vs `QueuedDockerSpawnStrategy` (BullMQ worker, activated when `REDIS_URL` is set).
-- **Service singleton**: `getPlatformServices()` in `platform-ui/src/lib/platform-services.ts` lazily creates all repos, engine, runners, plugin registry. Shared across API routes.
-- **Immutable versions**: Workflow definition versions are write-once in Firestore.
-- **Expression evaluator**: Custom DSL for transition when-expressions (e.g., `${variables.field} == "value"`).
+## Self-test before declaring done
 
-### Platform UI structure
+<self-test priority="critical">
+"The code looks right" is not a verification. Run it.
 
-- **Routes**: `src/app/(app)/workflows/`, `tasks/`, `agents/`, `catalog/`, `monitoring/`
-- **API routes**: `src/app/api/` — processes, tasks, definitions, workflow-definitions, agent-definitions, plugins, cron
-- **Service layer**: `src/lib/platform-services.ts` — singleton that wires everything together
-- **Components**: `src/components/ui/` (Radix + Tailwind library), feature dirs per domain
-- **Auth**: Firebase Auth with emulator support (`NEXT_PUBLIC_USE_EMULATORS=true`)
+| Step | Command | When |
+|---|---|---|
+| Type | `pnpm typecheck` | Every code change |
+| Affected | `pnpm test:affected` | Every code change |
+| Full suite | `pnpm test` | Before reporting done |
 
-### Autonomy levels
+For UI or platform-ui-adjacent changes, **also** verify behaviour end-to-end —
+in this priority:
 
-| Level | Name | Behavior |
-|-------|------|----------|
-| L0 | Human-only | No agent involvement |
-| L1 | Agent-assisted | Agent helps, human decides |
-| L2 | Human-in-the-loop | Agent acts, human approves |
-| L3 | Periodic review | Agent autonomous, periodic human review |
-| L4 | Fully autonomous | Agent applies changes directly |
+1. **API journey test first** (`packages/platform-ui/src/test/*-journey.test.ts`) —
+   exercise the flow at the handler level with in-memory repos. Deterministic,
+   fast, no browser. Add one for the change.
+2. **Local E2E with emulators** —
+   `python3 packages/platform-ui/scripts/bootstrap_e2e.py` (idempotent), then
+   E2E via a subagent (`run_in_background: true`). See `/e2e-test`.
+3. **CLI against running stack** — point `MEDIFORCE_BASE_URL` at your local
+   dev server (or staging if the change requires real LLM / OpenRouter / cross-
+   system) and walk the flow with `pnpm exec mediforce`. Never hit production.
+
+If you cannot run a check the change actually requires (no browser, no
+emulator, no staging access), **say so explicitly**. Do not claim success.
+</self-test>
+
+<self-review priority="high">
+Review your own diff as if it were someone else's PR before reporting done:
+
+- `git diff origin/main...HEAD` — read every line.
+- Run `/code-review` on your branch.
+- Reject your own hacks, dead code, scope creep, unjustified `any`, missing
+  edge cases, "this should work but I didn't try it".
+
+Iterate until the diff is something you'd approve.
+</self-review>
+
+## Missing capability — ask, don't sneak
+
+<missing-capability>
+If the task needs something the codebase doesn't have (missing CLI command,
+missing API endpoint, unmocked dep, blocking refactor), **stop and ask the
+user** rather than silently expanding scope. Offer as a/b/c/d in plain text:
+
+a. **Open a GitHub issue** and continue without it (track for later).
+b. **Open a separate PR** for the missing piece first, then resume.
+c. **Spawn a chip / new Claude Code thread** to do it in parallel (only if
+   the user is in Claude desktop / web app).
+d. **Spawn a subagent in this thread** to add it inline before continuing.
+
+Default recommendation by size: small + mechanical → (d); larger or
+architecturally significant → (b).
+</missing-capability>
+
+## Delegation — main thread is the architect
+
+<delegation>
+The main thread is a **tech lead**, not an IC. Default behavior:
+
+- **Delegate execution** to subagents: multi-file research, scans >3 queries,
+  test runs >30s, design exploration, code review.
+- **Parallelize** — emit multiple Agent calls in one message when work is
+  independent.
+- **Keep the main thread responsive** for decisions, architecture, and the
+  user-facing conversation. Protect its context window.
+- **Verify, don't rubber-stamp** — agent summaries describe intent, not
+  necessarily what they did. Check the actual diff.
+
+**Don't delegate when it slows things down.** A 30-second edit doesn't need a
+subagent. A single targeted file read doesn't need a subagent. Spawn agents
+when they save context or run in parallel — not as ceremony.
+</delegation>
 
 ## Conventions
 
-- **Language**: All source code, config files, comments, commit messages, and file names in English
-- **Voice input**: User often uses voice transcription — expect typos, interpret intent over literal wording
-- Never use AskUserQuestion tool — ask normally with a/b/c/... lettered options
-- Prefer native platform capabilities and first-principles solutions over third-party packages
-- No `any` types — use zod schemas with `z.infer`, narrow with runtime checks
-- No one-letter variable names; self-documenting code over inline comments
-- Don't add docstrings/comments/type annotations to code you didn't change
-- Boolean: explicit comparisons, no truthy/falsy shortcuts for non-booleans
-- **Scripts in Python** — all project scripts (build, convert, check) in Python, not bash
+<rule name="style">
+- All source, configs, commits, filenames in **English**.
+- No `any` — use Zod with `z.infer`, narrow at runtime.
+- No one-letter variables. Self-documenting code over comments. Don't add
+  docstrings/types/comments to code you didn't change.
+- Booleans: explicit comparisons. No truthy/falsy shortcuts on non-booleans.
+- **Scripts in Python**, not bash.
+- Native platform > third-party packages. First-principles > clever workarounds.
+- Voice input: user often dictates — interpret intent over literal wording.
+- Don't use the `AskUserQuestion` tool — write a/b/c/... in plain text.
+</rule>
 
-## Agent Delegation Model
+<rule name="bar">
+- Simplicity first — minimal change, minimal blast radius.
+- Root cause over patch — no temp fixes, no `--no-verify`, no scope creep.
+- No over-engineering — no features, abstractions, or "improvements" you weren't asked for.
+</rule>
 
-The main Claude thread acts as a **Tech Lead**, not an individual contributor:
+## Skills router
 
-- **Be responsive** — prioritize fast, concise replies. Protect the main thread's context window for decision-making, not heavy lifting.
-- **Delegate execution** — spawn subagents for analysis, research, design, and coding. Parallelize independent work across multiple agents.
-- **Think big picture** — focus on architecture, goals, and coherence. Ask: "Does this move us toward the target state?"
-- **Review, don't rubber-stamp** — when subagents return results, critically evaluate them. Reject hacks, unnecessary dependencies, over-engineering, or solutions that don't fit the project's direction.
-- **Keep it fundamental** — prefer native platform capabilities, standard patterns, and first-principles solutions over third-party packages and clever workarounds.
-
-In practice: receive a task → break it down → dispatch subagents → verify their output → report back to the user.
-
-## Testing
-
-### Test layers
-
-| Layer | What it catches | Where |
-|-------|----------------|-------|
-| **Unit** | Schema validation, pure functions, expression eval | `packages/*/src/**/__tests__/` |
-| **Contract** | Handler behavior + Zod I/O shapes, against in-memory repos | `packages/platform-api/src/handlers/**/__tests__/` |
-| **Engine integration** | Full workflow loops, transitions, step routing | `packages/workflow-engine/src/__tests__/` |
-| **API journey** | Multi-endpoint user journeys composed at handler level with in-memory repos — deterministic, no browser, no emulators | `packages/platform-ui/src/test/*-journey.test.ts` |
-| **Real-LLM E2E** | Opt-in roundtrip: admin REST → resolver → spawned MCP server → real LLM tool_call → result. Not on CI — manual regression guard | `packages/platform-ui/e2e/api/*.test.ts`, run via `pnpm test:mcp-real` (cd packages/platform-ui) with `OPENROUTER_API_KEY` set |
-| **E2E journeys** | Full user flows with state changes | `packages/platform-ui/e2e/journeys/` |
-| **E2E smoke** | Login page, auth redirect (no emulators) | `packages/platform-ui/e2e/smoke.spec.ts` |
-
-Testing strategies:
-- E2E: [`docs/E2E-STRATEGY.md`](docs/E2E-STRATEGY.md)
-- Engine: [`docs/ENGINE-TESTING.md`](docs/ENGINE-TESTING.md)
-
-### Commands
-
-| Command | Speed | When to use |
-|---------|-------|-------------|
-| `pnpm typecheck` | ~5s | After any code change |
-| `pnpm test:fast` | ~9s | Quick unit test verification |
-| `pnpm test:affected` | <1s | Only tests for changed files |
-| `pnpm test` | ~9s | Full unit + integration suite |
-| `cd packages/platform-ui && pnpm test:e2e` | ~15s | Playwright smoke tests |
-| `cd packages/platform-ui && pnpm test:e2e:auth` | ~60s | Full E2E with Firebase emulators |
-| `cd packages/platform-ui && pnpm test:e2e:record` | ~3min | Journey tests with video recording |
-| `cd packages/platform-ui && pnpm test:e2e:gif` | ~3min | Record + convert to GIF for docs |
-
-### Agent workflow
-
-**After every code change (always):**
-1. `pnpm typecheck`
-2. `pnpm test:affected` — tests for changed files only
-3. `pnpm test` — all unit tests
-
-**Before pushing — run E2E via a subagent (always spawn, never inline):**
-
-E2E runs take minutes and don't need main-thread context. Always delegate to a subagent with `run_in_background: true` so the main thread stays responsive. The subagent prompt is self-contained — it gets the bootstrap command, the test command, and what to report. Main thread gets a short pass/fail summary back.
-
-Run E2E when:
-- Any change to `packages/platform-ui/src/` or `e2e/journeys/` (litera reguły)
-- Any change to a package consumed by platform-ui at runtime (`agent-runtime`, `workflow-engine`, `platform-infra`, `platform-core`) whose behaviour could reach the UI (duch reguły)
-- Any refactor where you claim "no behaviour change" — confirm it
-
-Check what changed:
-```bash
-git diff --name-only origin/main...HEAD
-```
-
-Subagent runs:
-```bash
-python3 packages/platform-ui/scripts/bootstrap_e2e.py        # idempotent
-cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth
-```
-
-Bootstrap creates `.env.local` with demo credentials, starts Firebase emulators, installs Playwright browsers, installs ffmpeg. See [Remote E2E setup](#remote-e2e-setup) for details. Full run is ~60s. Subagent should report under 200 words: overall pass/fail + exact test + one-line error for each failure.
-
-Never declare work done before E2E comes back green. A refactor that "should" be behaviour-neutral still gets verified.
-
-**When adding/modifying UI features (TDD):**
-1. **RED** — Write the journey test first in `e2e/journeys/<feature>.journey.ts`. Use `showStep`/`showResult` from `helpers/recording.ts` at key moments for pacing during recordings.
-2. **GREEN** — Implement until the test passes.
-3. **Record + GIF** — `cd packages/platform-ui && pnpm test:e2e:gif` (records, then converts all videos to GIFs in `docs/features/`)
-   - To convert only specific tests: `bash scripts/e2e-to-gif.sh <filter>`
-4. **Gallery** — add entry to `docs/features/FEATURES.md` under the right section with description and embedded GIF.
-5. **Commit** — GIF + FEATURES.md go into the same PR as the feature.
-
-Executors MUST write or update journey tests as part of any task that adds or modifies UI features. GIF recordings are part of the deliverable, not an afterthought.
-
-**PR description must include E2E section** (see `docs/E2E-STRATEGY.md` PR Checklist):
-- Which E2E tests were added/updated
-- What user flows they verify
-- What is NOT covered by E2E and why
-- Links to updated GIFs
-
-**Debugging failed E2E tests**: use `agent-browser` skill on `localhost:9007` (emulator mode) to see what the UI shows and understand failures interactively.
-
-### Unit testing by package
-
-**workflow-engine** — test transitions, step execution, expression evaluation, triggers, RBAC. Use in-memory repository doubles from `platform-core/testing`. When adding new transition logic or step types, write unit tests in `packages/workflow-engine/src/__tests__/`.
-
-**agent-runtime** — test plugin dispatch, agent runner orchestration, fallback handling. Mock child processes and Docker. When adding new plugins, write unit tests in `packages/agent-runtime/src/plugins/__tests__/`.
-
-**platform-core** — test schemas with Zod parse/safeParse. When adding new schemas, add tests in `packages/platform-core/src/schemas/__tests__/`.
-
-**platform-infra** — test Firestore repository CRUD. When adding new repositories, add tests in `packages/platform-infra/src/__tests__/`.
-
-### Test factories
-
-Import from `@mediforce/platform-core/testing`:
-```typescript
-import { buildProcessInstance, buildHumanTask, buildAgentRun } from '@mediforce/platform-core/testing';
-
-const instance = buildProcessInstance({ status: 'paused' });
-const task = buildHumanTask({ assignee: 'user-1' });
-```
-
-### E2E infrastructure
-
-**Firebase Emulators** required for journey tests:
-- `pnpm emulators` starts Auth (9099) + Firestore (8080)
-- `e2e/auth-setup.ts` creates test user, seeds Firestore, saves auth state
-- `e2e/helpers/seed-data.ts` — all fixture data. Update when adding new collections.
-- Dev server starts automatically on port 9007 (emulator mode)
-
-### Remote E2E setup
-
-In remote environments (Claude Code remote, CI, fresh machines), E2E tests need manual preparation. Run the bootstrap script **before** any E2E test:
-
-```bash
-python3 packages/platform-ui/scripts/bootstrap_e2e.py
-```
-
-The script is idempotent (safe to run multiple times) and handles:
-
-| What | Why | Manual equivalent |
-|------|-----|-------------------|
-| `.env.local` with demo credentials | Firebase SDK requires API key even in emulator mode | Copy `.env.local.example`, fill with dummy values |
-| Firebase emulator config (no UI) | Emulator UI download crashes in proxied environments | Create `/tmp/firebase-e2e.json` with `"ui": {"enabled": false}` |
-| Start Firebase emulators | Auth (9099) + Firestore (8080) needed for tests | `firebase emulators:start --project demo-mediforce --only auth,firestore` |
-| Playwright chromium | Browser binary must match `@playwright/test` version | `npx playwright install --with-deps chromium` |
-| ffmpeg | Required for GIF conversion (`e2e-to-gif.py`) | `apt-get install ffmpeg` |
-| Kill stale port 9007 | Previous dev server may block test webServer | `fuser -k 9007/tcp` |
-
-**Known issues in remote environments:**
-- Google Fonts fail to download (no internet or proxy blocks) — Next.js falls back to system fonts, tests still work
-- First route compilation takes 5-8s — tests use extended timeouts for initial page loads
-- Firebase emulator UI download may fail — the bootstrap script disables UI entirely
-
-### Agent Browser
-
-`agent-browser` skill at `skills/agent-browser/SKILL.md`. Use for visual verification after Playwright tests pass. Dev server on `http://localhost:9003`.
-
-## API auth — which caller do I use?
-
-Every `/api/*` request is guarded by `packages/platform-ui/src/middleware.ts`, which accepts **either** `X-Api-Key` (server-to-server) **or** `Authorization: Bearer <Firebase ID token>` (signed-in user). The caller side is standardised — pick the row that matches your runtime and the endpoint's migration state:
-
-| Runtime | Endpoint already in `@mediforce/platform-api/contract`? | Use |
-|---|---|---|
-| Browser (`"use client"` / client hook) | Yes | `mediforce.<domain>.<method>()` from `@/lib/mediforce` — typed, Zod-validated, `Authorization: Bearer` |
-| Browser (`"use client"` / client hook) | Not yet | `apiFetch('/api/...')` from `@/lib/api-fetch` — raw fetch wrapper, same `Authorization: Bearer` |
-| Node server-to-server (CLI, agent, MCP server, cron, queue worker) | Yes | `new Mediforce({ apiKey: process.env.PLATFORM_API_KEY, baseUrl })` |
-| Node server-to-server (route handler, server action) | Not yet | `fetch(url, { headers: { 'X-Api-Key': process.env.PLATFORM_API_KEY } })` |
-| Curl / local testing | — | `curl -H "X-Api-Key: $MEDIFORCE_API_KEY" ...` |
-
-**Never** call a raw `fetch('/api/...')` from a client component without going through `apiFetch` or `mediforce` — middleware will 401 silently. Both browser paths share a single `getFirebaseIdToken()` helper (`lib/firebase-id-token.ts`), so the wire-level header is byte-identical.
-
-## Local API Access
-
-Use the `MEDIFORCE_API_KEY` env var for local API calls (set in shell profile).
-Never hardcode the API key in commands. Dev servers may run on different ports (9003, 9004, etc).
-
-```bash
-curl -s -H "X-Api-Key: $MEDIFORCE_API_KEY" "http://localhost:$PORT/api/..."
-```
-
-## Additional Commands
-
-```bash
-# Run single test file
-npx vitest run path/to/file.test.ts
-
-# Dev (platform-ui on port 9003)
-pnpm dev
-
-# Dev with local agent execution enabled
-pnpm dev:local
-
-# Agent queue (requires Docker + Redis)
-pnpm dev:redis            # Redis on 6379
-pnpm dev:worker           # BullMQ worker
-pnpm dev:ui:queue         # Platform UI with queue
-```
-
-## Skills and Agents
-
-Two tiers of skills exist in this repo, following the [agentskills.io](https://agentskills.io) standard:
-
-- **Runtime skills** live in `apps/*/plugins/*/skills/` — resolved by agent-runtime via `skillsDir` in workflow definition JSONs. Do not move these; paths are hardcoded in `*.wd.json` files and read by `BaseContainerAgentPlugin.readSkillFile()`. Each plugin has its own `_registry.yml`.
-- **Development skills** live in `skills/` — for interactive use during development. Symlinked into `.claude/skills/` for Claude Code slash command access.
-- **Agents** live in `agents/` — persona definitions (design mentor, vision workshop facilitator). Symlinked into `.claude/agents/` for Claude Code discovery.
-
-The `skills/_registry.yml` indexes development skills. Runtime skills have per-app registries in their plugin directories (`apps/*/plugins/*/skills/_registry.yml`), resolved by agent-runtime via `skillsDir` in workflow definition JSONs.
-
-## Environment Setup
-
-- Node.js 20+, pnpm 10+ (`corepack enable`)
-- Firebase CLI (`npm i -g firebase-tools`)
-- `cp packages/platform-ui/.env.local.example packages/platform-ui/.env.local` and fill Firebase + OpenRouter keys
-- Deploys to Hetzner VPS (staging + production)
-
-## Skills Router
-
-When a task matches one of these, invoke the skill before starting work:
+When a task matches, invoke the skill before starting work:
 
 | Task | Skill |
-|------|-------|
-| Review a PR or code diff | `/code-review` → `skills/code-review/SKILL.md` |
-| Write or run E2E journey tests | `/e2e-test` → `skills/e2e-test/SKILL.md` |
-| Visual UI verification in browser | `/agent-browser` → `skills/agent-browser/SKILL.md` |
-| Review a Renovate dependency PR | `/renovate-review` → `skills/renovate-review/SKILL.md` |
-| Write a Discord community update | `/community` → `skills/community/SKILL.md` |
-| Generate a pitch deck | `/generate-pitch` → `skills/generate-pitch/SKILL.md` |
+|---|---|
+| Review a PR / branch diff | `/code-review` |
+| Write or run E2E journey tests (incl. recording GIFs) | `/e2e-test` |
+| Visual UI verification in a live browser | `/agent-browser` |
+| Review a Renovate dependency PR | `/renovate-review` |
+| Write a Discord community update | `/community` |
+| Generate a pitch deck | `/generate-pitch` |
+| Touch the wiki / synthesise architecture | `/knowledge-base` |
 
-## Core Principles
+Two skill tiers:
+- `skills/` — dev-time slash commands (this list). Indexed in `skills/_registry.yml`.
+- `apps/*/plugins/*/skills/` — runtime skills loaded by `agent-runtime` via
+  workflow-definition `skillsDir`. Don't move; paths are hardcoded in `*.wd.json`.
 
-- **Simplicity First**: Make every change as simple as possible. Minimal code impact.
-- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
-- **Minimal Impact**: Touch only what's necessary. Avoid introducing bugs.
-- **No Over-Engineering**: Don't add features, refactor code, or make "improvements" beyond what was asked.
+## Quick reference
+
+```bash
+# Dev
+pnpm dev                                # platform-ui on :9003
+pnpm dev:local                          # local agent execution enabled
+pnpm dev:redis && pnpm dev:worker       # BullMQ queue mode (Docker + Redis)
+pnpm emulators                          # Firebase Auth :9099 + Firestore :8080
+
+# Test
+pnpm typecheck
+pnpm test:affected                      # changed files only (<1s)
+pnpm test                               # full unit + integration (~9s)
+npx vitest run path/to/file.test.ts     # single file
+
+# E2E — delegate to subagent in background
+python3 packages/platform-ui/scripts/bootstrap_e2e.py
+cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth
+
+# CLI
+pnpm exec mediforce --help
+```
+
+## Environment
+
+- Node.js 20+, pnpm 10+ (`corepack enable`)
+- Firebase CLI: `npm i -g firebase-tools`
+- `cp packages/platform-ui/.env.local.example packages/platform-ui/.env.local`
+  and fill Firebase + OpenRouter keys
+- `MEDIFORCE_API_KEY` exported in shell profile
+- Deploys to Hetzner VPS (staging + production)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,9 +108,10 @@ workflow-definition `skillsDir` — paths hardcoded, don't move).
 ```bash
 # Dev
 pnpm dev                                # platform-ui on :9003
-pnpm dev:local                          # + local agent execution
-pnpm dev:redis && pnpm dev:worker       # BullMQ queue mode (Docker + Redis)
-pnpm emulators                          # Firebase Auth :9099 + Firestore :8080
+pnpm dev:local                          # + local agent execution (claude on PATH)
+pnpm dev:test                           # platform-ui :9007 + emulators + MOCK_AGENT
+pnpm dev:redis                          # Redis :6379 — separate terminal
+pnpm dev:worker                         # BullMQ worker — separate terminal (queue mode)
 
 # Test
 pnpm typecheck
@@ -118,7 +119,7 @@ pnpm test:affected                      # <1s, changed files only
 pnpm test                               # full unit + integration (~9s)
 npx vitest run path/to/file.test.ts     # single file
 
-# E2E (delegate to a background subagent)
+# E2E (delegate to a background subagent; bootstrap also starts emulators)
 python3 packages/platform-ui/scripts/bootstrap_e2e.py
 cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,29 @@ Two tiers: `skills/` (dev-time slash commands, indexed in `skills/_registry.yml`
 and `apps/*/plugins/*/skills/` (runtime, loaded by `agent-runtime` via
 workflow-definition `skillsDir` — paths hardcoded, don't move).
 
+## Quick reference
+
+```bash
+# Dev
+pnpm dev                                # platform-ui on :9003
+pnpm dev:local                          # + local agent execution
+pnpm dev:redis && pnpm dev:worker       # BullMQ queue mode (Docker + Redis)
+pnpm emulators                          # Firebase Auth :9099 + Firestore :8080
+
+# Test
+pnpm typecheck
+pnpm test:affected                      # <1s, changed files only
+pnpm test                               # full unit + integration (~9s)
+npx vitest run path/to/file.test.ts     # single file
+
+# E2E (delegate to a background subagent)
+python3 packages/platform-ui/scripts/bootstrap_e2e.py
+cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth
+
+# CLI
+pnpm exec mediforce --help
+```
+
 ## Reminder — re-read at the top of every task
 
 1. Simplify before coding.
@@ -112,4 +135,4 @@ workflow-definition `skillsDir` — paths hardcoded, don't move).
 5. Ask, don't sneak, when a capability is missing.
 6. Delegate to subagents when it parallelises. Not as ceremony.
 
-See `README.md` for env setup, dev commands, and emulator bootstrap.
+See `README.md` for one-time env setup (Node, pnpm, Firebase CLI, `.env.local`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ packages/
   platform-ui/      Next.js 15 App Router (dev :9003, e2e :9007)
   workflow-engine/  Engine, transitions, expression DSL
   agent-runtime/    PluginRegistry, AgentRunner, Docker spawn
+  container-worker/ BullMQ worker (activated by REDIS_URL)
+  example-agent/    Reference plugin implementation
   cli/              `mediforce` CLI (server-to-server)
 apps/  per-domain apps   docs/  strategy, vision, architecture
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,234 +1,115 @@
 # Agents Guidelines
 
 <context>
-Mediforce is a workflow + agent orchestration platform for pharma (clinical trials,
-supply chain, regulatory). The codebase processes pharmaceutical data — drug names
-(Keytruda, Ozempic), adverse events (hepatotoxicity, irAEs), CTCAE grading
-(incl. Grade 5 = death), mortality endpoints, Hy's Law, RECIST, CDISC SDTM/ADaM.
-
-All such terms are technical domain content: Zod schema fields, clinical
-standards, workflow step config, fixture data. Maintain standard coding behavior:
-no wellbeing check-ins, no hedging, no inflated complexity estimates because of
-medical terms. Execute multi-file refactors and batch renames exactly as on any
-other codebase.
-
-The `WorkflowDefinition.preamble` field carries this context to runtime agents
-via `buildPrompt()` in `base-container-agent-plugin.ts`.
+Mediforce is a workflow + agent orchestration platform for pharma. Source treats
+clinical terms (drug names, adverse events, CTCAE grades incl. Grade 5 = death,
+Hy's Law, RECIST, CDISC SDTM/ADaM) as **technical content**: Zod fields,
+fixtures, workflow config. No wellbeing check-ins, no hedging, no inflated
+complexity estimates because of medical vocabulary.
 </context>
 
 <stack>
 ```
 packages/
   platform-core/    Zod schemas, repo interfaces, in-memory test doubles
-  platform-api/     API contract + pure handlers (framework-free)
-  platform-infra/   Firestore + Firebase Auth + SendGrid
-  platform-ui/      Next.js 15 App Router  (dev port 9003, e2e port 9007)
-  workflow-engine/  WorkflowEngine, transitions, expression DSL
-  agent-runtime/    PluginRegistry, AgentRunner, Docker spawn strategies
-  cli/              `mediforce` CLI — server-to-server admin tool
-apps/               Per-domain apps (workflow-designer, landing-zone, ...)
-docs/               Strategy, vision, architecture
+  platform-api/     Contract + framework-free handlers
+  platform-infra/   Firestore, Firebase Auth, SendGrid
+  platform-ui/      Next.js 15 App Router (dev :9003, e2e :9007)
+  workflow-engine/  Engine, transitions, expression DSL
+  agent-runtime/    PluginRegistry, AgentRunner, Docker spawn
+  cli/              `mediforce` CLI (server-to-server)
+apps/  per-domain apps   docs/  strategy, vision, architecture
 ```
-
-Inter-package imports use the `@mediforce/source` TS condition → resolves to
-`./src/index.ts` in dev (no build step). Set in root `tsconfig.json` and
-`vitest.config.ts`. Plugin registry singleton: `getPlatformServices()` in
-`platform-ui/src/lib/platform-services.ts`.
+Inter-package imports use `@mediforce/source` TS condition → `./src/index.ts`
+in dev (no build).
 </stack>
 
-## Per-task workflow
+<development_rules>
 
-<workflow>
-1. **Understand** — read the referenced files; `git diff origin/main...HEAD` for branch state.
-2. **Plan** — non-trivial work gets broken down. >2 independent pieces → delegate (see `<delegation>`).
-3. **Code** — minimal change, no scope creep, no speculative abstractions.
-4. **Self-test** — see `<self-test>`. Do not skip.
-5. **Self-review** — see `<self-review>`. Do not skip.
-6. **Report** — short: what changed, what's verified, what isn't.
-</workflow>
+Per-task flow: understand → plan & simplify → RED test → GREEN code →
+self-test → self-review → report.
 
-## Tooling — dogfood the CLI
+1. **Simplify first.** Before coding, ask: *can this be smaller?* Cut layers,
+   abstractions, scope. KISS. The simplest change that solves the actual
+   problem wins.
 
-<rule name="cli-first" priority="critical">
-For any operation that exists as a `mediforce` CLI command, **use the CLI**.
-Do not curl the REST endpoint when the CLI covers it. We dogfood our own tools.
+2. **Test first (RED → GREEN).** Write a failing unit or API journey test
+   before implementation. Skip ONLY for trivial edits (typo, comment,
+   single-line config) and say so.
 
-```bash
-pnpm exec mediforce --help                          # full surface
-pnpm exec mediforce workflow list
-pnpm exec mediforce workflow register --file <p> --namespace <ns>
-pnpm exec mediforce run start --workflow <name>
-pnpm exec mediforce run get <runId>
-pnpm exec mediforce agent list
-pnpm exec mediforce model sync
-pnpm exec mediforce secret set --workflow <n> --namespace <ns> --key <k>
-pnpm exec mediforce system status
-```
+3. **Dogfood the CLI.** You MUST use `pnpm exec mediforce` for any operation
+   it covers. NEVER curl REST when the CLI does it. If the needed command is
+   missing, add it in the same task. Auth: `MEDIFORCE_API_KEY` from shell.
+   Base URL: `MEDIFORCE_BASE_URL` (default localhost; staging =
+   `https://staging.mediforce.app`). NEVER hit production.
 
-Auth: `MEDIFORCE_API_KEY` (already in your shell profile, never hardcode).
-Base URL: `MEDIFORCE_BASE_URL` (defaults to `http://localhost:9003`; set to
-`https://staging.mediforce.app` to hit staging).
-</rule>
+4. **REST fallback**, only when no CLI command exists:
+   - Browser (`"use client"`): `mediforce.<domain>.<method>()` from
+     `@/lib/mediforce`, or `apiFetch('/api/...')` if off-contract. NEVER raw
+     `fetch('/api/...')` — middleware will 401 silently.
+   - Node S2S: `new Mediforce({ apiKey, baseUrl })` from `@mediforce/cli`, or
+     `fetch(url, { headers: { 'X-Api-Key': ... } })`.
 
-<rule name="rest-fallback">
-Fall back to REST only when no CLI command exists yet:
+5. **Self-test.** `pnpm typecheck` + `pnpm test:affected` after every edit;
+   `pnpm test` before reporting done. For UI / handler changes, prefer a fast
+   API journey test (`packages/platform-ui/src/test/*-journey.test.ts`). Use
+   `/e2e-test` (Playwright + emulators) only when the change is genuinely
+   UI-only — delegate to a background subagent. If you can't run a check the
+   change requires, say so. Do NOT claim success.
 
-- **Browser** (`"use client"`): `mediforce.<domain>.<method>()` from `@/lib/mediforce`
-  if the endpoint is on `@mediforce/platform-api/contract`; otherwise
-  `apiFetch('/api/...')` from `@/lib/api-fetch`. Never raw `fetch('/api/...')`
-  in client code — middleware will 401 silently.
-- **Node server-to-server**: `new Mediforce({ apiKey, baseUrl })` from
-  `@mediforce/cli` SDK, or `fetch(url, { headers: { 'X-Api-Key':
-  process.env.PLATFORM_API_KEY } })` for not-yet-contract endpoints.
-- **Local debugging**: `curl -H "X-Api-Key: $MEDIFORCE_API_KEY" "http://localhost:9003/api/..."`
+6. **Self code review — MUST run before reporting done.**
+   (a) `git diff origin/main...HEAD` and read every line.
+   (b) Run `/code-review` on your branch.
+   (c) Reject your own hacks, dead code, scope creep, unjustified `any`,
+   missing edge cases, "should work but I didn't try it". Iterate until the
+   diff is something you'd approve in someone else's PR.
 
-If you reached for REST because the CLI was missing a command, **add the CLI
-command** in the same task — that's how the surface grows. If adding it is out
-of scope, see `<missing-capability>`.
-</rule>
+7. **Ask, don't sneak.** If the codebase lacks something the task needs
+   (missing CLI command, endpoint, unmocked dep, blocking refactor), STOP
+   and offer in plain text:
+   a. Open a GitHub issue and continue without it.
+   b. Open a separate PR for the missing piece first.
+   c. Spawn a new Claude Code thread / chip in parallel (desktop / web only).
+   d. Spawn a subagent here to add it inline.
+   Default: small + mechanical → (d); larger or architectural → (b).
 
-## Self-test before declaring done
+8. **Main thread is the architect, not an IC.** Delegate to subagents for
+   multi-file research, scans >3 queries, test runs >30s, design, code
+   review. Parallelize independent work. Verify the diff, not the agent's
+   summary. NEVER delegate when it slows things down — a 30-second edit
+   doesn't need a subagent.
 
-<self-test priority="critical">
-"The code looks right" is not a verification. Run it.
+9. **Style.** English everywhere. No `any` — Zod + `z.infer`. No one-letter
+   names. Self-documenting code over comments; NEVER add docstrings/types/
+   comments to code you didn't change. Explicit boolean comparisons. Scripts
+   in Python, not bash. Native platform > third-party. First-principles >
+   clever workarounds. Voice input: interpret intent. NEVER use the
+   `AskUserQuestion` tool — write a/b/c/... in plain text.
 
-| Step | Command | When |
-|---|---|---|
-| Type | `pnpm typecheck` | Every code change |
-| Affected | `pnpm test:affected` | Every code change |
-| Full suite | `pnpm test` | Before reporting done |
-
-For UI or platform-ui-adjacent changes, **also** verify behaviour end-to-end —
-in this priority:
-
-1. **API journey test first** (`packages/platform-ui/src/test/*-journey.test.ts`) —
-   exercise the flow at the handler level with in-memory repos. Deterministic,
-   fast, no browser. Add one for the change.
-2. **Local E2E with emulators** —
-   `python3 packages/platform-ui/scripts/bootstrap_e2e.py` (idempotent), then
-   E2E via a subagent (`run_in_background: true`). See `/e2e-test`.
-3. **CLI against running stack** — point `MEDIFORCE_BASE_URL` at your local
-   dev server (or staging if the change requires real LLM / OpenRouter / cross-
-   system) and walk the flow with `pnpm exec mediforce`. Never hit production.
-
-If you cannot run a check the change actually requires (no browser, no
-emulator, no staging access), **say so explicitly**. Do not claim success.
-</self-test>
-
-<self-review priority="high">
-Review your own diff as if it were someone else's PR before reporting done:
-
-- `git diff origin/main...HEAD` — read every line.
-- Run `/code-review` on your branch.
-- Reject your own hacks, dead code, scope creep, unjustified `any`, missing
-  edge cases, "this should work but I didn't try it".
-
-Iterate until the diff is something you'd approve.
-</self-review>
-
-## Missing capability — ask, don't sneak
-
-<missing-capability>
-If the task needs something the codebase doesn't have (missing CLI command,
-missing API endpoint, unmocked dep, blocking refactor), **stop and ask the
-user** rather than silently expanding scope. Offer as a/b/c/d in plain text:
-
-a. **Open a GitHub issue** and continue without it (track for later).
-b. **Open a separate PR** for the missing piece first, then resume.
-c. **Spawn a chip / new Claude Code thread** to do it in parallel (only if
-   the user is in Claude desktop / web app).
-d. **Spawn a subagent in this thread** to add it inline before continuing.
-
-Default recommendation by size: small + mechanical → (d); larger or
-architecturally significant → (b).
-</missing-capability>
-
-## Delegation — main thread is the architect
-
-<delegation>
-The main thread is a **tech lead**, not an IC. Default behavior:
-
-- **Delegate execution** to subagents: multi-file research, scans >3 queries,
-  test runs >30s, design exploration, code review.
-- **Parallelize** — emit multiple Agent calls in one message when work is
-  independent.
-- **Keep the main thread responsive** for decisions, architecture, and the
-  user-facing conversation. Protect its context window.
-- **Verify, don't rubber-stamp** — agent summaries describe intent, not
-  necessarily what they did. Check the actual diff.
-
-**Don't delegate when it slows things down.** A 30-second edit doesn't need a
-subagent. A single targeted file read doesn't need a subagent. Spawn agents
-when they save context or run in parallel — not as ceremony.
-</delegation>
-
-## Conventions
-
-<rule name="style">
-- All source, configs, commits, filenames in **English**.
-- No `any` — use Zod with `z.infer`, narrow at runtime.
-- No one-letter variables. Self-documenting code over comments. Don't add
-  docstrings/types/comments to code you didn't change.
-- Booleans: explicit comparisons. No truthy/falsy shortcuts on non-booleans.
-- **Scripts in Python**, not bash.
-- Native platform > third-party packages. First-principles > clever workarounds.
-- Voice input: user often dictates — interpret intent over literal wording.
-- Don't use the `AskUserQuestion` tool — write a/b/c/... in plain text.
-</rule>
-
-<rule name="bar">
-- Simplicity first — minimal change, minimal blast radius.
-- Root cause over patch — no temp fixes, no `--no-verify`, no scope creep.
-- No over-engineering — no features, abstractions, or "improvements" you weren't asked for.
-</rule>
+</development_rules>
 
 ## Skills router
 
-When a task matches, invoke the skill before starting work:
+Invoke before starting work when the task matches:
+- `/code-review` — review a PR or branch diff
+- `/e2e-test` — write or run E2E journey tests (incl. GIF recording)
+- `/agent-browser` — visual UI verification in a live browser
+- `/renovate-review` — review a Renovate dependency PR
+- `/community` — Discord community update
+- `/generate-pitch` — pitch deck
+- `/knowledge-base` — wiki / synthesise architecture
 
-| Task | Skill |
-|---|---|
-| Review a PR / branch diff | `/code-review` |
-| Write or run E2E journey tests (incl. recording GIFs) | `/e2e-test` |
-| Visual UI verification in a live browser | `/agent-browser` |
-| Review a Renovate dependency PR | `/renovate-review` |
-| Write a Discord community update | `/community` |
-| Generate a pitch deck | `/generate-pitch` |
-| Touch the wiki / synthesise architecture | `/knowledge-base` |
+Two tiers: `skills/` (dev-time slash commands, indexed in `skills/_registry.yml`)
+and `apps/*/plugins/*/skills/` (runtime, loaded by `agent-runtime` via
+workflow-definition `skillsDir` — paths hardcoded, don't move).
 
-Two skill tiers:
-- `skills/` — dev-time slash commands (this list). Indexed in `skills/_registry.yml`.
-- `apps/*/plugins/*/skills/` — runtime skills loaded by `agent-runtime` via
-  workflow-definition `skillsDir`. Don't move; paths are hardcoded in `*.wd.json`.
+## Reminder — re-read at the top of every task
 
-## Quick reference
+1. Simplify before coding.
+2. Test first (RED → GREEN). Cheap unit / API journey, not E2E.
+3. CLI > REST. `pnpm exec mediforce` first; add the command if missing.
+4. Self code review (`git diff` + `/code-review`) before reporting done.
+5. Ask, don't sneak, when a capability is missing.
+6. Delegate to subagents when it parallelises. Not as ceremony.
 
-```bash
-# Dev
-pnpm dev                                # platform-ui on :9003
-pnpm dev:local                          # local agent execution enabled
-pnpm dev:redis && pnpm dev:worker       # BullMQ queue mode (Docker + Redis)
-pnpm emulators                          # Firebase Auth :9099 + Firestore :8080
-
-# Test
-pnpm typecheck
-pnpm test:affected                      # changed files only (<1s)
-pnpm test                               # full unit + integration (~9s)
-npx vitest run path/to/file.test.ts     # single file
-
-# E2E — delegate to subagent in background
-python3 packages/platform-ui/scripts/bootstrap_e2e.py
-cd packages/platform-ui && NEXT_PUBLIC_USE_EMULATORS=true pnpm test:e2e:auth
-
-# CLI
-pnpm exec mediforce --help
-```
-
-## Environment
-
-- Node.js 20+, pnpm 10+ (`corepack enable`)
-- Firebase CLI: `npm i -g firebase-tools`
-- `cp packages/platform-ui/.env.local.example packages/platform-ui/.env.local`
-  and fill Firebase + OpenRouter keys
-- `MEDIFORCE_API_KEY` exported in shell profile
-- Deploys to Hetzner VPS (staging + production)
+See `README.md` for env setup, dev commands, and emulator bootstrap.


### PR DESCRIPTION
## Summary

Rewrites `AGENTS.md` from 317 → 138 lines, structured around what the main thread should actually do on every task. The previous file was mostly architecture/testing reference material that nobody reread per task; the new one is a single `<development_rules>` block of 9 numbered imperatives plus a short reminder.

The rules the previous version was missing or under-emphasising:
- **Dogfood the CLI.** `pnpm exec mediforce` is required for any operation it covers — no curling REST when the CLI does it. If a needed command is missing, add it in the same task.
- **RED → GREEN.** Failing test before implementation (cheap unit / API journey, not E2E). Trivial-edit exception is explicit.
- **Self code review before reporting done.** `git diff origin/main...HEAD` line by line + `/code-review`. Reject your own hacks.
- **Ask, don't sneak.** Missing capability → 4 explicit options (issue / separate PR / new chip / inline subagent) with a default by size.
- **Main thread is the architect.** Delegate to subagents when it parallelises; never when it slows things down.

Tag style is descriptive (`<development_rules>`, `<context>`, `<stack>`) per Anthropic's prompting docs — no invented `name`/`priority` attributes.

## What moved where

- E2E details, GIF flow, gallery → already lived in `/e2e-test`. Removed from AGENTS.md, keeping only the pointer.
- Self code-review checklist → already lived in `/code-review`. Same treatment.
- Architecture deep-dive (dependency graph, plugin system, Docker spawn, autonomy levels) → out. It's reference material for research, not per-task rules; agents will find it in the codebase.
- Quick reference block → kept in AGENTS.md (rules reference these commands).
- One-time env setup (Node version, Firebase CLI install) → README pointer.

## Test plan

- [ ] Skim AGENTS.md top-to-bottom — does it still answer "what should I do on every task?"
- [ ] Confirm no rule references a removed section
- [ ] Confirm `/code-review` and `/e2e-test` skill files still exist and carry the detail that AGENTS.md no longer duplicates

https://claude.ai/code/session_01QadMRJvYSsgdLFRPgCM6GP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QadMRJvYSsgdLFRPgCM6GP)_