### PR TITLE
fix: distinct "Awaiting approval" step status for L3 agent reviews

### DIFF
--- a/packages/platform-ui/src/components/processes/__tests__/step-status.test.ts
+++ b/packages/platform-ui/src/components/processes/__tests__/step-status.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import type { ProcessInstance, StepExecution, Step } from '@mediforce/platform-core';
+import { getEffectiveStatus } from '../step-status';
+
+function makeStep(overrides: Partial<Step> = {}): Step {
+  return {
+    id: 'step-1',
+    name: 'Step 1',
+    type: 'task',
+    ...overrides,
+  } as Step;
+}
+
+function makeInstance(overrides: Partial<ProcessInstance> = {}): ProcessInstance {
+  return {
+    id: 'i1',
+    definitionName: 'wf',
+    definitionVersion: '1',
+    status: 'running',
+    currentStepId: 'step-1',
+    variables: {},
+    triggerType: 'manual',
+    triggerPayload: {},
+    createdAt: '2026-05-11T00:00:00.000Z',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+    createdBy: 'u1',
+    pauseReason: null,
+    error: null,
+    assignedRoles: [],
+    deleted: false,
+    archived: false,
+    ...overrides,
+  } as ProcessInstance;
+}
+
+function makeExec(overrides: Partial<StepExecution> = {}): StepExecution {
+  return {
+    id: 'e1',
+    instanceId: 'i1',
+    stepId: 'step-1',
+    status: 'completed',
+    input: {},
+    output: null,
+    verdict: null,
+    executedBy: 'agent:foo',
+    startedAt: '2026-05-11T00:00:00.000Z',
+    completedAt: '2026-05-11T00:01:00.000Z',
+    iterationNumber: 0,
+    gateResult: null,
+    error: null,
+    ...overrides,
+  } as StepExecution;
+}
+
+describe('getEffectiveStatus', () => {
+  it('returns "awaiting_approval" when exec completed but instance paused awaiting_agent_approval on this step', () => {
+    const step = makeStep();
+    const instance = makeInstance({ status: 'paused', pauseReason: 'awaiting_agent_approval', currentStepId: 'step-1' });
+    const exec = makeExec({ status: 'completed' });
+
+    expect(getEffectiveStatus(step, instance, [exec])).toBe('awaiting_approval');
+  });
+
+  it('returns "waiting" when exec completed but instance paused waiting_for_human on this step', () => {
+    const step = makeStep();
+    const instance = makeInstance({ status: 'paused', pauseReason: 'waiting_for_human', currentStepId: 'step-1' });
+    const exec = makeExec({ status: 'completed' });
+
+    expect(getEffectiveStatus(step, instance, [exec])).toBe('waiting');
+  });
+
+  it('returns "completed" when exec completed and currentStepId moved past this step', () => {
+    const step = makeStep({ id: 'step-1' });
+    const instance = makeInstance({ status: 'paused', pauseReason: 'awaiting_agent_approval', currentStepId: 'step-2' });
+    const exec = makeExec({ status: 'completed', stepId: 'step-1' });
+
+    expect(getEffectiveStatus(step, instance, [exec])).toBe('completed');
+  });
+
+  it('returns "completed" for terminal completed instance', () => {
+    const step = makeStep();
+    const instance = makeInstance({ status: 'completed', currentStepId: 'step-1' });
+    const exec = makeExec({ status: 'completed' });
+
+    expect(getEffectiveStatus(step, instance, [exec])).toBe('completed');
+  });
+
+  it('returns "awaiting_approval" when exec is running but instance paused awaiting_agent_approval', () => {
+    const step = makeStep();
+    const instance = makeInstance({ status: 'paused', pauseReason: 'awaiting_agent_approval', currentStepId: 'step-1' });
+    const exec = makeExec({ status: 'running', completedAt: null });
+
+    expect(getEffectiveStatus(step, instance, [exec])).toBe('awaiting_approval');
+  });
+
+  it('returns "running" when exec running and instance running', () => {
+    const step = makeStep();
+    const instance = makeInstance({ status: 'running', currentStepId: 'step-1' });
+    const exec = makeExec({ status: 'running', completedAt: null });
+
+    expect(getEffectiveStatus(step, instance, [exec])).toBe('running');
+  });
+
+  it('returns "pending" when no exec and instance not on this step', () => {
+    const step = makeStep({ id: 'step-2' });
+    const instance = makeInstance({ currentStepId: 'step-1' });
+
+    expect(getEffectiveStatus(step, instance, [])).toBe('pending');
+  });
+});

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -3,12 +3,13 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { CheckCircle2, Clock, XCircle, Circle, Pause, User, Bot, Cog, ChevronDown, ChevronRight, FileText, FileCode } from 'lucide-react';
+import { CheckCircle2, Clock, XCircle, Circle, Pause, User, UserCheck, Bot, Cog, ChevronDown, ChevronRight, FileText, FileCode } from 'lucide-react';
 import type { ProcessInstance, StepExecution, Step } from '@mediforce/platform-core';
 import { AutonomyBadge } from '../agents/autonomy-badge';
 import { RetryStepButton } from './retry-step-button';
 import { cn } from '@/lib/utils';
 import { getWorkflowStatus } from '@/lib/workflow-status';
+import { getEffectiveStatus, type EffectiveStatus } from './step-status';
 import { formatDuration, formatCostUsd } from '@/lib/format';
 import { useUserDisplayNames } from '@/hooks/use-users';
 
@@ -52,50 +53,6 @@ interface StepStatusPanelProps {
   stepDetailBaseHref?: string;
 }
 
