### PR TITLE
feat(ui): unify agent output rendering across step + task pages

### DIFF
--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/__tests__/agent-output-from-envelope.test.ts
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/__tests__/agent-output-from-envelope.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentOutputEnvelope } from '@mediforce/platform-core';
+import { agentOutputFromEnvelope } from '../agent-output-from-envelope';
+
+function buildEnvelope(overrides: Partial<AgentOutputEnvelope> = {}): AgentOutputEnvelope {
+  return {
+    confidence: 0.9,
+    reasoning_summary: 'looks good',
+    reasoning_chain: [],
+    annotations: [],
+    model: 'claude-sonnet-4-5',
+    duration_ms: 1234,
+    result: { ok: true },
+    ...overrides,
+  };
+}
+
+describe('agentOutputFromEnvelope', () => {
+  it('maps confidence, reasoning, result, model, duration', () => {
+    const envelope = buildEnvelope({
+      confidence: 0.42,
+      confidence_rationale: 'mid certainty',
+      reasoning_summary: 'because reasons',
+      model: 'gpt-5',
+      duration_ms: 5000,
+      result: { foo: 'bar' },
+    });
+
+    const out = agentOutputFromEnvelope(envelope);
+
+    expect(out.confidence).toBe(0.42);
+    expect(out.confidence_rationale).toBe('mid certainty');
+    expect(out.reasoning).toBe('because reasons');
+    expect(out.model).toBe('gpt-5');
+    expect(out.duration_ms).toBe(5000);
+    expect(out.result).toEqual({ foo: 'bar' });
+  });
+
+  it('passes git metadata and presentation through', () => {
+    const git = {
+      commitSha: 'deadbeef',
+      branch: 'feat/x',
+      changedFiles: ['a.ts', 'b.ts'],
+      repoUrl: 'https://github.com/org/repo',
+    };
+    const envelope = buildEnvelope({
+      gitMetadata: git,
+      presentation: '<div>html</div>',
+    });
+
+    const out = agentOutputFromEnvelope(envelope);
+
+    expect(out.gitMetadata).toEqual(git);
+    expect(out.presentation).toBe('<div>html</div>');
+  });
+
+  it('passes tokenUsage through', () => {
+    const envelope = buildEnvelope({
+      tokenUsage: { inputTokens: 100, outputTokens: 200 },
+    });
+
+    const out = agentOutputFromEnvelope(envelope);
+
+    expect(out.tokenUsage).toEqual({ inputTokens: 100, outputTokens: 200 });
+  });
+
+  it('returns null tokenUsage when envelope omits it', () => {
+    const out = agentOutputFromEnvelope(buildEnvelope());
+    expect(out.tokenUsage).toBeNull();
+  });
+
+  it('returns null estimatedCostUsd — envelope schema does not carry cost', () => {
+    const out = agentOutputFromEnvelope(
+      buildEnvelope({ tokenUsage: { inputTokens: 10, outputTokens: 20 } }),
+    );
+    expect(out.estimatedCostUsd).toBeNull();
+  });
+
+  it('always returns null escalationReason — envelope has no escalation field', () => {
+    const out = agentOutputFromEnvelope(buildEnvelope());
+    expect(out.escalationReason).toBeNull();
+  });
+
+  it('falls back to null for missing optional fields', () => {
+    const out = agentOutputFromEnvelope(buildEnvelope());
+
+    expect(out.confidence_rationale).toBeNull();
+    expect(out.gitMetadata).toBeNull();
+    expect(out.presentation).toBeNull();
+  });
+});

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/agent-output-from-envelope.ts
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/agent-output-from-envelope.ts
@@ -1,0 +1,30 @@
+import type { AgentRun } from '@mediforce/platform-core';
+import type { AgentOutputData } from '@/components/tasks/task-utils';
+
+/**
+ * Map an `AgentOutputEnvelope` (Firestore source of truth) into the
+ * UI-friendly `AgentOutputData` shape consumed by `AgentOutputDisplay`.
+ *
+ * NOTE: `AgentOutputEnvelope` schema doesn't carry `estimatedCostUsd` (see
+ * `agent-output-envelope.ts`). Cost calculation needs the model registry
+ * which is server-only, so we surface `null` here and rely on the existing
+ * server-side `estimateCostField` (in `execute-agent-step.ts`) to populate
+ * cost on `StepExecution.agentOutput` for the legacy display path.
+ */
+export function agentOutputFromEnvelope(
+  envelope: NonNullable<AgentRun['envelope']>,
+): AgentOutputData {
+  return {
+    confidence: envelope.confidence,
+    confidence_rationale: envelope.confidence_rationale ?? null,
+    reasoning: envelope.reasoning_summary,
+    result: envelope.result,
+    model: envelope.model,
+    duration_ms: envelope.duration_ms,
+    gitMetadata: envelope.gitMetadata ?? null,
+    presentation: envelope.presentation ?? null,
+    escalationReason: null,
+    estimatedCostUsd: null,
+    tokenUsage: envelope.tokenUsage ?? null,
+  };
+}

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
@@ -5,32 +5,16 @@ import { useMemo, useState } from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { format } from 'date-fns';
 import { CheckCircle2, Clock, XCircle, Circle, Pause, Bot, User, ExternalLink, FileText, GitBranch, Gauge, ChevronDown, ChevronRight, MessageSquare, DollarSign } from 'lucide-react';
-import { where } from 'firebase/firestore';
-import type { StepExecution, Step, AgentEvent, HumanTask, AgentRun } from '@mediforce/platform-core';
+import type { StepExecution, Step, AgentEvent, HumanTask } from '@mediforce/platform-core';
 import { useProcessInstance, useSubcollection } from '@/hooks/use-process-instances';
 import { useProcessDefinitionVersions } from '@/hooks/use-process-definitions';
 import { useInstanceTasks } from '@/hooks/use-instance-tasks';
-import { useCollection } from '@/hooks/use-collection';
+import { useAgentRunsForStep } from '@/hooks/use-agent-runs';
 import { getAgentOutput, type AgentOutputData } from '@/components/tasks/task-utils';
 import { AgentOutputDisplay } from '@/components/agents/agent-output-display';
+import { agentOutputFromEnvelope } from './agent-output-from-envelope';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
 import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
