### PR TITLE
fix: migrate public pages from Firestore hooks to API calls

### DIFF
--- a/packages/platform-ui/src/app/(app)/[handle]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/page.tsx
@@ -450,7 +450,7 @@ function WorkflowCatalogPublic({ handle }: { handle: string }) {
     [definitions],
   );
 
-  const emptyInstances = useMemo(() => new Map<string, string>(), []);
+  const emptyTaskMap = useMemo(() => new Map<string, string>(), []);
 
   return (
     <div className="flex flex-col gap-4">
@@ -478,7 +478,7 @@ function WorkflowCatalogPublic({ handle }: { handle: string }) {
               instances={[]}
               showCompleted={true}
               handle={handle}
-              activeTaskByInstance={emptyInstances}
+              activeTaskByInstance={emptyTaskMap}
               isMember={false}
             />
           ))}

--- a/packages/platform-ui/src/app/(app)/[handle]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/page.tsx
@@ -9,11 +9,12 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import { Pencil, Check, X, Settings, GitBranch, Plus } from 'lucide-react';
 import { getWorkspaceIcon } from '@/lib/workspace-icons';
 import { db } from '@/lib/firebase';
-import { useAuth } from '@/contexts/auth-context';
+import { useNamespaceRole } from '@/hooks/use-namespace-role';
 import { useNamespace } from '@/hooks/use-namespace';
 import { useUserProfiles } from '@/hooks/use-users';
 import { useProcessDefinitions } from '@/hooks/use-process-definitions';
 import { useProcessInstances } from '@/hooks/use-process-instances';
+import { useWorkflowDefinitionsApi } from '@/hooks/use-workflows-api';
 import { useMyTasks } from '@/hooks/use-tasks';
 import { ProcessCard, DisplayPopover, WorkflowCatalogSkeletons, isActiveStatus } from '@/components/processes/process-card';
 import { WorkflowProblems } from '@/components/processes/workflow-problems';
@@ -96,29 +97,6 @@ function useWorkspaceMembers(handle: string, enabled: boolean) {
   }, [handle, enabled]);
 
   return { members, totalCount };
-}
-
-function useCurrentUserRole(handle: string, uid: string | undefined): string | null {
-  const [role, setRole] = React.useState<string | null>(null);
-
-  React.useEffect(() => {
-    if (!handle || uid === undefined) {
-      setRole(null);
-      return;
-    }
-    getDoc(doc(db, 'namespaces', handle, 'members', uid))
-      .then((snap) => {
-        if (snap.exists()) {
-          const data = snap.data();
-          setRole(typeof data.role === 'string' ? data.role : null);
-        } else {
-          setRole(null);
-        }
-      })
-      .catch(() => setRole(null));
-  }, [handle, uid]);
-
-  return role;
 }
 
 // ---------------------------------------------------------------------------
