### PR TITLE
fix(landing-zone): remove cron trigger from CDISCPILOT01

### DIFF
--- a/apps/landing-zone/src/__tests__/workflow-definition.test.ts
+++ b/apps/landing-zone/src/__tests__/workflow-definition.test.ts
@@ -26,14 +26,13 @@ describe('landing-zone-CDISCPILOT01.wd.json', () => {
     expect(result.data.namespace).toBe('appsilon');
   });
 
-  it('has a cron trigger', () => {
+  it('has a manual trigger and no cron trigger', () => {
     const result = loadDefinition();
     expect(result.success).toBe(true);
     if (!result.success) return;
 
-    const cronTrigger = result.data.triggers.find((t) => t.type === 'cron');
-    expect(cronTrigger).toBeDefined();
-    expect(cronTrigger?.schedule).toBeDefined();
+    expect(result.data.triggers.find((t) => t.type === 'manual')).toBeDefined();
+    expect(result.data.triggers.find((t) => t.type === 'cron')).toBeUndefined();
   });
 
   it('declares inputForNextRun for SFTP listing carry-over', () => {

--- a/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
+++ b/apps/landing-zone/src/landing-zone-CDISCPILOT01.wd.json
@@ -28,7 +28,6 @@
     "DATA_MANAGER_EMAIL": "{{DATA_MANAGER_EMAIL_CDISCPILOT01}}"
   },
   "triggers": [
-    { "name": "poll-sftp", "type": "cron", "schedule": "*/15 * * * *" },
     { "name": "manual", "type": "manual" }
   ],
   "inputForNextRun": [


### PR DESCRIPTION
## Summary

- Drops the `poll-sftp` cron trigger from `landing-zone-CDISCPILOT01.wd.json`. The SFTP poll was firing every 15 minutes on staging because the workflow editor was unable to remove the trigger via the UI.
- Updates the corresponding test in `apps/landing-zone/src/__tests__/workflow-definition.test.ts` to assert no cron trigger and a manual trigger.

## Context

Staging is already fixed — a new version (v28) of `landing-zone-CDISCPILOT01` was posted via the API directly to `https://staging.mediforce.ai`, with the cron trigger removed and `preamble` / `inputForNextRun` / `workspace` restored (these had been silently stripped by previous editor saves on v27).

This PR syncs the repo seed JSON with the staging fix so a fresh seed will not re-introduce the cron trigger.

## Editor bug

Reason the editor could not save the trigger removal (along with several other field-stripping symptoms) is documented in [#393](https://github.com/Appsilon/mediforce/issues/393). That issue is intentionally facts-only — root cause / fix is open.

## Test plan

- [ ] `npx vitest run apps/landing-zone/src/__tests__/workflow-definition.test.ts` passes
- [ ] Next heartbeat (`POST /api/cron/heartbeat`) does not fire `landing-zone-CDISCPILOT01` on staging