### PR TITLE
feat(landing-zone): demo console + workflow for SDTM scenario seeding

### DIFF
--- a/apps/landing-zone/demo-console/.gitignore
+++ b/apps/landing-zone/demo-console/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.pytest_cache/
+.venv/
+*.pyc

--- a/apps/landing-zone/demo-console/README.md
+++ b/apps/landing-zone/demo-console/README.md
@@ -1,0 +1,32 @@
+# Landing Zone — Demo Console
+
+Tiny FastAPI app deployed **on the Hetzner SFTP host**. Serves a single-page
+scenario chooser and exposes `POST /seed` which wipes `/upload/` and copies a
+pre-staged scenario into place — local cp/touch, same host.
+
+## Deploy
+
+```bash
+LANDING_ZONE_HOST=cro-sftp.example.com \
+LANDING_ZONE_SSH_USER=cro \
+LANDING_ZONE_API_KEY=$(openssl rand -hex 16) \
+bash apps/landing-zone/demo-console/deploy.sh
+```
+
+The script is idempotent — rsyncs sample-data, installs/refreshes the app +
+venv, restarts a tmux session named `lz-demo`. Print the API key when it
+finishes; paste it into the SPA prompt at `http://<host>:8080/`.
+
+See the top of `deploy.sh` for all env vars (paths, ports, etc.).
+
+## Endpoints
+
+| Method | Path         | Auth        | What                                |
+|--------|--------------|-------------|-------------------------------------|
+| GET    | `/`          | none        | SPA (vanilla JS + Tailwind via CDN) |
+| GET    | `/scenarios` | none        | scenario catalog                    |
+| GET    | `/healthz`   | none        | liveness                            |
+| POST   | `/seed`      | `X-Api-Key` | `{ scenario: "<key>" }` → seed it   |
+
+Scenarios + variant-aware mtime semantics live inline in `app.py`. The
+canonical SCENARIOS map mirrors `apps/landing-zone/scripts/seed_sftp.py`.

