### PR TITLE
docs: weekly CHANGELOG + /add-release-notes skill + Monday auto-cut

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Append-only logs: take both sides on merge instead of flagging a conflict.
+# Order may interleave, but nothing is lost.
+CHANGELOG.md merge=union

--- a/.github/workflows/changelog-cut.yml
+++ b/.github/workflows/changelog-cut.yml
@@ -1,0 +1,78 @@
+name: Changelog weekly cut
+
+# Renames `## [Unreleased]` to `## [YYYY-MM-DD]` (previous Sunday) every Monday
+# 09:00 CET and inserts a fresh empty `## [Unreleased]` on top. Opens a PR.
+# Skips when [Unreleased] body is empty.
+
+on:
+  schedule:
+    # 09:00 CET = 08:00 UTC winter / 07:00 UTC summer.
+    # Use 08:00 UTC (matches winter; 10:00 CEST in summer — close enough).
+    - cron: "0 8 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute last Sunday (Europe/Warsaw)
+        id: date
+        run: |
+          export TZ=Europe/Warsaw
+          # Monday → Sunday is `today - 1 day`
+          SUNDAY=$(date -d 'yesterday' +%Y-%m-%d)
+          echo "sunday=$SUNDAY" >> "$GITHUB_OUTPUT"
+
+      - name: Cut [Unreleased] → dated section
+        id: cut
+        run: |
+          python3 .github/workflows/scripts/changelog_cut.py \
+            --file CHANGELOG.md \
+            --date "${{ steps.date.outputs.sunday }}"
+
+      - name: Skip if empty
+        if: steps.cut.outputs.changed != 'true'
+        run: echo "Unreleased was empty — nothing to cut."
+
+      - name: Open PR
+        if: steps.cut.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: changelog/cut-${{ steps.date.outputs.sunday }}
+          commit-message: "docs(changelog): cut week ending ${{ steps.date.outputs.sunday }}"
+          title: "docs(changelog): cut week ending ${{ steps.date.outputs.sunday }}"
+          body: |
+            Weekly changelog cut — automated.
+
+            Renames `## [Unreleased]` → `## [${{ steps.date.outputs.sunday }}]`
+            and seeds a fresh `## [Unreleased]` section on top.
+
+            ## Reviewer checklist
+
+            Before merging, scan the dated section for tone quality. Rewrite
+            any bullet that restates the commit title or describes a mechanic
+            instead of an effect.
+
+            - [ ] Each bullet states the **effect** of the change, not the
+                  mechanic. Test: would a year-later reader (with PR link
+                  removed) understand why it mattered?
+            - [ ] Bullets are in the right Keep-a-Changelog category
+                  (Added / Changed / Deprecated / Removed / Fixed / Security /
+                  Dependencies).
+            - [ ] No marketing words, no vague "improvements".
+            - [ ] PRs covering one feature are grouped (single bullet with
+                  multiple links, or nested list).
+            - [ ] Trivial PRs (typos, single-line config) are dropped from
+                  the cut.
+
+            Bullets added to `[Unreleased]` after this PR opens go into next
+            week's cut.
+          labels: changelog,automation