-
-function agentOutputFromEnvelope(envelope: NonNullable<AgentRun['envelope']>): AgentOutputData {
-  return {
-    confidence: envelope.confidence,
-    confidence_rationale: envelope.confidence_rationale ?? null,
-    reasoning: envelope.reasoning_summary,
-    result: envelope.result,
-    model: envelope.model,
-    duration_ms: envelope.duration_ms,
-    gitMetadata: envelope.gitMetadata ?? null,
-    presentation: envelope.presentation ?? null,
-    escalationReason: null,
-    estimatedCostUsd: null,
-    tokenUsage: envelope.tokenUsage ?? null,
-  };
-}
 
 function StatusIcon({ status }: { status: string }) {
   switch (status) {
@@ -108,16 +92,7 @@ export default function StepDetailPage() {
   //      this is the source of truth and carries `presentation` HTML.
   //   2. HumanTask.completionData.agentOutput (only for L3 review steps) —
   //      fallback for older runs where envelope wasn't queryable.
-  const agentRunConstraints = useMemo(
-    () => (runId && decodedStepId
-      ? [where('processInstanceId', '==', runId), where('stepId', '==', decodedStepId)]
-      : []),
-    [runId, decodedStepId],
-  );
-  const { data: agentRuns } = useCollection<AgentRun>(
-    runId && decodedStepId ? 'agentRuns' : '',
-    agentRunConstraints,
-  );
+  const { data: agentRuns } = useAgentRunsForStep(runId ?? null, decodedStepId || null);
   const { tasks: instanceTasks } = useInstanceTasks(runId ?? undefined);
   const agentOutput = useMemo((): AgentOutputData | null => {
     const latestRun = agentRuns
@@ -160,7 +135,7 @@ export default function StepDetailPage() {
   }
 
   const stepName = definitionStep?.name ?? formatStepName(decodedStepId);
-  const isAgent = execution?.agentOutput !== undefined;
+  const hasAgentBadge = agentOutput !== null || execution?.agentOutput !== undefined;
 
   return (
     <div className="p-6 space-y-6 max-w-6xl">
@@ -169,7 +144,7 @@ export default function StepDetailPage() {
         <div className="flex items-center gap-3">
           {execution && <StatusIcon status={execution.status} />}
           <h2 className="text-2xl font-headline font-semibold">{stepName}</h2>
-          {isAgent && (
+          {hasAgentBadge && (
             <span className="inline-flex items-center gap-1 rounded-full bg-violet-100 dark:bg-violet-900/30 px-2 py-0.5 text-xs text-violet-700 dark:text-violet-300">
               <Bot className="h-3 w-3" /> Agent
             </span>

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
@@ -2,14 +2,35 @@
 
 import { useParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
-import Link from 'next/link';
+import * as Collapsible from '@radix-ui/react-collapsible';
 import { format } from 'date-fns';
-import { ArrowLeft, CheckCircle2, Clock, XCircle, Circle, Pause, Bot, User, ExternalLink, FileText, GitBranch, Gauge, ChevronDown, ChevronRight, MessageSquare, DollarSign } from 'lucide-react';
-import type { StepExecution, Step, AgentEvent } from '@mediforce/platform-core';
+import { CheckCircle2, Clock, XCircle, Circle, Pause, Bot, User, ExternalLink, FileText, GitBranch, Gauge, ChevronDown, ChevronRight, MessageSquare, DollarSign } from 'lucide-react';
+import { where } from 'firebase/firestore';
+import type { StepExecution, Step, AgentEvent, HumanTask, AgentRun } from '@mediforce/platform-core';
 import { useProcessInstance, useSubcollection } from '@/hooks/use-process-instances';
 import { useProcessDefinitionVersions } from '@/hooks/use-process-definitions';
+import { useInstanceTasks } from '@/hooks/use-instance-tasks';
+import { useCollection } from '@/hooks/use-collection';
+import { getAgentOutput, type AgentOutputData } from '@/components/tasks/task-utils';
+import { AgentOutputDisplay } from '@/components/agents/agent-output-display';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
 import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
+
+function agentOutputFromEnvelope(envelope: NonNullable<AgentRun['envelope']>): AgentOutputData {
+  return {
+    confidence: envelope.confidence,
+    confidence_rationale: envelope.confidence_rationale ?? null,
+    reasoning: envelope.reasoning_summary,
+    result: envelope.result,
+    model: envelope.model,
+    duration_ms: envelope.duration_ms,
+    gitMetadata: envelope.gitMetadata ?? null,
+    presentation: envelope.presentation ?? null,
+    escalationReason: null,
+    estimatedCostUsd: null,
+    tokenUsage: envelope.tokenUsage ?? null,
+  };
+}
 
 function StatusIcon({ status }: { status: string }) {
   switch (status) {
@@ -82,6 +103,42 @@ export default function StepDetailPage() {
       .find((e) => e.type === 'prompt') ?? null;
   }, [agentEvents, decodedStepId]);
 
+  // Locate the agent output for this step. Two sources, in order:
+  //   1. AgentRun envelope (always present for any agent step — L2/L3) —
+  //      this is the source of truth and carries `presentation` HTML.
+  //   2. HumanTask.completionData.agentOutput (only for L3 review steps) —
+  //      fallback for older runs where envelope wasn't queryable.
+  const agentRunConstraints = useMemo(
+    () => (runId && decodedStepId
+      ? [where('processInstanceId', '==', runId), where('stepId', '==', decodedStepId)]
+      : []),
+    [runId, decodedStepId],
+  );
+  const { data: agentRuns } = useCollection<AgentRun>(
+    runId && decodedStepId ? 'agentRuns' : '',
+    agentRunConstraints,
+  );
+  const { tasks: instanceTasks } = useInstanceTasks(runId ?? undefined);
+  const agentOutput = useMemo((): AgentOutputData | null => {
+    const latestRun = agentRuns
+      .slice()
+      .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())[0];
+    if (latestRun?.envelope) {
+      return agentOutputFromEnvelope(latestRun.envelope);
+    }
+    const candidates = instanceTasks
+      .filter((task: HumanTask) => task.stepId === decodedStepId)
+      .sort(
+        (a: HumanTask, b: HumanTask) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+    for (const task of candidates) {
+      const output = getAgentOutput(task);
+      if (output) return output;
+    }
+    return null;
+  }, [agentRuns, instanceTasks, decodedStepId]);
+
   const loading = instanceLoading || stepsLoading || eventsLoading;
 
   if (loading) {
@@ -102,7 +159,6 @@ export default function StepDetailPage() {
     );
   }
 
-  const backHref = `/${handle}/workflows/${encodeURIComponent(decodedName)}/runs/${runId}`;
   const stepName = definitionStep?.name ?? formatStepName(decodedStepId);
   const isAgent = execution?.agentOutput !== undefined;
 
@@ -141,16 +197,46 @@ export default function StepDetailPage() {
         )}
       </div>
 
-      {/* Two-column: Input | Output */}
-      {execution ? (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <InputColumn
-            execution={execution}
-            previousStepName={previousStepName}
-            promptEvent={promptEvent}
-          />
-          <OutputColumn execution={execution} />
+      {/* Agent output snapshot — the rich tabbed view (metrics, files, tabs)
+          shared with human reviewers. Becomes the primary content for any
+          agent step. */}
+      {agentOutput && runId && (
+        <div className="rounded-lg border bg-card">
+          <AgentOutputDisplay agentOutput={agentOutput} instanceId={runId} />
         </div>
+      )}
+
+      {/* Raw step IO. For agent steps this is debug info (the engine's view
+          of transitions/output) so we collapse it. For script/gate steps it
+          IS the main view, so render expanded. */}
+      {execution ? (
+        agentOutput ? (
+          <Collapsible.Root>
+            <Collapsible.Trigger className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors">
+              <ChevronDown className="h-3 w-3 transition-transform data-[state=closed]:-rotate-90" />
+              Step IO (debug)
+            </Collapsible.Trigger>
+            <Collapsible.Content className="mt-3">
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <InputColumn
+                  execution={execution}
+                  previousStepName={previousStepName}
+                  promptEvent={promptEvent}
+                />
+                <OutputColumn execution={execution} />
+              </div>
+            </Collapsible.Content>
+          </Collapsible.Root>
+        ) : (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <InputColumn
+              execution={execution}
+              previousStepName={previousStepName}
+              promptEvent={promptEvent}
+            />
+            <OutputColumn execution={execution} />
+          </div>
+        )
       ) : (
         <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
           This step has not been executed yet.
@@ -345,26 +431,15 @@ function GitSection({ git }: { git: { commitSha: string; branch: string; changed
       <div className="flex items-center gap-4 text-sm">
         <span className="font-mono text-xs">{git.branch}</span>
         {browsable ? (
-          <>
-            <a
-              href={`${git.repoUrl}/commit/${git.commitSha}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 font-mono text-xs text-primary hover:underline"
-            >
-              {git.commitSha.slice(0, 7)}
-              <ExternalLink className="h-3 w-3" />
-            </a>
-            <a
-              href={`${git.repoUrl}/compare/main...${git.branch}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-            >
-              View diff
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          </>
+          <a
+            href={`${git.repoUrl}/commit/${git.commitSha}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-mono text-xs text-primary hover:underline"
+          >
+            {git.commitSha.slice(0, 7)}
+            <ExternalLink className="h-3 w-3" />
+          </a>
         ) : (
           <span className="font-mono text-xs text-muted-foreground">
             {git.commitSha.slice(0, 7)}

--- a/packages/platform-ui/src/components/agents/__tests__/agent-output-display.test.tsx
+++ b/packages/platform-ui/src/components/agents/__tests__/agent-output-display.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { MarkdownContent } from '../agent-output-display';
+
+const DUPLICATE_KEY_PATTERN = /Encountered two children with the same key/;
+
+describe('MarkdownContent', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders mixed blocks without React duplicate-key warnings', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const content = [
+      '# Heading One',
+      '',
+      'A paragraph of text.',
+      '',
+      '- list item one',
+      '- list item two',
+      '',
+      '| col a | col b |',
+      '| --- | --- |',
+      '| v1   | v2   |',
+      '',
+      '---',
+      '',
+      'Another paragraph.',
+    ].join('\n');
+
+    render(<MarkdownContent content={content} />);
+
+    const duplicateKeyCalls = consoleError.mock.calls.filter((args) =>
+      args.some((arg) => typeof arg === 'string' && DUPLICATE_KEY_PATTERN.test(arg)),
+    );
+    expect(duplicateKeyCalls).toEqual([]);
+  });
+
+  it('handles paragraph immediately followed by heading (same line index) without key collisions', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Adjacent blocks that, with the old `key={index}`-after-increment scheme,
+    // both ended up emitting `key={2}` for distinct elements.
+    const content = ['paragraph', '## Heading', 'paragraph again', '## Another'].join('\n');
+
+    render(<MarkdownContent content={content} />);
+
+    const duplicateKeyCalls = consoleError.mock.calls.filter((args) =>
+      args.some((arg) => typeof arg === 'string' && DUPLICATE_KEY_PATTERN.test(arg)),
+    );
+    expect(duplicateKeyCalls).toEqual([]);
+  });
+});

--- a/packages/platform-ui/src/components/agents/agent-output-display.tsx
+++ b/packages/platform-ui/src/components/agents/agent-output-display.tsx
@@ -24,6 +24,11 @@ import { cn, isBrowsableRepoUrl } from '@/lib/utils';
 interface AgentOutputDisplayProps {
   agentOutput: AgentOutputData;
   instanceId: string;
+  /**
+   * Optional host-controlled signal fired when content availability changes
+   * (result metadata or fetched file content is ready). Safe to ignore when
+   * the host doesn't need to react to content availability.
+   */
   onContentLoaded?: (hasContent: boolean) => void;
 }
 
@@ -51,7 +56,11 @@ export function AgentOutputDisplay({
   instanceId,
   onContentLoaded,
 }: AgentOutputDisplayProps) {
-  const hasPresentation = typeof agentOutput.presentation === 'string' && agentOutput.presentation.length > 0;
+  const presentationHtml =
+    typeof agentOutput.presentation === 'string' && agentOutput.presentation.length > 0
+      ? agentOutput.presentation
+      : null;
+  const hasPresentation = presentationHtml !== null;
   const iframeRef = React.useRef<HTMLIFrameElement>(null);
   const [iframeHeight, setIframeHeight] = React.useState(300);
   const { resolvedTheme } = useTheme();
@@ -94,10 +103,15 @@ export function AgentOutputDisplay({
 
   React.useEffect(() => {
     if (!outputFilePath) return;
+    // Reset state so a previous file's content doesn't show during a new fetch.
+    setFileContent(null);
+    setFileError(null);
     setFileLoading(true);
+    let cancelled = false;
     apiFetch(`/api/agent-output-file?path=${encodeURIComponent(outputFilePath)}&instanceId=${encodeURIComponent(instanceId)}`)
       .then((res) => res.json() as Promise<{ content?: string; error?: string }>)
       .then((data) => {
+        if (cancelled) return;
         if (data.error && !data.content) {
           setFileError(data.error);
         } else if (data.content) {
@@ -105,9 +119,16 @@ export function AgentOutputDisplay({
         }
       })
       .catch((err: unknown) => {
+        if (cancelled) return;
         setFileError(err instanceof Error ? err.message : 'Failed to fetch file');
       })
-      .finally(() => setFileLoading(false));
+      .finally(() => {
+        if (cancelled) return;
+        setFileLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [outputFilePath, instanceId]);
 
   // Content is available if we have result metadata or file content
@@ -161,11 +182,11 @@ export function AgentOutputDisplay({
           ))}
         </Tabs.List>
 
-        {hasPresentation && (
+        {presentationHtml !== null && (
           <Tabs.Content value="presentation" className="p-4">
             <iframe
               ref={iframeRef}
-              srcDoc={buildSrcdoc(agentOutput.presentation!, agentOutput.result, isDark)}
+              srcDoc={buildSrcdoc(presentationHtml, agentOutput.result, isDark)}
               sandbox="allow-scripts"
               style={{ width: '100%', height: iframeHeight, border: 'none' }}
               title="Agent presentation"
@@ -346,6 +367,9 @@ export function MarkdownContent({ content }: { content: string }) {
   const lines = content.split('\n');
   const elements: React.ReactNode[] = [];
   let index = 0;
+  // Monotonic React key — bumped on every push so two blocks ending at the
+  // same line index don't collide (e.g. paragraph then heading).
+  let keyCounter = 0;
 
   while (index < lines.length) {
     const line = lines[index];
@@ -356,7 +380,7 @@ export function MarkdownContent({ content }: { content: string }) {
       const level = headingMatch[1].length;
       const text = headingMatch[2];
       const Tag = `h${level}` as keyof React.JSX.IntrinsicElements;
-      elements.push(<Tag key={index}>{text}</Tag>);
+      elements.push(<Tag key={keyCounter++}>{text}</Tag>);
       index++;
       continue;
     }
@@ -368,7 +392,7 @@ export function MarkdownContent({ content }: { content: string }) {
         tableLines.push(lines[index]);
         index++;
       }
-      elements.push(<MarkdownTable key={index} lines={tableLines} />);
+      elements.push(<MarkdownTable key={keyCounter++} lines={tableLines} />);
       continue;
     }
 
@@ -380,7 +404,7 @@ export function MarkdownContent({ content }: { content: string }) {
         index++;
       }
       elements.push(
-        <ul key={index}>
+        <ul key={keyCounter++}>
           {listItems.map((item, itemIndex) => (
             <li key={itemIndex}><InlineMarkdown text={item} /></li>
           ))}
@@ -397,7 +421,7 @@ export function MarkdownContent({ content }: { content: string }) {
         index++;
       }
       elements.push(
-        <ol key={index}>
+        <ol key={keyCounter++}>
           {listItems.map((item, itemIndex) => (
             <li key={itemIndex}><InlineMarkdown text={item} /></li>
           ))}
@@ -408,7 +432,7 @@ export function MarkdownContent({ content }: { content: string }) {
 
     // Horizontal rule
     if (line.match(/^---+$/)) {
-      elements.push(<hr key={index} />);
+      elements.push(<hr key={keyCounter++} />);
       index++;
       continue;
     }
@@ -435,7 +459,7 @@ export function MarkdownContent({ content }: { content: string }) {
     }
     if (paraLines.length > 0) {
       elements.push(
-        <p key={index}>
+        <p key={keyCounter++}>
           {paraLines.map((line, lineIdx) => (
             <React.Fragment key={lineIdx}>
               {lineIdx > 0 && <br />}
@@ -544,7 +568,12 @@ function looksLikeMarkdown(value: string): boolean {
   );
 }
 
-function looksLikeYaml(value: string): boolean {
+/**
+ * True for strings that look like a structured code block — YAML (`---`,
+ * `- key:`) or JSON shape (`{` / `[`). Used to route values into a strict
+ * <pre> block so their structure is preserved.
+ */
+function looksLikeStructuredString(value: string): boolean {
   const trimmed = value.trim();
   if (trimmed.startsWith('---')) return true;
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return true;
@@ -557,7 +586,7 @@ function classifyEntry(key: string, value: unknown): EntryKind {
     return 'object-array';
   }
   if (typeof value === 'string') {
-    if (YAML_KEY_PATTERN.test(key) || looksLikeYaml(value)) {
+    if (YAML_KEY_PATTERN.test(key) || looksLikeStructuredString(value)) {
       if (value.length > SHORT_STRING_CHAR_THRESHOLD || value.includes('\n')) return 'yaml';
     }
     if (MARKDOWN_KEY_PATTERN.test(key) && value.length > SHORT_STRING_CHAR_THRESHOLD) return 'markdown';

--- a/packages/platform-ui/src/components/agents/agent-output-display.tsx
+++ b/packages/platform-ui/src/components/agents/agent-output-display.tsx
@@ -1,0 +1,973 @@
+'use client';
+
+import * as React from 'react';
+import * as Tabs from '@radix-ui/react-tabs';
+import * as Collapsible from '@radix-ui/react-collapsible';
+import { useTheme } from 'next-themes';
+import {
+  ChevronDown,
+  Clock,
+  Code,
+  DollarSign,
+  ExternalLink,
+  FileText,
+  Gauge,
+  Loader2,
+  MonitorPlay,
+} from 'lucide-react';
+import type { AgentOutputData } from '@/components/tasks/task-utils';
+import { buildSrcdoc, clampIframeHeight, isIframeResizeMessage } from '@/components/tasks/iframe-helpers';
+import { apiFetch } from '@/lib/api-fetch';
+import { formatCostUsd, formatDuration } from '@/lib/format';
+import { cn, isBrowsableRepoUrl } from '@/lib/utils';
+
+interface AgentOutputDisplayProps {
+  agentOutput: AgentOutputData;
+  instanceId: string;
+  onContentLoaded?: (hasContent: boolean) => void;
+}
+
+/** Try to extract an output_file path from the result's `raw` field. */
+function extractOutputFilePath(result: Record<string, unknown>): string | null {
+  const raw = result.raw;
+  if (typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof parsed.output_file === 'string') return parsed.output_file;
+  } catch {
+    // not JSON
+  }
+  return null;
+}
+
+/**
+ * Full agent output view: metrics header, generated files, then a tabbed pane
+ * (presentation iframe, fetched output file content, extracted-data summary,
+ * raw JSON). Shared between the human-task review wrapper and the workflow
+ * step detail page.
+ */
+export function AgentOutputDisplay({
+  agentOutput,
+  instanceId,
+  onContentLoaded,
+}: AgentOutputDisplayProps) {
+  const hasPresentation = typeof agentOutput.presentation === 'string' && agentOutput.presentation.length > 0;
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const [iframeHeight, setIframeHeight] = React.useState(300);
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  React.useEffect(() => {
+    if (!hasPresentation) return;
+    const handler = (event: MessageEvent) => {
+      if (
+        isIframeResizeMessage(event.data) &&
+        iframeRef.current &&
+        event.source === iframeRef.current.contentWindow
+      ) {
+        setIframeHeight((prev) => {
+          const next = clampIframeHeight(event.data.height);
+          return next > 0 ? next : prev;
+        });
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [hasPresentation]);
+
+  // Sync theme changes to iframe
+  React.useEffect(() => {
+    if (!hasPresentation) return;
+    iframeRef.current?.contentWindow?.postMessage({ type: 'theme', dark: isDark }, '*');
+  }, [isDark, hasPresentation]);
+
+  const hasContent = agentOutput.result !== null && Object.keys(agentOutput.result).length > 0;
+
+  const outputFilePath = React.useMemo(
+    () => (agentOutput.result ? extractOutputFilePath(agentOutput.result) : null),
+    [agentOutput.result],
+  );
+
+  const [fileContent, setFileContent] = React.useState<string | null>(null);
+  const [fileLoading, setFileLoading] = React.useState(false);
+  const [fileError, setFileError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!outputFilePath) return;
+    setFileLoading(true);
+    apiFetch(`/api/agent-output-file?path=${encodeURIComponent(outputFilePath)}&instanceId=${encodeURIComponent(instanceId)}`)
+      .then((res) => res.json() as Promise<{ content?: string; error?: string }>)
+      .then((data) => {
+        if (data.error && !data.content) {
+          setFileError(data.error);
+        } else if (data.content) {
+          setFileContent(data.content);
+        }
+      })
+      .catch((err: unknown) => {
+        setFileError(err instanceof Error ? err.message : 'Failed to fetch file');
+      })
+      .finally(() => setFileLoading(false));
+  }, [outputFilePath, instanceId]);
+
+  // Content is available if we have result metadata or file content
+  const contentReady = hasContent || fileContent !== null;
+
+  React.useEffect(() => {
+    onContentLoaded?.(contentReady);
+  }, [contentReady, onContentLoaded]);
+
+  if (!hasContent) {
+    return (
+      <div className="rounded-lg border border-dashed p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          No agent output to review.
+        </p>
+      </div>
+    );
+  }
+
+  const hasFileTab = fileContent !== null || fileLoading || outputFilePath !== null;
+  const defaultTab = hasPresentation ? 'presentation' : hasFileTab ? 'content' : 'summary';
+
+  return (
+    <div>
+      <MetricsHeader agentOutput={agentOutput} />
+      {agentOutput.gitMetadata && agentOutput.gitMetadata.changedFiles.length > 0 && (
+        <GeneratedFiles git={agentOutput.gitMetadata} />
+      )}
+
+      <Tabs.Root defaultValue={defaultTab}>
+        <Tabs.List className="flex gap-1 border-b px-4">
+          {[
+            ...(hasPresentation ? [{ value: 'presentation', label: 'Presentation', icon: MonitorPlay }] : []),
+            ...(hasFileTab ? [{ value: 'content', label: 'Content', icon: FileText }] : []),
+            { value: 'summary', label: 'Extracted Data', icon: FileText },
+            { value: 'full', label: 'Raw JSON', icon: Code },
+          ].map(({ value, label, icon: Icon }) => (
+            <Tabs.Trigger
+              key={value}
+              value={value}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium',
+                'text-muted-foreground border-b-2 border-transparent -mb-px',
+                'transition-colors',
+                'data-[state=active]:border-primary data-[state=active]:text-primary',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {label}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+
+        {hasPresentation && (
+          <Tabs.Content value="presentation" className="p-4">
+            <iframe
+              ref={iframeRef}
+              srcDoc={buildSrcdoc(agentOutput.presentation!, agentOutput.result, isDark)}
+              sandbox="allow-scripts"
+              style={{ width: '100%', height: iframeHeight, border: 'none' }}
+              title="Agent presentation"
+            />
+          </Tabs.Content>
+        )}
+
+        {hasFileTab && (
+          <Tabs.Content value="content" className="p-4">
+            {fileLoading && (
+              <div className="flex items-center gap-2 py-8 justify-center text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="text-sm">Loading content...</span>
+              </div>
+            )}
+            {fileError && (
+              <div className="text-sm text-amber-600 dark:text-amber-400 py-4">
+                {fileError}
+              </div>
+            )}
+            {fileContent && (
+              <div className="prose prose-sm dark:prose-invert max-w-none overflow-auto max-h-[600px]">
+                <MarkdownContent content={fileContent} />
+              </div>
+            )}
+          </Tabs.Content>
+        )}
+
+        <Tabs.Content value="summary" className="p-4">
+          <MetadataSummary result={agentOutput.result!} />
+        </Tabs.Content>
+
+        <Tabs.Content value="full" className="p-4">
+          <pre className="rounded-md bg-muted p-4 text-xs overflow-auto max-h-[600px] whitespace-pre-wrap break-words">
+            {JSON.stringify(agentOutput.result, null, 2)}
+          </pre>
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  );
+}
+
+// ── Metrics header ──────────────────────────────────────────────────────────
+
+function MetricsHeader({ agentOutput }: { agentOutput: AgentOutputData }) {
+  const confidencePct = agentOutput.confidence !== null
+    ? Math.round(agentOutput.confidence * 100)
+    : null;
+
+  const hasAnyMetric =
+    confidencePct !== null ||
+    agentOutput.model !== null ||
+    agentOutput.duration_ms !== null ||
+    agentOutput.estimatedCostUsd !== null ||
+    agentOutput.tokenUsage !== null;
+
+  if (!hasAnyMetric && !agentOutput.reasoning && !agentOutput.confidence_rationale) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 pt-3 pb-2 space-y-1.5 border-b">
+      {hasAnyMetric && (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {confidencePct !== null && (
+            <span className="inline-flex items-center gap-1">
+              <Gauge className="h-3 w-3" />
+              <span>Confidence:</span>
+              <span className={cn(
+                'font-medium',
+                confidencePct >= 80 ? 'text-green-600 dark:text-green-400' :
+                confidencePct >= 50 ? 'text-amber-600 dark:text-amber-400' :
+                'text-red-600 dark:text-red-400',
+              )}>{confidencePct}%</span>
+            </span>
+          )}
+          {agentOutput.model && (
+            <span className="inline-flex items-center gap-1">
+              Model: <span className="font-mono">{agentOutput.model}</span>
+            </span>
+          )}
+          {agentOutput.duration_ms !== null && (
+            <span className="inline-flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {formatDuration(agentOutput.duration_ms)}
+            </span>
+          )}
+          {agentOutput.estimatedCostUsd !== null && (
+            <span className="inline-flex items-center gap-1">
+              <DollarSign className="h-3 w-3" />
+              <span className="font-medium">{formatCostUsd(agentOutput.estimatedCostUsd)}</span>
+            </span>
+          )}
+          {agentOutput.tokenUsage && (
+            <span className="inline-flex items-center gap-1">
+              <span>{agentOutput.tokenUsage.inputTokens.toLocaleString()}</span>
+              <span>/</span>
+              <span>{agentOutput.tokenUsage.outputTokens.toLocaleString()} tokens</span>
+            </span>
+          )}
+        </div>
+      )}
+      {agentOutput.reasoning && (
+        <p className="text-xs text-muted-foreground italic line-clamp-2">{agentOutput.reasoning}</p>
+      )}
+      {agentOutput.confidence_rationale && (
+        <p className="text-xs text-muted-foreground italic">{agentOutput.confidence_rationale}</p>
+      )}
+    </div>
+  );
+}
+
+// ── Generated files (git changedFiles) ──────────────────────────────────────
+
+function GeneratedFiles({
+  git,
+}: {
+  git: NonNullable<AgentOutputData['gitMetadata']>;
+}) {
+  const browsable = isBrowsableRepoUrl(git.repoUrl);
+  const files = git.changedFiles;
+  const collapsedByDefault = files.length > 5;
+  const [open, setOpen] = React.useState(!collapsedByDefault);
+
+  return (
+    <div className="px-4 py-2 border-b">
+      <Collapsible.Root open={open} onOpenChange={setOpen}>
+        <Collapsible.Trigger className="flex w-full items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors">
+          <ChevronDown className={cn('h-3 w-3 transition-transform', !open && '-rotate-90')} />
+          <FileText className="h-3 w-3" />
+          Generated Files
+          <span className="normal-case font-normal text-muted-foreground/70">({files.length})</span>
+          {browsable && (
+            <a
+              href={`${git.repoUrl}/commit/${git.commitSha}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(event) => event.stopPropagation()}
+              className="ml-2 inline-flex items-center gap-1 font-mono text-[11px] hover:text-foreground transition-colors"
+            >
+              {git.commitSha.slice(0, 7)}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <ul className="mt-1.5 space-y-0.5">
+            {files.map((file) => (
+              <li key={file}>
+                {browsable ? (
+                  <a
+                    href={`${git.repoUrl}/blob/${git.commitSha}/${file}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs font-mono text-primary hover:underline"
+                  >
+                    {file}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                ) : (
+                  <span className="inline-flex items-center gap-1 text-xs font-mono text-muted-foreground">
+                    {file}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </div>
+  );
+}
+
+// ── Markdown rendering ──────────────────────────────────────────────────────
+
+/** Simple markdown renderer — renders headings, bold, lists, tables, and paragraphs. */
+export function MarkdownContent({ content }: { content: string }) {
+  const lines = content.split('\n');
+  const elements: React.ReactNode[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const text = headingMatch[2];
+      const Tag = `h${level}` as keyof React.JSX.IntrinsicElements;
+      elements.push(<Tag key={index}>{text}</Tag>);
+      index++;
+      continue;
+    }
+
+    // Table: detect lines starting with |
+    if (line.trim().startsWith('|')) {
+      const tableLines: string[] = [];
+      while (index < lines.length && lines[index].trim().startsWith('|')) {
+        tableLines.push(lines[index]);
+        index++;
+      }
+      elements.push(<MarkdownTable key={index} lines={tableLines} />);
+      continue;
+    }
+
+    // Unordered list items
+    if (line.match(/^\s*[-*]\s+/)) {
+      const listItems: string[] = [];
+      while (index < lines.length && lines[index].match(/^\s*[-*]\s+/)) {
+        listItems.push(lines[index].replace(/^\s*[-*]\s+/, ''));
+        index++;
+      }
+      elements.push(
+        <ul key={index}>
+          {listItems.map((item, itemIndex) => (
+            <li key={itemIndex}><InlineMarkdown text={item} /></li>
+          ))}
+        </ul>,
+      );
+      continue;
+    }
+
+    // Ordered list items
+    if (line.match(/^\s*\d+\.\s+/)) {
+      const listItems: string[] = [];
+      while (index < lines.length && lines[index].match(/^\s*\d+\.\s+/)) {
+        listItems.push(lines[index].replace(/^\s*\d+\.\s+/, ''));
+        index++;
+      }
+      elements.push(
+        <ol key={index}>
+          {listItems.map((item, itemIndex) => (
+            <li key={itemIndex}><InlineMarkdown text={item} /></li>
+          ))}
+        </ol>,
+      );
+      continue;
+    }
+
+    // Horizontal rule
+    if (line.match(/^---+$/)) {
+      elements.push(<hr key={index} />);
+      index++;
+      continue;
+    }
+
+    // Empty line
+    if (line.trim() === '') {
+      index++;
+      continue;
+    }
+
+    // Paragraph — collect consecutive non-empty, non-special lines
+    const paraLines: string[] = [];
+    while (
+      index < lines.length &&
+      lines[index].trim() !== '' &&
+      !lines[index].match(/^#{1,6}\s/) &&
+      !lines[index].trim().startsWith('|') &&
+      !lines[index].match(/^\s*[-*]\s+/) &&
+      !lines[index].match(/^\s*\d+\.\s+/) &&
+      !lines[index].match(/^---+$/)
+    ) {
+      paraLines.push(lines[index]);
+      index++;
+    }
+    if (paraLines.length > 0) {
+      elements.push(
+        <p key={index}>
+          {paraLines.map((line, lineIdx) => (
+            <React.Fragment key={lineIdx}>
+              {lineIdx > 0 && <br />}
+              <InlineMarkdown text={line} />
+            </React.Fragment>
+          ))}
+        </p>,
+      );
+    }
+  }
+
+  return <>{elements}</>;
+}
+
+function InlineMarkdown({ text }: { text: string }) {
+  // Tokenize: **bold**, `code`, https://url. Order matters — process longer/wrapped tokens first.
+  const tokenPattern = /(\*\*[^*]+\*\*|`[^`]+`|https?:\/\/[^\s)]+)/g;
+  const parts = text.split(tokenPattern);
+  return (
+    <>
+      {parts.map((part, partIndex) => {
+        if (part.startsWith('**') && part.endsWith('**')) {
+          return <strong key={partIndex}>{part.slice(2, -2)}</strong>;
+        }
+        if (part.startsWith('`') && part.endsWith('`') && part.length > 1) {
+          return (
+            <code key={partIndex} className="rounded bg-muted px-1 py-0.5 text-[0.85em] font-mono">
+              {part.slice(1, -1)}
+            </code>
+          );
+        }
+        if (/^https?:\/\//.test(part)) {
+          return (
+            <a
+              key={partIndex}
+              href={part}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline break-all"
+            >
+              {part}
+            </a>
+          );
+        }
+        return <React.Fragment key={partIndex}>{part}</React.Fragment>;
+      })}
+    </>
+  );
+}
+
+function MarkdownTable({ lines }: { lines: string[] }) {
+  if (lines.length < 2) return null;
+
+  const parseRow = (line: string): string[] =>
+    line.split('|').slice(1, -1).map((cell) => cell.trim());
+
+  const headers = parseRow(lines[0]);
+  // Skip separator line (index 1)
+  const bodyLines = lines.slice(2);
+
+  return (
+    <div className="overflow-x-auto">
+      <table>
+        <thead>
+          <tr>
+            {headers.map((header, headerIndex) => (
+              <th key={headerIndex}><InlineMarkdown text={header} /></th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {bodyLines.map((line, rowIndex) => {
+            const cells = parseRow(line);
+            return (
+              <tr key={rowIndex}>
+                {cells.map((cell, cellIndex) => (
+                  <td key={cellIndex}><InlineMarkdown text={cell} /></td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Extracted Data summary ──────────────────────────────────────────────────
+
+type EntryKind = 'object-array' | 'short' | 'markdown' | 'yaml' | 'long-text';
+
+const MARKDOWN_KEY_PATTERN = /^pr[-_ ]?body$|^body$|^markdown$|^notes$|^description$/i;
+const YAML_KEY_PATTERN = /_yaml$|_json$/i;
+const LONG_TEXT_CHAR_THRESHOLD = 200;
+const SHORT_STRING_CHAR_THRESHOLD = 80;
+
+function looksLikeMarkdown(value: string): boolean {
+  return (
+    value.includes('\n\n') &&
+    (
+      /(^|\n)#{1,6}\s/.test(value) ||
+      /\*\*[^*]+\*\*/.test(value) ||
+      /(^|\n)\s*-\s\[[ x]\]\s/.test(value) ||
+      /^\s*#\s/.test(value)
+    )
+  );
+}
+
+function looksLikeYaml(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('---')) return true;
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return true;
+  // YAML list of objects: "- key:" on first non-empty line
+  return /^- \w+:/.test(trimmed);
+}
+
+function classifyEntry(key: string, value: unknown): EntryKind {
+  if (Array.isArray(value) && value.length > 0 && value.every((item) => typeof item === 'object' && item !== null && !Array.isArray(item))) {
+    return 'object-array';
+  }
+  if (typeof value === 'string') {
+    if (YAML_KEY_PATTERN.test(key) || looksLikeYaml(value)) {
+      if (value.length > SHORT_STRING_CHAR_THRESHOLD || value.includes('\n')) return 'yaml';
+    }
+    if (MARKDOWN_KEY_PATTERN.test(key) && value.length > SHORT_STRING_CHAR_THRESHOLD) return 'markdown';
+    if (looksLikeMarkdown(value)) return 'markdown';
+    if (value.length > LONG_TEXT_CHAR_THRESHOLD || value.includes('\n')) return 'long-text';
+  }
+  return 'short';
+}
+
+const ENTRY_KIND_ORDER: Record<EntryKind, number> = {
+  'object-array': 0,
+  'short': 1,
+  'markdown': 2,
+  'yaml': 3,
+  'long-text': 4,
+};
+
+interface ClassifiedEntry {
+  key: string;
+  value: unknown;
+  kind: EntryKind;
+}
+
+function MetadataSummary({ result }: { result: Record<string, unknown> }) {
+  const classified = React.useMemo<ClassifiedEntry[]>(
+    () =>
+      Object.entries(result)
+        .filter(([, value]) => !isEmptyValue(value))
+        .map(([key, value]) => ({ key, value, kind: classifyEntry(key, value) }))
+        .sort((a, b) => ENTRY_KIND_ORDER[a.kind] - ENTRY_KIND_ORDER[b.kind]),
+    [result],
+  );
+
+  const shortEntries = classified.filter((e) => e.kind === 'short');
+  const otherEntries = classified.filter((e) => e.kind !== 'short');
+
+  return (
+    <div className="space-y-4">
+      {otherEntries
+        .filter((entry) => entry.kind === 'object-array')
+        .map(({ key, value }) => (
+          <ObjectArrayBlock key={key} entryKey={key} value={value as Record<string, unknown>[]} />
+        ))}
+
+      {shortEntries.length > 0 && (
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2">
+          {shortEntries.map(({ key, value }) => (
+            <div key={key}>
+              <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-0.5">
+                {formatKey(key)}
+              </dt>
+              <dd className="text-sm">
+                <MetadataValue value={value} />
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      {otherEntries
+        .filter((entry) => entry.kind === 'markdown')
+        .map(({ key, value }) => (
+          <MarkdownBlock key={key} entryKey={key} value={value as string} />
+        ))}
+
+      {otherEntries
+        .filter((entry) => entry.kind === 'yaml')
+        .map(({ key, value }) => (
+          <CodeBlock key={key} entryKey={key} value={value as string} />
+        ))}
+
+      {otherEntries
+        .filter((entry) => entry.kind === 'long-text')
+        .map(({ key, value }) => (
+          <LongTextBlock key={key} entryKey={key} value={value as string} />
+        ))}
+    </div>
+  );
+}
+
+function ObjectArrayBlock({ entryKey, value }: { entryKey: string; value: Record<string, unknown>[] }) {
+  // Detect if this looks like a list of rules (Linear-style card layout).
+  const allRuleLike = value.every((item) => isRuleLike(item));
+
+  return (
+    <div>
+      <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+        {formatKey(entryKey)} <span className="normal-case font-normal text-muted-foreground/70">({value.length})</span>
+      </dt>
+      <dd className="text-sm">
+        <div className="space-y-2">
+          {value.map((item, index) =>
+            allRuleLike ? (
+              <RuleCard key={index} item={item} />
+            ) : (
+              <ObjectCard key={index} item={item} />
+            ),
+          )}
+        </div>
+      </dd>
+    </div>
+  );
+}
+
+/** A rule-like entry has both `message` and at least one of `id`/`severity`. */
+function isRuleLike(item: Record<string, unknown>): boolean {
+  const hasMessage = typeof item.message === 'string' && item.message.length > 0;
+  const hasIdOrSeverity = typeof item.id === 'string' || typeof item.severity === 'string';
+  return hasMessage && hasIdOrSeverity;
+}
+
+const RULE_PRIMARY_KEYS = new Set(['id', 'domain', 'severity', 'message', 'variable', 'check']);
+
+interface SeverityStyle {
+  label: string;
+  className: string;
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string' && value.trim().length === 0) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value as Record<string, unknown>).length === 0;
+  return false;
+}
+
+function severityStyle(value: string): SeverityStyle {
+  const normalized = value.toLowerCase().trim();
+  if (/(critical|fatal|error)/.test(normalized)) {
+    return { label: value, className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' };
+  }
+  if (/(major|high)/.test(normalized)) {
+    return { label: value, className: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' };
+  }
+  if (/(warn|warning|medium|moderate)/.test(normalized)) {
+    return { label: value, className: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300' };
+  }
+  if (/(minor|low|info)/.test(normalized)) {
+    return { label: value, className: 'bg-muted text-muted-foreground' };
+  }
+  return { label: value, className: 'bg-muted text-muted-foreground' };
+}
+
+function RuleCard({ item }: { item: Record<string, unknown> }) {
+  const id = typeof item.id === 'string' ? item.id : null;
+  const domain = typeof item.domain === 'string' ? item.domain : null;
+  const severity = typeof item.severity === 'string' ? item.severity : null;
+  const message = typeof item.message === 'string' ? item.message : null;
+  const variable = typeof item.variable === 'string' ? item.variable : null;
+  const check = typeof item.check === 'string' ? item.check : null;
+
+  const otherEntries = Object.entries(item).filter(
+    ([key, value]) => !RULE_PRIMARY_KEYS.has(key) && !isEmptyValue(value),
+  );
+
+  const meta: React.ReactNode[] = [];
+  if (variable) meta.push(<span key="variable" className="font-mono">{variable}</span>);
+  if (check) meta.push(<span key="check" className="font-mono">{check}</span>);
+
+  const sev = severity ? severityStyle(severity) : null;
+
+  return (
+    <div className="rounded-md border p-3 hover:bg-muted/30 transition-colors">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          {id && <span className="font-mono text-xs font-medium truncate">{id}</span>}
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          {domain && (
+            <span className="inline-flex rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+              {domain}
+            </span>
+          )}
+          {sev && (
+            <span className={cn('inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium', sev.className)}>
+              {sev.label}
+            </span>
+          )}
+        </div>
+      </div>
+      {message && (
+        <p className="mt-1.5 text-sm leading-normal break-words">{message}</p>
+      )}
+      {meta.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+          {meta.map((node, index) => (
+            <React.Fragment key={index}>
+              {index > 0 && <span aria-hidden>·</span>}
+              {node}
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+      {otherEntries.length > 0 && (
+        <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+          {otherEntries.map(([subKey, subValue]) => (
+            <div key={subKey}>
+              <dt className="text-muted-foreground font-medium mb-0.5">{formatKey(subKey)}</dt>
+              <dd className="break-words">
+                <MetadataValue value={subValue} />
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}
+
+function ObjectCard({ item }: { item: Record<string, unknown> }) {
+  const entries = Object.entries(item);
+  // Use a 2-col grid when every value is short; otherwise fall back to single column.
+  const allShort = entries.every(([, v]) => {
+    if (v === null || v === undefined) return true;
+    if (typeof v === 'string') return v.length <= SHORT_STRING_CHAR_THRESHOLD && !v.includes('\n');
+    if (typeof v === 'number' || typeof v === 'boolean') return true;
+    return false;
+  });
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-2">
+      <dl
+        className={cn(
+          'gap-y-1 text-xs',
+          allShort ? 'grid grid-cols-2 gap-x-3' : 'grid grid-cols-1',
+        )}
+      >
+        {entries.map(([subKey, subValue]) => (
+          <div key={subKey}>
+            <dt className="text-muted-foreground font-medium mb-0.5">{formatKey(subKey)}</dt>
+            <dd className="break-words">
+              <MetadataValue value={subValue} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function MarkdownBlock({ entryKey, value }: { entryKey: string; value: string }) {
+  return (
+    <Collapsible.Root defaultOpen>
+      <dt className="mb-1">
+        <Collapsible.Trigger className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors">
+          <ChevronDown className="h-3 w-3 transition-transform data-[state=closed]:-rotate-90" />
+          {formatKey(entryKey)}
+        </Collapsible.Trigger>
+      </dt>
+      <dd className="text-sm">
+        <Collapsible.Content>
+          <div className="prose prose-sm dark:prose-invert max-w-none overflow-auto max-h-[400px] rounded-md border bg-muted/20 p-3">
+            <MarkdownContent content={value} />
+          </div>
+        </Collapsible.Content>
+      </dd>
+    </Collapsible.Root>
+  );
+}
+
+/** Strict-pre code block for YAML/JSON-shaped strings — preserves structure exactly. */
+function CodeBlock({ entryKey, value }: { entryKey: string; value: string }) {
+  const lineCount = value.split('\n').length;
+  const summary = `${lineCount} line${lineCount === 1 ? '' : 's'}`;
+
+  return (
+    <Collapsible.Root>
+      <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+        {formatKey(entryKey)}
+      </dt>
+      <dd>
+        <Collapsible.Trigger className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+          <ChevronDown className="h-3 w-3 transition-transform data-[state=closed]:-rotate-90" />
+          <span>{summary}</span>
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <pre className="mt-2 rounded-md bg-muted p-3 text-xs leading-relaxed font-mono whitespace-pre overflow-x-auto max-h-[400px] overflow-y-auto">
+            <code>{value}</code>
+          </pre>
+        </Collapsible.Content>
+      </dd>
+    </Collapsible.Root>
+  );
+}
+
+function LongTextBlock({ entryKey, value }: { entryKey: string; value: string }) {
+  const lineCount = value.split('\n').length;
+  const preview = value.slice(0, 60).replace(/\s+/g, ' ').trim();
+  const summary = lineCount > 1 ? `${lineCount} lines` : `${preview}${value.length > 60 ? '…' : ''}`;
+
+  return (
+    <Collapsible.Root>
+      <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
+        {formatKey(entryKey)}
+      </dt>
+      <dd>
+        <Collapsible.Trigger className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+          <ChevronDown className="h-3 w-3 transition-transform data-[state=closed]:-rotate-90" />
+          <span>{summary}</span>
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <pre className="mt-2 rounded-md bg-muted p-3 text-xs overflow-auto max-h-[400px] whitespace-pre-wrap break-words font-mono">
+            {value}
+          </pre>
+        </Collapsible.Content>
+      </dd>
+    </Collapsible.Root>
+  );
+}
+
+function MetadataValue({ value }: { value: unknown }) {
+  if (value === null || value === undefined) {
+    return <span className="text-muted-foreground italic">-</span>;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if ((trimmed.startsWith('[') && trimmed.endsWith(']')) || (trimmed.startsWith('{') && trimmed.endsWith('}'))) {
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (typeof parsed === 'object' && parsed !== null) {
+          return <MetadataValue value={parsed} />;
+        }
+      } catch {
+        // Not valid JSON, fall through to plain string
+      }
+    }
+    if (/^https?:\/\//.test(trimmed)) {
+      return (
+        <a
+          href={trimmed}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary hover:underline break-all"
+        >
+          {trimmed}
+        </a>
+      );
+    }
+    return <span className="whitespace-pre-wrap break-words">{value}</span>;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return <span className="font-mono text-xs">{String(value)}</span>;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="text-muted-foreground italic">None</span>;
+
+    // Simple string arrays render as comma-separated pills
+    if (value.every((item) => typeof item === 'string')) {
+      return (
+        <div className="flex flex-wrap gap-1.5">
+          {value.map((item, index) => (
+            <span key={index} className="inline-flex rounded-full bg-muted px-2.5 py-0.5 text-xs">
+              {item as string}
+            </span>
+          ))}
+        </div>
+      );
+    }
+
+    // Object arrays render as a list of cards
+    return (
+      <div className="space-y-1.5">
+        {value.map((item, index) => (
+          <div key={index} className="rounded-md border bg-muted/30 p-2">
+            {typeof item === 'object' && item !== null ? (
+              <dl className="grid grid-cols-1 gap-y-1 text-xs">
+                {Object.entries(item as Record<string, unknown>).map(([subKey, subValue]) => (
+                  <div key={subKey}>
+                    <dt className="text-muted-foreground font-medium mb-0.5">{formatKey(subKey)}</dt>
+                    <dd className="break-words">
+                      <MetadataValue value={subValue} />
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            ) : (
+              <span className="text-xs"><MetadataValue value={item} /></span>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (typeof value === 'object') {
+    return (
+      <div className="rounded-md border bg-muted/30 p-2">
+        <dl className="grid grid-cols-1 gap-y-1 text-xs">
+          {Object.entries(value as Record<string, unknown>).map(([subKey, subValue]) => (
+            <div key={subKey}>
+              <dt className="text-muted-foreground font-medium mb-0.5">{formatKey(subKey)}</dt>
+              <dd className="break-words">
+                <MetadataValue value={subValue} />
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    );
+  }
+
+  return <span>{String(value)}</span>;
+}
+
+function formatKey(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/packages/platform-ui/src/components/processes/__tests__/run-results-panel.test.ts
+++ b/packages/platform-ui/src/components/processes/__tests__/run-results-panel.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { parseGithubPrUrl } from '../run-results-panel';
+
+describe('parseGithubPrUrl', () => {
+  it('parses a plain PR URL', () => {
+    expect(parseGithubPrUrl('https://github.com/org/repo/pull/123')).toEqual({
+      org: 'org',
+      repo: 'repo',
+      number: '123',
+    });
+  });
+
+  it('parses PR URL with extra path segments (/files)', () => {
+    expect(parseGithubPrUrl('https://github.com/org/repo/pull/123/files')).toEqual({
+      org: 'org',
+      repo: 'repo',
+      number: '123',
+    });
+  });
+
+  it('parses PR URL with a query string', () => {
+    expect(parseGithubPrUrl('https://github.com/org/repo/pull/123?diff=split')).toEqual({
+      org: 'org',
+      repo: 'repo',
+      number: '123',
+    });
+  });
+
+  it('parses PR URL with a fragment', () => {
+    expect(parseGithubPrUrl('https://github.com/org/repo/pull/123#issuecomment-1')).toEqual({
+      org: 'org',
+      repo: 'repo',
+      number: '123',
+    });
+  });
+
+  it('returns null for a non-GitHub URL', () => {
+    expect(parseGithubPrUrl('https://gitlab.com/org/repo/pull/123')).toBeNull();
+  });
+
+  it('returns null for an issues URL on GitHub', () => {
+    expect(parseGithubPrUrl('https://github.com/org/repo/issues/123')).toBeNull();
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseGithubPrUrl('not-a-url')).toBeNull();
+    expect(parseGithubPrUrl('')).toBeNull();
+    expect(parseGithubPrUrl('https://github.com/org/repo/pull/abc')).toBeNull();
+  });
+
+  it('rejects http:// (non-https) GitHub URLs', () => {
+    expect(parseGithubPrUrl('http://github.com/org/repo/pull/123')).toBeNull();
+  });
+});

--- a/packages/platform-ui/src/components/processes/run-results-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-results-panel.tsx
@@ -91,7 +91,12 @@ function GithubMark({ className }: { className?: string }) {
   );
 }
 
-function parseGithubPrUrl(url: string): { org: string; repo: string; number: string } | null {
+/**
+ * Parse a GitHub Pull Request URL into its org / repo / number parts.
+ * Returns `null` for non-GitHub or malformed URLs. Accepts trailing path
+ * segments (e.g. `/files`), query strings, and fragments.
+ */
+export function parseGithubPrUrl(url: string): { org: string; repo: string; number: string } | null {
   const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/);
   if (!match) return null;
   return { org: match[1], repo: match[2], number: match[3] };

--- a/packages/platform-ui/src/components/processes/run-results-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-results-panel.tsx
@@ -10,6 +10,122 @@ interface RunResultsPanelProps {
   stepExecutions: StepExecution[];
 }
 
+const RESULT_KEY_LABELS: Record<string, string> = {
+  prurl: 'PR URL',
+  prcreated: 'PR Created',
+  proposedruleids: 'Proposed Rule IDs',
+  branch: 'Branch',
+  reason: 'Reason',
+};
+
+function formatResultKey(key: string): string {
+  const normalized = key.toLowerCase().replace(/_/g, '');
+  const explicit = RESULT_KEY_LABELS[normalized];
+  if (explicit) return explicit;
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function findPrUrl(result: Record<string, unknown>): { key: string; url: string } | null {
+  for (const [key, value] of Object.entries(result)) {
+    const normalized = key.toLowerCase().replace(/_/g, '');
+    if (normalized === 'prurl' && typeof value === 'string' && value.startsWith('https://')) {
+      return { key, url: value };
+    }
+  }
+  return null;
+}
+
+function isEmptyResultValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string' && value.length === 0) return true;
+  if (Array.isArray(value) && value.length === 0) return true;
+  return false;
+}
+
+function ResultValue({ value }: { value: unknown }) {
+  if (typeof value === 'boolean') {
+    return <span className="text-sm">{value ? 'Yes' : 'No'}</span>;
+  }
+  if (typeof value === 'string') {
+    if (value.startsWith('https://')) {
+      return (
+        <a
+          href={value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline break-all"
+        >
+          {value}
+          <ExternalLink className="h-3 w-3 shrink-0" />
+        </a>
+      );
+    }
+    return <span className="text-sm font-mono break-all">{value}</span>;
+  }
+  if (typeof value === 'number') {
+    return <span className="text-sm font-mono">{value}</span>;
+  }
+  if (Array.isArray(value)) {
+    return (
+      <span className="text-sm font-mono break-all">
+        {value.map((item) => (typeof item === 'string' ? item : JSON.stringify(item))).join(', ')}
+      </span>
+    );
+  }
+  return <span className="text-sm font-mono break-all">{JSON.stringify(value)}</span>;
+}
+
+function GithubMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
+function parseGithubPrUrl(url: string): { org: string; repo: string; number: string } | null {
+  const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/);
+  if (!match) return null;
+  return { org: match[1], repo: match[2], number: match[3] };
+}
+
+function ViewPullRequestButton({ url }: { url: string }) {
+  const parsed = parseGithubPrUrl(url);
+  if (parsed) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 rounded-md border bg-card px-3 py-1.5 text-sm hover:bg-muted/50 transition-colors"
+      >
+        <GithubMark className="h-3.5 w-3.5 shrink-0" />
+        <span className="text-muted-foreground">{parsed.org}/{parsed.repo}</span>
+        <span className="font-semibold">#{parsed.number}</span>
+      </a>
+    );
+  }
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+    >
+      View Pull Request
+      <ExternalLink className="h-3.5 w-3.5" />
+    </a>
+  );
+}
+
 function findFinalAgentOutput(stepExecutions: StepExecution[]): {
   stepId: string;
   output: AgentOutputSnapshot;
@@ -103,6 +219,10 @@ export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
         {/* Git deliverables */}
         {git && (
           <div className="space-y-2">
+            {result && (() => {
+              const pr = findPrUrl(result);
+              return pr ? <ViewPullRequestButton url={pr.url} /> : null;
+            })()}
             <div className="flex items-center gap-4 text-sm">
               <div className="flex items-center gap-1.5">
                 <GitBranch className="h-3.5 w-3.5 text-muted-foreground" />
@@ -170,16 +290,35 @@ export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
         )}
 
         {/* Result data (non-git output) */}
-        {!git && result && Object.keys(result).length > 0 && (
-          <div>
-            <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1.5">
-              Output
-            </h4>
-            <pre className="rounded-md bg-muted p-3 text-xs overflow-auto max-h-[300px] whitespace-pre-wrap break-words">
-              {JSON.stringify(result, null, 2)}
-            </pre>
-          </div>
-        )}
+        {!git && result && Object.keys(result).length > 0 && (() => {
+          const pr = findPrUrl(result);
+          const remainingEntries = Object.entries(result).filter(([key, value]) => {
+            if (pr && key === pr.key) return false;
+            return !isEmptyResultValue(value);
+          });
+          return (
+            <div className="space-y-3">
+              {pr && <ViewPullRequestButton url={pr.url} />}
+              {remainingEntries.length > 0 && (
+                <div>
+                  <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1.5">
+                    Output
+                  </h4>
+                  <dl className="space-y-1.5">
+                    {remainingEntries.map(([key, value]) => (
+                      <div key={key} className="flex flex-wrap items-baseline gap-2 text-sm">
+                        <dt className="text-muted-foreground">{formatResultKey(key)}:</dt>
+                        <dd className="min-w-0 flex-1">
+                          <ResultValue value={value} />
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </div>
+              )}
+            </div>
+          );
+        })()}
       </div>
     </div>
   );

--- a/packages/platform-ui/src/components/tasks/__tests__/agent-output-review-panel.test.tsx
+++ b/packages/platform-ui/src/components/tasks/__tests__/agent-output-review-panel.test.tsx
@@ -11,6 +11,8 @@ function buildAgentOutput(overrides: Partial<AgentOutputData> = {}): AgentOutput
     result: null,
     model: null,
     duration_ms: null,
+    estimatedCostUsd: null,
+    tokenUsage: null,
     gitMetadata: null,
     presentation: null,
     escalationReason: null,
@@ -142,6 +144,130 @@ describe('AgentOutputReviewPanel', () => {
     render(<AgentOutputReviewPanel agentOutput={agentOutput} />);
 
     expect(screen.getByText(/escalated: iterations limit reached/i)).toBeInTheDocument();
+  });
+
+  it('does not render a Git tab even when gitMetadata is present', () => {
+    const agentOutput = buildAgentOutput({
+      result: { verdict: 'approve' },
+      gitMetadata: {
+        commitSha: 'abcdef1234567890',
+        branch: 'agent/run-42',
+        changedFiles: ['file.ts'],
+        repoUrl: 'https://github.com/example/repo',
+      },
+    });
+
+    render(<AgentOutputReviewPanel agentOutput={agentOutput} />);
+
+    // No "Git" tab trigger
+    const tabs = screen.queryAllByRole('tab');
+    expect(tabs.find((tab) => tab.textContent === 'Git')).toBeUndefined();
+    // No compare link
+    const links = document.querySelectorAll('a');
+    for (const a of Array.from(links)) {
+      expect(a.getAttribute('href') ?? '').not.toContain('/compare/main...');
+    }
+  });
+
+  it('renders object-array entries before long-text entries in Extracted Data', () => {
+    const longYaml = ['line1', 'line2', 'line3', 'line4', 'line5'].join('\n');
+    const agentOutput = buildAgentOutput({
+      presentation: null,
+      result: {
+        proposed_rules_yaml: longYaml,
+        proposed_rules: [
+          { rule_id: 'R1', description: 'first' },
+          { rule_id: 'R2', description: 'second' },
+        ],
+      },
+    });
+
+    render(<AgentOutputReviewPanel agentOutput={agentOutput} />);
+
+    // The object-array header contains a "(2)" count suffix; the long-text
+    // header is the plain "Proposed Rules Yaml" label.
+    const yamlLabel = screen.getByText('Proposed Rules Yaml');
+    const rulesLabel = Array.from(document.querySelectorAll('dt'))
+      .find((node) => node.textContent?.startsWith('Proposed Rules ')) ?? null;
+    expect(rulesLabel).not.toBeNull();
+
+    expect(
+      rulesLabel!.compareDocumentPosition(yamlLabel) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('renders cost and token usage when present (single metrics row)', () => {
+    const agentOutput = buildAgentOutput({
+      result: { ok: true },
+      confidence: 0.88,
+      model: 'haiku',
+      duration_ms: 78000,
+      estimatedCostUsd: 0.0123,
+      tokenUsage: { inputTokens: 59, outputTokens: 6297 },
+    });
+
+    render(<AgentOutputReviewPanel agentOutput={agentOutput} instanceId="run-1" />);
+
+    expect(screen.getByText(/\$0\.012/)).toBeInTheDocument();
+    // Tokens shown as "in/out" with localized separators
+    expect(screen.getByText(/59/)).toBeInTheDocument();
+    expect(screen.getByText(/6,297/)).toBeInTheDocument();
+    // Confidence rendered exactly once now that the display owns the metrics row
+    const matches = screen.queryAllByText(/88%/);
+    expect(matches.length).toBe(1);
+  });
+
+  it('renders rule-card layout for object-array entries with id+message+severity', () => {
+    const agentOutput = buildAgentOutput({
+      result: {
+        proposed_rules: [
+          {
+            id: 'R-001',
+            domain: 'AE',
+            severity: 'critical',
+            message: 'Adverse event missing onset date',
+            variable: 'AESTDTC',
+            check: 'is_required',
+          },
+        ],
+      },
+    });
+
+    render(<AgentOutputReviewPanel agentOutput={agentOutput} instanceId="run-1" />);
+
+    // The rule id should be visible
+    expect(screen.getByText('R-001')).toBeInTheDocument();
+    // Severity rendered as a pill (case-insensitive label "critical")
+    expect(screen.getByText('critical')).toBeInTheDocument();
+    // Message becomes primary content
+    expect(screen.getByText('Adverse event missing onset date')).toBeInTheDocument();
+  });
+
+  it('preserves YAML structure with strict-pre (no wrap collapse)', async () => {
+    const yaml = '- id: R-001\n  domain: AE\n  message: Missing date\n- id: R-002\n  domain: CM\n  message: Bad code';
+    const agentOutput = buildAgentOutput({
+      presentation: null,
+      result: { proposed_rules_yaml: yaml },
+    });
+
+    const { container } = render(
+      <AgentOutputReviewPanel agentOutput={agentOutput} instanceId="run-1" />,
+    );
+
+    // Open the collapsible trigger that summarises the YAML
+    const trigger = Array.from(container.querySelectorAll('button')).find(
+      (btn) => btn.textContent?.includes('lines'),
+    );
+    expect(trigger).toBeDefined();
+    trigger!.click();
+
+    // Wait a tick for Collapsible.Content to render
+    await Promise.resolve();
+
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre!.className).toMatch(/whitespace-pre\b/);
+    expect(pre!.className).not.toMatch(/whitespace-pre-wrap/);
   });
 
   it('escapes closing script tags in result data', () => {

--- a/packages/platform-ui/src/components/tasks/agent-output-review-panel.tsx
+++ b/packages/platform-ui/src/components/tasks/agent-output-review-panel.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import * as React from 'react';
-import * as Tabs from '@radix-ui/react-tabs';
-import { useTheme } from 'next-themes';
-import { AlertTriangle, Bot, Code, ExternalLink, FileText, Gauge, GitBranch, Loader2, MonitorPlay } from 'lucide-react';
+import { AlertTriangle, Bot } from 'lucide-react';
 import type { AgentOutputData } from './task-utils';
 import { formatStepName } from './task-utils';
-import { buildSrcdoc, clampIframeHeight, isIframeResizeMessage } from './iframe-helpers';
-import { apiFetch } from '@/lib/api-fetch';
-import { cn, isBrowsableRepoUrl } from '@/lib/utils';
+import { AgentOutputDisplay } from '@/components/agents/agent-output-display';
 
 interface AgentOutputReviewPanelProps {
   agentOutput: AgentOutputData;
@@ -17,90 +13,19 @@ interface AgentOutputReviewPanelProps {
   instanceId: string;
 }
 
-/** Try to extract an output_file path from the result's `raw` field. */
-function extractOutputFilePath(result: Record<string, unknown>): string | null {
-  const raw = result.raw;
-  if (typeof raw !== 'string') return null;
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    if (typeof parsed.output_file === 'string') return parsed.output_file;
-  } catch {
-    // not JSON
-  }
-  return null;
-}
-
+/**
+ * Review-mode wrapper around {@link AgentOutputDisplay}. Adds only the
+ * "Agent Output for Review" label, step name, and the escalation pill. All
+ * metrics, git metadata, and tabbed content live inside `AgentOutputDisplay`
+ * so the step detail page and the human-review page render the same body.
+ */
 export function AgentOutputReviewPanel({
   agentOutput,
   stepId,
   onContentLoaded,
   instanceId,
 }: AgentOutputReviewPanelProps) {
-  const hasPresentation = typeof agentOutput.presentation === 'string' && agentOutput.presentation.length > 0;
-  const iframeRef = React.useRef<HTMLIFrameElement>(null);
-  const [iframeHeight, setIframeHeight] = React.useState(300);
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
-
-  React.useEffect(() => {
-    if (!hasPresentation) return;
-    const handler = (event: MessageEvent) => {
-      if (
-        isIframeResizeMessage(event.data) &&
-        iframeRef.current &&
-        event.source === iframeRef.current.contentWindow
-      ) {
-        setIframeHeight((prev) => {
-          const next = clampIframeHeight(event.data.height);
-          return next > 0 ? next : prev;
-        });
-      }
-    };
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  }, [hasPresentation]);
-
-  // Sync theme changes to iframe
-  React.useEffect(() => {
-    if (!hasPresentation) return;
-    iframeRef.current?.contentWindow?.postMessage({ type: 'theme', dark: isDark }, '*');
-  }, [isDark, hasPresentation]);
-
   const hasContent = agentOutput.result !== null && Object.keys(agentOutput.result).length > 0;
-
-  const outputFilePath = React.useMemo(
-    () => (agentOutput.result ? extractOutputFilePath(agentOutput.result) : null),
-    [agentOutput.result],
-  );
-
-  const [fileContent, setFileContent] = React.useState<string | null>(null);
-  const [fileLoading, setFileLoading] = React.useState(false);
-  const [fileError, setFileError] = React.useState<string | null>(null);
-
-  React.useEffect(() => {
-    if (!outputFilePath) return;
-    setFileLoading(true);
-    apiFetch(`/api/agent-output-file?path=${encodeURIComponent(outputFilePath)}&instanceId=${encodeURIComponent(instanceId)}`)
-      .then((res) => res.json() as Promise<{ content?: string; error?: string }>)
-      .then((data) => {
-        if (data.error && !data.content) {
-          setFileError(data.error);
-        } else if (data.content) {
-          setFileContent(data.content);
-        }
-      })
-      .catch((err: unknown) => {
-        setFileError(err instanceof Error ? err.message : 'Failed to fetch file');
-      })
-      .finally(() => setFileLoading(false));
-  }, [outputFilePath]);
-
-  // Content is available if we have result metadata or file content
-  const contentReady = hasContent || fileContent !== null;
-
-  React.useEffect(() => {
-    onContentLoaded?.(contentReady);
-  }, [contentReady, onContentLoaded]);
 
   if (!hasContent) {
     return (
@@ -116,467 +41,37 @@ export function AgentOutputReviewPanel({
     ? Math.round(agentOutput.confidence * 100)
     : null;
 
-  const hasFileTab = fileContent !== null || fileLoading || outputFilePath !== null;
-  const hasGitTab = agentOutput.gitMetadata !== null;
-  const defaultTab = hasPresentation ? 'presentation' : hasGitTab ? 'git' : hasFileTab ? 'content' : 'summary';
-
   return (
     <div className="rounded-lg border">
-      {/* Header with agent metadata */}
-      <div className="px-4 pt-3 pb-0">
-        <div className="flex items-center gap-2 mb-2">
-          <Bot className="h-4 w-4 text-purple-500" />
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-            Agent Output for Review
+      <div className="px-4 pt-3 pb-2 flex items-center gap-2">
+        <Bot className="h-4 w-4 text-purple-500" />
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Agent Output for Review
+        </span>
+        {stepId && (
+          <span className="text-xs font-medium text-foreground">
+            — {formatStepName(stepId)}
           </span>
-          {stepId && (
-            <span className="text-xs font-medium text-foreground">
-              — {formatStepName(stepId)}
-            </span>
-          )}
-          {agentOutput.escalationReason !== null && (
-            <span
-              className="inline-flex items-center gap-1 rounded-full border border-amber-500/50 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
-              title={`Agent escalated to human because of ${agentOutput.escalationReason.replace(/_/g, ' ')}. Review the recommendation and approve or request revision.`}
-            >
-              <AlertTriangle className="h-3 w-3" />
-              Escalated: {formatEscalationReason(agentOutput.escalationReason)}
-              {agentOutput.escalationReason === 'low_confidence' && confidencePct !== null && ` (${confidencePct}%)`}
-            </span>
-          )}
-        </div>
-        <div className="flex flex-wrap gap-3 text-xs text-muted-foreground mb-2">
-          {confidencePct !== null && (
-            <span className="inline-flex items-center gap-1">
-              <Gauge className="h-3 w-3" />
-              Confidence: <span className={cn(
-                'font-medium',
-                confidencePct >= 80 ? 'text-green-600 dark:text-green-400' :
-                confidencePct >= 50 ? 'text-amber-600 dark:text-amber-400' :
-                'text-red-600 dark:text-red-400'
-              )}>{confidencePct}%</span>
-            </span>
-          )}
-          {agentOutput.model && (
-            <span>Model: <span className="font-mono">{agentOutput.model}</span></span>
-          )}
-          {agentOutput.duration_ms !== null && (
-            <span>Duration: {formatDuration(agentOutput.duration_ms)}</span>
-          )}
-          {agentOutput.gitMetadata !== null && (
-            <>
-              <span className="inline-flex items-center gap-1">
-                <GitBranch className="h-3 w-3" />
-                <span className="font-mono">{agentOutput.gitMetadata.branch}</span>
-              </span>
-              {isBrowsableRepoUrl(agentOutput.gitMetadata.repoUrl) ? (
-                <a
-                  href={`${agentOutput.gitMetadata.repoUrl}/commit/${agentOutput.gitMetadata.commitSha}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 font-mono hover:text-foreground transition-colors"
-                >
-                  {agentOutput.gitMetadata.commitSha.slice(0, 7)}
-                  <ExternalLink className="h-3 w-3" />
-                </a>
-              ) : (
-                <span className="font-mono">
-                  {agentOutput.gitMetadata.commitSha.slice(0, 7)}
-                </span>
-              )}
-            </>
-          )}
-        </div>
-        {agentOutput.confidence_rationale && (
-          <p className="text-xs text-muted-foreground italic mb-2">{agentOutput.confidence_rationale}</p>
         )}
-        {agentOutput.reasoning && (
-          <p className="text-sm text-muted-foreground mb-2">{agentOutput.reasoning}</p>
+        {agentOutput.escalationReason !== null && (
+          <span
+            className="inline-flex items-center gap-1 rounded-full border border-amber-500/50 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+            title={`Agent escalated to human because of ${agentOutput.escalationReason.replace(/_/g, ' ')}. Review the recommendation and approve or request revision.`}
+          >
+            <AlertTriangle className="h-3 w-3" />
+            Escalated: {formatEscalationReason(agentOutput.escalationReason)}
+            {agentOutput.escalationReason === 'low_confidence' && confidencePct !== null && ` (${confidencePct}%)`}
+          </span>
         )}
       </div>
 
-      <Tabs.Root defaultValue={defaultTab}>
-        <Tabs.List className="flex gap-1 border-b px-4">
-          {[
-            ...(hasPresentation ? [{ value: 'presentation', label: 'Presentation', icon: MonitorPlay }] : []),
-            ...(hasFileTab ? [{ value: 'content', label: 'Content', icon: FileText }] : []),
-            ...(hasGitTab ? [{ value: 'git', label: 'Git', icon: GitBranch }] : []),
-            { value: 'summary', label: 'Extracted Data', icon: FileText },
-            { value: 'full', label: 'Raw JSON', icon: Code },
-          ].map(({ value, label, icon: Icon }) => (
-            <Tabs.Trigger
-              key={value}
-              value={value}
-              className={cn(
-                'inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium',
-                'text-muted-foreground border-b-2 border-transparent -mb-px',
-                'transition-colors',
-                'data-[state=active]:border-primary data-[state=active]:text-primary',
-              )}
-            >
-              <Icon className="h-3.5 w-3.5" />
-              {label}
-            </Tabs.Trigger>
-          ))}
-        </Tabs.List>
-
-        {hasPresentation && (
-          <Tabs.Content value="presentation" className="p-4">
-            <iframe
-              ref={iframeRef}
-              srcDoc={buildSrcdoc(agentOutput.presentation!, agentOutput.result, isDark)}
-              sandbox="allow-scripts"
-              style={{ width: '100%', height: iframeHeight, border: 'none' }}
-              title="Agent presentation"
-            />
-          </Tabs.Content>
-        )}
-
-        {hasFileTab && (
-          <Tabs.Content value="content" className="p-4">
-            {fileLoading && (
-              <div className="flex items-center gap-2 py-8 justify-center text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span className="text-sm">Loading content...</span>
-              </div>
-            )}
-            {fileError && (
-              <div className="text-sm text-amber-600 dark:text-amber-400 py-4">
-                {fileError}
-              </div>
-            )}
-            {fileContent && (
-              <div className="prose prose-sm dark:prose-invert max-w-none overflow-auto max-h-[600px]">
-                <MarkdownContent content={fileContent} />
-              </div>
-            )}
-          </Tabs.Content>
-        )}
-
-        {hasGitTab && agentOutput.gitMetadata !== null && (
-          <Tabs.Content value="git" className="p-4 space-y-4">
-            {isBrowsableRepoUrl(agentOutput.gitMetadata.repoUrl) && (
-              <a
-                href={`${agentOutput.gitMetadata.repoUrl}/compare/main...${agentOutput.gitMetadata.branch}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-              >
-                View diff on GitHub
-                <ExternalLink className="h-3.5 w-3.5" />
-              </a>
-            )}
-            {agentOutput.gitMetadata.changedFiles.length > 0 && (
-              <div>
-                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
-                  Changed Files
-                </h4>
-                <ul className="space-y-1">
-                  {agentOutput.gitMetadata.changedFiles.map((file) => (
-                    <li key={file}>
-                      {isBrowsableRepoUrl(agentOutput.gitMetadata!.repoUrl) ? (
-                        <a
-                          href={`${agentOutput.gitMetadata!.repoUrl}/blob/${agentOutput.gitMetadata!.commitSha}/${file}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-sm font-mono text-primary hover:underline"
-                        >
-                          {file}
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
-                      ) : (
-                        <span className="inline-flex items-center gap-1 text-sm font-mono text-muted-foreground">
-                          {file}
-                        </span>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </Tabs.Content>
-        )}
-
-        <Tabs.Content value="summary" className="p-4">
-          <MetadataSummary result={agentOutput.result!} />
-        </Tabs.Content>
-
-        <Tabs.Content value="full" className="p-4">
-          <pre className="rounded-md bg-muted p-4 text-xs overflow-auto max-h-[600px] whitespace-pre-wrap break-words">
-            {JSON.stringify(agentOutput.result, null, 2)}
-          </pre>
-        </Tabs.Content>
-      </Tabs.Root>
+      <AgentOutputDisplay
+        agentOutput={agentOutput}
+        instanceId={instanceId}
+        onContentLoaded={onContentLoaded}
+      />
     </div>
   );
-}
-
-/** Simple markdown renderer — renders headings, bold, lists, tables, and paragraphs. */
-function MarkdownContent({ content }: { content: string }) {
-  const lines = content.split('\n');
-  const elements: React.ReactNode[] = [];
-  let index = 0;
-
-  while (index < lines.length) {
-    const line = lines[index];
-
-    // Headings
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
-    if (headingMatch) {
-      const level = headingMatch[1].length;
-      const text = headingMatch[2];
-      const Tag = `h${level}` as keyof React.JSX.IntrinsicElements;
-      elements.push(<Tag key={index}>{text}</Tag>);
-      index++;
-      continue;
-    }
-
-    // Table: detect lines starting with |
-    if (line.trim().startsWith('|')) {
-      const tableLines: string[] = [];
-      while (index < lines.length && lines[index].trim().startsWith('|')) {
-        tableLines.push(lines[index]);
-        index++;
-      }
-      elements.push(<MarkdownTable key={index} lines={tableLines} />);
-      continue;
-    }
-
-    // Unordered list items
-    if (line.match(/^\s*[-*]\s+/)) {
-      const listItems: string[] = [];
-      while (index < lines.length && lines[index].match(/^\s*[-*]\s+/)) {
-        listItems.push(lines[index].replace(/^\s*[-*]\s+/, ''));
-        index++;
-      }
-      elements.push(
-        <ul key={index}>
-          {listItems.map((item, itemIndex) => (
-            <li key={itemIndex}><InlineMarkdown text={item} /></li>
-          ))}
-        </ul>,
-      );
-      continue;
-    }
-
-    // Ordered list items
-    if (line.match(/^\s*\d+\.\s+/)) {
-      const listItems: string[] = [];
-      while (index < lines.length && lines[index].match(/^\s*\d+\.\s+/)) {
-        listItems.push(lines[index].replace(/^\s*\d+\.\s+/, ''));
-        index++;
-      }
-      elements.push(
-        <ol key={index}>
-          {listItems.map((item, itemIndex) => (
-            <li key={itemIndex}><InlineMarkdown text={item} /></li>
-          ))}
-        </ol>,
-      );
-      continue;
-    }
-
-    // Horizontal rule
-    if (line.match(/^---+$/)) {
-      elements.push(<hr key={index} />);
-      index++;
-      continue;
-    }
-
-    // Empty line
-    if (line.trim() === '') {
-      index++;
-      continue;
-    }
-
-    // Paragraph — collect consecutive non-empty, non-special lines
-    const paraLines: string[] = [];
-    while (
-      index < lines.length &&
-      lines[index].trim() !== '' &&
-      !lines[index].match(/^#{1,6}\s/) &&
-      !lines[index].trim().startsWith('|') &&
-      !lines[index].match(/^\s*[-*]\s+/) &&
-      !lines[index].match(/^\s*\d+\.\s+/) &&
-      !lines[index].match(/^---+$/)
-    ) {
-      paraLines.push(lines[index]);
-      index++;
-    }
-    if (paraLines.length > 0) {
-      elements.push(
-        <p key={index}>
-          <InlineMarkdown text={paraLines.join(' ')} />
-        </p>,
-      );
-    }
-  }
-
-  return <>{elements}</>;
-}
-
-function InlineMarkdown({ text }: { text: string }) {
-  // Bold: **text**
-  const parts = text.split(/(\*\*[^*]+\*\*)/g);
-  return (
-    <>
-      {parts.map((part, partIndex) => {
-        if (part.startsWith('**') && part.endsWith('**')) {
-          return <strong key={partIndex}>{part.slice(2, -2)}</strong>;
-        }
-        return <React.Fragment key={partIndex}>{part}</React.Fragment>;
-      })}
-    </>
-  );
-}
-
-function MarkdownTable({ lines }: { lines: string[] }) {
-  if (lines.length < 2) return null;
-
-  const parseRow = (line: string): string[] =>
-    line.split('|').slice(1, -1).map((cell) => cell.trim());
-
-  const headers = parseRow(lines[0]);
-  // Skip separator line (index 1)
-  const bodyLines = lines.slice(2);
-
-  return (
-    <div className="overflow-x-auto">
-      <table>
-        <thead>
-          <tr>
-            {headers.map((header, headerIndex) => (
-              <th key={headerIndex}><InlineMarkdown text={header} /></th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {bodyLines.map((line, rowIndex) => {
-            const cells = parseRow(line);
-            return (
-              <tr key={rowIndex}>
-                {cells.map((cell, cellIndex) => (
-                  <td key={cellIndex}><InlineMarkdown text={cell} /></td>
-                ))}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function MetadataSummary({ result }: { result: Record<string, unknown> }) {
-  const entries = Object.entries(result);
-
-  return (
-    <div className="space-y-4">
-      {entries.map(([key, value]) => (
-        <div key={key}>
-          <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
-            {formatKey(key)}
-          </dt>
-          <dd className="text-sm">
-            <MetadataValue value={value} />
-          </dd>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function MetadataValue({ value }: { value: unknown }) {
-  if (value === null || value === undefined) {
-    return <span className="text-muted-foreground italic">-</span>;
-  }
-
-  if (typeof value === 'string') {
-    // Detect stringified JSON and render it structured
-    const trimmed = value.trim();
-    if ((trimmed.startsWith('[') && trimmed.endsWith(']')) || (trimmed.startsWith('{') && trimmed.endsWith('}'))) {
-      try {
-        const parsed: unknown = JSON.parse(trimmed);
-        if (typeof parsed === 'object' && parsed !== null) {
-          return <MetadataValue value={parsed} />;
-        }
-      } catch {
-        // Not valid JSON, fall through to plain string
-      }
-    }
-    return <span className="whitespace-pre-wrap break-words">{value}</span>;
-  }
-
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return <span className="font-mono text-xs">{String(value)}</span>;
-  }
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) return <span className="text-muted-foreground italic">None</span>;
-
-    // Simple string arrays render as comma-separated
-    if (value.every((item) => typeof item === 'string')) {
-      return (
-        <div className="flex flex-wrap gap-1.5">
-          {value.map((item, index) => (
-            <span key={index} className="inline-flex rounded-full bg-muted px-2.5 py-0.5 text-xs">
-              {item as string}
-            </span>
-          ))}
-        </div>
-      );
-    }
-
-    // Object arrays render as a list of cards
-    return (
-      <div className="space-y-2">
-        {value.map((item, index) => (
-          <div key={index} className="rounded-md border bg-muted/30 p-3">
-            {typeof item === 'object' && item !== null ? (
-              <dl className="grid grid-cols-1 gap-y-2 text-xs">
-                {Object.entries(item as Record<string, unknown>).map(([subKey, subValue]) => (
-                  <div key={subKey}>
-                    <dt className="text-muted-foreground font-medium mb-0.5">{formatKey(subKey)}</dt>
-                    <dd className="break-words">
-                      <MetadataValue value={subValue} />
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            ) : (
-              <span className="text-xs"><MetadataValue value={item} /></span>
-            )}
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  if (typeof value === 'object') {
-    return (
-      <div className="rounded-md border bg-muted/30 p-3">
-        <dl className="grid grid-cols-1 gap-y-2 text-xs">
-          {Object.entries(value as Record<string, unknown>).map(([subKey, subValue]) => (
-            <div key={subKey}>
-              <dt className="text-muted-foreground font-medium mb-0.5">{formatKey(subKey)}</dt>
-              <dd className="break-words">
-                <MetadataValue value={subValue} />
-              </dd>
-            </div>
-          ))}
-        </dl>
-      </div>
-    );
-  }
-
-  return <span>{String(value)}</span>;
-}
-
-function formatKey(key: string): string {
-  return key
-    .replace(/_/g, ' ')
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 function formatEscalationReason(reason: 'low_confidence' | 'timeout' | 'error' | 'iterations_limit'): string {
@@ -586,13 +81,4 @@ function formatEscalationReason(reason: 'low_confidence' | 'timeout' | 'error' |
     case 'error': return 'error';
     case 'iterations_limit': return 'iterations limit reached';
   }
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.round(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
 }

--- a/packages/platform-ui/src/components/tasks/task-utils.ts
+++ b/packages/platform-ui/src/components/tasks/task-utils.ts
@@ -73,6 +73,14 @@ export function getAgentOutput(task: HumanTask): AgentOutputData | null {
       ? escalationReason
       : null;
 
+  const rawTokenUsage = agentOutput.tokenUsage as Record<string, unknown> | undefined;
+  const tokenUsage: TokenUsageData | null =
+    rawTokenUsage &&
+    typeof rawTokenUsage.inputTokens === 'number' &&
+    typeof rawTokenUsage.outputTokens === 'number'
+      ? { inputTokens: rawTokenUsage.inputTokens, outputTokens: rawTokenUsage.outputTokens }
+      : null;
+
   return {
     confidence: typeof agentOutput.confidence === 'number' ? agentOutput.confidence : null,
     confidence_rationale: typeof agentOutput.confidence_rationale === 'string' ? agentOutput.confidence_rationale : null,
@@ -80,6 +88,8 @@ export function getAgentOutput(task: HumanTask): AgentOutputData | null {
     result: (agentOutput.result as Record<string, unknown> | null) ?? null,
     model: typeof agentOutput.model === 'string' ? agentOutput.model : null,
     duration_ms: typeof agentOutput.duration_ms === 'number' ? agentOutput.duration_ms : null,
+    estimatedCostUsd: typeof agentOutput.estimatedCostUsd === 'number' ? agentOutput.estimatedCostUsd : null,
+    tokenUsage,
     gitMetadata,
     presentation: typeof agentOutput.presentation === 'string' ? agentOutput.presentation : null,
     escalationReason: normalizedEscalation,
@@ -114,6 +124,11 @@ export interface GitMetadataData {
   repoUrl: string;
 }
 
+export interface TokenUsageData {
+  inputTokens: number;
+  outputTokens: number;
+}
+
 export type EscalationReason = 'low_confidence' | 'timeout' | 'error' | 'iterations_limit' | null;
 
 export interface AgentOutputData {
@@ -123,6 +138,8 @@ export interface AgentOutputData {
   result: Record<string, unknown> | null;
   model: string | null;
   duration_ms: number | null;
+  estimatedCostUsd: number | null;
+  tokenUsage: TokenUsageData | null;
   gitMetadata: GitMetadataData | null;
   presentation: string | null;
   escalationReason: EscalationReason;

--- a/packages/platform-ui/src/hooks/use-agent-runs.ts
+++ b/packages/platform-ui/src/hooks/use-agent-runs.ts
@@ -2,10 +2,10 @@
 
 import * as React from 'react';
 import { useMemo } from 'react';
-import { orderBy, doc, onSnapshot } from 'firebase/firestore';
+import { orderBy, where, doc, onSnapshot } from 'firebase/firestore';
 import type { AgentRun, ProcessInstance } from '@mediforce/platform-core';
 import { db } from '@/lib/firebase';
-import { useCollection } from './use-collection';
+import { useCollection, type FirestoreState } from './use-collection';
 
 export function useAgentRuns() {
   // Always order by startedAt desc — most recent runs first
@@ -31,6 +31,28 @@ export function useProcessNameMap(): Map<string, string> {
     }
     return map;
   }, [instances]);
+}
+
+/**
+ * Subscribe to `agentRuns` filtered server-side by processInstanceId + stepId.
+ * Returns an empty result while either argument is missing.
+ *
+ * Two equality predicates on a single collection don't require a composite
+ * index — Firestore serves them by intersecting single-field indexes.
+ */
+export function useAgentRunsForStep(
+  processInstanceId: string | null,
+  stepId: string | null,
+): FirestoreState<AgentRun> {
+  const enabled = processInstanceId !== null && stepId !== null;
+  const constraints = useMemo(
+    () =>
+      enabled
+        ? [where('processInstanceId', '==', processInstanceId), where('stepId', '==', stepId)]
+        : [],
+    [enabled, processInstanceId, stepId],
+  );
+  return useCollection<AgentRun>(enabled ? 'agentRuns' : '', constraints);
 }
 
 export function useAgentRun(runId: string | null) {


### PR DESCRIPTION
## Summary

- Extract `AgentOutputDisplay` shared between the human task review panel and the workflow step detail page. Both surfaces now render the same presentation iframe, metrics, generated files, and Extracted Data / Raw JSON tabs.
- Step detail page reads agent envelope from `agentRuns` (with `HumanTask.completionData.agentOutput` as fallback), so **L2 auto-runner steps** like `interpret-validation` finally expose their HTML report — previously the rich view was only visible during L3 human review.
- Run summary's PR link is now a GitHub-style chip (`org/repo #N` + GH mark) instead of a raw URL dump; non-git results render as clean key-value pairs (no more raw `<pre>JSON.stringify(...)</pre>`).

## UI polish in the Extracted Data tab

- **Linear-style rule cards** when object-array entries look like validation rules: mono `id`, neutral `domain` pill, color-coded severity pill, message as the primary body, `variable · check` mono meta line.
- **Strict-pre YAML/JSON blocks** preserve structure (was collapsing to one wrapped paragraph).
- **Markdown** for `pr_body` and similar fields: headings, lists, inline code, auto-link, hard line breaks.
- **Empty values filtered** so blank `Params` cards and `—` rows no longer appear.

## Other

- Git tab removed from the agent output review panel (broken `compare/main...{branch}` link on not-yet-pushed branches). The compact branch + commit chip stays in the metrics header.
- Two-column INPUT/OUTPUT becomes a collapsed "Step IO (debug)" section for agent steps that have a richer Agent Output view; non-agent steps keep the original two-column layout.
- New unit tests cover Git-tab removal, entry ordering, rule-card layout, YAML preservation, and cost/token rendering.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 2197 passed, 2 skipped
- [x] Browser-verified against the `landing-zone-CDISCPILOT01` run on staging data: propose-rules step, interpret-validation step, new-rules-branch step, run summary, and pending human task review page