-type EffectiveStatus = 'pending' | 'running' | 'completed' | 'failed' | 'waiting';
-
-function getEffectiveStatus(
-  step: Step,
-  instance: ProcessInstance,
-  stepExecutions: StepExecution[],
-): EffectiveStatus {
-  // Find the latest execution for this step (by startedAt if multiple)
-  const execs = stepExecutions
-    .filter((e) => e.stepId === step.id)
-    .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
-
-  const exec = execs[0];
-
-  if (exec) {
-    if (exec.status === 'running' || exec.status === 'pending') {
-      // If instance is paused on this step, show 'waiting' instead of 'running'
-      // (e.g. L3 agent step paused for human review — execution record stays 'running')
-      if (
-        instance.currentStepId === step.id
-        && getWorkflowStatus(instance).displayStatus === 'waiting_for_human'
-      ) {
-        return 'waiting';
-      }
-      return 'running';
-    }
-    if (exec.status === 'completed') return 'completed';
-    if (exec.status === 'escalated' || exec.status === 'paused') return 'waiting';
-    if (exec.status === 'failed') return 'failed';
-  }
-
-  // No execution record yet — derive from instance state
-  if (instance.currentStepId === step.id) {
-    if (getWorkflowStatus(instance).displayStatus === 'waiting_for_human') {
-      return 'waiting';
-    }
-    if (instance.status === 'running') {
-      return 'running';
-    }
-  }
-
-  return 'pending';
-}
-
 function StatusIcon({ status }: { status: EffectiveStatus }) {
   switch (status) {
     case 'completed':
@@ -106,6 +63,8 @@ function StatusIcon({ status }: { status: EffectiveStatus }) {
       return <XCircle className="h-4 w-4 text-red-500 shrink-0" />;
     case 'waiting':
       return <Pause className="h-4 w-4 text-amber-500 shrink-0" />;
+    case 'awaiting_approval':
+      return <UserCheck className="h-4 w-4 text-amber-500 shrink-0" />;
     case 'pending':
     default:
       return <Circle className="h-4 w-4 text-muted-foreground shrink-0" />;
@@ -118,6 +77,7 @@ function StatusLabel({ status }: { status: EffectiveStatus }) {
     running: 'text-blue-700 dark:text-blue-300',
     failed: 'text-red-700 dark:text-red-300',
     waiting: 'text-amber-700 dark:text-amber-300',
+    awaiting_approval: 'text-amber-700 dark:text-amber-300',
     pending: 'text-muted-foreground',
   };
   const labels: Record<EffectiveStatus, string> = {
@@ -125,6 +85,7 @@ function StatusLabel({ status }: { status: EffectiveStatus }) {
     running: 'Running',
     failed: 'Failed',
     waiting: 'Waiting',
+    awaiting_approval: 'Awaiting approval',
     pending: 'Pending',
   };
   return (
@@ -345,6 +306,7 @@ function getLeftBorderClass(status: EffectiveStatus): string {
     case 'running':
       return 'border-l-4 border-blue-500';
     case 'waiting':
+    case 'awaiting_approval':
       return 'border-l-4 border-amber-500';
     default:
       return 'border-l-4 border-transparent';

--- a/packages/platform-ui/src/components/processes/step-status.ts
+++ b/packages/platform-ui/src/components/processes/step-status.ts
@@ -1,0 +1,48 @@
+import type { ProcessInstance, StepExecution, Step } from '@mediforce/platform-core';
+import { getWorkflowStatus } from '@/lib/workflow-status';
+
+export type EffectiveStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'waiting'
+  | 'awaiting_approval';
+
+export function getEffectiveStatus(
+  step: Step,
+  instance: ProcessInstance,
+  stepExecutions: StepExecution[],
+): EffectiveStatus {
+  const execs = stepExecutions
+    .filter((e) => e.stepId === step.id)
+    .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+
+  const exec = execs[0];
+
+  const isCurrent = instance.currentStepId === step.id;
+  const wf = getWorkflowStatus(instance);
+  const isWaiting = wf.displayStatus === 'waiting_for_human';
+  const waitingKind: EffectiveStatus =
+    wf.rawReason === 'awaiting_agent_approval' ? 'awaiting_approval' : 'waiting';
+
+  if (exec) {
+    if (exec.status === 'running' || exec.status === 'pending') {
+      if (isCurrent && isWaiting) return waitingKind;
+      return 'running';
+    }
+    if (exec.status === 'completed') {
+      if (isCurrent && isWaiting) return waitingKind;
+      return 'completed';
+    }
+    if (exec.status === 'escalated' || exec.status === 'paused') return 'waiting';
+    if (exec.status === 'failed') return 'failed';
+  }
+
+  if (isCurrent) {
+    if (isWaiting) return waitingKind;
+    if (instance.status === 'running') return 'running';
+  }
+
+  return 'pending';
+}


### PR DESCRIPTION
## Summary

- L3 agent steps save StepExecution as `completed` then pause the workflow with `awaiting_agent_approval`. The step list rendered "Completed" alongside the workflow's "Waiting" badge + open approve/revise task — three signals, all individually correct, together confusing.
- Adds new `EffectiveStatus = 'awaiting_approval'` with amber `UserCheck` icon and "Awaiting approval" label. Applies when `instance.currentStepId === step.id` && `pauseReason === 'awaiting_agent_approval'`, for any exec status.
- Generic `waiting_for_human` pauses keep the existing "Waiting" label — the new label is reserved for "agent did work, human reviews verdict".
- Extracts `getEffectiveStatus` to a pure module (`step-status.ts`) so it can be unit-tested without pulling in the React/Firebase chain.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 7 new unit tests for `getEffectiveStatus` (RED → GREEN). Covers awaiting_agent_approval, waiting_for_human, terminal completed, currentStep moved past, no-exec pending.
- [ ] Manual check on staging run `sdtm-rule-migration-live/runs/befa2069-...`: step should now show "Awaiting approval" instead of "Completed".