### PR TITLE
fix: load OpenRouter API key from workspace secrets in cowork

### DIFF
--- a/packages/platform-ui/src/app/actions/cowork.ts
+++ b/packages/platform-ui/src/app/actions/cowork.ts
@@ -2,6 +2,8 @@
 
 import { getPlatformServices, getAppBaseUrl } from '@/lib/platform-services';
 import type { ConversationTurn } from '@mediforce/platform-core';
+import { getNamespaceSecretsForRuntime } from '@/app/actions/namespace-secrets';
+import { getWorkflowSecretsForRuntime } from '@/app/actions/workflow-secrets';
 
 // ---------------------------------------------------------------------------
 // sendMessage — streams model response, returns final result
@@ -237,7 +239,7 @@ export async function synthesizeArtifact(
   transcript: string,
   comment?: string,
 ): Promise<SynthesizeArtifactResult> {
-  const { coworkSessionRepo } = getPlatformServices();
+  const { coworkSessionRepo, instanceRepo } = getPlatformServices();
 
   const session = await coworkSessionRepo.getById(sessionId);
   if (!session) {
@@ -248,12 +250,21 @@ export async function synthesizeArtifact(
     return { success: false, error: `Cannot synthesize for a ${session.status} session` };
   }
 
-  const model = session.voiceConfig?.synthesisModel ?? 'anthropic/claude-sonnet-4';
-
-  const openRouterApiKey = process.env.OPENROUTER_API_KEY ?? process.env.DOCKER_OPENROUTER_API_KEY;
-  if (!openRouterApiKey) {
-    return { success: false, error: 'OPENROUTER_API_KEY is not configured' };
+  const instance = await instanceRepo.getById(session.processInstanceId);
+  if (!instance?.namespace || !instance.definitionName) {
+    return { success: false, error: 'Cannot resolve workspace for this session' };
   }
+
+  const [nsSecrets, wfSecrets] = await Promise.all([
+    getNamespaceSecretsForRuntime(instance.namespace),
+    getWorkflowSecretsForRuntime(instance.namespace, instance.definitionName),
+  ]);
+  const openRouterApiKey = { ...nsSecrets, ...wfSecrets }['OPENROUTER_API_KEY'];
+  if (!openRouterApiKey) {
+    return { success: false, error: 'OPENROUTER_API_KEY not configured in workspace secrets' };
+  }
+
+  const model = session.voiceConfig?.synthesisModel ?? 'anthropic/claude-sonnet-4';
 
   const schemaBlock = session.outputSchema
     ? `\n\nTarget JSON schema:\n${JSON.stringify(session.outputSchema, null, 2)}`

--- a/packages/platform-ui/src/app/api/cowork/[sessionId]/chat/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/[sessionId]/chat/route.ts
@@ -3,6 +3,8 @@ import { getPlatformServices } from '@/lib/platform-services';
 import { resolveCallerIdentity, requireNamespaceAccess } from '@/lib/api-auth';
 import { buildMessages, buildToolsArray, buildMcpSystemPromptSection } from '@/lib/cowork/build-messages';
 import { callOpenRouter } from '@/lib/cowork/openrouter';
+import { getNamespaceSecretsForRuntime } from '@/app/actions/namespace-secrets';
+import { getWorkflowSecretsForRuntime } from '@/app/actions/workflow-secrets';
 import { McpClientManager } from '@mediforce/mcp-client';
 import type { McpToolDefinition } from '@mediforce/mcp-client';
 
@@ -38,8 +40,8 @@ export async function POST(
     return NextResponse.json({ error: 'Session not found' }, { status: 404 });
   }
 
-  const nsInstance = await instanceRepo.getById(session.processInstanceId);
-  const denied = requireNamespaceAccess(caller, nsInstance?.namespace);
+  const instance = await instanceRepo.getById(session.processInstanceId);
+  const denied = requireNamespaceAccess(caller, instance?.namespace);
   if (denied) return denied;
 
   if (session.status !== 'active') {
@@ -56,12 +58,28 @@ export async function POST(
     return NextResponse.json({ error: 'message string required' }, { status: 400 });
   }
 
-  // Load step context from process instance variables
-  let stepContext: Record<string, unknown> | undefined;
-  const instance = await instanceRepo.getById(session.processInstanceId);
-  if (instance) {
-    stepContext = instance.variables as Record<string, unknown>;
+  const namespace = instance?.namespace;
+  const workflowName = instance?.definitionName;
+
+  if (!namespace || !workflowName) {
+    return NextResponse.json({ error: 'Cannot resolve workspace for this session' }, { status: 400 });
   }
+
+  const [nsSecrets, wfSecrets] = await Promise.all([
+    getNamespaceSecretsForRuntime(namespace),
+    getWorkflowSecretsForRuntime(namespace, workflowName),
+  ]);
+  const secrets = { ...nsSecrets, ...wfSecrets };
+  const openRouterKey = secrets['OPENROUTER_API_KEY'];
+
+  if (!openRouterKey) {
+    return NextResponse.json(
+      { error: 'OPENROUTER_API_KEY not configured in workspace secrets' },
+      { status: 400 },
+    );
+  }
+
+  const stepContext = instance.variables as Record<string, unknown> | undefined;
 
   // Connect to MCP servers BEFORE persisting the human turn so that a connection
   // failure does not leave an orphan user message with no agent reply in Firestore.
@@ -116,7 +134,7 @@ export async function POST(
 
     // Tool execution loop
     for (let iteration = 0; iteration < MAX_TOOL_LOOP_ITERATIONS; iteration++) {
-      const response = await callOpenRouter(model, messages, tools);
+      const response = await callOpenRouter(model, messages, tools, openRouterKey);
 
       agentText = response.content;
 

--- a/packages/platform-ui/src/app/api/cowork/[sessionId]/message/route.ts
+++ b/packages/platform-ui/src/app/api/cowork/[sessionId]/message/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
 import { resolveCallerIdentity, requireNamespaceAccess } from '@/lib/api-auth';
 import { buildMessages, ARTIFACT_TOOL } from '@/lib/cowork/build-messages';
+import { getNamespaceSecretsForRuntime } from '@/app/actions/namespace-secrets';
+import { getWorkflowSecretsForRuntime } from '@/app/actions/workflow-secrets';
 
 /**
  * POST /api/cowork/:sessionId/message
@@ -34,8 +36,8 @@ export async function POST(
     });
   }
 
-  const nsInstance = await instanceRepo.getById(session.processInstanceId);
-  const denied = requireNamespaceAccess(caller, nsInstance?.namespace);
+  const instance = await instanceRepo.getById(session.processInstanceId);
+  const denied = requireNamespaceAccess(caller, instance?.namespace);
   if (denied) return denied;
 
   if (session.status !== 'active') {
@@ -55,12 +57,31 @@ export async function POST(
     });
   }
 
-  // Load step context from process instance variables (previous step output)
-  let stepContext: Record<string, unknown> | undefined;
-  const instance = await instanceRepo.getById(session.processInstanceId);
-  if (instance) {
-    stepContext = instance.variables as Record<string, unknown>;
+  const namespace = instance?.namespace;
+  const workflowName = instance?.definitionName;
+
+  if (!namespace || !workflowName) {
+    return new Response(JSON.stringify({ error: 'Cannot resolve workspace for this session' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
+
+  const [nsSecrets, wfSecrets] = await Promise.all([
+    getNamespaceSecretsForRuntime(namespace),
+    getWorkflowSecretsForRuntime(namespace, workflowName),
+  ]);
+  const secrets = { ...nsSecrets, ...wfSecrets };
+  const openRouterKey = secrets['OPENROUTER_API_KEY'];
+
+  if (!openRouterKey) {
+    return new Response(
+      JSON.stringify({ error: 'OPENROUTER_API_KEY not configured in workspace secrets' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const stepContext = instance.variables as Record<string, unknown> | undefined;
 
   // Save human turn immediately
   const humanTurnId = crypto.randomUUID();
@@ -95,7 +116,7 @@ export async function POST(
           {
             method: 'POST',
             headers: {
-              Authorization: `Bearer ${process.env.OPENROUTER_API_KEY ?? process.env.DOCKER_OPENROUTER_API_KEY ?? ''}`,
+              Authorization: `Bearer ${openRouterKey}`,
               'Content-Type': 'application/json',
             },
             body: JSON.stringify({

--- a/packages/platform-ui/src/lib/cowork/openrouter.ts
+++ b/packages/platform-ui/src/lib/cowork/openrouter.ts
@@ -25,9 +25,8 @@ export async function callOpenRouter(
   model: string,
   messages: ChatMessage[],
   tools: Array<{ type: string; function: Record<string, unknown> }>,
+  apiKey: string,
 ): Promise<OpenRouterResponse> {
-  const apiKey = process.env.OPENROUTER_API_KEY ?? process.env.DOCKER_OPENROUTER_API_KEY ?? '';
-
   const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- Cowork chat, SSE message, and voice synthesis endpoints now load `OPENROUTER_API_KEY` from namespace + workflow secrets (same pattern as `execute-agent-step`)
- Removes hardcoded `process.env.OPENROUTER_API_KEY` / `process.env.DOCKER_OPENROUTER_API_KEY` from all cowork endpoints
- Fixes duplicate `instanceRepo.getById` calls in chat and message route handlers
- Returns clear 400 error when key is missing from workspace secrets

## Test plan
- [ ] Set `OPENROUTER_API_KEY` in namespace secrets, verify cowork chat works
- [ ] Remove key from secrets, verify clear error message in UI
- [ ] Verify workflow-level secret overrides namespace-level secret
- [ ] Test voice synthesis (synthesizeArtifact) uses workspace secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)