@@ -457,7 +435,60 @@ function UserWorkspaces({ namespace }: { namespace: Namespace }) {
 // Workflow catalog section
 // ---------------------------------------------------------------------------
 
-function WorkflowCatalog({ handle, namespace, isMember }: { handle: string; namespace: Namespace; isMember: boolean }) {
+function WorkflowCatalog({ handle, isMember }: { handle: string; isMember: boolean }) {
+  if (isMember) {
+    return <WorkflowCatalogMember handle={handle} />;
+  }
+  return <WorkflowCatalogPublic handle={handle} />;
+}
+
+function WorkflowCatalogPublic({ handle }: { handle: string }) {
+  const { definitions, loading } = useWorkflowDefinitionsApi(handle);
+
+  const sorted = useMemo(
+    () => [...definitions].filter((d) => d.archived !== true).sort((a, b) => a.name.localeCompare(b.name)),
+    [definitions],
+  );
+
+  const emptyInstances = useMemo(() => new Map<string, string>(), []);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Workflows</h2>
+      </div>
+
+      {loading ? (
+        <WorkflowCatalogSkeletons />
+      ) : sorted.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-4 text-center py-16">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+            <GitBranch className="h-7 w-7 text-muted-foreground" />
+          </div>
+          <div>
+            <p className="font-medium">No public workflows yet</p>
+          </div>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {sorted.map((definition) => (
+            <ProcessCard
+              key={definition.name}
+              definition={definition}
+              instances={[]}
+              showCompleted={true}
+              handle={handle}
+              activeTaskByInstance={emptyInstances}
+              isMember={false}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WorkflowCatalogMember({ handle }: { handle: string }) {
   const [showCompleted, setShowCompleted] = React.useState(true);
   const [showArchived, setShowArchived] = React.useState(false);
 
@@ -510,14 +541,13 @@ function WorkflowCatalog({ handle, namespace, isMember }: { handle: string; name
   }, [visibleDefinitions, instancesByDefinition]);
 
   return (
-    <WorkflowSecretKeysProvider handle={isMember ? handle : ''} workflowNames={isMember ? workflowNames : []}>
+    <WorkflowSecretKeysProvider handle={handle} workflowNames={workflowNames}>
     <div className="flex flex-col gap-4">
-      {isMember && <OpenRouterCreditsIndicator handle={handle} />}
-      {isMember && <WorkflowProblems handle={handle} latestDocs={latestDocs} loading={defsLoading} />}
+      <OpenRouterCreditsIndicator handle={handle} />
+      <WorkflowProblems handle={handle} latestDocs={latestDocs} loading={defsLoading} />
 
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Workflows</h2>
-        {isMember && (
         <div className="flex items-center gap-2">
           <DisplayPopover
             showCompleted={showCompleted}
@@ -537,7 +567,6 @@ function WorkflowCatalog({ handle, namespace, isMember }: { handle: string; name
             New Workflow
           </Link>
         </div>
-        )}
       </div>
 
       {loading ? (
@@ -548,14 +577,11 @@ function WorkflowCatalog({ handle, namespace, isMember }: { handle: string; name
             <GitBranch className="h-7 w-7 text-muted-foreground" />
           </div>
           <div>
-            <p className="font-medium">{isMember ? 'No workflows defined yet' : 'No public workflows yet'}</p>
-            {isMember && (
+            <p className="font-medium">No workflows defined yet</p>
             <p className="text-sm text-muted-foreground mt-1">
               Create your first workflow to start orchestrating agents and humans.
             </p>
-            )}
           </div>
-          {isMember && (
           <Link
             href={`/${handle}/workflows/new`}
             className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
@@ -563,7 +589,6 @@ function WorkflowCatalog({ handle, namespace, isMember }: { handle: string; name
             <Plus className="h-3.5 w-3.5" />
             New Workflow
           </Link>
-          )}
         </div>
       ) : sortedDefinitions.length === 0 ? (
         <div className="text-center py-16 text-sm text-muted-foreground">
@@ -583,7 +608,7 @@ function WorkflowCatalog({ handle, namespace, isMember }: { handle: string; name
               steps={stepsByDefinition.get(definition.name)}
               handle={handle}
               activeTaskByInstance={activeTaskByInstance}
-              isMember={isMember}
+              isMember={true}
             />
           ))}
         </div>
@@ -602,15 +627,13 @@ export default function ProfilePage() {
   const rawHandle = params.handle;
   const handle = Array.isArray(rawHandle) ? rawHandle[0] : rawHandle;
 
-  const { firebaseUser } = useAuth();
   const { namespace, loading, error } = useNamespace(handle ?? '');
-  const currentRole = useCurrentUserRole(handle ?? '', firebaseUser?.uid);
-  const canEdit = currentRole === 'owner' || currentRole === 'admin';
+  const { role: currentRole, canAdmin: canEdit, loading: roleLoading } = useNamespaceRole(handle ?? '');
   const isMember = currentRole !== null;
   const userProfiles = useUserProfiles();
   const [profileImgError, setProfileImgError] = useState(false);
 
-  if (loading) {
+  if (loading || roleLoading) {
     return (
       <div className="flex flex-1 items-center justify-center p-6">
         <div className="text-sm text-muted-foreground animate-pulse">Loading…</div>
@@ -704,7 +727,7 @@ export default function ProfilePage() {
       <UserWorkspaces namespace={namespace} />
 
       {/* Workflow catalog */}
-      <WorkflowCatalog handle={handle ?? ''} namespace={namespace} isMember={isMember} />
+      <WorkflowCatalog handle={handle ?? ''} isMember={isMember} />
     </div>
   );
 }

--- a/packages/platform-ui/src/app/(app)/[handle]/runs/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/runs/page.tsx
@@ -45,11 +45,10 @@ export default function RunsPage() {
     );
   }
 
-  return <RunsPageContent />;
+  return <RunsPageContent handle={handle} />;
 }
 
-function RunsPageContent() {
-  const { handle } = useParams<{ handle: string }>();
+function RunsPageContent({ handle }: { handle: string }) {
   const searchParams = useSearchParams();
   const workflowFilter = searchParams.get('workflow');
   const [showArchivedRuns, setShowArchivedRuns] = React.useState(false);

--- a/packages/platform-ui/src/app/(app)/[handle]/runs/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/runs/page.tsx
@@ -1,15 +1,54 @@
 'use client';
 
 import * as React from 'react';
+import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
-import { Archive } from 'lucide-react';
+import { Archive, Lock } from 'lucide-react';
 import { useProcessInstances } from '@/hooks/use-process-instances';
 import { useMyTasks } from '@/hooks/use-tasks';
+import { useNamespaceRole } from '@/hooks/use-namespace-role';
 import { RunsTable } from '@/components/processes/runs-table';
 import { formatStepName } from '@/components/tasks/task-utils';
 import { cn } from '@/lib/utils';
 
 export default function RunsPage() {
+  const { handle } = useParams<{ handle: string }>();
+  const { role, loading: roleLoading } = useNamespaceRole(handle);
+
+  if (roleLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <div className="text-sm text-muted-foreground animate-pulse">Loading…</div>
+      </div>
+    );
+  }
+
+  if (role === null) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-4 p-6">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+          <Lock className="h-7 w-7 text-muted-foreground" />
+        </div>
+        <div className="text-center">
+          <p className="font-medium">Runs are only visible to workspace members</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            Join this workspace to see workflow runs.
+          </p>
+        </div>
+        <Link
+          href={`/${handle}`}
+          className="text-sm text-primary hover:underline"
+        >
+          Back to profile
+        </Link>
+      </div>
+    );
+  }
+
+  return <RunsPageContent />;
+}
+
+function RunsPageContent() {
   const { handle } = useParams<{ handle: string }>();
   const searchParams = useSearchParams();
   const workflowFilter = searchParams.get('workflow');

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -19,11 +19,96 @@ import { formatCron } from '@/lib/format-cron';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/auth-context';
 import { useAllUserNamespaces } from '@/hooks/use-all-user-namespaces';
+import { useNamespaceRole } from '@/hooks/use-namespace-role';
+import { useWorkflowDefinitionApi } from '@/hooks/use-workflows-api';
 import { WorkflowSecretsEditor } from '@/components/workflows/workflow-secrets-editor';
 
 
 export default function ProcessDefinitionPage() {
   const { name, handle } = useParams<{ name: string; handle: string }>();
+  const { role, loading: roleLoading } = useNamespaceRole(handle);
+
+  if (roleLoading) {
+    return (
+      <div className="p-6 space-y-4 animate-pulse">
+        <div className="h-4 w-20 rounded bg-muted" />
+        <div className="h-7 w-48 rounded bg-muted" />
+        <div className="h-48 rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (role === null) {
+    return <ProcessDefinitionPagePublic name={name} handle={handle} />;
+  }
+
+  return <ProcessDefinitionPageMember name={name} handle={handle} />;
+}
+
+function ProcessDefinitionPagePublic({ name, handle }: { name: string; handle: string }) {
+  const decodedName = decodeURIComponent(name);
+  const { definition, loading, error } = useWorkflowDefinitionApi(decodedName);
+
+  if (loading) {
+    return (
+      <div className="p-6 space-y-4 animate-pulse">
+        <div className="h-4 w-20 rounded bg-muted" />
+        <div className="h-7 w-48 rounded bg-muted" />
+        <div className="h-48 rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (error !== null || definition === null) {
+    return (
+      <div className="p-6 text-center text-sm text-muted-foreground">
+        Workflow &ldquo;{decodedName}&rdquo; not found.{' '}
+        <Link href={`/${handle}`} className="underline">Back to catalog</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-0">
+      <div className="border-b px-6 py-4">
+        <div>
+          {definition.visibility === 'private' && (
+            <span className="rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-600">
+              Private
+            </span>
+          )}
+          {definition.description && (
+            <p className="text-sm text-muted-foreground mt-0.5">{definition.description}</p>
+          )}
+          <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
+            {definition.namespace && (
+              <>
+                <span className="flex items-center gap-1">
+                  Owned by{' '}
+                  <Link
+                    href={`/${definition.namespace}`}
+                    className="rounded-full bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600 hover:bg-blue-500/20 transition-colors"
+                  >
+                    @{definition.namespace}
+                  </Link>
+                </span>
+                <span className="text-border">&middot;</span>
+              </>
+            )}
+            <span className="flex items-center gap-1">
+              <Layers className="h-3 w-3" />
+              {definition.steps.length} steps
+            </span>
+            <RepoLink definition={definition as Record<string, unknown>} />
+            <AppLink definition={definition as Record<string, unknown>} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const decodedName = decodeURIComponent(name);

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -47,7 +47,7 @@ export default function ProcessDefinitionPage() {
 
 function ProcessDefinitionPagePublic({ name, handle }: { name: string; handle: string }) {
   const decodedName = decodeURIComponent(name);
-  const { definition, loading, error } = useWorkflowDefinitionApi(decodedName);
+  const { definition, loading, error } = useWorkflowDefinitionApi(handle, decodedName);
 
   if (loading) {
     return (
@@ -72,11 +72,6 @@ function ProcessDefinitionPagePublic({ name, handle }: { name: string; handle: s
     <div className="flex flex-1 flex-col gap-0">
       <div className="border-b px-6 py-4">
         <div>
-          {definition.visibility === 'private' && (
-            <span className="rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-600">
-              Private
-            </span>
-          )}
           {definition.description && (
             <p className="text-sm text-muted-foreground mt-0.5">{definition.description}</p>
           )}
@@ -99,8 +94,8 @@ function ProcessDefinitionPagePublic({ name, handle }: { name: string; handle: s
               <Layers className="h-3 w-3" />
               {definition.steps.length} steps
             </span>
-            <RepoLink definition={definition as Record<string, unknown>} />
-            <AppLink definition={definition as Record<string, unknown>} />
+            <RepoLink definition={definition} />
+            <AppLink definition={definition} />
           </div>
         </div>
       </div>
@@ -235,8 +230,8 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
                   )}
                 </span>
               ))}
-              <RepoLink definition={latest as Record<string, unknown>} />
-              <AppLink definition={latest as Record<string, unknown>} />
+              <RepoLink definition={latest} />
+              <AppLink definition={latest} />
             </div>
           </div>
 
@@ -497,9 +492,9 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
   );
 }
 
-function RepoLink({ definition }: { definition: Record<string, unknown> | null }) {
+function RepoLink({ definition }: { definition: { repo?: { url: string; branch?: string; directory?: string } } | null }) {
   if (!definition?.repo) return null;
-  const repo = definition.repo as { url: string; branch?: string; directory?: string };
+  const repo = definition.repo;
   let href = repo.url;
   if (repo.branch) {
     href += `/tree/${repo.branch}`;
@@ -519,11 +514,11 @@ function RepoLink({ definition }: { definition: Record<string, unknown> | null }
   );
 }
 
-function AppLink({ definition }: { definition: Record<string, unknown> | null }) {
+function AppLink({ definition }: { definition: { url?: string } | null }) {
   if (!definition?.url) return null;
   return (
     <a
-      href={definition.url as string}
+      href={definition.url}
       target="_blank"
       rel="noopener noreferrer"
       className="inline-flex items-center gap-1 hover:text-foreground transition-colors"

--- a/packages/platform-ui/src/app/api/workflow-definitions/[name]/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/[name]/route.ts
@@ -41,6 +41,14 @@ export async function GET(
     );
   }
 
+  const namespaceParam = request.nextUrl.searchParams.get('namespace');
+  if (namespaceParam !== null && definition.namespace !== namespaceParam) {
+    return NextResponse.json(
+      { error: `Workflow '${name}' not found` },
+      { status: 404 },
+    );
+  }
+
   if (!callerCanAccess(caller, definition.namespace)) {
     if (definition.visibility !== 'public') {
       return NextResponse.json(

--- a/packages/platform-ui/src/app/api/workflow-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/route.ts
@@ -16,6 +16,9 @@ export async function GET(request: Request): Promise<NextResponse> {
   const caller = await resolveCallerIdentity(request, namespaceRepo);
   if (caller instanceof NextResponse) return caller;
 
+  const url = new URL(request.url);
+  const namespaceFilter = url.searchParams.get('namespace');
+
   const { definitions } = await processRepo.listWorkflowDefinitions(false);
 
   const result = definitions.map((group) => {
@@ -38,7 +41,11 @@ export async function GET(request: Request): Promise<NextResponse> {
         return item.definition.visibility === 'public';
       });
 
-  return NextResponse.json({ definitions: filtered });
+  const namespaced = namespaceFilter !== null
+    ? filtered.filter((item) => item.definition?.namespace === namespaceFilter)
+    : filtered;
+
+  return NextResponse.json({ definitions: namespaced });
 }
 
 /**

--- a/packages/platform-ui/src/hooks/__tests__/use-workflows-api.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-workflows-api.test.ts
@@ -24,7 +24,7 @@ describe('mapApiToDefinitionGroups', () => {
       },
     }];
 
-    const result = mapApiToDefinitionGroups(items, 'acme');
+    const result = mapApiToDefinitionGroups(items);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
@@ -49,7 +49,7 @@ describe('mapApiToDefinitionGroups', () => {
     });
   });
 
-  it('filters by namespace handle', () => {
+  it('maps multiple items', () => {
     const items: ApiDefinitionItem[] = [
       {
         name: 'wf-a',
@@ -72,14 +72,13 @@ describe('mapApiToDefinitionGroups', () => {
           version: 1,
           steps: [],
           triggers: [],
-          namespace: 'ns-b',
+          namespace: 'ns-a',
         },
       },
     ];
 
-    const result = mapApiToDefinitionGroups(items, 'ns-a');
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe('wf-a');
+    const result = mapApiToDefinitionGroups(items);
+    expect(result).toHaveLength(2);
   });
 
   it('skips items with null definition', () => {
@@ -90,7 +89,7 @@ describe('mapApiToDefinitionGroups', () => {
       definition: null,
     }];
 
-    const result = mapApiToDefinitionGroups(items, 'any');
+    const result = mapApiToDefinitionGroups(items);
     expect(result).toHaveLength(0);
   });
 
@@ -108,7 +107,7 @@ describe('mapApiToDefinitionGroups', () => {
       },
     }];
 
-    const result = mapApiToDefinitionGroups(items, 'ns');
+    const result = mapApiToDefinitionGroups(items);
     expect(result[0].hasManualTrigger).toBe(false);
   });
 });

--- a/packages/platform-ui/src/hooks/__tests__/use-workflows-api.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-workflows-api.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { mapApiToDefinitionGroups, type ApiDefinitionItem } from '../use-workflows-api';
+
+describe('mapApiToDefinitionGroups', () => {
+  it('maps API response to DefinitionGroup shape', () => {
+    const items: ApiDefinitionItem[] = [{
+      name: 'test-workflow',
+      latestVersion: 2,
+      defaultVersion: 1,
+      definition: {
+        name: 'test-workflow',
+        version: 2,
+        steps: [
+          { id: 'start', type: 'start' },
+          { id: 'process', type: 'agent' },
+          { id: 'end', type: 'terminal' },
+        ],
+        triggers: [{ type: 'manual', name: 'default' }],
+        title: 'Test Workflow',
+        description: 'A test',
+        namespace: 'acme',
+        visibility: 'public',
+        repo: { url: 'https://github.com/example/repo' },
+      },
+    }];
+
+    const result = mapApiToDefinitionGroups(items, 'acme');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      name: 'test-workflow',
+      title: 'Test Workflow',
+      description: 'A test',
+      latestVersion: '2',
+      versions: [{
+        version: '2',
+        stepCount: 3,
+        triggerCount: 1,
+        title: 'Test Workflow',
+        description: 'A test',
+      }],
+      stepCount: 3,
+      hasManualTrigger: true,
+      repo: { url: 'https://github.com/example/repo' },
+      url: undefined,
+      archived: undefined,
+      namespace: 'acme',
+      visibility: 'public',
+    });
+  });
+
+  it('filters by namespace handle', () => {
+    const items: ApiDefinitionItem[] = [
+      {
+        name: 'wf-a',
+        latestVersion: 1,
+        defaultVersion: 1,
+        definition: {
+          name: 'wf-a',
+          version: 1,
+          steps: [],
+          triggers: [],
+          namespace: 'ns-a',
+        },
+      },
+      {
+        name: 'wf-b',
+        latestVersion: 1,
+        defaultVersion: 1,
+        definition: {
+          name: 'wf-b',
+          version: 1,
+          steps: [],
+          triggers: [],
+          namespace: 'ns-b',
+        },
+      },
+    ];
+
+    const result = mapApiToDefinitionGroups(items, 'ns-a');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('wf-a');
+  });
+
+  it('skips items with null definition', () => {
+    const items: ApiDefinitionItem[] = [{
+      name: 'broken',
+      latestVersion: 1,
+      defaultVersion: 1,
+      definition: null,
+    }];
+
+    const result = mapApiToDefinitionGroups(items, 'any');
+    expect(result).toHaveLength(0);
+  });
+
+  it('detects no manual trigger', () => {
+    const items: ApiDefinitionItem[] = [{
+      name: 'cron-only',
+      latestVersion: 1,
+      defaultVersion: 1,
+      definition: {
+        name: 'cron-only',
+        version: 1,
+        steps: [{ id: 's1', type: 'start' }],
+        triggers: [{ type: 'cron', name: 'nightly' }],
+        namespace: 'ns',
+      },
+    }];
+
+    const result = mapApiToDefinitionGroups(items, 'ns');
+    expect(result[0].hasManualTrigger).toBe(false);
+  });
+});

--- a/packages/platform-ui/src/hooks/use-workflows-api.ts
+++ b/packages/platform-ui/src/hooks/use-workflows-api.ts
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiFetch } from '@/lib/api-fetch';
+import type { DefinitionGroup } from './use-process-definitions';
+
+export interface ApiDefinitionItem {
+  name: string;
+  latestVersion: number;
+  defaultVersion: number;
+  definition: {
+    name: string;
+    version: number;
+    steps: Array<{ id: string; type: string }>;
+    triggers: Array<{ type: string; name: string }>;
+    title?: string;
+    description?: string;
+    repo?: { url: string; branch?: string; directory?: string };
+    url?: string;
+    archived?: boolean;
+    namespace?: string;
+    visibility?: string;
+  } | null;
+}
+
+export function mapApiToDefinitionGroups(
+  items: ApiDefinitionItem[],
+  handle: string,
+): DefinitionGroup[] {
+  return items
+    .filter((item) => item.definition !== null && item.definition.namespace === handle)
+    .map((item) => {
+      const def = item.definition!;
+      return {
+        name: def.name,
+        title: def.title,
+        description: def.description,
+        latestVersion: String(def.version),
+        versions: [{
+          version: String(def.version),
+          stepCount: def.steps.length,
+          triggerCount: def.triggers.length,
+          title: def.title,
+          description: def.description,
+        }],
+        stepCount: def.steps.length,
+        hasManualTrigger: def.triggers.some((t) => t.type === 'manual'),
+        repo: def.repo,
+        url: def.url,
+        archived: def.archived,
+        namespace: def.namespace,
+        visibility: def.visibility,
+      };
+    });
+}
+
+export function useWorkflowDefinitionsApi(handle: string): {
+  definitions: DefinitionGroup[];
+  loading: boolean;
+  error: Error | null;
+} {
+  const [definitions, setDefinitions] = useState<DefinitionGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!handle) {
+      setDefinitions([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    apiFetch('/api/workflow-definitions')
+      .then((res) => {
+        if (!res.ok) throw new Error(`API error: ${res.status}`);
+        return res.json();
+      })
+      .then((data: { definitions: ApiDefinitionItem[] }) => {
+        if (cancelled) return;
+        setDefinitions(mapApiToDefinitionGroups(data.definitions, handle));
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setDefinitions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [handle]);
+
+  return { definitions, loading, error };
+}
+
+export function useWorkflowDefinitionApi(name: string): {
+  definition: ApiDefinitionItem['definition'];
+  loading: boolean;
+  error: Error | null;
+} {
+  const [definition, setDefinition] = useState<ApiDefinitionItem['definition']>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!name) {
+      setDefinition(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    apiFetch(`/api/workflow-definitions/${encodeURIComponent(name)}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`API error: ${res.status}`);
+        return res.json();
+      })
+      .then((data: { definition: ApiDefinitionItem['definition'] }) => {
+        if (cancelled) return;
+        setDefinition(data.definition);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setDefinition(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [name]);
+
+  return { definition, loading, error };
+}

--- a/packages/platform-ui/src/hooks/use-workflows-api.ts
+++ b/packages/platform-ui/src/hooks/use-workflows-api.ts
@@ -25,10 +25,9 @@ export interface ApiDefinitionItem {
 
 export function mapApiToDefinitionGroups(
   items: ApiDefinitionItem[],
-  handle: string,
 ): DefinitionGroup[] {
   return items
-    .filter((item) => item.definition !== null && item.definition.namespace === handle)
+    .filter((item) => item.definition !== null)
     .map((item) => {
       const def = item.definition!;
       return {
@@ -73,14 +72,14 @@ export function useWorkflowDefinitionsApi(handle: string): {
     let cancelled = false;
     setLoading(true);
 
-    apiFetch('/api/workflow-definitions')
+    apiFetch(`/api/workflow-definitions?namespace=${encodeURIComponent(handle)}`)
       .then((res) => {
         if (!res.ok) throw new Error(`API error: ${res.status}`);
         return res.json();
       })
       .then((data: { definitions: ApiDefinitionItem[] }) => {
         if (cancelled) return;
-        setDefinitions(mapApiToDefinitionGroups(data.definitions, handle));
+        setDefinitions(mapApiToDefinitionGroups(data.definitions));
         setError(null);
       })
       .catch((err: unknown) => {
@@ -98,7 +97,7 @@ export function useWorkflowDefinitionsApi(handle: string): {
   return { definitions, loading, error };
 }
 
-export function useWorkflowDefinitionApi(name: string): {
+export function useWorkflowDefinitionApi(namespace: string, name: string): {
   definition: ApiDefinitionItem['definition'];
   loading: boolean;
   error: Error | null;
@@ -108,7 +107,7 @@ export function useWorkflowDefinitionApi(name: string): {
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    if (!name) {
+    if (!name || !namespace) {
       setDefinition(null);
       setLoading(false);
       return;
@@ -117,7 +116,7 @@ export function useWorkflowDefinitionApi(name: string): {
     let cancelled = false;
     setLoading(true);
 
-    apiFetch(`/api/workflow-definitions/${encodeURIComponent(name)}`)
+    apiFetch(`/api/workflow-definitions/${encodeURIComponent(name)}?namespace=${encodeURIComponent(namespace)}`)
       .then((res) => {
         if (!res.ok) throw new Error(`API error: ${res.status}`);
         return res.json();
@@ -137,7 +136,7 @@ export function useWorkflowDefinitionApi(name: string): {
       });
 
     return () => { cancelled = true; };
-  }, [name]);
+  }, [namespace, name]);
 
   return { definition, loading, error };
 }


### PR DESCRIPTION
## Summary
- Non-member views (profile, workflow detail, runs) were loading data directly from Firestore, bypassing API visibility filtering and leaking private workflow definitions to the browser
- Split each page into member/non-member components: non-members load through API (visibility-filtered), members keep Firestore hooks (authorized, real-time)
- Runs page gated entirely for non-members with "members only" message

## Changes
- **Profile page**: `WorkflowCatalog` → `WorkflowCatalogPublic` (API) / `WorkflowCatalogMember` (Firestore); replaced `useCurrentUserRole` with `useNamespaceRole` (adds loading state, eliminates flash)
- **Workflow detail page**: non-members see read-only header via `useWorkflowDefinitionApi`; no runs/secrets/menu
- **Runs page**: non-members see lock icon + back link; Firestore hooks only mount for members
- **New hook**: `use-workflows-api.ts` — `useWorkflowDefinitionsApi(handle)`, `useWorkflowDefinitionApi(name)`, tested `mapApiToDefinitionGroups`

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 2130 passed (1 pre-existing flaky Docker test)
- [x] 4 unit tests for `mapApiToDefinitionGroups`
- [ ] Manual: log in as user A, visit user B's profile → Network tab shows API call, no Firestore reads, no private workflows
- [ ] Manual: log in as user A, visit own profile → all workflows visible, real-time updates work
- [ ] Manual: non-member visits `/@handle/runs` → sees "members only" gate
- [ ] Manual: non-member visits public workflow detail → sees read-only header, no runs/secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)