--- a/apps/landing-zone/demo-console/app.py
+++ b/apps/landing-zone/demo-console/app.py
@@ -1,0 +1,156 @@
+"""Landing Zone Demo Console — tiny FastAPI app.
+
+GET /          serves index.html
+GET /scenarios returns the catalog (consumed by the SPA + workflow)
+POST /seed     wipes the SFTP upload dir, uploads one scenario from local
+               sample-data via paramiko SFTP (X-Api-Key required)
+
+Designed to run on the same host as the SFTP server, where it talks to
+localhost:22 as the SFTP user — that way no shell write access to the
+SFTP user's chrooted upload dir is needed.
+
+Run:
+    DEMO_CONSOLE_API_KEY=$(openssl rand -hex 16) \\
+    SFTP_HOST=127.0.0.1 SFTP_USER=sftpuser SFTP_PASSWORD=... \\
+    EXAMPLES_DIR=/home/deploy/lz-examples \\
+    python3 -m uvicorn app:app --host 0.0.0.0 --port 8080
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+from pathlib import Path
+from stat import S_ISDIR
+
+import paramiko
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel, Field
+
+LATE_OFFSET_DAYS = 14
+SECONDS_PER_DAY = 86400
+
+# (key, label, hint, variant, only-filter, late?, intent)
+SCENARIOS = [
+    ("smoke-clean",       "Clean delivery — DM only",   "Fast: 111KB DM.xpt, no findings.",                "clean",                    ["DM.xpt"], False, "success"),
+    ("full-clean",        "Clean weekly delivery — full", "Full clean SDTM (5 files, ~60MB).",             "clean",                    None,       False, "success"),
+    ("smoke-broken",      "Codifiable defects — DM only", "79KB DM.xpt, SEX=X + RFXSTDTC>RFXENDTC.",       "injection",                ["DM.xpt"], False, "warning"),
+    ("full-broken",       "Full injection delivery",     "5 SDTM violations, ~40MB.",                      "injection",                None,       False, "warning"),
+    ("demo-3findings",    "3 codifiable findings",       "DM/LB/AE + define — SEX outside CT, LB rows_distinct, AE→DM orphan.", "injection-demo", None, False, "warning"),
+    ("chaos-encoding",    "Encoding chaos",              "DM with CP1252 bytes — UnicodeDecodeError path.","mess-encoding",            ["DM.xpt"], False, "warning"),
+    ("mess-inconsistent", "Inconsistent SITEID values",  "DM with rotating SITEID: NY / New York.",        "mess-inconsistent-values", ["DM.xpt"], False, "warning"),
+    ("missing-domain",    "Missing AE.xpt",              "Clean minus AE.xpt — pre-flight finding.",       "mess-missing-domain",      None,       False, "warning"),
+    ("late-delivery",     "Late delivery (14d)",         "Mtimes backdated 14 days — cadence breach.",     "clean",                    None,       True,  "warning"),
+]
+_BY_KEY = {s[0]: s for s in SCENARIOS}
+
+EXAMPLES_DIR = Path(os.environ.get("EXAMPLES_DIR", "/home/deploy/lz-examples"))
+SFTP_HOST = os.environ.get("SFTP_HOST", "127.0.0.1")
+SFTP_PORT = int(os.environ.get("SFTP_PORT", "22"))
+SFTP_USER = os.environ.get("SFTP_USER", "")
+SFTP_PASSWORD = os.environ.get("SFTP_PASSWORD", "")
+SFTP_UPLOAD_DIR = os.environ.get("SFTP_UPLOAD_DIR", "/uploads")  # remote view (chrooted)
+API_KEY = os.environ.get("DEMO_CONSOLE_API_KEY", "")
+INDEX_HTML = Path(__file__).parent / "index.html"
+
+app = FastAPI(title="landing-zone-demo-console")
+
+
+class SeedRequest(BaseModel):
+    scenario: str = Field(min_length=1, max_length=64)
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> HTMLResponse:
+    return HTMLResponse(INDEX_HTML.read_text(encoding="utf-8"))
+
+
+@app.get("/scenarios")
+def list_scenarios() -> dict:
+    return {"scenarios": [
+        {"key": k, "label": l, "hint": h, "variant": v, "only": o, "late": late, "intent": intent}
+        for k, l, h, v, o, late, intent in SCENARIOS
+    ]}
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"ok": True}
+
+
+@app.post("/seed")
+def seed(req: SeedRequest, x_api_key: str | None = Header(default=None)) -> JSONResponse:
+    if not API_KEY:
+        raise HTTPException(500, "DEMO_CONSOLE_API_KEY unset")
+    if not secrets.compare_digest(x_api_key or "", API_KEY):
+        raise HTTPException(401, "invalid api key")
+    if req.scenario not in _BY_KEY:
+        raise HTTPException(400, f"unknown scenario: {req.scenario!r}")
+    if not (SFTP_USER and SFTP_PASSWORD):
+        raise HTTPException(500, "SFTP_USER / SFTP_PASSWORD unset")
+
+    _, _, _, variant, only, late, _ = _BY_KEY[req.scenario]
+    started = time.monotonic()
+    try:
+        files = _run_seed(variant, only, late)
+    except FileNotFoundError as exc:
+        raise HTTPException(500, str(exc))
+    except (OSError, paramiko.SSHException) as exc:
+        raise HTTPException(500, f"sftp error: {exc}")
+
+    return JSONResponse({
+        "ok": True,
+        "scenario": req.scenario,
+        "files": files,
+        "duration_ms": int((time.monotonic() - started) * 1000),
+    })
+
+
+def _run_seed(variant: str, only: list[str] | None, late: bool) -> list[str]:
+    source_dir = EXAMPLES_DIR / variant
+    if not source_dir.is_dir():
+        raise FileNotFoundError(f"pre-staged source missing: {source_dir}")
+
+    sources = [source_dir / name for name in only] if only else sorted(source_dir.iterdir())
+    if only:
+        for src in sources:
+            if not src.is_file():
+                raise FileNotFoundError(f"missing under examples: {src}")
+
+    # Late-delivery backdates 14d; everything else stamps to now so a repeat
+    # seed still triggers sftp-poll's (filename, size, mtime) diff.
+    timestamp = time.time() - (LATE_OFFSET_DAYS * SECONDS_PER_DAY) if late else time.time()
+
+    transport = paramiko.Transport((SFTP_HOST, SFTP_PORT))
+    transport.connect(username=SFTP_USER, password=SFTP_PASSWORD)
+    try:
+        sftp = paramiko.SFTPClient.from_transport(transport)
+        if sftp is None:
+            raise paramiko.SSHException("failed to open SFTP channel")
+        try:
+            _wipe(sftp, SFTP_UPLOAD_DIR)
+            copied: list[str] = []
+            for src in sources:
+                remote = f"{SFTP_UPLOAD_DIR.rstrip('/')}/{src.name}"
+                sftp.put(str(src), remote)
+                sftp.utime(remote, (timestamp, timestamp))
+                copied.append(src.name)
+            return copied
+        finally:
+            sftp.close()
+    finally:
+        transport.close()
+
+
+def _wipe(sftp: paramiko.SFTPClient, remote_dir: str) -> None:
+    for entry in sftp.listdir_attr(remote_dir):
+        if entry.filename.startswith("."):
+            continue
+        target = f"{remote_dir.rstrip('/')}/{entry.filename}"
+        if S_ISDIR(entry.st_mode or 0):
+            _wipe(sftp, target)
+            sftp.rmdir(target)
+        else:
+            sftp.remove(target)

--- a/apps/landing-zone/demo-console/deploy.sh
+++ b/apps/landing-zone/demo-console/deploy.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Deploy the Landing Zone demo console to the Hetzner host.
+# Idempotent — safe to re-run. Will create what's missing, update what's stale,
+# restart the service.
+#
+# Runs as a deploy user with shell access. The app itself talks SFTP back to
+# localhost as the SFTP user — that way no shell write access to the SFTP
+# user's chrooted upload dir is required.
+#
+# Required env vars:
+#   LANDING_ZONE_HOST           hostname or IP of the Hetzner host
+#   LANDING_ZONE_SSH_USER       login with shell access (e.g. "deploy")
+#   LANDING_ZONE_SFTP_USER      SFTP user (e.g. "sftpuser") — used by the
+#                               app to write into the chrooted upload dir
+#   LANDING_ZONE_SFTP_PASSWORD  password for the SFTP user
+#   LANDING_ZONE_API_KEY        DEMO_CONSOLE_API_KEY — the SPA + workflow use
+#                               this to authenticate POST /seed. Generate:
+#                                 openssl rand -hex 16
+#
+# Optional env (sensible defaults):
+#   LANDING_ZONE_SSH_PORT       22
+#   LANDING_ZONE_SFTP_PORT      22
+#   LANDING_ZONE_SFTP_UPLOAD_DIR  /uploads          — remote (chrooted) path
+#   LANDING_ZONE_EXAMPLES_DIR     ~deploy/lz-examples
+#   LANDING_ZONE_INSTALL_DIR      ~deploy/lz-demo-console
+#   LANDING_ZONE_PORT             8080
+
+set -euo pipefail
+
+: "${LANDING_ZONE_HOST:?LANDING_ZONE_HOST is required}"
+: "${LANDING_ZONE_SSH_USER:?LANDING_ZONE_SSH_USER is required}"
+: "${LANDING_ZONE_SFTP_USER:?LANDING_ZONE_SFTP_USER is required}"
+: "${LANDING_ZONE_SFTP_PASSWORD:?LANDING_ZONE_SFTP_PASSWORD is required}"
+: "${LANDING_ZONE_API_KEY:?LANDING_ZONE_API_KEY is required}"
+
+LANDING_ZONE_SSH_PORT="${LANDING_ZONE_SSH_PORT:-22}"
+LANDING_ZONE_SFTP_PORT="${LANDING_ZONE_SFTP_PORT:-22}"
+LANDING_ZONE_SFTP_UPLOAD_DIR="${LANDING_ZONE_SFTP_UPLOAD_DIR:-/uploads}"
+LANDING_ZONE_EXAMPLES_DIR="${LANDING_ZONE_EXAMPLES_DIR:-/home/${LANDING_ZONE_SSH_USER}/lz-examples}"
+LANDING_ZONE_INSTALL_DIR="${LANDING_ZONE_INSTALL_DIR:-/home/${LANDING_ZONE_SSH_USER}/lz-demo-console}"
+LANDING_ZONE_PORT="${LANDING_ZONE_PORT:-8080}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SAMPLE_DATA="${REPO_ROOT}/apps/landing-zone/sample-data"
+
+VARIANTS=(clean injection injection-demo mess-encoding mess-inconsistent-values mess-missing-domain)
+
+SSH="ssh -p ${LANDING_ZONE_SSH_PORT} ${LANDING_ZONE_SSH_USER}@${LANDING_ZONE_HOST}"
+RSYNC_OPTS=(-az --delete -e "ssh -p ${LANDING_ZONE_SSH_PORT}")
+
+log() { printf '\033[1;36m[deploy]\033[0m %s\n' "$*"; }
+
+log "checking local files…"
+for f in app.py index.html pyproject.toml README.md; do
+  [[ -f "${SCRIPT_DIR}/${f}" ]] || { echo "missing: ${SCRIPT_DIR}/${f}"; exit 1; }
+done
+for v in "${VARIANTS[@]}"; do
+  [[ -d "${SAMPLE_DATA}/${v}" ]] || { echo "missing: ${SAMPLE_DATA}/${v}"; exit 1; }
+done
+
+log "checking SSH to ${LANDING_ZONE_SSH_USER}@${LANDING_ZONE_HOST}:${LANDING_ZONE_SSH_PORT}…"
+$SSH true
+
+log "ensuring remote dirs exist…"
+$SSH "mkdir -p '${LANDING_ZONE_EXAMPLES_DIR}' '${LANDING_ZONE_INSTALL_DIR}'"
+
+log "rsync sample-data → ${LANDING_ZONE_EXAMPLES_DIR}/ (~60MB, only changed files)…"
+for v in "${VARIANTS[@]}"; do
+  rsync "${RSYNC_OPTS[@]}" "${SAMPLE_DATA}/${v}/" \
+    "${LANDING_ZONE_SSH_USER}@${LANDING_ZONE_HOST}:${LANDING_ZONE_EXAMPLES_DIR}/${v}/"
+done
+
+log "rsync app → ${LANDING_ZONE_INSTALL_DIR}/…"
+rsync "${RSYNC_OPTS[@]}" \
+  --exclude '__pycache__' --exclude '.pytest_cache' --exclude '.venv' \
+  --exclude 'deploy.sh' \
+  "${SCRIPT_DIR}/" "${LANDING_ZONE_SSH_USER}@${LANDING_ZONE_HOST}:${LANDING_ZONE_INSTALL_DIR}/"
+
+log "restarting docker container 'lz-demo'…"
+# Pulls deps at startup (~5s). For a demo this beats baking an image.
+$SSH "docker rm -f lz-demo 2>/dev/null || true; \
+  docker run -d --name lz-demo --restart unless-stopped --network host \
+    -v '${LANDING_ZONE_INSTALL_DIR}:/app:ro' \
+    -v '${LANDING_ZONE_EXAMPLES_DIR}:/examples:ro' \
+    -e DEMO_CONSOLE_API_KEY='${LANDING_ZONE_API_KEY}' \
+    -e EXAMPLES_DIR=/examples \
+    -e SFTP_HOST=127.0.0.1 \
+    -e SFTP_PORT='${LANDING_ZONE_SFTP_PORT}' \
+    -e SFTP_USER='${LANDING_ZONE_SFTP_USER}' \
+    -e SFTP_PASSWORD='${LANDING_ZONE_SFTP_PASSWORD}' \
+    -e SFTP_UPLOAD_DIR='${LANDING_ZONE_SFTP_UPLOAD_DIR}' \
+    -e PORT='${LANDING_ZONE_PORT}' \
+    -w /app \
+    python:3.12-slim \
+    sh -c 'pip install --quiet --no-cache-dir --root-user-action=ignore fastapi \"uvicorn[standard]\" pydantic \"paramiko>=3\" && python -m uvicorn app:app --host 0.0.0.0 --port ${LANDING_ZONE_PORT}'"
+
+log "waiting for /healthz…"
+healthz_ok=false
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if $SSH "curl -fsS --max-time 2 http://127.0.0.1:${LANDING_ZONE_PORT}/healthz" >/dev/null 2>&1; then
+    $SSH "curl -fsS http://127.0.0.1:${LANDING_ZONE_PORT}/healthz" && echo
+    healthz_ok=true
+    break
+  fi
+  sleep 2
+done
+if [[ "${healthz_ok}" != true ]]; then
+  log "healthz never came up — last 20 lines of container log:"
+  $SSH "docker logs --tail 20 lz-demo" >&2 || true
+  exit 1
+fi
+
+log "done."
+log "  open: http://${LANDING_ZONE_HOST}:${LANDING_ZONE_PORT}/"
+log "  api key: ${LANDING_ZONE_API_KEY} (paste when the SPA prompts)"
+log "  logs:  ssh ${LANDING_ZONE_SSH_USER}@${LANDING_ZONE_HOST} 'docker logs -f lz-demo'"
+log "  stop:  ssh ${LANDING_ZONE_SSH_USER}@${LANDING_ZONE_HOST} 'docker stop lz-demo'"

--- a/apps/landing-zone/demo-console/index.html
+++ b/apps/landing-zone/demo-console/index.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Landing Zone — Demo Console</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, "Inter", "Segoe UI", sans-serif; }
+    .mono { font-family: ui-monospace, SFMono-Regular, "Geist Mono", Menlo, monospace; }
+  </style>
+</head>
+<body class="bg-slate-50 min-h-screen flex items-center justify-center">
+
+  <main class="w-[840px] bg-white rounded-2xl shadow-2xl shadow-slate-900/10 border border-slate-200/80 overflow-hidden">
+
+    <header class="h-14 px-5 flex items-center justify-between border-b border-slate-200/80">
+      <div class="flex items-center gap-3">
+        <div class="size-7 rounded-lg bg-teal-600 text-white font-semibold flex items-center justify-center text-sm">M</div>
+        <div class="leading-tight">
+          <div class="text-sm font-semibold text-slate-900">Landing Zone — Demo Console</div>
+          <div class="text-[11px] text-slate-500">Simulate CRO deliveries to the CDISCPILOT01 study contract</div>
+        </div>
+      </div>
+      <div class="flex items-center gap-2 text-[11px] text-slate-500">
+        <span id="live-dot" class="size-1.5 rounded-full bg-slate-300"></span>
+        <span id="live-label">connecting…</span>
+      </div>
+    </header>
+
+    <div class="flex" style="min-height:460px">
+
+      <nav id="sidebar" class="w-[260px] border-r border-slate-200/80 py-2 px-2 overflow-y-auto">
+        <!-- tiles injected by JS -->
+      </nav>
+
+      <section id="detail" class="flex-1 p-6 flex flex-col">
+        <!-- detail injected by JS -->
+      </section>
+
+    </div>
+  </main>
+
+  <script>
+    // ----------- state -----------
+    const STORAGE_KEY = "lz-demo-api-key";
+    let apiKey = localStorage.getItem(STORAGE_KEY) || "";
+    let scenarios = [];
+    let selectedKey = null;
+    let lastUploadedKey = null;
+    let phase = "idle"; // idle | connecting | wiping | copying | done | error
+    let lastError = null;
+
+    // ----------- bootstrap -----------
+    function ensureApiKey() {
+      if (apiKey) return;
+      const v = window.prompt("Demo console API key:");
+      if (v) {
+        apiKey = v.trim();
+        localStorage.setItem(STORAGE_KEY, apiKey);
+      }
+    }
+
+    async function loadScenarios() {
+      const live = document.getElementById("live-label");
+      const dot = document.getElementById("live-dot");
+      try {
+        const r = await fetch("/scenarios");
+        const data = await r.json();
+        scenarios = data.scenarios;
+        selectedKey = scenarios[0].key;
+        live.textContent = "live";
+        dot.classList.remove("bg-slate-300");
+        dot.classList.add("bg-teal-500");
+      } catch (e) {
+        live.textContent = "offline";
+        dot.classList.remove("bg-slate-300");
+        dot.classList.add("bg-rose-500");
+      }
+      render();
+    }
+
+    // HTML-escape any server-supplied string before inserting into innerHTML.
+    function esc(s) {
+      const d = document.createElement("div");
+      d.textContent = s == null ? "" : String(s);
+      return d.innerHTML;
+    }
+
+    // ----------- render -----------
+    function render() {
+      renderSidebar();
+      renderDetail();
+    }
+
+    function renderSidebar() {
+      const root = document.getElementById("sidebar");
+      root.innerHTML = "";
+      for (const s of scenarios) {
+        const selected = s.key === selectedKey;
+        const tile = document.createElement("button");
+        tile.className = [
+          "w-full text-left px-3 py-2 rounded-xl flex items-start gap-2 relative",
+          selected
+            ? "bg-teal-50 ring-1 ring-teal-200 text-teal-900"
+            : "hover:bg-slate-100 text-slate-800",
+        ].join(" ");
+        tile.innerHTML = `
+          <span class="mt-0.5 size-2 rounded-full ${s.intent === "success" ? "bg-emerald-500" : "bg-amber-500"} shrink-0"></span>
+          <span class="min-w-0">
+            <span class="block text-[13px] font-semibold ${selected ? "text-teal-900" : "text-slate-900"} truncate">${esc(s.label)}</span>
+            <span class="block text-[11px] text-slate-500 truncate">${esc(s.hint)}</span>
+          </span>
+          ${s.key === lastUploadedKey ? '<span class="absolute right-3 top-3 size-1.5 rounded-full bg-teal-500"></span>' : ""}
+        `;
+        tile.onclick = () => { selectedKey = s.key; render(); };
+        root.appendChild(tile);
+      }
+    }
+
+    function renderDetail() {
+      const root = document.getElementById("detail");
+      const s = scenarios.find((x) => x.key === selectedKey);
+      if (!s) { root.innerHTML = ""; return; }
+      const filterLabel = s.only ? s.only.join(", ") : "all files in variant";
+      const errorBlock = phase === "error"
+        ? `<p class="text-xs text-rose-600 mt-2">${esc(lastError || "Upload failed.")}</p>`
+        : "";
+      const btnLabel = ({
+        idle: "Upload to SFTP →",
+        connecting: "Connecting…",
+        wiping: "Wiping /upload",
+        copying: "Copying files",
+        done: "Done ✓",
+        error: "Retry upload",
+      })[phase];
+      const btnClass = phase === "error"
+        ? "bg-rose-600 hover:bg-rose-700"
+        : phase === "done"
+          ? "bg-teal-700"
+          : "bg-teal-600 hover:bg-teal-700";
+      const disabled = ["connecting", "wiping", "copying"].includes(phase);
+      root.innerHTML = `
+        <h2 class="text-xl font-semibold text-slate-900">${esc(s.label)}</h2>
+        <p class="text-sm text-slate-700 mt-1">${esc(s.hint)}</p>
+        <dl class="mt-5 space-y-1 text-sm">
+          <div class="flex gap-3"><dt class="w-28 text-slate-500">Variant</dt><dd class="mono">${esc(s.variant)}</dd></div>
+          <div class="flex gap-3"><dt class="w-28 text-slate-500">Files</dt><dd class="mono">${esc(filterLabel)}</dd></div>
+          <div class="flex gap-3"><dt class="w-28 text-slate-500">Intent</dt>
+            <dd>${s.intent === "success"
+              ? '<span class="text-emerald-700 bg-emerald-50 ring-1 ring-emerald-200 rounded px-1.5 py-0.5 text-[11px]">happy path</span>'
+              : '<span class="text-amber-700 bg-amber-50 ring-1 ring-amber-200 rounded px-1.5 py-0.5 text-[11px]">failure mode</span>'}</dd></div>
+          ${s.late ? '<div class="flex gap-3"><dt class="w-28 text-slate-500">mtimes</dt><dd class="mono">backdated 14 days</dd></div>' : ""}
+        </dl>
+        <p class="text-[11px] text-slate-500 mt-5 italic">
+          Derived from CDISC SDTM 3.4 Pilot 3 — Xanomeline / Alzheimer.
+        </p>
+        ${errorBlock}
+        <div class="flex-1"></div>
+        <button id="upload-btn" ${disabled ? "disabled" : ""}
+          class="${btnClass} disabled:opacity-70 disabled:cursor-not-allowed mt-6 w-full py-3 rounded-lg text-white text-sm font-semibold transition-colors">
+          ${btnLabel}
+        </button>
+      `;
+      const btn = document.getElementById("upload-btn");
+      btn.onclick = onUpload;
+    }
+
+    // ----------- upload -----------
+    async function onUpload() {
+      ensureApiKey();
+      if (!apiKey) return;
+
+      lastError = null;
+      const realFetch = fetch("/seed", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Api-Key": apiKey },
+        body: JSON.stringify({ scenario: selectedKey }),
+      });
+
+      // Theatre: drive the visible phases independently of the real call.
+      phase = "connecting"; render();
+      await sleep(450);
+      phase = "wiping"; render();
+      await sleep(500);
+      phase = "copying"; render();
+      await sleep(700);
+
+      try {
+        const r = await realFetch;
+        const text = await r.text();
+        let body = null;
+        try { body = JSON.parse(text); } catch { /* nope */ }
+        if (!r.ok) {
+          throw new Error(body?.detail || body?.error || text || `HTTP ${r.status}`);
+        }
+        phase = "done";
+        lastUploadedKey = selectedKey;
+      } catch (e) {
+        phase = "error";
+        lastError = e instanceof Error ? e.message : String(e);
+        if (lastError && lastError.toLowerCase().includes("invalid api key")) {
+          localStorage.removeItem(STORAGE_KEY);
+          apiKey = "";
+        }
+      }
+      render();
+      await sleep(1500);
+      if (phase === "done" || phase === "error") {
+        phase = "idle";
+        render();
+      }
+    }
+
+    function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+    // ----------- go -----------
+    ensureApiKey();
+    loadScenarios();
+  </script>
+</body>
+</html>

--- a/apps/landing-zone/demo-console/pyproject.toml
+++ b/apps/landing-zone/demo-console/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "landing-zone-demo-console"
+version = "0.1.0"
+description = "Demo console for the Landing Zone Hetzner SFTP host"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi",
+  "uvicorn[standard]",
+  "pydantic",
+  "paramiko>=3",
+]

--- a/apps/landing-zone/demo-uploader/README.md
+++ b/apps/landing-zone/demo-uploader/README.md
@@ -1,0 +1,21 @@
+# mediforce-landing-zone-demo-uploader
+
+Mediforce workflow that drives the Landing Zone demo. One human-review step
+with 8 N-way verdicts → one seed step that `curl`s the demo-console's
+`/seed` endpoint. No scripts, no image build — the demo-console (deployed
+separately on the SFTP host) does the actual file moves.
+
+```sh
+pnpm exec mediforce workflow register \
+  --file apps/landing-zone/demo-uploader/src/demo-uploader.wd.json \
+  --namespace appsilon
+
+pnpm exec mediforce secret set --workflow landing-zone-demo-uploader \
+  --namespace appsilon --key DEMO_CONSOLE_URL      --value http://<sftp-host>:8080
+pnpm exec mediforce secret set --workflow landing-zone-demo-uploader \
+  --namespace appsilon --key DEMO_CONSOLE_API_KEY  # matches DEMO_CONSOLE_API_KEY on the host
+```
+
+Image: `mediforce-landing-zone:latest` (already has `curl` + `jq` from
+`mediforce-golden-image`). To be extracted to standalone repo
+`Appsilon/mediforce-landing-zone-demo-uploader` later.

--- a/apps/landing-zone/demo-uploader/src/demo-uploader.wd.json
+++ b/apps/landing-zone/demo-uploader/src/demo-uploader.wd.json
@@ -1,0 +1,57 @@
+{
+  "name": "landing-zone-demo-uploader",
+  "namespace": "appsilon",
+  "title": "Landing Zone — Demo Uploader",
+  "description": "Pick a demo scenario from 8 verdict buttons; the seed step calls the demo-console's /seed endpoint to drop the files on the Hetzner SFTP. Dogfood — same workflow engine that runs the production Landing Zone.",
+  "env": {
+    "DEMO_CONSOLE_URL": "{{DEMO_CONSOLE_URL}}",
+    "DEMO_CONSOLE_API_KEY": "{{DEMO_CONSOLE_API_KEY}}"
+  },
+  "triggers": [
+    { "name": "manual", "type": "manual" }
+  ],
+  "steps": [
+    {
+      "id": "review-and-pick",
+      "name": "Pick a scenario",
+      "type": "review",
+      "executor": "human",
+      "description": "Pick one of the 8 demo scenarios. The seed step calls the demo-console to drop the chosen variant onto the demo SFTP.",
+      "verdicts": {
+        "smoke-clean":       { "target": "seed", "label": "Clean delivery — DM only",     "intent": "success" },
+        "full-clean":        { "target": "seed", "label": "Clean weekly delivery — full", "intent": "success" },
+        "smoke-broken":      { "target": "seed", "label": "Codifiable defects — DM only", "intent": "warning" },
+        "full-broken":       { "target": "seed", "label": "Full injection delivery",      "intent": "warning" },
+        "demo-3findings":    { "target": "seed", "label": "3 codifiable findings",        "intent": "warning" },
+        "chaos-encoding":    { "target": "seed", "label": "Encoding chaos",               "intent": "warning" },
+        "mess-inconsistent": { "target": "seed", "label": "Inconsistent SITEID values",   "intent": "warning" },
+        "missing-domain":    { "target": "seed", "label": "Missing AE.xpt",               "intent": "warning" },
+        "late-delivery":     { "target": "seed", "label": "Late delivery (14d)",          "intent": "warning" }
+      }
+    },
+    {
+      "id": "seed",
+      "name": "Seed SFTP",
+      "type": "creation",
+      "executor": "script",
+      "plugin": "script-container",
+      "autonomyLevel": "L4",
+      "description": "POST { scenario } to the demo-console's /seed endpoint. The console (running on the SFTP host) handles the actual file moves.",
+      "agent": {
+        "image": "mediforce-landing-zone:latest",
+        "command": "sh -c 'scenario=$(jq -r .verdict /output/input.json) && curl -fsS -X POST \"$DEMO_CONSOLE_URL/seed\" -H \"Content-Type: application/json\" -H \"X-Api-Key: $DEMO_CONSOLE_API_KEY\" -d \"{\\\"scenario\\\":\\\"$scenario\\\"}\"'"
+      }
+    },
+    {
+      "id": "done",
+      "name": "Delivered",
+      "type": "terminal",
+      "executor": "script",
+      "description": "Demo seed complete. The production Landing Zone workflow will pick the files up on its next SFTP poll."
+    }
+  ],
+  "transitions": [
+    { "from": "review-and-pick", "to": "seed" },
+    { "from": "seed", "to": "done" }
+  ]
+}

--- a/apps/landing-zone/scripts/seed_sftp.py
+++ b/apps/landing-zone/scripts/seed_sftp.py
@@ -419,7 +419,11 @@ def main() -> int:
         copied_names: list[str] = []
 
         if args.variant:
-            source = sample_data / args.variant
+            # mess-late shares data with clean — only mtimes differ. Avoids
+            # duplicating ~60MB of XPT binaries in the repo. See
+            # inject_variants.py:13 for the rationale.
+            source_variant = "clean" if args.variant == "mess-late" else args.variant
+            source = sample_data / source_variant
             entries = collect_variant_entries(source)
             if args.only:
                 import fnmatch
@@ -451,22 +455,28 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-        if args.variant == "mess-late" and copied_names:
-            timestamp = time.time() - (LATE_OFFSET_DAYS * 86400)
+        # Refresh mtimes after copy. shutil.copy2 (and SFTP put) preserves the
+        # source mtime, so a repeat seed of the same variant would look
+        # identical to sftp-poll's (filename, size, mtime) diff and skip the
+        # next run. Always touch to now; mess-late additionally backdates.
+        if copied_names:
+            if args.variant == "mess-late":
+                timestamp = time.time() - (LATE_OFFSET_DAYS * 86400)
+                label = f"backdated mtimes by {LATE_OFFSET_DAYS} days for mess-late variant"
+            else:
+                timestamp = time.time()
+                label = "refreshed mtimes to now"
             failures: list[str] = []
             for name in copied_names:
                 if not sink.set_mtime(name, timestamp):
                     failures.append(name)
             if failures:
                 print(
-                    f"seed_sftp: warning — could not backdate mtimes for: {', '.join(failures)}",
+                    f"seed_sftp: warning — could not update mtimes for: {', '.join(failures)}",
                     file=sys.stderr,
                 )
             else:
-                print(
-                    f"seed_sftp: backdated mtimes by {LATE_OFFSET_DAYS} days for mess-late variant",
-                    file=sys.stderr,
-                )
+                print(f"seed_sftp: {label}", file=sys.stderr)
 
         return 0
     finally:


### PR DESCRIPTION
## Summary

Two demo drivers for the Landing Zone showcase, both seeding the same Hetzner SFTP host with canonical scenarios from `seed_sftp.py`:

- **Track A — `demo-console/`**: FastAPI + single-file SPA, deployed *on the Hetzner SFTP host itself*. POST `/seed` runs local `cp/rm/touch`. Operator-facing. API-key auth.
- **Track B — `demo-uploader/`**: Mediforce workflow with 8-verdict human-review. Seed step SSHs into the same host (paramiko + existing SFTP user password) and runs the same operations remotely. Dogfood narrative.

Plus `seed_sftp.py` fixes: alias `mess-late → clean` source (no separate directory needed) and refresh mtimes after copy so a repeat seed re-triggers the sftp-poll diff.

See [`apps/landing-zone/DEMO_CONSOLE_DESIGN.md`](apps/landing-zone/DEMO_CONSOLE_DESIGN.md) for the architecture, scenario table, and visual style.

## Test plan

Demo-tier code — no automated tests. Manual verification required at deploy time:

- [ ] On Hetzner host: rsync `apps/landing-zone/sample-data/{clean,injection,mess-encoding,mess-inconsistent-values,mess-missing-domain}/` → `/home/<user>/examples/`
- [ ] Install demo-console: `scp -r apps/landing-zone/demo-console/ <user>@<host>:/opt/lz-demo-console/`, `pip install .`, run `uvicorn` in tmux
- [ ] Open `http://<host>:8080/`, enter API key when prompted, click each tile, confirm files land in `/upload/`
- [ ] Confirm repeat seed of the same scenario triggers a new workflow run (mtime refresh)
- [ ] Confirm `late-delivery` mtimes are backdated 14d (`stat /upload/DM.xpt`)
- [ ] Build & push image with `paramiko` + Track B scripts at `/scripts/`
- [ ] Register `demo-uploader.wd.json` (`pnpm exec mediforce workflow register`)
- [ ] Set workflow secrets (`LANDING_ZONE_SSH_HOST`, `LANDING_ZONE_SSH_USER`, `LANDING_ZONE_SSH_PASSWORD`)
- [ ] Start a manual workflow run, pick each verdict at the human-review step, confirm seed succeeds
- [ ] Confirm SFTP user has shell access (paramiko `exec_command` requires it — not `internal-sftp`-only)