### PR TITLE
docs: add triggerInput to workflow-designer agent skills

### DIFF
--- a/apps/workflow-designer/plugins/workflow-designer/skills/generate-execution-proposals/SKILL.md
+++ b/apps/workflow-designer/plugins/workflow-designer/skills/generate-execution-proposals/SKILL.md
@@ -78,6 +78,7 @@ For each proposal, take the parsed structure and add execution config to every s
   "version": 1,
   "description": "string",
   "roles": ["string"],
+  "triggerInput": [ /* copied from structure if present */ ],
   "steps": [ /* WorkflowStep[] */ ],
   "transitions": [ /* copied from structure */ ],
   "triggers": [ /* copied from structure */ ]
@@ -205,8 +206,8 @@ If you do NOT follow this contract, the platform will receive an empty result.
 ```
 9. For `claude-code-agent` steps, include `agent.model` (use `"sonnet"`)
 10. Each proposal needs a distinct `label` and `description` explaining the trade-offs
-11. **Preserve all structural fields** from the original YAML — `params`, `verdicts`, `selection`, `description`, `metadata`, etc. must be copied as-is into every proposal
-12. **transitions and triggers** are copied verbatim from the structure into every proposal
+11. **Preserve all structural fields** from the original YAML — `params`, `verdicts`, `selection`, `description`, `metadata`, `triggerInput`, etc. must be copied as-is into every proposal
+12. **transitions, triggers, and triggerInput** are copied verbatim from the structure into every proposal
 13. Tailor proposals to the user's stated preferences when available
 
 ### Output Shape

--- a/apps/workflow-designer/plugins/workflow-designer/skills/generate-steps/SKILL.md
+++ b/apps/workflow-designer/plugins/workflow-designer/skills/generate-steps/SKILL.md
@@ -89,6 +89,16 @@ steps:                # Required. At least one step.
     # OMIT these fields — they are added by the execution proposal step:
     # executor, autonomyLevel, plugin, agent, review, env, allowedRoles, stepParams
 
+triggerInput:         # Optional. Typed fields the user fills in when starting a run.
+  - name: string      # Required. Field name (unique across all triggerInput fields).
+    type: string|number|boolean|date|select|multiselect|textarea  # Default: string
+    required: true|false  # Default: false
+    description: string   # Optional but recommended.
+    default: value        # Optional default value.
+    options:              # Required when type is select or multiselect.
+      - "option-1"
+      - "option-2"
+
 transitions:          # Required. Edges connecting steps.
   - from: step-id
     to: step-id
@@ -148,6 +158,8 @@ when: 'else'
 9. **Step IDs** should be kebab-case and descriptive (e.g., "extract-data", not "step-1")
 10. **Triggers** — always include at least a `manual` trigger. Add `cron` or `webhook` if the user's description implies scheduled or event-driven execution.
 11. **Do NOT include executor, agent, plugin, env, or autonomyLevel** — those are assigned in the execution proposal step
+12. **triggerInput vs step params** — use `triggerInput` when the data is needed up-front before the workflow starts (study ID, environment, config flags). Use `params` on the first step when the data is part of the first step's creative work (describe an idea, write a brief). Rule of thumb: if the user must provide it to even begin, it is `triggerInput`; if it is the first step's output, it is `params`.
+13. **triggerInput field names must be unique** — no duplicates within the `triggerInput` array. The server rejects definitions with duplicate names.
 
 ## Step Type Guide
 
@@ -430,6 +442,66 @@ transitions:
   - from: publish
     to: done
 ```
+
+### 7. Trigger input (typed fields at run start)
+
+Use `triggerInput` when the workflow needs configuration before it begins — IDs, environment selectors, flags. The user fills these in at "Start Run" time (UI form or CLI `--input`).
+
+```yaml
+name: site-data-export
+version: 1
+description: Export clinical site data for a given study and environment
+
+triggerInput:
+  - name: studyId
+    type: string
+    required: true
+    description: Study identifier (e.g. NCT02453282)
+  - name: environment
+    type: select
+    required: true
+    description: Target environment for the export
+    options:
+      - staging
+      - production
+  - name: dryRun
+    type: boolean
+    required: false
+    description: Preview export without writing files
+    default: false
+
+triggers:
+  - name: manual
+    type: manual
+
+steps:
+  - id: fetch-sites
+    name: Fetch Sites
+    type: creation
+  - id: export-data
+    name: Export Data
+    type: creation
+  - id: review-export
+    name: Review Export
+    type: review
+    verdicts:
+      approve:
+        target: done
+      revise:
+        target: export-data
+  - id: done
+    name: Done
+    type: terminal
+
+transitions:
+  - from: fetch-sites
+    to: export-data
+  - from: export-data
+    to: review-export
+  # No transitions from review-export — verdicts handle it
+```
+
+Note: `triggerInput` values are available to steps via `variables.studyId`, `variables.environment`, etc. The first step does NOT need `params` for these — they are already in the workflow context.
 
 ## Real Examples
 


### PR DESCRIPTION
## Summary
- Workflow-designer agents (generate-steps, generate-execution-proposals) didn't know about `triggerInput` — the typed fields users fill in when starting a workflow run
- Added `triggerInput` to the schema section, design rules (when to use triggerInput vs step params), and a new pattern example (#7: trigger input) in generate-steps SKILL.md
- Updated generate-execution-proposals to preserve `triggerInput` when building complete WorkflowDefinitions

## Test plan
- [ ] Run workflow-designer on staging: create a workflow that needs start-run inputs (e.g. "export clinical site data for a given study and environment")
- [ ] Verify generated YAML includes `triggerInput` with correct field types
- [ ] Verify execution proposals preserve `triggerInput` in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)