### PR TITLE
feat: per-user API keys for CLI and API access

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -40,6 +40,7 @@ import { modelSyncCommand } from './commands/model-sync.js';
 import { secretSetCommand } from './commands/secret-set.js';
 import { secretListCommand } from './commands/secret-list.js';
 import { secretDeleteCommand } from './commands/secret-delete.js';
+import { whoamiCommand } from './commands/whoami.js';
 import { consoleOutput, type OutputSink } from './output.js';
 
 export interface RunCliInput {
@@ -70,6 +71,7 @@ Commands:
   run list                                           List recent runs
   run start --workflow <name>                        Start a new run (manual trigger)
   run get <runId>                                    Fetch a single run's status
+  whoami                                              Show current identity and namespaces
   system status                                      Docker infrastructure status
   system images                                      List Docker images on host
   system rmi <imageId>                               Remove a Docker image
@@ -167,6 +169,10 @@ export async function runCli(input: RunCliInput): Promise<number> {
   }
 
   const [command, subcommand, ...rest] = args;
+
+  if (command === 'whoami') {
+    return whoamiCommand({ argv: subcommand ? [subcommand, ...rest] : rest, env: input.env, output });
+  }
 
   // Namespace-only invocation (no subcommand): print the namespaced HELP and
   // exit 2 instead of the generic `Unknown command: workflow undefined`.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -41,6 +41,9 @@ import { secretSetCommand } from './commands/secret-set.js';
 import { secretListCommand } from './commands/secret-list.js';
 import { secretDeleteCommand } from './commands/secret-delete.js';
 import { whoamiCommand } from './commands/whoami.js';
+import { apiKeyCreateCommand } from './commands/api-key-create.js';
+import { apiKeyListCommand } from './commands/api-key-list.js';
+import { apiKeyRevokeCommand } from './commands/api-key-revoke.js';
 import { consoleOutput, type OutputSink } from './output.js';
 
 export interface RunCliInput {
@@ -72,6 +75,9 @@ Commands:
   run start --workflow <name>                        Start a new run (manual trigger)
   run get <runId>                                    Fetch a single run's status
   whoami                                              Show current identity and namespaces
+  api-key create --label <name> [--user <uid>]       Create a personal API key
+  api-key list [--user <uid>]                        List API keys
+  api-key revoke <keyId> [--user <uid>]              Revoke an API key
   system status                                      Docker infrastructure status
   system images                                      List Docker images on host
   system rmi <imageId>                               Remove a Docker image
@@ -172,6 +178,32 @@ export async function runCli(input: RunCliInput): Promise<number> {
 
   if (command === 'whoami') {
     return whoamiCommand({ argv: subcommand ? [subcommand, ...rest] : rest, env: input.env, output });
+  }
+
+  const API_KEY_HELP = `Usage: mediforce api-key <subcommand> [options]
+
+Subcommands:
+  create --label <name> [--user <uid>]   Create a personal API key
+  list [--user <uid>]                    List API keys
+  revoke <keyId> [--user <uid>]          Revoke an API key
+
+Run \`mediforce api-key <subcommand> --help\` for subcommand-specific flags.
+`;
+
+  if (command === 'api-key' && subcommand === undefined) {
+    output.stderr('mediforce api-key: missing subcommand');
+    output.stderr('');
+    output.stderr(API_KEY_HELP);
+    return 2;
+  }
+  if (command === 'api-key' && subcommand === 'create') {
+    return apiKeyCreateCommand({ argv: rest, env: input.env, output });
+  }
+  if (command === 'api-key' && subcommand === 'list') {
+    return apiKeyListCommand({ argv: rest, env: input.env, output });
+  }
+  if (command === 'api-key' && subcommand === 'revoke') {
+    return apiKeyRevokeCommand({ argv: rest, env: input.env, output });
   }
 
   // Namespace-only invocation (no subcommand): print the namespaced HELP and

--- a/packages/cli/src/commands/api-key-create.ts
+++ b/packages/cli/src/commands/api-key-create.ts
@@ -1,0 +1,96 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce api-key create --label <name> [--user <uid>] [options]
+
+Create a personal API key. The plaintext key is shown once — copy it immediately.
+
+With a personal key (mf_): creates a key for yourself.
+With the global PLATFORM_API_KEY + --user: creates a key for the specified user.
+
+Required flags:
+  --label <name>      Human-readable label for the key
+
+Optional flags:
+  --user <uid>        Firebase UID of the target user (admin mode)
+  --base-url <url>    API base URL (default: http://localhost:9003)
+  --json              Emit JSON instead of human-readable output
+  --help, -h          Show this help text
+`;
+
+const OPTIONS = {
+  label: { type: 'string' },
+  user: { type: 'string' },
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function apiKeyCreateCommand(input: CommandInput): Promise<number> {
+  let flags: { label?: string; user?: string; 'base-url'?: string; json?: boolean; help?: boolean };
+  try {
+    const parsed = parseArgs({ args: input.argv, options: OPTIONS, strict: true, allowPositionals: false });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce api-key create: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  if (flags.help === true) { input.output.stdout(HELP); return 0; }
+
+  if (!flags.label) {
+    printError(input.output, { error: '--label is required' }, false);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  const jsonMode = flags.json === true;
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    const data = await mediforce.apiKeys.create({
+      label: flags.label,
+      ...(flags.user ? { userId: flags.user } : {}),
+    });
+
+    if (jsonMode) {
+      printJson(input.output, data);
+      return 0;
+    }
+
+    input.output.stdout(`API key created:`);
+    input.output.stdout(`  ID:      ${data.id}`);
+    input.output.stdout(`  Label:   ${data.label}`);
+    input.output.stdout(`  User:    ${data.userId}`);
+    input.output.stdout(`  Key:     ${data.plaintext}`);
+    input.output.stdout('');
+    input.output.stdout('Copy this key now — you will not see it again.');
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
+    } else {
+      printError(input.output, { error: err instanceof Error ? err.message : String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/api-key-list.ts
+++ b/packages/cli/src/commands/api-key-list.ts
@@ -1,0 +1,95 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce api-key list [--user <uid>] [options]
+
+List API keys for the current user, or for a specified user (admin mode).
+
+Optional flags:
+  --user <uid>        Firebase UID of the target user (admin mode)
+  --base-url <url>    API base URL (default: http://localhost:9003)
+  --json              Emit JSON instead of human-readable output
+  --help, -h          Show this help text
+`;
+
+const OPTIONS = {
+  user: { type: 'string' },
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function apiKeyListCommand(input: CommandInput): Promise<number> {
+  let flags: { user?: string; 'base-url'?: string; json?: boolean; help?: boolean };
+  try {
+    const parsed = parseArgs({ args: input.argv, options: OPTIONS, strict: true, allowPositionals: false });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce api-key list: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  if (flags.help === true) { input.output.stdout(HELP); return 0; }
+
+  const jsonMode = flags.json === true;
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    const data = await mediforce.apiKeys.list(flags.user ? { userId: flags.user } : undefined);
+
+    if (jsonMode) {
+      printJson(input.output, data);
+      return 0;
+    }
+
+    const active = data.keys.filter((k) => !k.revokedAt);
+    const revoked = data.keys.filter((k) => k.revokedAt);
+
+    if (active.length === 0 && revoked.length === 0) {
+      input.output.stdout('No API keys found.');
+      return 0;
+    }
+
+    if (active.length > 0) {
+      input.output.stdout(`Active keys (${active.length}):`);
+      for (const k of active) {
+        const lastUsed = k.lastUsedAt ? ` | last used: ${k.lastUsedAt.slice(0, 10)}` : '';
+        input.output.stdout(`  ${k.keyPrefix}...  ${k.label.padEnd(20)}  created: ${k.createdAt.slice(0, 10)}${lastUsed}  [${k.id}]`);
+      }
+    }
+
+    if (revoked.length > 0) {
+      input.output.stdout(`\nRevoked keys (${revoked.length}):`);
+      for (const k of revoked) {
+        input.output.stdout(`  ${k.keyPrefix}...  ${k.label.padEnd(20)}  revoked: ${k.revokedAt!.slice(0, 10)}  [${k.id}]`);
+      }
+    }
+
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
+    } else {
+      printError(input.output, { error: err instanceof Error ? err.message : String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/api-key-revoke.ts
+++ b/packages/cli/src/commands/api-key-revoke.ts
@@ -1,0 +1,89 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce api-key revoke <keyId> [--user <uid>] [options]
+
+Revoke an API key. The key will immediately stop working.
+
+Required positional:
+  <keyId>             ID of the API key to revoke
+
+Optional flags:
+  --user <uid>        Firebase UID of the key owner (admin mode)
+  --base-url <url>    API base URL (default: http://localhost:9003)
+  --json              Emit JSON instead of human-readable output
+  --help, -h          Show this help text
+`;
+
+const OPTIONS = {
+  user: { type: 'string' },
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function apiKeyRevokeCommand(input: CommandInput): Promise<number> {
+  let flags: { user?: string; 'base-url'?: string; json?: boolean; help?: boolean };
+  let positionals: string[];
+  try {
+    const parsed = parseArgs({ args: input.argv, options: OPTIONS, strict: true, allowPositionals: true });
+    flags = parsed.values;
+    positionals = parsed.positionals;
+  } catch (err) {
+    input.output.stderr(`mediforce api-key revoke: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  if (flags.help === true) { input.output.stdout(HELP); return 0; }
+
+  const keyId = positionals[0];
+  if (!keyId) {
+    printError(input.output, { error: '<keyId> is required' }, false);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  const jsonMode = flags.json === true;
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    await mediforce.apiKeys.revoke({
+      keyId,
+      ...(flags.user ? { userId: flags.user } : {}),
+    });
+
+    if (jsonMode) {
+      printJson(input.output, { ok: true, keyId });
+      return 0;
+    }
+
+    input.output.stdout(`API key ${keyId} revoked.`);
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
+    } else {
+      printError(input.output, { error: err instanceof Error ? err.message : String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -1,0 +1,80 @@
+import { parseArgs } from 'node:util';
+import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { resolveConfig } from '../config.js';
+import { printJson, printError, type OutputSink } from '../output.js';
+
+interface CommandInput {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  output: OutputSink;
+}
+
+const HELP = `Usage: mediforce whoami [options]
+
+Show the identity and namespace access for the current API key.
+
+Optional flags:
+  --base-url <url>    API base URL (default: http://localhost:9003)
+  --json              Emit JSON instead of human-readable output
+  --help, -h          Show this help text
+`;
+
+const OPTIONS = {
+  'base-url': { type: 'string' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+} as const;
+
+export async function whoamiCommand(input: CommandInput): Promise<number> {
+  let flags: { 'base-url'?: string; json?: boolean; help?: boolean };
+  try {
+    const parsed = parseArgs({ args: input.argv, options: OPTIONS, strict: true, allowPositionals: false });
+    flags = parsed.values;
+  } catch (err) {
+    input.output.stderr(`mediforce whoami: ${String(err)}`);
+    input.output.stderr('');
+    input.output.stderr(HELP);
+    return 2;
+  }
+
+  if (flags.help === true) {
+    input.output.stdout(HELP);
+    return 0;
+  }
+
+  const jsonMode = flags.json === true;
+
+  let config;
+  try {
+    config = resolveConfig({ flagBaseUrl: flags['base-url'], env: input.env });
+  } catch (err) {
+    printError(input.output, { error: String(err) }, jsonMode);
+    return 2;
+  }
+
+  const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
+  try {
+    const data = await mediforce.me.whoami();
+
+    if (jsonMode) {
+      printJson(input.output, data);
+      return 0;
+    }
+
+    if (data.kind === 'apiKey') {
+      input.output.stdout('Identity:    global API key (unrestricted)');
+      input.output.stdout('Namespaces:  all (admin access)');
+    } else {
+      input.output.stdout(`Identity:    user ${data.uid}`);
+      input.output.stdout(`Namespaces:  ${data.namespaces.length > 0 ? data.namespaces.join(', ') : '(none)'}`);
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof ApiError) {
+      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
+    } else {
+      printError(input.output, { error: err instanceof Error ? err.message : String(err) }, jsonMode);
+    }
+    return 1;
+  }
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -31,7 +31,7 @@ export function resolveApiKey(env: Record<string, string | undefined>): string {
     return fromPlatform;
   }
   throw new Error(
-    'mediforce: missing API key. Set MEDIFORCE_API_KEY to your personal API key (create one in Settings > API Keys).',
+    'mediforce: missing API key. Set MEDIFORCE_API_KEY to a personal API key (Settings > API Keys) or PLATFORM_API_KEY for CI/deploy.',
   );
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -31,7 +31,7 @@ export function resolveApiKey(env: Record<string, string | undefined>): string {
     return fromPlatform;
   }
   throw new Error(
-    'mediforce: missing API key. Set MEDIFORCE_API_KEY (or PLATFORM_API_KEY).',
+    'mediforce: missing API key. Set MEDIFORCE_API_KEY to your personal API key (create one in Settings > API Keys).',
   );
 }
 

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -150,6 +150,33 @@ export interface ListNamespacesOutput {
   namespaces: NamespaceInfo[];
 }
 
+export interface ApiKeyEntry {
+  id: string;
+  label: string;
+  keyPrefix: string;
+  userId: string;
+  createdAt: string;
+  lastUsedAt?: string;
+  revokedAt?: string;
+}
+
+export interface ListApiKeysOutput {
+  keys: ApiKeyEntry[];
+}
+
+export interface CreateApiKeyOutput {
+  id: string;
+  userId: string;
+  label: string;
+  keyPrefix: string;
+  createdAt: string;
+  plaintext: string;
+}
+
+export interface RevokeApiKeyOutput {
+  ok: true;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -164,6 +191,12 @@ export class ApiError extends Error {
 export class Mediforce {
   readonly tasks: {
     list: (input: ListTasksInput) => Promise<ListTasksOutput>;
+  };
+
+  readonly apiKeys: {
+    list: (input?: { userId?: string }) => Promise<ListApiKeysOutput>;
+    create: (input: { label: string; userId?: string }) => Promise<CreateApiKeyOutput>;
+    revoke: (input: { keyId: string; userId?: string }) => Promise<RevokeApiKeyOutput>;
   };
 
   readonly workflows: {
@@ -249,6 +282,27 @@ export class Mediforce {
         );
       }
     }
+
+    this.apiKeys = {
+      list: async (input) => {
+        const qs = input?.userId ? toSearchParams({ userId: input.userId }) : '';
+        const res = await this.request(`/api/api-keys${qs}`);
+        return parseJsonOrThrow(res, 'mediforce.apiKeys.list') as Promise<ListApiKeysOutput>;
+      },
+      create: async (input) => {
+        const res = await this.request('/api/api-keys', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        });
+        return parseJsonOrThrow(res, 'mediforce.apiKeys.create') as Promise<CreateApiKeyOutput>;
+      },
+      revoke: async (input) => {
+        const qs = input.userId ? toSearchParams({ userId: input.userId }) : '';
+        const res = await this.request(`/api/api-keys/${input.keyId}${qs}`, { method: 'DELETE' });
+        return parseJsonOrThrow(res, 'mediforce.apiKeys.revoke') as Promise<RevokeApiKeyOutput>;
+      },
+    };
 
     this.tasks = {
       list: async (input) => {

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -134,6 +134,22 @@ export type ClientConfig =
   | (BaseClientConfig & { bearerToken: () => Promise<string | null>; apiKey?: never; fetch?: never })
   | (BaseClientConfig & { fetch: typeof fetch; apiKey?: never; bearerToken?: never });
 
+export interface WhoamiOutput {
+  kind: 'apiKey' | 'user';
+  uid?: string;
+  namespaces: string[];
+}
+
+export interface NamespaceInfo {
+  handle: string;
+  type: string;
+  displayName: string;
+}
+
+export interface ListNamespacesOutput {
+  namespaces: NamespaceInfo[];
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -186,6 +202,11 @@ export class Mediforce {
     set: (input: SetSecretInput) => Promise<SetSecretOutput>;
     list: (input: ListSecretKeysInput) => Promise<ListSecretKeysOutput>;
     delete: (input: DeleteSecretInput) => Promise<DeleteSecretOutput>;
+  };
+
+  readonly me: {
+    whoami: () => Promise<WhoamiOutput>;
+    namespaces: () => Promise<ListNamespacesOutput>;
   };
 
   readonly system: {
@@ -468,6 +489,17 @@ export class Mediforce {
         const res = await this.request(`/api/workflow-secrets${qs}`, { method: 'DELETE' });
         const body = await parseJsonOrThrow(res, 'mediforce.secrets.delete');
         return DeleteSecretOutputSchema.parse(body);
+      },
+    };
+
+    this.me = {
+      whoami: async () => {
+        const res = await this.request('/api/me');
+        return parseJsonOrThrow(res, 'mediforce.me.whoami') as Promise<WhoamiOutput>;
+      },
+      namespaces: async () => {
+        const res = await this.request('/api/me/namespaces');
+        return parseJsonOrThrow(res, 'mediforce.me.namespaces') as Promise<ListNamespacesOutput>;
       },
     };
 

--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -12,6 +12,7 @@ import {
   FirestoreOAuthProviderRepository,
   FirestoreAgentOAuthTokenRepository,
   FirestoreModelRegistryRepository,
+  FirestoreApiKeyRepository,
   FirestoreWorkflowSecretsRepository,
   FirestoreNamespaceSecretsRepository,
   getAdminFirestore,
@@ -72,6 +73,7 @@ export interface PlatformServices {
   oauthProviderRepo: FirestoreOAuthProviderRepository;
   agentOAuthTokenRepo: FirestoreAgentOAuthTokenRepository;
   modelRegistryRepo: FirestoreModelRegistryRepository;
+  apiKeyRepo: FirestoreApiKeyRepository;
   secretsRepo: FirestoreWorkflowSecretsRepository;
   namespaceSecretsRepo: FirestoreNamespaceSecretsRepository;
 }
@@ -98,6 +100,7 @@ export function getPlatformServices(): PlatformServices {
   const oauthProviderRepo = new FirestoreOAuthProviderRepository(db);
   const agentOAuthTokenRepo = new FirestoreAgentOAuthTokenRepository(db);
   const modelRegistryRepo = new FirestoreModelRegistryRepository(db);
+  const apiKeyRepo = new FirestoreApiKeyRepository(db);
   const secretsRepo = new FirestoreWorkflowSecretsRepository(db);
   const namespaceSecretsRepo = new FirestoreNamespaceSecretsRepository(db);
   const eventLog = new FirestoreAgentEventLog(db);
@@ -208,6 +211,7 @@ export function getPlatformServices(): PlatformServices {
     oauthProviderRepo,
     agentOAuthTokenRepo,
     modelRegistryRepo,
+    apiKeyRepo,
     secretsRepo,
     namespaceSecretsRepo,
   };

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -84,6 +84,8 @@ export {
   StepMcpRestrictionSchema,
   StepMcpRestrictionEntrySchema,
   ToolCatalogEntrySchema,
+  ApiKeySchema,
+  CreateApiKeyInputSchema,
 } from './schemas/index.js';
 
 // Types (re-exported from schemas for convenience)
@@ -166,6 +168,8 @@ export type {
   StepMcpRestriction,
   StepMcpRestrictionEntry,
   ToolCatalogEntry,
+  ApiKey,
+  CreateApiKeyInput,
 } from './schemas/index.js';
 
 // Interfaces (repository and service contracts)

--- a/packages/platform-core/src/schemas/__tests__/api-key.test.ts
+++ b/packages/platform-core/src/schemas/__tests__/api-key.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { ApiKeySchema, CreateApiKeyInputSchema } from '../api-key.js';
+
+const valid = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  userId: 'firebase-uid-123',
+  keyHash: 'a'.repeat(64),
+  keyPrefix: 'mf_a1B2c3D4',
+  label: 'CI key',
+  createdAt: '2026-05-11T10:00:00.000Z',
+};
+
+describe('ApiKeySchema', () => {
+  it('parses a valid key', () => {
+    const result = ApiKeySchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses with optional fields', () => {
+    const result = ApiKeySchema.safeParse({
+      ...valid,
+      lastUsedAt: '2026-05-11T12:00:00.000Z',
+      revokedAt: '2026-05-11T14:00:00.000Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing required fields', () => {
+    const { label: _, ...noLabel } = valid;
+    expect(ApiKeySchema.safeParse(noLabel).success).toBe(false);
+  });
+
+  it('rejects empty label', () => {
+    expect(ApiKeySchema.safeParse({ ...valid, label: '' }).success).toBe(false);
+  });
+
+  it('rejects label over 128 chars', () => {
+    expect(ApiKeySchema.safeParse({ ...valid, label: 'x'.repeat(129) }).success).toBe(false);
+  });
+
+  it('rejects extra fields (strict)', () => {
+    expect(ApiKeySchema.safeParse({ ...valid, extra: true }).success).toBe(false);
+  });
+
+  it('rejects invalid UUID for id', () => {
+    expect(ApiKeySchema.safeParse({ ...valid, id: 'not-a-uuid' }).success).toBe(false);
+  });
+});
+
+describe('CreateApiKeyInputSchema', () => {
+  it('parses valid input', () => {
+    expect(CreateApiKeyInputSchema.safeParse({ label: 'My key' }).success).toBe(true);
+  });
+
+  it('rejects empty label', () => {
+    expect(CreateApiKeyInputSchema.safeParse({ label: '' }).success).toBe(false);
+  });
+});

--- a/packages/platform-core/src/schemas/__tests__/api-key.test.ts
+++ b/packages/platform-core/src/schemas/__tests__/api-key.test.ts
@@ -45,6 +45,15 @@ describe('ApiKeySchema', () => {
   it('rejects invalid UUID for id', () => {
     expect(ApiKeySchema.safeParse({ ...valid, id: 'not-a-uuid' }).success).toBe(false);
   });
+
+  it('rejects keyHash that is not 64-char hex', () => {
+    expect(ApiKeySchema.safeParse({ ...valid, keyHash: 'short' }).success).toBe(false);
+    expect(ApiKeySchema.safeParse({ ...valid, keyHash: 'g'.repeat(64) }).success).toBe(false);
+  });
+
+  it('rejects keyPrefix without mf_ prefix', () => {
+    expect(ApiKeySchema.safeParse({ ...valid, keyPrefix: 'sk_a1B2c3D4' }).success).toBe(false);
+  });
 });
 
 describe('CreateApiKeyInputSchema', () => {

--- a/packages/platform-core/src/schemas/api-key.ts
+++ b/packages/platform-core/src/schemas/api-key.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const ApiKeySchema = z.object({
   id: z.string().uuid(),
   userId: z.string().min(1),
-  keyHash: z.string().min(1),
-  keyPrefix: z.string().min(1),
+  keyHash: z.string().regex(/^[0-9a-f]{64}$/),
+  keyPrefix: z.string().regex(/^mf_[A-Za-z0-9_-]{1,8}$/),
   label: z.string().min(1).max(128),
   createdAt: z.string().datetime(),
   lastUsedAt: z.string().datetime().optional(),

--- a/packages/platform-core/src/schemas/api-key.ts
+++ b/packages/platform-core/src/schemas/api-key.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const ApiKeySchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().min(1),
+  keyHash: z.string().min(1),
+  keyPrefix: z.string().min(1),
+  label: z.string().min(1).max(128),
+  createdAt: z.string().datetime(),
+  lastUsedAt: z.string().datetime().optional(),
+  revokedAt: z.string().datetime().optional(),
+}).strict();
+
+export type ApiKey = z.infer<typeof ApiKeySchema>;
+
+export const CreateApiKeyInputSchema = z.object({
+  label: z.string().min(1).max(128),
+});
+
+export type CreateApiKeyInput = z.infer<typeof CreateApiKeyInputSchema>;

--- a/packages/platform-core/src/schemas/index.ts
+++ b/packages/platform-core/src/schemas/index.ts
@@ -230,6 +230,13 @@ export {
 } from './cron-trigger-state.js';
 
 export {
+  ApiKeySchema,
+  CreateApiKeyInputSchema,
+  type ApiKey,
+  type CreateApiKeyInput,
+} from './api-key.js';
+
+export {
   ModelRegistryEntrySchema,
   ModelRegistryMetaSchema,
   CreateModelRegistryEntryInputSchema,

--- a/packages/platform-infra/src/__tests__/api-key-crypto.test.ts
+++ b/packages/platform-infra/src/__tests__/api-key-crypto.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { generateApiKey, hashApiKey } from '../crypto/api-key-crypto.js';
+
+describe('generateApiKey', () => {
+  it('returns plaintext with mf_ prefix', () => {
+    const { plaintext } = generateApiKey();
+    expect(plaintext.startsWith('mf_')).toBe(true);
+  });
+
+  it('returns plaintext of at least 40 characters', () => {
+    const { plaintext } = generateApiKey();
+    expect(plaintext.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('returns a keyPrefix that is first 11 chars of plaintext', () => {
+    const { plaintext, keyPrefix } = generateApiKey();
+    expect(keyPrefix).toBe(plaintext.slice(0, 11));
+  });
+
+  it('returns a keyHash that matches hashApiKey(plaintext)', () => {
+    const { plaintext, keyHash } = generateApiKey();
+    expect(keyHash).toBe(hashApiKey(plaintext));
+  });
+
+  it('generates unique keys on each call', () => {
+    const a = generateApiKey();
+    const b = generateApiKey();
+    expect(a.plaintext).not.toBe(b.plaintext);
+    expect(a.keyHash).not.toBe(b.keyHash);
+  });
+});
+
+describe('hashApiKey', () => {
+  it('returns a 64-char hex string', () => {
+    const hash = hashApiKey('mf_test');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic', () => {
+    const a = hashApiKey('mf_abc');
+    const b = hashApiKey('mf_abc');
+    expect(a).toBe(b);
+  });
+});

--- a/packages/platform-infra/src/crypto/api-key-crypto.ts
+++ b/packages/platform-infra/src/crypto/api-key-crypto.ts
@@ -1,0 +1,16 @@
+import { createHash, randomBytes } from 'crypto';
+
+const KEY_PREFIX = 'mf_';
+const RAW_BYTES = 32;
+
+export function generateApiKey(): { plaintext: string; keyHash: string; keyPrefix: string } {
+  const raw = randomBytes(RAW_BYTES);
+  const plaintext = KEY_PREFIX + raw.toString('base64url');
+  const keyHash = hashApiKey(plaintext);
+  const keyPrefix = plaintext.slice(0, 11);
+  return { plaintext, keyHash, keyPrefix };
+}
+
+export function hashApiKey(plaintext: string): string {
+  return createHash('sha256').update(plaintext).digest('hex');
+}

--- a/packages/platform-infra/src/firestore/api-key-repository.ts
+++ b/packages/platform-infra/src/firestore/api-key-repository.ts
@@ -1,0 +1,48 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import { ApiKeySchema, type ApiKey } from '@mediforce/platform-core';
+
+export class FirestoreApiKeyRepository {
+  constructor(private readonly db: Firestore) {}
+
+  private col() {
+    return this.db.collection('apiKeys');
+  }
+
+  async create(apiKey: ApiKey): Promise<void> {
+    const parsed = ApiKeySchema.parse(apiKey);
+    await this.col().doc(parsed.id).set(parsed);
+  }
+
+  async getByKeyHash(keyHash: string): Promise<ApiKey | null> {
+    const snap = await this.col()
+      .where('keyHash', '==', keyHash)
+      .limit(1)
+      .get();
+    if (snap.empty) return null;
+    return ApiKeySchema.parse(snap.docs[0]!.data());
+  }
+
+  async listByUser(userId: string): Promise<ApiKey[]> {
+    const snap = await this.col()
+      .where('userId', '==', userId)
+      .orderBy('createdAt', 'desc')
+      .get();
+    return snap.docs.map((doc) => ApiKeySchema.parse(doc.data()));
+  }
+
+  async revoke(keyId: string): Promise<boolean> {
+    const ref = this.col().doc(keyId);
+    const snap = await ref.get();
+    if (!snap.exists) return false;
+    await ref.update({ revokedAt: new Date().toISOString() });
+    return true;
+  }
+
+  async delete(keyId: string): Promise<void> {
+    await this.col().doc(keyId).delete();
+  }
+
+  async touchLastUsed(keyId: string): Promise<void> {
+    await this.col().doc(keyId).update({ lastUsedAt: new Date().toISOString() });
+  }
+}

--- a/packages/platform-infra/src/firestore/api-key-repository.ts
+++ b/packages/platform-infra/src/firestore/api-key-repository.ts
@@ -38,10 +38,6 @@ export class FirestoreApiKeyRepository {
     return true;
   }
 
-  async delete(keyId: string): Promise<void> {
-    await this.col().doc(keyId).delete();
-  }
-
   async touchLastUsed(keyId: string): Promise<void> {
     await this.col().doc(keyId).update({ lastUsedAt: new Date().toISOString() });
   }

--- a/packages/platform-infra/src/index.ts
+++ b/packages/platform-infra/src/index.ts
@@ -35,5 +35,7 @@ export { getAdminAuth, getAdminFirestore } from './auth/firebase-admin-init.js';
 export { FirebaseInviteService } from './auth/firebase-invite-service.js';
 export { backfillInstanceNamespaces } from './migrations/backfill-instance-namespaces.js';
 export { FirestoreModelRegistryRepository } from './firestore/model-registry-repository.js';
+export { FirestoreApiKeyRepository } from './firestore/api-key-repository.js';
+export { generateApiKey, hashApiKey } from './crypto/api-key-crypto.js';
 export { syncFromOpenRouter } from './sync/openrouter-sync.js';
 

--- a/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
@@ -33,6 +33,7 @@ import { NamespaceMemberSchema } from '@mediforce/platform-core';
 import type { NamespaceMember } from '@mediforce/platform-core';
 import { cn } from '@/lib/utils';
 import { NamespaceSecretsEditor } from '@/components/namespace/namespace-secrets-editor';
+import { ApiKeysManager } from '@/components/namespace/api-keys-manager';
 
 type NamespaceMemberWithId = NamespaceMember & { id: string };
 
@@ -878,7 +879,17 @@ export default function WorkspaceConfigPage() {
           </div>
         )}
 
-        {/* ── Section 5: Administration ──────────────────────────────────── */}
+        {/* ── Section 5: API Keys ────────────────────────────────────────── */}
+        {firebaseUser?.uid && (
+          <div className="mb-10 space-y-4">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">API Keys</h2>
+            <div className="rounded-lg border bg-card px-4 py-5">
+              <ApiKeysManager />
+            </div>
+          </div>
+        )}
+
+        {/* ── Section 6: Administration ──────────────────────────────────── */}
         {canEditProfile && (
           <div className="mb-10 space-y-4">
             <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Administration</h2>

--- a/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/[name]/route.ts
@@ -8,9 +8,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string; name: string }> },
 ): Promise<NextResponse> {
   const { id, name } = await params;
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const body = await request.json().catch(() => null);
@@ -44,9 +44,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string; name: string }> },
 ): Promise<NextResponse> {
   const { id, name } = await params;
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const agent = await agentDefinitionRepo.getById(id);

--- a/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/[id]/mcp-servers/route.ts
@@ -7,9 +7,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const agent = await agentDefinitionRepo.getById(id);

--- a/packages/platform-ui/src/app/api/agent-definitions/[id]/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/[id]/route.ts
@@ -23,9 +23,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const agent = await agentDefinitionRepo.getById(id);
@@ -44,9 +44,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const agent = await agentDefinitionRepo.getById(id);
@@ -68,9 +68,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   const { id } = await params;
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const agent = await agentDefinitionRepo.getById(id);

--- a/packages/platform-ui/src/app/api/agent-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/route.ts
@@ -4,9 +4,9 @@ import { getPlatformServices } from '@/lib/platform-services';
 import { resolveCallerIdentity, requireNamespaceAccess } from '@/lib/api-auth';
 
 export async function GET(request: Request): Promise<NextResponse> {
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const agents = await agentDefinitionRepo.list();
@@ -20,9 +20,9 @@ export async function GET(request: Request): Promise<NextResponse> {
 }
 
 export async function POST(request: Request): Promise<NextResponse> {
-  const { agentDefinitionRepo, namespaceRepo } = getPlatformServices();
+  const { agentDefinitionRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const body = await request.json();

--- a/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getPlatformServices } from '@/lib/platform-services';
+import { resolveCallerIdentity } from '@/lib/api-auth';
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ keyId: string }> },
+): Promise<NextResponse> {
+  const { namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
+  if (caller instanceof NextResponse) return caller;
+  if (caller.kind !== 'user') {
+    return NextResponse.json({ error: 'Per-user auth required' }, { status: 403 });
+  }
+
+  const { keyId } = await params;
+  const keys = await apiKeyRepo.listByUser(caller.uid);
+  const key = keys.find((k) => k.id === keyId);
+  if (!key) {
+    return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+  }
+
+  const revoked = await apiKeyRepo.revoke(keyId);
+  if (!revoked) {
+    return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
@@ -11,26 +11,25 @@ export async function DELETE(
   if (caller instanceof NextResponse) return caller;
 
   const { keyId } = await params;
-  const url = new URL(request.url);
-  const queryUserId = url.searchParams.get('userId');
 
+  let ownerUid: string;
   if (caller.kind === 'apiKey') {
+    const url = new URL(request.url);
+    const queryUserId = url.searchParams.get('userId');
     if (!queryUserId) {
       return NextResponse.json(
         { error: 'Global API key requires ?userId=<uid> parameter' },
         { status: 400 },
       );
     }
-    const keys = await apiKeyRepo.listByUser(queryUserId);
-    if (!keys.some((k) => k.id === keyId)) {
-      return NextResponse.json({ error: 'API key not found' }, { status: 404 });
-    }
+    ownerUid = queryUserId;
   } else {
-    const ownerUid = queryUserId ?? caller.uid;
-    const keys = await apiKeyRepo.listByUser(ownerUid);
-    if (!keys.some((k) => k.id === keyId)) {
-      return NextResponse.json({ error: 'API key not found' }, { status: 404 });
-    }
+    ownerUid = caller.uid;
+  }
+
+  const keys = await apiKeyRepo.listByUser(ownerUid);
+  if (!keys.some((k) => k.id === keyId)) {
+    return NextResponse.json({ error: 'API key not found' }, { status: 404 });
   }
 
   const revoked = await apiKeyRepo.revoke(keyId);

--- a/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
@@ -12,6 +12,7 @@ export async function DELETE(
 
   const { keyId } = await params;
 
+  // See resolveTargetUser in ../route.ts for rationale on global key + userId.
   let ownerUid: string;
   if (caller.kind === 'apiKey') {
     const url = new URL(request.url);

--- a/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts
@@ -9,15 +9,28 @@ export async function DELETE(
   const { namespaceRepo, apiKeyRepo } = getPlatformServices();
   const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
-  if (caller.kind !== 'user') {
-    return NextResponse.json({ error: 'Per-user auth required' }, { status: 403 });
-  }
 
   const { keyId } = await params;
-  const keys = await apiKeyRepo.listByUser(caller.uid);
-  const key = keys.find((k) => k.id === keyId);
-  if (!key) {
-    return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+  const url = new URL(request.url);
+  const queryUserId = url.searchParams.get('userId');
+
+  if (caller.kind === 'apiKey') {
+    if (!queryUserId) {
+      return NextResponse.json(
+        { error: 'Global API key requires ?userId=<uid> parameter' },
+        { status: 400 },
+      );
+    }
+    const keys = await apiKeyRepo.listByUser(queryUserId);
+    if (!keys.some((k) => k.id === keyId)) {
+      return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+    }
+  } else {
+    const ownerUid = queryUserId ?? caller.uid;
+    const keys = await apiKeyRepo.listByUser(ownerUid);
+    if (!keys.some((k) => k.id === keyId)) {
+      return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+    }
   }
 
   const revoked = await apiKeyRepo.revoke(keyId);

--- a/packages/platform-ui/src/app/api/api-keys/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/api-keys/__tests__/route.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+
+const mockListByUser = vi.fn();
+const mockCreate = vi.fn();
+const mockRevoke = vi.fn();
+
+vi.mock('@/lib/platform-services', () => ({
+  getPlatformServices: () => ({
+    namespaceRepo: {},
+    apiKeyRepo: {
+      listByUser: mockListByUser,
+      create: mockCreate,
+      revoke: mockRevoke,
+    },
+  }),
+}));
+
+const mockResolveCallerIdentity = vi.fn();
+vi.mock('@/lib/api-auth', () => ({
+  resolveCallerIdentity: (...args: unknown[]) => mockResolveCallerIdentity(...args),
+}));
+
+vi.mock('@mediforce/platform-infra', () => ({
+  generateApiKey: () => ({
+    plaintext: 'mf_test1234567890abcdefghijklmnopqrstuvwxyz',
+    keyHash: 'a'.repeat(64),
+    keyPrefix: 'mf_test12',
+  }),
+}));
+
+vi.mock('crypto', async () => {
+  const actual = await vi.importActual<typeof import('crypto')>('crypto');
+  return { ...actual, randomUUID: () => '00000000-0000-0000-0000-000000000001' };
+});
+
+import { GET, POST } from '../route';
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(`http://localhost${url}`, init);
+}
+
+const userCaller = { kind: 'user' as const, uid: 'user-1', namespaces: new Set(['ns']) };
+const adminCaller = { kind: 'apiKey' as const };
+
+describe('GET /api/api-keys', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('lists keys for authenticated user', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+    mockListByUser.mockResolvedValue([
+      { id: 'k1', userId: 'user-1', keyHash: 'a'.repeat(64), keyPrefix: 'mf_abc', label: 'test', createdAt: '2026-01-01T00:00:00.000Z' },
+    ]);
+
+    const res = await GET(makeRequest('/api/api-keys'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.keys).toHaveLength(1);
+    expect(body.keys[0].keyHash).toBeUndefined();
+    expect(body.keys[0].keyPrefix).toBe('mf_abc');
+  });
+
+  it('user cannot list other users keys via userId param', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+    mockListByUser.mockResolvedValue([]);
+
+    await GET(makeRequest('/api/api-keys?userId=victim'));
+
+    expect(mockListByUser).toHaveBeenCalledWith('user-1');
+  });
+
+  it('admin requires userId param', async () => {
+    mockResolveCallerIdentity.mockReturnValue(adminCaller);
+
+    const res = await GET(makeRequest('/api/api-keys'));
+    expect(res.status).toBe(400);
+  });
+
+  it('admin can list keys for a user', async () => {
+    mockResolveCallerIdentity.mockReturnValue(adminCaller);
+    mockListByUser.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/api-keys?userId=target-uid'));
+    expect(res.status).toBe(200);
+    expect(mockListByUser).toHaveBeenCalledWith('target-uid');
+  });
+});
+
+describe('POST /api/api-keys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListByUser.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(undefined);
+  });
+
+  it('creates key and returns plaintext', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+
+    const res = await POST(makeRequest('/api/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'my key' }),
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.plaintext).toMatch(/^mf_/);
+    expect(body.userId).toBe('user-1');
+    expect(body.label).toBe('my key');
+  });
+
+  it('user cannot create key for another user', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+
+    const res = await POST(makeRequest('/api/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'sneaky', userId: 'victim' }),
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.userId).toBe('user-1');
+  });
+
+  it('admin can create key for another user', async () => {
+    mockResolveCallerIdentity.mockReturnValue(adminCaller);
+
+    const res = await POST(makeRequest('/api/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'for user', userId: 'target-uid' }),
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.userId).toBe('target-uid');
+  });
+
+  it('enforces MAX_ACTIVE_KEYS', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+    mockListByUser.mockResolvedValue(
+      Array.from({ length: 10 }, (_, i) => ({ id: `k${i}`, userId: 'user-1' })),
+    );
+
+    const res = await POST(makeRequest('/api/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 'too many' }),
+    }));
+
+    expect(res.status).toBe(429);
+  });
+
+  it('rejects invalid body', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+
+    const res = await POST(makeRequest('/api/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: '' }),
+    }));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid request body');
+  });
+
+  it('does not leak Zod details', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+
+    const res = await POST(makeRequest('/api/api-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label: 123 }),
+    }));
+
+    const body = await res.json();
+    expect(body.error).toBe('Invalid request body');
+    expect(JSON.stringify(body)).not.toContain('Expected string');
+  });
+});
+
+describe('DELETE /api/api-keys/[keyId]', () => {
+  // Bracket dirs break Vite dynamic imports — test the route logic via
+  // the same mocks (resolveCallerIdentity + apiKeyRepo) and a minimal
+  // inline handler that mirrors [keyId]/route.ts.
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  async function callDelete(url: string, keyId: string) {
+    const caller = mockResolveCallerIdentity();
+    if (caller instanceof NextResponse) return caller;
+
+    if (caller.kind === 'apiKey') {
+      const u = new URL(`http://localhost${url}`);
+      const qUserId = u.searchParams.get('userId');
+      if (!qUserId) return NextResponse.json({ error: 'Global API key requires ?userId=<uid> parameter' }, { status: 400 });
+      const keys = await mockListByUser(qUserId);
+      if (!keys.some((k: { id: string }) => k.id === keyId)) return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+    } else {
+      const keys = await mockListByUser(caller.uid);
+      if (!keys.some((k: { id: string }) => k.id === keyId)) return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+    }
+    const revoked = await mockRevoke(keyId);
+    if (!revoked) return NextResponse.json({ error: 'API key not found' }, { status: 404 });
+    return NextResponse.json({ ok: true });
+  }
+
+  it('user can revoke own key', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+    mockListByUser.mockResolvedValue([{ id: 'k1', userId: 'user-1' }]);
+    mockRevoke.mockResolvedValue(true);
+
+    const res = await callDelete('/api/api-keys/k1', 'k1');
+    expect(res.status).toBe(200);
+    expect(mockListByUser).toHaveBeenCalledWith('user-1');
+  });
+
+  it('user cannot revoke another users key', async () => {
+    mockResolveCallerIdentity.mockReturnValue(userCaller);
+    mockListByUser.mockResolvedValue([]);
+
+    const res = await callDelete('/api/api-keys/k1?userId=victim', 'k1');
+    expect(res.status).toBe(404);
+    expect(mockListByUser).toHaveBeenCalledWith('user-1');
+  });
+
+  it('admin requires userId param', async () => {
+    mockResolveCallerIdentity.mockReturnValue(adminCaller);
+
+    const res = await callDelete('/api/api-keys/k1', 'k1');
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/platform-ui/src/app/api/api-keys/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/route.ts
@@ -7,15 +7,32 @@ import { resolveCallerIdentity } from '@/lib/api-auth';
 
 const MAX_ACTIVE_KEYS = 10;
 
+function resolveTargetUser(
+  caller: { kind: 'apiKey' } | { kind: 'user'; uid: string },
+  queryUserId: string | null,
+): { userId: string } | NextResponse {
+  if (caller.kind === 'user') {
+    return { userId: queryUserId ?? caller.uid };
+  }
+  if (!queryUserId) {
+    return NextResponse.json(
+      { error: 'Global API key requires ?userId=<uid> parameter' },
+      { status: 400 },
+    );
+  }
+  return { userId: queryUserId };
+}
+
 export async function GET(request: Request): Promise<NextResponse> {
   const { namespaceRepo, apiKeyRepo } = getPlatformServices();
   const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
-  if (caller.kind !== 'user') {
-    return NextResponse.json({ error: 'Per-user auth required' }, { status: 403 });
-  }
 
-  const keys = await apiKeyRepo.listByUser(caller.uid);
+  const url = new URL(request.url);
+  const target = resolveTargetUser(caller, url.searchParams.get('userId'));
+  if (target instanceof NextResponse) return target;
+
+  const keys = await apiKeyRepo.listByUser(target.userId);
   return NextResponse.json({
     keys: keys.map(({ keyHash: _, ...rest }) => rest),
   });
@@ -25,9 +42,6 @@ export async function POST(request: Request): Promise<NextResponse> {
   const { namespaceRepo, apiKeyRepo } = getPlatformServices();
   const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
-  if (caller.kind !== 'user') {
-    return NextResponse.json({ error: 'Per-user auth required' }, { status: 403 });
-  }
 
   let body: unknown;
   try {
@@ -44,7 +58,11 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
-  const existing = await apiKeyRepo.listByUser(caller.uid);
+  const targetUserId = (body as Record<string, unknown>).userId as string | undefined;
+  const target = resolveTargetUser(caller, targetUserId ?? null);
+  if (target instanceof NextResponse) return target;
+
+  const existing = await apiKeyRepo.listByUser(target.userId);
   const active = existing.filter((k) => !k.revokedAt);
   if (active.length >= MAX_ACTIVE_KEYS) {
     return NextResponse.json(
@@ -59,7 +77,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   await apiKeyRepo.create({
     id,
-    userId: caller.uid,
+    userId: target.userId,
     keyHash,
     keyPrefix,
     label: parsed.data.label,
@@ -68,6 +86,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   return NextResponse.json({
     id,
+    userId: target.userId,
     label: parsed.data.label,
     keyPrefix,
     createdAt: now,

--- a/packages/platform-ui/src/app/api/api-keys/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/route.ts
@@ -12,6 +12,10 @@ const CreateBodySchema = z.object({
   userId: z.string().min(1).optional(),
 });
 
+// Deliberate: global PLATFORM_API_KEY can target any userId. This solves the
+// bootstrap problem (admin creates first personal key for a user headless).
+// Global key already has unrestricted access to all namespaces/data — managing
+// personal keys does not expand the security surface.
 function resolveTargetUser(
   caller: { kind: 'apiKey' } | { kind: 'user'; uid: string },
   requestedUserId: string | undefined,

--- a/packages/platform-ui/src/app/api/api-keys/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/route.ts
@@ -1,26 +1,31 @@
 import { NextResponse } from 'next/server';
 import { randomUUID } from 'crypto';
-import { CreateApiKeyInputSchema } from '@mediforce/platform-core';
+import { z } from 'zod';
 import { generateApiKey } from '@mediforce/platform-infra';
 import { getPlatformServices } from '@/lib/platform-services';
 import { resolveCallerIdentity } from '@/lib/api-auth';
 
 const MAX_ACTIVE_KEYS = 10;
 
+const CreateBodySchema = z.object({
+  label: z.string().min(1).max(128),
+  userId: z.string().min(1).optional(),
+});
+
 function resolveTargetUser(
   caller: { kind: 'apiKey' } | { kind: 'user'; uid: string },
-  queryUserId: string | null,
+  requestedUserId: string | undefined,
 ): { userId: string } | NextResponse {
   if (caller.kind === 'user') {
-    return { userId: queryUserId ?? caller.uid };
+    return { userId: caller.uid };
   }
-  if (!queryUserId) {
+  if (!requestedUserId) {
     return NextResponse.json(
-      { error: 'Global API key requires ?userId=<uid> parameter' },
+      { error: 'Global API key requires userId parameter' },
       { status: 400 },
     );
   }
-  return { userId: queryUserId };
+  return { userId: requestedUserId };
 }
 
 export async function GET(request: Request): Promise<NextResponse> {
@@ -29,7 +34,8 @@ export async function GET(request: Request): Promise<NextResponse> {
   if (caller instanceof NextResponse) return caller;
 
   const url = new URL(request.url);
-  const target = resolveTargetUser(caller, url.searchParams.get('userId'));
+  const queryUserId = url.searchParams.get('userId') ?? undefined;
+  const target = resolveTargetUser(caller, queryUserId);
   if (target instanceof NextResponse) return target;
 
   const keys = await apiKeyRepo.listByUser(target.userId);
@@ -47,19 +53,15 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = await request.json();
   } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
   }
 
-  const parsed = CreateApiKeyInputSchema.safeParse(body);
+  const parsed = CreateBodySchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.issues.map((i) => i.message).join('; ') },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
   }
 
-  const targetUserId = (body as Record<string, unknown>).userId as string | undefined;
-  const target = resolveTargetUser(caller, targetUserId ?? null);
+  const target = resolveTargetUser(caller, parsed.data.userId);
   if (target instanceof NextResponse) return target;
 
   const existing = await apiKeyRepo.listByUser(target.userId);

--- a/packages/platform-ui/src/app/api/api-keys/route.ts
+++ b/packages/platform-ui/src/app/api/api-keys/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { randomUUID } from 'crypto';
+import { CreateApiKeyInputSchema } from '@mediforce/platform-core';
+import { generateApiKey } from '@mediforce/platform-infra';
+import { getPlatformServices } from '@/lib/platform-services';
+import { resolveCallerIdentity } from '@/lib/api-auth';
+
+const MAX_ACTIVE_KEYS = 10;
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
+  if (caller instanceof NextResponse) return caller;
+  if (caller.kind !== 'user') {
+    return NextResponse.json({ error: 'Per-user auth required' }, { status: 403 });
+  }
+
+  const keys = await apiKeyRepo.listByUser(caller.uid);
+  return NextResponse.json({
+    keys: keys.map(({ keyHash: _, ...rest }) => rest),
+  });
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const { namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
+  if (caller instanceof NextResponse) return caller;
+  if (caller.kind !== 'user') {
+    return NextResponse.json({ error: 'Per-user auth required' }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = CreateApiKeyInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues.map((i) => i.message).join('; ') },
+      { status: 400 },
+    );
+  }
+
+  const existing = await apiKeyRepo.listByUser(caller.uid);
+  const active = existing.filter((k) => !k.revokedAt);
+  if (active.length >= MAX_ACTIVE_KEYS) {
+    return NextResponse.json(
+      { error: `Maximum ${MAX_ACTIVE_KEYS} active API keys per user` },
+      { status: 429 },
+    );
+  }
+
+  const { plaintext, keyHash, keyPrefix } = generateApiKey();
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  await apiKeyRepo.create({
+    id,
+    userId: caller.uid,
+    keyHash,
+    keyPrefix,
+    label: parsed.data.label,
+    createdAt: now,
+  });
+
+  return NextResponse.json({
+    id,
+    label: parsed.data.label,
+    keyPrefix,
+    createdAt: now,
+    plaintext,
+  }, { status: 201 });
+}

--- a/packages/platform-ui/src/app/api/cowork/[sessionId]/chat/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/[sessionId]/chat/route.ts
@@ -28,9 +28,9 @@ export async function POST(
   { params }: { params: Promise<{ sessionId: string }> },
 ): Promise<NextResponse> {
   const { sessionId } = await params;
-  const { coworkSessionRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+  const { coworkSessionRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const session = await coworkSessionRepo.getById(sessionId);

--- a/packages/platform-ui/src/app/api/cowork/[sessionId]/finalize/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/[sessionId]/finalize/route.ts
@@ -15,9 +15,9 @@ export async function POST(
   { params }: { params: Promise<{ sessionId: string }> },
 ): Promise<NextResponse> {
   const { sessionId } = await params;
-  const { coworkSessionRepo, instanceRepo, auditRepo, engine, namespaceRepo } = getPlatformServices();
+  const { coworkSessionRepo, instanceRepo, auditRepo, engine, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const session = await coworkSessionRepo.getById(sessionId);

--- a/packages/platform-ui/src/app/api/cowork/[sessionId]/message/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/[sessionId]/message/route.ts
@@ -21,9 +21,9 @@ export async function POST(
   { params }: { params: Promise<{ sessionId: string }> },
 ): Promise<Response> {
   const { sessionId } = await params;
-  const { coworkSessionRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+  const { coworkSessionRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const session = await coworkSessionRepo.getById(sessionId);

--- a/packages/platform-ui/src/app/api/cowork/[sessionId]/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/[sessionId]/route.ts
@@ -12,9 +12,9 @@ export async function GET(
   { params }: { params: Promise<{ sessionId: string }> },
 ): Promise<NextResponse> {
   const { sessionId } = await params;
-  const { coworkSessionRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+  const { coworkSessionRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const session = await coworkSessionRepo.getById(sessionId);

--- a/packages/platform-ui/src/app/api/cowork/by-instance/[instanceId]/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/by-instance/[instanceId]/route.ts
@@ -12,9 +12,9 @@ export async function GET(
   { params }: { params: Promise<{ instanceId: string }> },
 ): Promise<NextResponse> {
   const { instanceId } = await params;
-  const { coworkSessionRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+  const { coworkSessionRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/me/namespaces/route.ts
+++ b/packages/platform-ui/src/app/api/me/namespaces/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getPlatformServices } from '@/lib/platform-services';
+import { resolveCallerIdentity } from '@/lib/api-auth';
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
+  if (caller instanceof NextResponse) return caller;
+
+  if (caller.kind === 'apiKey') {
+    return NextResponse.json({ namespaces: [] });
+  }
+
+  const memberships = await namespaceRepo.getNamespacesByUser(caller.uid);
+  const namespaces = memberships.map((ns) => ({
+    handle: ns.handle,
+    type: ns.type,
+    displayName: ns.displayName,
+  }));
+
+  return NextResponse.json({ namespaces });
+}

--- a/packages/platform-ui/src/app/api/me/route.ts
+++ b/packages/platform-ui/src/app/api/me/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getPlatformServices } from '@/lib/platform-services';
+import { resolveCallerIdentity } from '@/lib/api-auth';
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const { namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
+  if (caller instanceof NextResponse) return caller;
+
+  if (caller.kind === 'apiKey') {
+    return NextResponse.json({
+      kind: 'apiKey',
+      namespaces: [],
+    });
+  }
+
+  return NextResponse.json({
+    kind: 'user',
+    uid: caller.uid,
+    namespaces: [...caller.namespaces].sort(),
+  });
+}

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/advance/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/advance/route.ts
@@ -17,9 +17,9 @@ export async function POST(
     const { instanceId } = await params;
     const body = await req.json() as AdvanceStepBody;
 
-    const { instanceRepo, processRepo, namespaceRepo } = getPlatformServices();
+    const { instanceRepo, processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/audit/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/audit/route.ts
@@ -8,9 +8,9 @@ export async function GET(
 ): Promise<NextResponse> {
   try {
     const { instanceId } = await params;
-    const { auditRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+    const { auditRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/cancel/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/cancel/route.ts
@@ -8,9 +8,9 @@ export async function POST(
 ): Promise<NextResponse> {
   try {
     const { instanceId } = await params;
-    const { instanceRepo, namespaceRepo } = getPlatformServices();
+    const { instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/resume/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/resume/route.ts
@@ -13,9 +13,9 @@ export async function POST(
 ): Promise<NextResponse> {
   try {
     const { instanceId } = await params;
-    const { instanceRepo, auditRepo, namespaceRepo } = getPlatformServices();
+    const { instanceRepo, auditRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/route.ts
@@ -8,9 +8,9 @@ export async function GET(
 ): Promise<NextResponse> {
   try {
     const { instanceId } = await params;
-    const { instanceRepo, namespaceRepo } = getPlatformServices();
+    const { instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -18,9 +18,9 @@ export async function POST(
   { params }: { params: Promise<{ instanceId: string }> },
 ): Promise<NextResponse> {
   const { instanceId } = await params;
-  const { instanceRepo, processRepo, auditRepo, namespaceRepo } = getPlatformServices();
+  const { instanceRepo, processRepo, auditRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   let stepsExecuted = 0;

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/steps/[stepId]/retry/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/steps/[stepId]/retry/route.ts
@@ -16,9 +16,9 @@ export async function POST(
 ): Promise<NextResponse> {
   try {
     const { instanceId, stepId } = await params;
-    const { engine, instanceRepo, namespaceRepo } = getPlatformServices();
+    const { engine, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/steps/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/steps/route.ts
@@ -35,9 +35,9 @@ export async function GET(
 ): Promise<NextResponse> {
   try {
     const { instanceId } = await params;
-    const { instanceRepo, processRepo, namespaceRepo } = getPlatformServices();
+    const { instanceRepo, processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instance = await instanceRepo.getById(instanceId);

--- a/packages/platform-ui/src/app/api/processes/route.ts
+++ b/packages/platform-ui/src/app/api/processes/route.ts
@@ -16,9 +16,9 @@ interface StartWorkflowBody {
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
     const body = (await req.json()) as StartWorkflowBody;
-    const { manualTrigger, processRepo, namespaceRepo } = getPlatformServices();
+    const { manualTrigger, processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const requestNamespace = body.namespace ?? '';
@@ -65,12 +65,14 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       }
     }
 
+    const triggeredBy = caller.kind === 'user' ? caller.uid : body.triggeredBy;
+
     const result = await manualTrigger.fireWorkflow({
       namespace: definition.namespace,
       definitionName: body.definitionName,
       definitionVersion: version,
       triggerName: body.triggerName ?? 'manual',
-      triggeredBy: body.triggeredBy,
+      triggeredBy,
       payload,
     });
 
@@ -84,7 +86,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       },
       body: JSON.stringify({
         appContext: payload,
-        triggeredBy: body.triggeredBy,
+        triggeredBy,
       }),
     }).catch((err) => {
       console.error(`[auto-runner] Failed to trigger run for ${result.instanceId}:`, err);

--- a/packages/platform-ui/src/app/api/runs/[runId]/route.ts
+++ b/packages/platform-ui/src/app/api/runs/[runId]/route.ts
@@ -23,9 +23,9 @@ export async function GET(
   { params }: { params: Promise<{ runId: string }> },
 ): Promise<NextResponse> {
   const { runId } = await params;
-  const { instanceRepo, processRepo, namespaceRepo } = getPlatformServices();
+  const { instanceRepo, processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const instance = await instanceRepo.getById(runId);

--- a/packages/platform-ui/src/app/api/runs/route.ts
+++ b/packages/platform-ui/src/app/api/runs/route.ts
@@ -22,8 +22,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const { workflow, status, limit } = parseResult.data;
 
   try {
-    const { instanceRepo, namespaceRepo } = getPlatformServices();
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const { instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const instances = await instanceRepo.list({

--- a/packages/platform-ui/src/app/api/system/openrouter-credits/route.ts
+++ b/packages/platform-ui/src/app/api/system/openrouter-credits/route.ts
@@ -36,9 +36,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   const { namespace } = parsed.data;
-  const { namespaceRepo, namespaceSecretsRepo } = getPlatformServices();
+  const { namespaceRepo, namespaceSecretsRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
   if (!callerCanAccess(caller, namespace)) {
     return NextResponse.json({ ...EMPTY, error: 'Forbidden' }, { status: 403 });

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts
@@ -18,9 +18,9 @@ export async function POST(
     const body = (await req.json()) as { userId?: string };
     const userId = body.userId ?? 'api-user';
 
-    const { humanTaskRepo, instanceRepo, auditRepo, namespaceRepo } = getPlatformServices();
+    const { humanTaskRepo, instanceRepo, auditRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const task = await humanTaskRepo.getById(taskId);

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/complete/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/complete/route.ts
@@ -31,10 +31,10 @@ export async function POST(
 
     const comment = body.comment ?? '';
 
-    const { humanTaskRepo, instanceRepo, auditRepo, engine, namespaceRepo } =
+    const { humanTaskRepo, instanceRepo, auditRepo, engine, namespaceRepo, apiKeyRepo } =
       getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     // 1. Load and validate task

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/resolve/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/resolve/route.ts
@@ -19,9 +19,9 @@ export async function POST(
 ): Promise<NextResponse> {
   try {
     const { taskId } = await params;
-    const { humanTaskRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+    const { humanTaskRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const task = await humanTaskRepo.getById(taskId);

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/route.ts
@@ -13,9 +13,9 @@ export async function GET(
 ): Promise<NextResponse> {
   try {
     const { taskId } = await params;
-    const { humanTaskRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+    const { humanTaskRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
+    const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
     if (caller instanceof NextResponse) return caller;
 
     const task = await humanTaskRepo.getById(taskId);

--- a/packages/platform-ui/src/app/api/tasks/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/route.ts
@@ -14,9 +14,9 @@ import type { ListTasksInput } from '@mediforce/platform-api/contract';
  *   - `status`               — repeatable; e.g. `?status=pending&status=claimed`
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const { humanTaskRepo, instanceRepo, namespaceRepo } = getPlatformServices();
+  const { humanTaskRepo, instanceRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
 
-  const caller = await resolveCallerIdentity(req, namespaceRepo);
+  const caller = await resolveCallerIdentity(req, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const params = req.nextUrl.searchParams;

--- a/packages/platform-ui/src/app/api/workflow-definitions/[name]/archive/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/[name]/archive/route.ts
@@ -23,8 +23,8 @@ export async function POST(
     );
   }
 
-  const { processRepo, namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const archiveNamespace = request.nextUrl.searchParams.get('namespace') ?? '';

--- a/packages/platform-ui/src/app/api/workflow-definitions/[name]/copy/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/[name]/copy/route.ts
@@ -9,8 +9,8 @@ export async function POST(
 ): Promise<NextResponse> {
   const { name: sourceName } = await params;
 
-  const { processRepo, namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const targetNamespace = request.nextUrl.searchParams.get('targetNamespace');

--- a/packages/platform-ui/src/app/api/workflow-definitions/[name]/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/[name]/route.ts
@@ -11,8 +11,8 @@ export async function GET(
   const versionParam = request.nextUrl.searchParams.get('version');
   const namespaceParam = request.nextUrl.searchParams.get('namespace');
 
-  const { processRepo, namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   let version: number;
@@ -69,8 +69,8 @@ export async function PATCH(
 ): Promise<NextResponse> {
   const { name } = await params;
 
-  const { processRepo, namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const patchNamespace = request.nextUrl.searchParams.get('namespace') ?? '';

--- a/packages/platform-ui/src/app/api/workflow-definitions/[name]/versions/[version]/archive/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/[name]/versions/[version]/archive/route.ts
@@ -31,8 +31,8 @@ export async function POST(
     );
   }
 
-  const { processRepo, namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const versionArchiveNamespace = request.nextUrl.searchParams.get('namespace') ?? '';

--- a/packages/platform-ui/src/app/api/workflow-definitions/by-image/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/by-image/route.ts
@@ -7,8 +7,8 @@ function normalizeImage(ref: string): string {
 }
 
 export async function GET(request: Request): Promise<NextResponse> {
-  const { processRepo, namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const url = new URL(request.url);

--- a/packages/platform-ui/src/app/api/workflow-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/route.ts
@@ -12,8 +12,8 @@ import { resolveCallerIdentity, requireNamespaceAccess, callerCanAccess } from '
  * the Workflow Designer edit flow.
  */
 export async function GET(request: Request): Promise<NextResponse> {
-  const { processRepo, namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { processRepo, namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const url = new URL(request.url);
@@ -59,8 +59,8 @@ export async function GET(request: Request): Promise<NextResponse> {
  * It overrides any `namespace` field in the request body.
  */
 export async function POST(request: Request): Promise<NextResponse> {
-  const { namespaceRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { namespaceRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const url = new URL(request.url);

--- a/packages/platform-ui/src/app/api/workflow-secrets/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-secrets/route.ts
@@ -8,8 +8,8 @@ import { getPlatformServices } from '@/lib/platform-services';
 import { resolveCallerIdentity, callerCanAccess } from '@/lib/api-auth';
 
 export async function GET(request: Request): Promise<NextResponse> {
-  const { namespaceRepo, secretsRepo, namespaceSecretsRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { namespaceRepo, secretsRepo, namespaceSecretsRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const url = new URL(request.url);
@@ -36,8 +36,8 @@ export async function GET(request: Request): Promise<NextResponse> {
 }
 
 export async function PUT(request: Request): Promise<NextResponse> {
-  const { namespaceRepo, secretsRepo, namespaceSecretsRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { namespaceRepo, secretsRepo, namespaceSecretsRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const url = new URL(request.url);
@@ -74,8 +74,8 @@ export async function PUT(request: Request): Promise<NextResponse> {
 }
 
 export async function DELETE(request: Request): Promise<NextResponse> {
-  const { namespaceRepo, secretsRepo, namespaceSecretsRepo } = getPlatformServices();
-  const caller = await resolveCallerIdentity(request, namespaceRepo);
+  const { namespaceRepo, secretsRepo, namespaceSecretsRepo, apiKeyRepo } = getPlatformServices();
+  const caller = await resolveCallerIdentity(request, namespaceRepo, apiKeyRepo);
   if (caller instanceof NextResponse) return caller;
 
   const url = new URL(request.url);

--- a/packages/platform-ui/src/components/namespace/api-keys-manager.tsx
+++ b/packages/platform-ui/src/components/namespace/api-keys-manager.tsx
@@ -53,6 +53,7 @@ export function ApiKeysManager() {
   const [newKey, setNewKey] = React.useState<{ plaintext: string; id: string } | null>(null);
   const [error, setError] = React.useState<string | null>(null);
   const [revoking, setRevoking] = React.useState<string | null>(null);
+  const [confirmingRevoke, setConfirmingRevoke] = React.useState<string | null>(null);
 
   const loadKeys = React.useCallback(async () => {
     try {
@@ -96,6 +97,11 @@ export function ApiKeysManager() {
   }
 
   async function handleRevoke(keyId: string) {
+    if (confirmingRevoke !== keyId) {
+      setConfirmingRevoke(keyId);
+      return;
+    }
+    setConfirmingRevoke(null);
     setRevoking(keyId);
     try {
       const res = await apiFetch(`/api/api-keys/${keyId}`, { method: 'DELETE' });
@@ -184,15 +190,26 @@ export function ApiKeysManager() {
                   {k.lastUsedAt && <>{' · '}Last used {timeAgo(k.lastUsedAt)}</>}
                 </p>
               </div>
-              <button
-                type="button"
-                onClick={() => handleRevoke(k.id)}
-                disabled={revoking === k.id}
-                className="opacity-0 group-hover:opacity-100 inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-all disabled:opacity-50"
-              >
-                <Trash2 className="h-3 w-3" />
-                Revoke
-              </button>
+              <div className="flex items-center gap-1">
+                {confirmingRevoke === k.id && (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmingRevoke(null)}
+                    className="inline-flex items-center rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted transition-all"
+                  >
+                    Cancel
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => handleRevoke(k.id)}
+                  disabled={revoking === k.id}
+                  className={`inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-all disabled:opacity-50 ${confirmingRevoke === k.id ? 'bg-destructive/10 opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
+                >
+                  <Trash2 className="h-3 w-3" />
+                  {confirmingRevoke === k.id ? 'Confirm revoke' : 'Revoke'}
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/packages/platform-ui/src/components/namespace/api-keys-manager.tsx
+++ b/packages/platform-ui/src/components/namespace/api-keys-manager.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import * as React from 'react';
+import { Plus, Trash2, Key, ClipboardCopy, Check, AlertTriangle } from 'lucide-react';
+import { apiFetch } from '@/lib/api-fetch';
+
+interface ApiKeyEntry {
+  id: string;
+  label: string;
+  keyPrefix: string;
+  createdAt: string;
+  lastUsedAt?: string;
+  revokedAt?: string;
+}
+
+function CopyKeyButton({ text }: { text: string }) {
+  const [copied, setCopied] = React.useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+    >
+      {copied ? <Check className="h-3 w-3" /> : <ClipboardCopy className="h-3 w-3" />}
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function ApiKeysManager() {
+  const [keys, setKeys] = React.useState<ApiKeyEntry[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [creating, setCreating] = React.useState(false);
+  const [label, setLabel] = React.useState('');
+  const [newKey, setNewKey] = React.useState<{ plaintext: string; id: string } | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [revoking, setRevoking] = React.useState<string | null>(null);
+
+  const loadKeys = React.useCallback(async () => {
+    try {
+      const res = await apiFetch('/api/api-keys');
+      if (!res.ok) return;
+      const data = await res.json();
+      setKeys(data.keys ?? []);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => { void loadKeys(); }, [loadKeys]);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!label.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/api/api-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: label.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? 'Failed to create key');
+        return;
+      }
+      setNewKey({ plaintext: data.plaintext, id: data.id });
+      setLabel('');
+      void loadKeys();
+    } catch {
+      setError('Network error');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleRevoke(keyId: string) {
+    setRevoking(keyId);
+    try {
+      const res = await apiFetch(`/api/api-keys/${keyId}`, { method: 'DELETE' });
+      if (res.ok) {
+        void loadKeys();
+      }
+    } catch {
+      // ignore
+    } finally {
+      setRevoking(null);
+    }
+  }
+
+  const activeKeys = keys.filter((k) => !k.revokedAt);
+  const revokedKeys = keys.filter((k) => k.revokedAt);
+
+  if (loading) {
+    return <p className="text-sm text-muted-foreground">Loading API keys...</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Personal API keys grant CLI and API access to all workspaces you belong to.
+      </p>
+
+      {/* New key reveal */}
+      {newKey && (
+        <div className="rounded-lg border border-amber-500/50 bg-amber-50 dark:bg-amber-950/20 p-4 space-y-2">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+              Copy this key now — you won&apos;t see it again.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded bg-muted px-3 py-2 font-mono text-xs break-all">
+            <span className="flex-1">{newKey.plaintext}</span>
+            <CopyKeyButton text={newKey.plaintext} />
+          </div>
+          <button
+            type="button"
+            onClick={() => setNewKey(null)}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Create form */}
+      <form onSubmit={handleCreate} className="flex items-center gap-2">
+        <input
+          type="text"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Key label (e.g. CI, laptop)"
+          className="flex-1 rounded-md border bg-background px-3 py-1.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          maxLength={128}
+        />
+        <button
+          type="submit"
+          disabled={creating || !label.trim()}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Create
+        </button>
+      </form>
+
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      {/* Active keys */}
+      {activeKeys.length > 0 && (
+        <div className="space-y-1">
+          {activeKeys.map((k) => (
+            <div key={k.id} className="flex items-center gap-3 rounded-md px-3 py-2 hover:bg-muted/50 group">
+              <Key className="h-4 w-4 text-muted-foreground shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{k.label}</p>
+                <p className="text-xs text-muted-foreground">
+                  <span className="font-mono">{k.keyPrefix}...</span>
+                  {' · '}
+                  Created {timeAgo(k.createdAt)}
+                  {k.lastUsedAt && <>{' · '}Last used {timeAgo(k.lastUsedAt)}</>}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRevoke(k.id)}
+                disabled={revoking === k.id}
+                className="opacity-0 group-hover:opacity-100 inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-all disabled:opacity-50"
+              >
+                <Trash2 className="h-3 w-3" />
+                Revoke
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {activeKeys.length === 0 && !newKey && (
+        <p className="text-sm text-muted-foreground">No active API keys.</p>
+      )}
+
+      {/* Revoked keys */}
+      {revokedKeys.length > 0 && (
+        <details className="text-xs text-muted-foreground">
+          <summary className="cursor-pointer hover:text-foreground">{revokedKeys.length} revoked key{revokedKeys.length > 1 ? 's' : ''}</summary>
+          <div className="mt-1 space-y-1 pl-2">
+            {revokedKeys.map((k) => (
+              <p key={k.id} className="font-mono line-through">{k.keyPrefix}... — {k.label}</p>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/packages/platform-ui/src/lib/__tests__/api-auth.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/api-auth.test.ts
@@ -3,9 +3,12 @@ import { NextResponse } from 'next/server';
 
 const mockVerifyIdToken = vi.fn();
 const mockGetNamespacesByUser = vi.fn();
+const mockGetByKeyHash = vi.fn();
+const mockTouchLastUsed = vi.fn();
 
 vi.mock('@mediforce/platform-infra', () => ({
   getAdminAuth: () => ({ verifyIdToken: mockVerifyIdToken }),
+  hashApiKey: (key: string) => `hash_${key}`,
 }));
 
 import {
@@ -20,6 +23,11 @@ const fakeNamespaceRepo = {
   getNamespacesByUser: mockGetNamespacesByUser,
 } as never;
 
+const fakeApiKeyRepo = {
+  getByKeyHash: mockGetByKeyHash,
+  touchLastUsed: mockTouchLastUsed,
+} as never;
+
 function makeRequest(headers: Record<string, string>): Request {
   return new Request('http://localhost/api/test', { headers });
 }
@@ -27,13 +35,15 @@ function makeRequest(headers: Record<string, string>): Request {
 describe('resolveCallerIdentity', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTouchLastUsed.mockResolvedValue(undefined);
     process.env.PLATFORM_API_KEY = 'test-api-key';
   });
 
-  it('returns apiKey identity for valid API key', async () => {
+  it('returns apiKey identity for valid global API key', async () => {
     const result = await resolveCallerIdentity(
       makeRequest({ 'X-Api-Key': 'test-api-key' }),
       fakeNamespaceRepo,
+      fakeApiKeyRepo,
     );
     expect(result).toEqual({ kind: 'apiKey' });
   });
@@ -42,6 +52,7 @@ describe('resolveCallerIdentity', () => {
     const result = await resolveCallerIdentity(
       makeRequest({}),
       fakeNamespaceRepo,
+      fakeApiKeyRepo,
     );
     expect(result).toBeInstanceOf(NextResponse);
     expect((result as NextResponse).status).toBe(401);
@@ -52,6 +63,7 @@ describe('resolveCallerIdentity', () => {
     const result = await resolveCallerIdentity(
       makeRequest({ Authorization: 'Bearer bad-token' }),
       fakeNamespaceRepo,
+      fakeApiKeyRepo,
     );
     expect(result).toBeInstanceOf(NextResponse);
     expect((result as NextResponse).status).toBe(401);
@@ -67,6 +79,7 @@ describe('resolveCallerIdentity', () => {
     const result = await resolveCallerIdentity(
       makeRequest({ Authorization: 'Bearer valid-token' }),
       fakeNamespaceRepo,
+      fakeApiKeyRepo,
     );
 
     expect(result).toEqual({
@@ -80,9 +93,84 @@ describe('resolveCallerIdentity', () => {
     const result = await resolveCallerIdentity(
       makeRequest({ 'X-Api-Key': 'wrong-key' }),
       fakeNamespaceRepo,
+      fakeApiKeyRepo,
     );
     expect(result).toBeInstanceOf(NextResponse);
     expect((result as NextResponse).status).toBe(401);
+  });
+
+  it('resolves mf_ key to user identity', async () => {
+    mockGetByKeyHash.mockResolvedValue({
+      id: 'key-1',
+      userId: 'uid-42',
+      keyHash: 'hash_mf_valid',
+      keyPrefix: 'mf_valid',
+      label: 'test',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    mockGetNamespacesByUser.mockResolvedValue([{ handle: 'my-ns' }]);
+
+    const result = await resolveCallerIdentity(
+      makeRequest({ 'X-Api-Key': 'mf_valid' }),
+      fakeNamespaceRepo,
+      fakeApiKeyRepo,
+    );
+
+    expect(result).toEqual({
+      kind: 'user',
+      uid: 'uid-42',
+      namespaces: new Set(['my-ns']),
+    });
+    expect(mockGetByKeyHash).toHaveBeenCalledWith('hash_mf_valid');
+  });
+
+  it('returns 401 for invalid mf_ key', async () => {
+    mockGetByKeyHash.mockResolvedValue(null);
+
+    const result = await resolveCallerIdentity(
+      makeRequest({ 'X-Api-Key': 'mf_nonexistent' }),
+      fakeNamespaceRepo,
+      fakeApiKeyRepo,
+    );
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(401);
+    const body = await (result as NextResponse).json();
+    expect(body.error).toMatch(/Invalid or revoked/);
+  });
+
+  it('returns 401 for revoked mf_ key', async () => {
+    mockGetByKeyHash.mockResolvedValue({
+      id: 'key-2',
+      userId: 'uid-42',
+      keyHash: 'hash_mf_revoked',
+      keyPrefix: 'mf_revoke',
+      label: 'old',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      revokedAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const result = await resolveCallerIdentity(
+      makeRequest({ 'X-Api-Key': 'mf_revoked' }),
+      fakeNamespaceRepo,
+      fakeApiKeyRepo,
+    );
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(401);
+    const body = await (result as NextResponse).json();
+    expect(body.error).toMatch(/Invalid or revoked/);
+  });
+
+  it('global key takes priority over mf_ prefix', async () => {
+    process.env.PLATFORM_API_KEY = 'mf_global_key';
+    const result = await resolveCallerIdentity(
+      makeRequest({ 'X-Api-Key': 'mf_global_key' }),
+      fakeNamespaceRepo,
+      fakeApiKeyRepo,
+    );
+    expect(result).toEqual({ kind: 'apiKey' });
+    expect(mockGetByKeyHash).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/platform-ui/src/lib/api-auth.ts
+++ b/packages/platform-ui/src/lib/api-auth.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
 import { getAdminAuth } from '@mediforce/platform-infra';
 import type { FirestoreNamespaceRepository, FirestoreApiKeyRepository } from '@mediforce/platform-infra';
 import { hashApiKey } from '@mediforce/platform-infra';
@@ -22,7 +23,9 @@ export async function resolveCallerIdentity(
     console.error('[api-auth] PLATFORM_API_KEY must not start with mf_ — collides with per-user key prefix');
   }
 
-  if (apiKeyHeader && expectedKey && apiKeyHeader === expectedKey) {
+  if (apiKeyHeader && expectedKey
+    && apiKeyHeader.length === expectedKey.length
+    && timingSafeEqual(Buffer.from(apiKeyHeader), Buffer.from(expectedKey))) {
     return { kind: 'apiKey' };
   }
 

--- a/packages/platform-ui/src/lib/api-auth.ts
+++ b/packages/platform-ui/src/lib/api-auth.ts
@@ -1,24 +1,40 @@
 import { NextResponse } from 'next/server';
 import { getAdminAuth } from '@mediforce/platform-infra';
-import type { FirestoreNamespaceRepository } from '@mediforce/platform-infra';
+import type { FirestoreNamespaceRepository, FirestoreApiKeyRepository } from '@mediforce/platform-infra';
+import { hashApiKey } from '@mediforce/platform-infra';
 
 export type CallerIdentity =
   | { kind: 'apiKey' }
   | { kind: 'user'; uid: string; namespaces: Set<string> };
 
-/**
- * Resolve caller identity from request headers.
- * API-key callers get unrestricted access. Firebase-token callers get their
- * namespace membership set. Returns NextResponse 401 on auth failure.
- */
+const LAST_USED_DEBOUNCE_MS = 60 * 60 * 1000; // 1 hour
+const lastUsedCache = new Map<string, number>();
+
 export async function resolveCallerIdentity(
   request: Request,
   namespaceRepo: FirestoreNamespaceRepository,
+  apiKeyRepo?: FirestoreApiKeyRepository,
 ): Promise<CallerIdentity | NextResponse> {
-  const apiKey = request.headers.get('X-Api-Key');
+  const apiKeyHeader = request.headers.get('X-Api-Key');
   const expectedKey = process.env.PLATFORM_API_KEY;
-  if (apiKey && expectedKey && apiKey === expectedKey) {
+
+  if (apiKeyHeader && expectedKey && apiKeyHeader === expectedKey) {
     return { kind: 'apiKey' };
+  }
+
+  if (apiKeyHeader && apiKeyRepo && apiKeyHeader.startsWith('mf_')) {
+    const keyHash = hashApiKey(apiKeyHeader);
+    const storedKey = await apiKeyRepo.getByKeyHash(keyHash);
+    if (storedKey && !storedKey.revokedAt) {
+      const now = Date.now();
+      const lastTouch = lastUsedCache.get(storedKey.id) ?? 0;
+      if (now - lastTouch > LAST_USED_DEBOUNCE_MS) {
+        lastUsedCache.set(storedKey.id, now);
+        void apiKeyRepo.touchLastUsed(storedKey.id).catch(() => {});
+      }
+      const namespaces = await namespaceRepo.getNamespacesByUser(storedKey.userId);
+      return { kind: 'user', uid: storedKey.userId, namespaces: new Set(namespaces.map((ns) => ns.handle)) };
+    }
   }
 
   const authHeader = request.headers.get('Authorization') ?? '';

--- a/packages/platform-ui/src/lib/api-auth.ts
+++ b/packages/platform-ui/src/lib/api-auth.ts
@@ -13,7 +13,7 @@ const lastUsedCache = new Map<string, number>();
 export async function resolveCallerIdentity(
   request: Request,
   namespaceRepo: FirestoreNamespaceRepository,
-  apiKeyRepo?: FirestoreApiKeyRepository,
+  apiKeyRepo: FirestoreApiKeyRepository,
 ): Promise<CallerIdentity | NextResponse> {
   const apiKeyHeader = request.headers.get('X-Api-Key');
   const expectedKey = process.env.PLATFORM_API_KEY;
@@ -22,19 +22,20 @@ export async function resolveCallerIdentity(
     return { kind: 'apiKey' };
   }
 
-  if (apiKeyHeader && apiKeyRepo && apiKeyHeader.startsWith('mf_')) {
+  if (apiKeyHeader && apiKeyHeader.startsWith('mf_')) {
     const keyHash = hashApiKey(apiKeyHeader);
     const storedKey = await apiKeyRepo.getByKeyHash(keyHash);
-    if (storedKey && !storedKey.revokedAt) {
-      const now = Date.now();
-      const lastTouch = lastUsedCache.get(storedKey.id) ?? 0;
-      if (now - lastTouch > LAST_USED_DEBOUNCE_MS) {
-        lastUsedCache.set(storedKey.id, now);
-        void apiKeyRepo.touchLastUsed(storedKey.id).catch(() => {});
-      }
-      const namespaces = await namespaceRepo.getNamespacesByUser(storedKey.userId);
-      return { kind: 'user', uid: storedKey.userId, namespaces: new Set(namespaces.map((ns) => ns.handle)) };
+    if (!storedKey || storedKey.revokedAt) {
+      return NextResponse.json({ error: 'Invalid or revoked API key' }, { status: 401 });
     }
+    const now = Date.now();
+    const lastTouch = lastUsedCache.get(storedKey.id) ?? 0;
+    if (now - lastTouch > LAST_USED_DEBOUNCE_MS) {
+      lastUsedCache.set(storedKey.id, now);
+      void apiKeyRepo.touchLastUsed(storedKey.id).catch(() => {});
+    }
+    const namespaces = await namespaceRepo.getNamespacesByUser(storedKey.userId);
+    return { kind: 'user', uid: storedKey.userId, namespaces: new Set(namespaces.map((ns) => ns.handle)) };
   }
 
   const authHeader = request.headers.get('Authorization') ?? '';

--- a/packages/platform-ui/src/lib/api-auth.ts
+++ b/packages/platform-ui/src/lib/api-auth.ts
@@ -18,6 +18,10 @@ export async function resolveCallerIdentity(
   const apiKeyHeader = request.headers.get('X-Api-Key');
   const expectedKey = process.env.PLATFORM_API_KEY;
 
+  if (expectedKey?.startsWith('mf_')) {
+    console.error('[api-auth] PLATFORM_API_KEY must not start with mf_ — collides with per-user key prefix');
+  }
+
   if (apiKeyHeader && expectedKey && apiKeyHeader === expectedKey) {
     return { kind: 'apiKey' };
   }

--- a/packages/platform-ui/src/middleware.ts
+++ b/packages/platform-ui/src/middleware.ts
@@ -41,7 +41,9 @@ function isOriginAllowed(origin: string): boolean {
 function hasValidApiKey(req: NextRequest): boolean {
   const provided = req.headers.get('X-Api-Key');
   const expected = process.env.PLATFORM_API_KEY;
-  return Boolean(provided) && Boolean(expected) && provided === expected;
+  const isGlobalKey = Boolean(provided) && Boolean(expected) && provided === expected;
+  const isPerUserKey = Boolean(provided) && provided!.startsWith('mf_') && provided!.length >= 40;
+  return isGlobalKey || isPerUserKey;
 }
 
 function extractBearer(req: NextRequest): string | null {


### PR DESCRIPTION
## Summary
- Personal API keys (`mf_` prefix) that resolve to user identity with namespace scoping — same as Firebase auth
- Global `PLATFORM_API_KEY` still works for CI/deploy (backward compatible)
- CRUD routes: `GET/POST /api/api-keys`, `DELETE /api/api-keys/[keyId]`
- Settings UI: create, list, revoke keys with one-time plaintext reveal
- All 32 API route files pass `apiKeyRepo` to `resolveCallerIdentity`
- `triggeredBy` prefers authenticated `caller.uid` over request body
- CLI works without code changes — just set `MEDIFORCE_API_KEY=mf_...`

## Architecture
- Key format: `mf_` + 32 random bytes (base64url), stored as SHA-256 hash
- Top-level `apiKeys` Firestore collection (not per-namespace) — one key works across all user's namespaces
- Auth flow: `X-Api-Key` header → hash → lookup → `getNamespacesByUser(uid)` → `kind: 'user'`
- `lastUsedAt` debounced to 1 write/hour per key

## New files
- `packages/platform-core/src/schemas/api-key.ts` — Zod schema
- `packages/platform-infra/src/crypto/api-key-crypto.ts` — generate + hash
- `packages/platform-infra/src/firestore/api-key-repository.ts` — Firestore CRUD
- `packages/platform-ui/src/app/api/api-keys/route.ts` — GET + POST
- `packages/platform-ui/src/app/api/api-keys/[keyId]/route.ts` — DELETE
- `packages/platform-ui/src/components/namespace/api-keys-manager.tsx` — UI component

## Test plan
- [ ] Create key via POST `/api/api-keys` — verify plaintext returned once
- [ ] `MEDIFORCE_API_KEY=mf_... pnpm exec mediforce workflow list` — returns only user's namespace workflows
- [ ] Revoke key via DELETE — verify subsequent requests return 401
- [ ] Global `PLATFORM_API_KEY` still works with unrestricted access
- [ ] Settings page shows API Keys section with create/revoke flow
- [ ] `pnpm typecheck && pnpm test` — 2156 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)