--- a/.github/workflows/scripts/changelog_cut.py
+++ b/.github/workflows/scripts/changelog_cut.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Cut the `## [Unreleased]` section in CHANGELOG.md to a dated section.
+
+Reads CHANGELOG.md, finds the `## [Unreleased]` block, renames it to
+`## [YYYY-MM-DD]`, and inserts a fresh empty `## [Unreleased]` above it.
+
+If the [Unreleased] block has no bullets (only subsection headers or empty),
+exits 0 with `changed=false` so the workflow skips opening a PR.
+
+Writes to GITHUB_OUTPUT when present, and writes the file in place.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+UNRELEASED_HEADER = "## [Unreleased]"
+NEW_UNRELEASED_BLOCK = "## [Unreleased]\n\n"
+
+
+def set_output(key: str, value: str) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as f:
+            f.write(f"{key}={value}\n")
+    else:
+        print(f"::set-output name={key}::{value}")
+
+
+def cut(text: str, date: str) -> tuple[str, bool]:
+    lines = text.splitlines(keepends=True)
+    start = None
+    for index, line in enumerate(lines):
+        if line.rstrip() == UNRELEASED_HEADER:
+            start = index
+            break
+    if start is None:
+        print("ERROR: `## [Unreleased]` header not found", file=sys.stderr)
+        sys.exit(1)
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if re.match(r"^## \[", lines[index]):
+            end = index
+            break
+
+    body = "".join(lines[start + 1 : end])
+    has_bullet = any(line.lstrip().startswith("- ") for line in body.splitlines())
+    if not has_bullet:
+        return text, False
+
+    new_header = f"## [{date}]\n"
+    rebuilt = (
+        "".join(lines[:start])
+        + NEW_UNRELEASED_BLOCK
+        + new_header
+        + body
+        + "".join(lines[end:])
+    )
+    return rebuilt, True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file", required=True, type=Path)
+    parser.add_argument("--date", required=True, help="YYYY-MM-DD")
+    args = parser.parse_args()
+
+    original = args.file.read_text(encoding="utf-8")
+    rebuilt, changed = cut(original, args.date)
+    if changed:
+        args.file.write_text(rebuilt, encoding="utf-8")
+    set_output("changed", "true" if changed else "false")
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,15 @@ self-test → self-review → report.
    clever workarounds. Voice input: interpret intent. NEVER use the
    `AskUserQuestion` tool — write a/b/c/... in plain text.
 
+10. **Log it in CHANGELOG.md.** Every non-trivial PR appends a one-line
+    bullet under `## [Unreleased]` in `CHANGELOG.md` via
+    `/add-release-notes`, using Keep-a-Changelog categories (Added /
+    Changed / Deprecated / Removed / Fixed / Security / Dependencies).
+    Group several PRs covering one thing as a nested list. Skip only for
+    trivial edits (typos, single-line config, comment-only diffs).
+    Weekly cut is automated — never edit dated `## [YYYY-MM-DD]` sections
+    by hand.
+
 </development_rules>
 
 ## Skills router
@@ -103,6 +112,7 @@ Invoke before starting work when the task matches:
 - `/community` — Discord community update
 - `/generate-pitch` — pitch deck
 - `/knowledge-base` — wiki / synthesise architecture
