### PR TITLE
docs: point Self-test rule to docs/knowledge-base/wiki/gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,11 @@ self-test → self-review → report.
    `pnpm test` before reporting done. For UI / handler changes, prefer a fast
    API journey test (`packages/platform-ui/src/test/*-journey.test.ts`). Use
    `/e2e-test` (Playwright + emulators) only when the change is genuinely
-   UI-only — delegate to a background subagent. If you can't run a check the
-   change requires, say so. Do NOT claim success.
+   UI-only — delegate to a background subagent. If a check fails for
+   environment reasons (remote / emulator / proxy / weird state), check
+   `docs/knowledge-base/wiki/gotchas/` or run `/knowledge-base` before
+   debugging from scratch. If you can't run a check the change requires,
+   say so. Do NOT claim success.
 
 6. **Self code review — MUST run before reporting done.**
    (a) `git diff origin/main...HEAD` and read every line.


### PR DESCRIPTION
## Summary

Follow-up to #352. The Self-test rule now explicitly tells agents to check `docs/knowledge-base/wiki/gotchas/` (or run `/knowledge-base`) when a check fails for environment reasons — remote E2E, emulator quirks, proxy issues — before debugging from scratch.

`/knowledge-base` was already in the skills router after #352, but described as "wiki / synthesise architecture", which sounds like it's for research, not troubleshooting. Most agents wouldn't think to invoke it when their E2E hangs in a fresh remote env. The wiki already has the fix (`docs/knowledge-base/wiki/gotchas/remote-e2e-setup.md` documents bootstrap_e2e.py, the firebase-e2e.json config, the proxy gotchas) — this just makes the trigger obvious from the workflow.

## Test plan

- [ ] Read AGENTS.md rule 5 — pointer reads naturally and doesn't bloat the rule
- [ ] Confirm `docs/knowledge-base/wiki/gotchas/remote-e2e-setup.md` exists and is the canonical fix doc

https://claude.ai/code/session_01QadMRJvYSsgdLFRPgCM6GP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QadMRJvYSsgdLFRPgCM6GP)_