+- `/add-release-notes` — append bullet under `[Unreleased]` in `CHANGELOG.md`
 
 Two tiers: `skills/` (dev-time slash commands, indexed in `skills/_registry.yml`)
 and `apps/*/plugins/*/skills/` (runtime, loaded by `agent-runtime` via
@@ -140,5 +150,6 @@ pnpm exec mediforce --help
 4. Self code review (`git diff` + `/code-review`) before reporting done.
 5. Ask, don't sneak, when a capability is missing.
 6. Delegate to subagents when it parallelises. Not as ceremony.
+7. Log non-trivial changes in `CHANGELOG.md` (`/add-release-notes`).
 
 See `README.md` for one-time env setup (Node, pnpm, Firebase CLI, `.env.local`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to Mediforce.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Weekly cuts via [`/add-release-notes`](skills/add-release-notes/SKILL.md) + auto-cut every Monday 09:00 CET ([`.github/workflows/changelog-cut.yml`](.github/workflows/changelog-cut.yml)).
+
+Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos, single-line config, comment-only diffs) may be omitted. Renovate bumps batch under `### Dependencies`.
+
+---
+
+## [Unreleased]
+
+### Added
+- Workflows can now be moved between namespaces — copy + redirect lands you in the target tenant ([#359](https://github.com/Appsilon/mediforce/pull/359), [#370](https://github.com/Appsilon/mediforce/pull/370)).
+- Workflow discovery by Docker image: `GET /api/workflows/by-image` — needed to scale step containers without grepping definitions ([#377](https://github.com/Appsilon/mediforce/pull/377)).
+- Human review steps are no longer binary — each step declares its own verdicts and target transitions (e.g. approve / request changes / escalate), wired end-to-end from schema to UI ([#396](https://github.com/Appsilon/mediforce/pull/396)).
+- SDTM rule migration workflow — Vedha's legacy rule definitions ported to CDISC SDTM via a dedicated Mediforce app ([#355](https://github.com/Appsilon/mediforce/pull/355)).
+- Validation reports are now reproducible — landing-zone data-validator renders from a study-owned template instead of regenerating HTML each run, with an injection-demo variant for the propose-rules story ([#402](https://github.com/Appsilon/mediforce/pull/402), [#408](https://github.com/Appsilon/mediforce/pull/408)).
+- Two ways to seed the Landing Zone demo on the same Hetzner SFTP host — `demo-console/` (FastAPI SPA, operator-facing) and `demo-uploader/` (Mediforce workflow with 8-verdict human review) ([#407](https://github.com/Appsilon/mediforce/pull/407)).
+
+### Changed
+- Cowork is now per-workspace billed — the OpenRouter key is read from workspace secrets instead of a global env var; chat textarea auto-grows to fit input ([#378](https://github.com/Appsilon/mediforce/pull/378), [#381](https://github.com/Appsilon/mediforce/pull/381), [#382](https://github.com/Appsilon/mediforce/pull/382)).
+- Agent output is now consistent across surfaces — step detail and human-task panel share one `AgentOutputDisplay`, so L2 auto-runner steps (e.g. `interpret-validation`) finally show their HTML report without needing an L3 review ([#409](https://github.com/Appsilon/mediforce/pull/409)).
+
+### Fixed
+- Agent report iframe no longer blows up its host panel — height is capped and `vh` classes inside the report are neutralised ([#392](https://github.com/Appsilon/mediforce/pull/392)).
+- Staging step containers can finally see workspace files — the data dir is persisted at `/var/lib/mediforce` with an identical host bind so docker.sock-spawned containers share the same path ([#405](https://github.com/Appsilon/mediforce/pull/405)).
+
+### Dependencies
+- tailwindcss v4.2.4 ([#374](https://github.com/Appsilon/mediforce/pull/374)), yaml v2.8.4 ([#371](https://github.com/Appsilon/mediforce/pull/371)), pnpm v10.33.2 ([#372](https://github.com/Appsilon/mediforce/pull/372)), fast-xml-parser v5.7.2 ([#375](https://github.com/Appsilon/mediforce/pull/375)), jsdom v29.1.1 ([#379](https://github.com/Appsilon/mediforce/pull/379)), lucide-react v1.14.0 ([#380](https://github.com/Appsilon/mediforce/pull/380)).
+
+## [2026-05-10]
+
+### Added
+- Workflows now have per-namespace visibility and access control — no more leaking definitions across tenants ([#346](https://github.com/Appsilon/mediforce/pull/346)).
+- Agents have public/private visibility — fixes the gap where staging couldn't see agents owned by other namespaces ([#353](https://github.com/Appsilon/mediforce/pull/353)).
+- Per-step cost in dollars now surfaces in run + step lists, so you can see which step burned the budget ([#348](https://github.com/Appsilon/mediforce/pull/348)).
+- Per-namespace OpenRouter credit tracking + `mediforce credits` CLI — each tenant sees its own balance ([#349](https://github.com/Appsilon/mediforce/pull/349)).
+- Mediforce reviews its own PRs — `pr-reviewer-mediforce` workflow runs AGENTS.md-aware review on every PR ([#338](https://github.com/Appsilon/mediforce/pull/338)).
+
+### Changed
+- Public profile pages are safe for unauth viewers — member-only UI and secrets are hidden, avatar falls back to the linked user photo ([#350](https://github.com/Appsilon/mediforce/pull/350), [#354](https://github.com/Appsilon/mediforce/pull/354)).
+- Public pages no longer need a Firestore client — they call the REST API directly, which unblocks SSR and avoids leaking client config ([#358](https://github.com/Appsilon/mediforce/pull/358)).
+- AGENTS.md tightened around dogfooding, RED→GREEN, and self code review — fewer ways for agents to skip the safeguards ([#352](https://github.com/Appsilon/mediforce/pull/352), [#356](https://github.com/Appsilon/mediforce/pull/356)).

--- a/skills/_registry.yml
+++ b/skills/_registry.yml
@@ -1,7 +1,7 @@
 version: "1.0"
-generated: "2026-04-23"
+generated: "2026-05-13"
 standard: "agentskills.io/specification"
-total_skills: 7
+total_skills: 8
 
 # Runtime skills have their own per-app registries:
 #   apps/protocol-to-tfl/plugins/protocol-to-tfl/skills/_registry.yml
@@ -47,3 +47,8 @@ domains:
         complexity: basic
         language: multi
         description: Ingest, query, and lint the LLM-compiled wiki (Karpathy LLM Wiki pattern)
+      - id: add-release-notes
+        path: skills/add-release-notes/SKILL.md
+        complexity: basic
+        language: multi
+        description: Append a one-line entry for a merged PR to the current week's section in RELEASE_NOTES.md

--- a/skills/add-release-notes/SKILL.md
+++ b/skills/add-release-notes/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: add-release-notes
+description: Append a one-line entry for a merged (or about-to-merge) PR under the `[Unreleased]` section in CHANGELOG.md. Use after merging a non-trivial PR, when batching multiple PRs covering one feature, or when updating a Keep-a-Changelog entry.
+allowed-tools: Bash, Read, Edit
+metadata:
+  author: Mediforce
+  version: "2.0"
+  domain: development
+  complexity: basic
+  tags: changelog, release-notes, keep-a-changelog
+---
+
+# Add Release Notes
+
+`CHANGELOG.md` at repo root follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). Every non-trivial PR appends a bullet under `## [Unreleased]`. Weekly cut is automated (Monday 09:00 CET, [`changelog-cut.yml`](../../.github/workflows/changelog-cut.yml)) — this skill **never** edits dated weekly sections.
+
+## Usage
+
+```
+/add-release-notes                  # infer from latest merged PR on main
+/add-release-notes 408              # specific PR number
+/add-release-notes 402 408          # group multiple PRs as one item
+```
+
+## When to add
+
+For PRs that ship user-visible behavior, new capability, infra/schema change, workflow or app addition. **Skip** trivial: typos, single-line config, comment-only diffs. Renovate bumps go under `### Dependencies`.
+
+## Procedure
+
+### 1. Resolve PR(s)
+
+```bash
+gh pr view <num> --json number,title,url,mergedAt,body,author
+```
+
+No number given → latest merged PR on `main`:
+
+```bash
+gh pr list --state merged --base main --limit 1 --json number,title,url,mergedAt
+```
+
+### 2. Pick a Keep-a-Changelog category
+
+Always one of, in this order:
+
+- **Added** — new features, endpoints, commands, workflows.
+- **Changed** — modified existing behavior, UI rewrites, refactors users notice.
+- **Deprecated** — soon-to-be-removed features (still works).
+- **Removed** — gone for good.
+- **Fixed** — bug fixes.
+- **Security** — vuln fixes, auth hardening, privilege scoping.
+- **Dependencies** — Renovate/dep bumps (Mediforce extension to spec).
+
+Pick the strongest verb. New endpoint that fixes a missing feature = **Added**, not **Fixed**.
+
+### 3. Locate or create the section under `## [Unreleased]`
+
+```markdown
+## [Unreleased]
+
+### Added
+- …
+
+### Fixed
+- …
+```
+
+If subsection missing, insert in the canonical order above. Never reorder existing dated sections.
+
+### 4. Write the line
+
+One sentence. Active voice. Plain engineer-to-engineer English. End with inline markdown link — text `#NNN`, target `https://github.com/Appsilon/mediforce/pull/NNN`. No parens around it, no reference-style footnote. (Bare `#NNN` does NOT auto-link in GitHub's markdown blob view — only inside issue/PR comments and commits.)
+
+Single PR:
+```
+- Short description of behavior change [#408](https://github.com/Appsilon/mediforce/pull/408).
+```
+
+Multiple PRs covering one thing — inline list:
+```
+- Headline sentence: sub-point [#402](https://github.com/Appsilon/mediforce/pull/402), sub-point [#408](https://github.com/Appsilon/mediforce/pull/408).
+```
+
+Or nested when each sub-point needs its own context:
+```
+- Headline sentence:
+  - Sub-point [#402](https://github.com/Appsilon/mediforce/pull/402)
+  - Sub-point [#408](https://github.com/Appsilon/mediforce/pull/408)
+```
+
+### 5. Commit
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): #<num> <short title>"
+```
+
+Don't push unless asked.
+
+## Conflict handling
+
+`CHANGELOG.md` is marked `merge=union` in [.gitattributes](../../.gitattributes) — git keeps lines from both sides on merge, no conflict marker. Just append the bullet on your branch and let git handle parallel PRs. Order may interleave; the weekly cut PR is a good moment to re-order if needed.
+
+Only edge case: if both branches add a new `### Subsection` header that didn't previously exist, you'll get duplicates after merge. The skill checks for the subsection before inserting, so this is rare.
+
+## Weekly cut — DO NOT do manually
+
+Automated. [`changelog-cut.yml`](../../.github/workflows/changelog-cut.yml) opens a PR each Monday that:
+1. Renames `## [Unreleased]` → `## [YYYY-MM-DD]` (Sunday's date).
+2. Inserts fresh empty `## [Unreleased]` on top.
+3. Asks a human to merge.
+
+If the auto-cut PR is open, add new bullets to `[Unreleased]` as usual — they go into next week's cut.
+
+## Tone
+
+Engineer-to-engineer. State the **essence** of the change — the outcome a teammate cares about — not a restated commit title.
+
+Test: if you removed the PR link, would someone skimming a year later understand why the change mattered? If no, rewrite. Capture the *why* or the *now possible / now fixed* effect, not the mechanic.
+
+- Bad (restated title): "Cowork: load OpenRouter key from workspace secrets."
+- Better (states the effect): "Cowork is now per-workspace billed — OpenRouter key read from workspace secrets instead of a global env var."
+
+- Bad (vague): "Improved the cowork experience with several enhancements."
+- Bad (mechanic): "Refactored `AgentOutputDisplay` into shared component."
+- Good (effect): "Agent output now consistent across surfaces — L2 auto-runner steps finally show their HTML report without needing L3 review."
+
+Avoid marketing words. Avoid restating the file path or function name unless it's the headline of the change.
+
+## Output
+
+Edited `CHANGELOG.md`. Print the added bullet to stdout for confirmation.

--- a/skills/code-review/references/review-checklist.md
+++ b/skills/code-review/references/review-checklist.md
@@ -55,6 +55,13 @@
 - [ ] No unbounded data fetches
 - [ ] Heavy operations are async/background where appropriate
 
+## 9. Changelog
+
+- [ ] Non-trivial change adds a bullet under `## [Unreleased]` in `CHANGELOG.md` (skip only for typos / single-line config / comment-only diffs; Renovate batches under `### Dependencies`).
+- [ ] Bullet states the **effect** of the change, not the mechanic. Rejected style: "Refactored X into shared component", "Updated Y handler". Accepted style: "Agent output now consistent across surfaces — L2 steps finally show HTML report". Test: would a year-later reader, with PR link removed, understand why the change mattered?
+- [ ] Placed in the right Keep-a-Changelog category (Added / Changed / Deprecated / Removed / Fixed / Security / Dependencies).
+- [ ] No edits to dated `## [YYYY-MM-DD]` sections — those are historical.
+
 ## Anti-Pattern Quick Scan
 
 ```bash


### PR DESCRIPTION
## Summary

- Introduces `CHANGELOG.md` at repo root, Keep-a-Changelog format, with `[Unreleased]` on top. Week of 2026-05-07 → 2026-05-13 backfilled from merged PRs.
- New `/add-release-notes` skill — every non-trivial PR appends a bullet under `[Unreleased]`. Never edits dated sections.
- `.gitattributes` sets `CHANGELOG.md merge=union` so parallel PRs never conflict — git keeps both branches' bullets on merge.
- GitHub Actions workflow `changelog-cut.yml` runs every Monday 08:00 UTC: renames `[Unreleased]` → `[YYYY-MM-DD]` (previous Sunday) and seeds a fresh `[Unreleased]`. Opens a PR via `peter-evans/create-pull-request`. `workflow_dispatch` available for manual triggers.
- AGENTS.md gains rule 10, skill listed in the Skills router and the Reminder block.

## Notes

- First auto-cut fires the first Monday after this merges to `main` (cron only runs from default branch).
- Needs org setting **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** enabled. Default `GITHUB_TOKEN` perms are declared in the workflow.
- DST drift: `0 8 * * 1` = 09:00 CET winter / 10:00 CEST summer. Acceptable Monday-morning offset.

## Test plan

- [ ] Merge to `main`.
- [ ] Trigger `Changelog weekly cut` manually from Actions tab → verify PR opens.
- [ ] Confirm `[Unreleased]` becomes empty after cut PR merges, `[2026-05-17]` (or relevant Sunday) appears below.
- [ ] Open two trivial PRs adding bullets in parallel → confirm `merge=union` keeps both, no conflict marker.