### PR TITLE
CLI: friendly error messages for network failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Agent report iframe no longer blows up its host panel — height is capped and `vh` classes inside the report are neutralised ([#392](https://github.com/Appsilon/mediforce/pull/392)).
 - Staging step containers can finally see workspace files — the data dir is persisted at `/var/lib/mediforce` with an identical host bind so docker.sock-spawned containers share the same path ([#405](https://github.com/Appsilon/mediforce/pull/405)).
 - CLI network failures now explain the unreachable API host, reason, and recovery hints instead of printing raw `TypeError: fetch failed` ([#397](https://github.com/Appsilon/mediforce/issues/397)).
-  - Follow-up: network classification now only applies to actual fetch failures, so local I/O errors (e.g. `EACCES`) keep their original message ([#397](https://github.com/Appsilon/mediforce/issues/397)).
+  - Follow-up: local I/O failures (for example `EACCES`) are no longer mislabeled as API network errors and now keep their original actionable message ([#397](https://github.com/Appsilon/mediforce/issues/397)).
   - Follow-up: dual-stack fetch failures now classify `AggregateError.errors[]` causes, and staging/remote URLs no longer suggest starting a local dev server ([#397](https://github.com/Appsilon/mediforce/issues/397)).
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ### Fixed
 - Agent report iframe no longer blows up its host panel — height is capped and `vh` classes inside the report are neutralised ([#392](https://github.com/Appsilon/mediforce/pull/392)).
 - Staging step containers can finally see workspace files — the data dir is persisted at `/var/lib/mediforce` with an identical host bind so docker.sock-spawned containers share the same path ([#405](https://github.com/Appsilon/mediforce/pull/405)).
+- CLI network failures now explain the unreachable API host, reason, and recovery hints instead of printing raw `TypeError: fetch failed` ([#397](https://github.com/Appsilon/mediforce/issues/397)).
 
 ### Dependencies
 - tailwindcss v4.2.4 ([#374](https://github.com/Appsilon/mediforce/pull/374)), yaml v2.8.4 ([#371](https://github.com/Appsilon/mediforce/pull/371)), pnpm v10.33.2 ([#372](https://github.com/Appsilon/mediforce/pull/372)), fast-xml-parser v5.7.2 ([#375](https://github.com/Appsilon/mediforce/pull/375)), jsdom v29.1.1 ([#379](https://github.com/Appsilon/mediforce/pull/379)), lucide-react v1.14.0 ([#380](https://github.com/Appsilon/mediforce/pull/380)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Staging step containers can finally see workspace files — the data dir is persisted at `/var/lib/mediforce` with an identical host bind so docker.sock-spawned containers share the same path ([#405](https://github.com/Appsilon/mediforce/pull/405)).
 - CLI network failures now explain the unreachable API host, reason, and recovery hints instead of printing raw `TypeError: fetch failed` ([#397](https://github.com/Appsilon/mediforce/issues/397)).
   - Follow-up: network classification now only applies to actual fetch failures, so local I/O errors (e.g. `EACCES`) keep their original message ([#397](https://github.com/Appsilon/mediforce/issues/397)).
+  - Follow-up: dual-stack fetch failures now classify `AggregateError.errors[]` causes, and staging/remote URLs no longer suggest starting a local dev server ([#397](https://github.com/Appsilon/mediforce/issues/397)).
 
 ### Dependencies
 - tailwindcss v4.2.4 ([#374](https://github.com/Appsilon/mediforce/pull/374)), yaml v2.8.4 ([#371](https://github.com/Appsilon/mediforce/pull/371)), pnpm v10.33.2 ([#372](https://github.com/Appsilon/mediforce/pull/372)), fast-xml-parser v5.7.2 ([#375](https://github.com/Appsilon/mediforce/pull/375)), jsdom v29.1.1 ([#379](https://github.com/Appsilon/mediforce/pull/379)), lucide-react v1.14.0 ([#380](https://github.com/Appsilon/mediforce/pull/380)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Agent report iframe no longer blows up its host panel — height is capped and `vh` classes inside the report are neutralised ([#392](https://github.com/Appsilon/mediforce/pull/392)).
 - Staging step containers can finally see workspace files — the data dir is persisted at `/var/lib/mediforce` with an identical host bind so docker.sock-spawned containers share the same path ([#405](https://github.com/Appsilon/mediforce/pull/405)).
 - CLI network failures now explain the unreachable API host, reason, and recovery hints instead of printing raw `TypeError: fetch failed` ([#397](https://github.com/Appsilon/mediforce/issues/397)).
+  - Follow-up: network classification now only applies to actual fetch failures, so local I/O errors (e.g. `EACCES`) keep their original message ([#397](https://github.com/Appsilon/mediforce/issues/397)).
 
 ### Dependencies
 - tailwindcss v4.2.4 ([#374](https://github.com/Appsilon/mediforce/pull/374)), yaml v2.8.4 ([#371](https://github.com/Appsilon/mediforce/pull/371)), pnpm v10.33.2 ([#372](https://github.com/Appsilon/mediforce/pull/372)), fast-xml-parser v5.7.2 ([#375](https://github.com/Appsilon/mediforce/pull/375)), jsdom v29.1.1 ([#379](https://github.com/Appsilon/mediforce/pull/379)), lucide-react v1.14.0 ([#380](https://github.com/Appsilon/mediforce/pull/380)).

--- a/packages/cli/src/__tests__/errors.test.ts
+++ b/packages/cli/src/__tests__/errors.test.ts
@@ -124,11 +124,36 @@ describe('formatCliError', () => {
     });
   });
 
+
+
+  it('falls back gracefully for fetch failures without a cause', () => {
+    const error = new TypeError('fetch failed');
+
+    expect(formatCliError(error, { baseUrl: 'http://localhost:9003' })).toMatchObject({
+      error: 'fetch failed',
+    });
+  });
+
+  it('formats network errors when baseUrl is undefined', () => {
+    const error = new TypeError('fetch failed', {
+      cause: { code: 'ETIMEDOUT' },
+    });
+
+    expect(formatCliError(error)).toMatchObject({
+      error: 'Cannot reach Mediforce API',
+      cause: {
+        code: 'ETIMEDOUT',
+        message: 'server unreachable, took too long',
+      },
+      hints: expect.arrayContaining(['Is the dev server running? Start with: pnpm dev:local']),
+    });
+  });
+
   it('does not reclassify non-fetch system errors as network errors', () => {
     const error = Object.assign(new Error('permission denied'), { code: 'EACCES' });
 
     expect(formatCliError(error, { baseUrl: 'http://localhost:9003' })).toMatchObject({
-      error: String(error),
+      error: 'permission denied',
     });
   });
 });

--- a/packages/cli/src/__tests__/errors.test.ts
+++ b/packages/cli/src/__tests__/errors.test.ts
@@ -94,4 +94,12 @@ describe('formatCliError', () => {
         ]),
       });
   });
+
+  it('does not reclassify non-fetch system errors as network errors', () => {
+    const error = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+
+    expect(formatCliError(error, { baseUrl: 'http://localhost:9003' })).toMatchObject({
+      error: String(error),
+    });
+  });
 });

--- a/packages/cli/src/__tests__/errors.test.ts
+++ b/packages/cli/src/__tests__/errors.test.ts
@@ -95,6 +95,35 @@ describe('formatCliError', () => {
       });
   });
 
+
+  it('extracts network system error from AggregateError fetch causes', () => {
+    const aggregateCause = new AggregateError([
+      { code: 'ECONNREFUSED', address: '127.0.0.1', port: 9003 },
+      { code: 'ETIMEDOUT' },
+    ]);
+    const error = new TypeError('fetch failed', { cause: aggregateCause });
+
+    expect(formatCliError(error, { baseUrl: 'http://localhost:9003' })).toMatchObject({
+      error: 'Cannot reach Mediforce API at http://localhost:9003',
+      cause: {
+        code: 'ECONNREFUSED',
+      },
+    });
+  });
+
+  it('omits local-dev hint for non-local base URL', () => {
+    const error = new TypeError('fetch failed', {
+      cause: { code: 'ETIMEDOUT' },
+    });
+
+    expect(formatCliError(error, { baseUrl: 'https://staging.mediforce.ai' })).toMatchObject({
+      hints: [
+        'To use a different host: export MEDIFORCE_BASE_URL=https://staging.mediforce.ai',
+        'Or pass --base-url https://staging.mediforce.ai to this command.',
+      ],
+    });
+  });
+
   it('does not reclassify non-fetch system errors as network errors', () => {
     const error = Object.assign(new Error('permission denied'), { code: 'EACCES' });
 

--- a/packages/cli/src/__tests__/errors.test.ts
+++ b/packages/cli/src/__tests__/errors.test.ts
@@ -1,0 +1,97 @@
+import { ApiError } from '@mediforce/platform-api/client';
+import { describe, expect, it } from 'vitest';
+import { formatCliError } from '../errors.js';
+
+describe('formatCliError', () => {
+  it('formats connection refused errors with the target URL and dev-server hint', () => {
+    const error = new TypeError('fetch failed', {
+      cause: { code: 'ECONNREFUSED', address: '127.0.0.1', port: 9003 },
+    });
+
+    expect(formatCliError(error, { baseUrl: 'http://localhost:9003' })).toMatchObject({
+      error: 'Cannot reach Mediforce API at http://localhost:9003',
+      cause: {
+        code: 'ECONNREFUSED',
+        message: 'connection refused',
+        address: '127.0.0.1',
+        port: 9003,
+      },
+      hints: expect.arrayContaining([
+        'Is the dev server running? Start with: pnpm dev:local',
+      ]),
+    });
+  });
+
+  it('formats DNS failures as hostname resolution errors', () => {
+    const error = new TypeError('fetch failed', {
+      cause: { code: 'ENOTFOUND', hostname: 'does-not-exist.invalid' },
+    });
+
+    expect(formatCliError(error, { baseUrl: 'https://does-not-exist.invalid' })).toMatchObject({
+      error: 'Cannot resolve Mediforce API host for https://does-not-exist.invalid',
+      cause: {
+        code: 'ENOTFOUND',
+        message: 'hostname not resolvable',
+        hostname: 'does-not-exist.invalid',
+      },
+    });
+  });
+
+  it('formats timeout failures distinctly', () => {
+    const error = new TypeError('fetch failed', {
+      cause: { code: 'UND_ERR_CONNECT_TIMEOUT' },
+    });
+
+    expect(formatCliError(error, { baseUrl: 'https://staging.mediforce.ai' })).toMatchObject({
+      error: 'Cannot reach Mediforce API at https://staging.mediforce.ai',
+      cause: {
+        code: 'UND_ERR_CONNECT_TIMEOUT',
+        message: 'server unreachable, took too long',
+      },
+    });
+  });
+
+  it('formats TLS failures as certificate problems', () => {
+    const error = new TypeError('fetch failed', {
+      cause: { code: 'CERT_HAS_EXPIRED' },
+    });
+
+    expect(formatCliError(error, { baseUrl: 'https://expired.badssl.com' })).toMatchObject({
+      error: 'Certificate problem reaching Mediforce API at https://expired.badssl.com',
+      cause: {
+        code: 'CERT_HAS_EXPIRED',
+        message: 'certificate problem',
+      },
+    });
+  });
+
+  it('adds API key hints for auth failures', () => {
+    expect(
+      formatCliError(new ApiError(401, 'Unauthorized', { error: 'Unauthorized' }), {
+        baseUrl: 'http://localhost:9003',
+      }),
+    ).toMatchObject({
+      status: 401,
+      hints: expect.arrayContaining(['Set MEDIFORCE_API_KEY to a valid API key.']),
+    });
+
+    expect(
+      formatCliError(new ApiError(403, 'Forbidden', { error: 'Forbidden' }), {
+        baseUrl: 'http://localhost:9003',
+      }),
+    ).toMatchObject({
+      status: 403,
+      hints: expect.arrayContaining(['Check that MEDIFORCE_API_KEY is valid for this workspace.']),
+    });
+  });
+
+  it('hints when a 404 looks like the base URL is not the API host', () => {
+    expect(formatCliError(new ApiError(404, 'Not found', {}), { baseUrl: 'https://example.com' }))
+      .toMatchObject({
+        status: 404,
+        hints: expect.arrayContaining([
+          'The base URL may be wrong. Point MEDIFORCE_BASE_URL at a Mediforce API host.',
+        ]),
+      });
+  });
+});

--- a/packages/cli/src/__tests__/workflow-list.test.ts
+++ b/packages/cli/src/__tests__/workflow-list.test.ts
@@ -90,4 +90,45 @@ describe('workflow list command', () => {
     const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
     expect(parsed).toMatchObject({ status: 403 });
   });
+
+  it('prints a friendly network error when the API is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed', {
+        cause: { code: 'ECONNREFUSED', address: '127.0.0.1', port: 9003 },
+      }),
+    );
+    const output = captureOutput();
+    const code = await workflowListCommand({
+      argv: [],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    const text = output.stderrLines.join('\n');
+    expect(text).toContain('Cannot reach Mediforce API at http://localhost:9003');
+    expect(text).toContain('Reason: connection refused (ECONNREFUSED 127.0.0.1:9003)');
+    expect(text).toContain('pnpm dev:local');
+    expect(text).not.toContain('TypeError: fetch failed');
+  });
+
+  it('keeps network errors structured in JSON mode', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed', {
+        cause: { code: 'ENOTFOUND', hostname: 'does-not-exist.invalid' },
+      }),
+    );
+    const output = captureOutput();
+    const code = await workflowListCommand({
+      argv: ['--base-url', 'https://does-not-exist.invalid', '--json'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(1);
+    expect(output.stderrLines).toEqual([]);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({
+      error: 'Cannot resolve Mediforce API host for https://does-not-exist.invalid',
+      cause: { code: 'ENOTFOUND', hostname: 'does-not-exist.invalid' },
+    });
+  });
 });

--- a/packages/cli/src/commands/agent-delete.ts
+++ b/packages/cli/src/commands/agent-delete.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -99,15 +100,7 @@ export async function agentDeleteCommand(input: CommandInput): Promise<number> {
     input.output.stdout(`Deleted agent ${id}`);
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/agent-get.ts
+++ b/packages/cli/src/commands/agent-get.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -99,15 +100,7 @@ export async function agentGetCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/agent-list.ts
+++ b/packages/cli/src/commands/agent-list.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -77,15 +78,7 @@ export async function agentListCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/agent-set-visibility.ts
+++ b/packages/cli/src/commands/agent-set-visibility.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -93,15 +94,7 @@ export async function agentSetVisibilityCommand(input: CommandInput): Promise<nu
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/model-get.ts
+++ b/packages/cli/src/commands/model-get.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -89,11 +90,7 @@ export async function modelGetCommand(input: CommandInput): Promise<number> {
     input.output.stdout(`Last synced: ${m.lastSyncedAt}`);
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/model-list.ts
+++ b/packages/cli/src/commands/model-list.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -147,11 +148,7 @@ export async function modelListCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/model-sync.ts
+++ b/packages/cli/src/commands/model-sync.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -68,11 +69,7 @@ export async function modelSyncCommand(input: CommandInput): Promise<number> {
     input.output.stdout(`Last synced: ${result.lastSyncedAt}`);
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/run-get.ts
+++ b/packages/cli/src/commands/run-get.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -113,15 +114,7 @@ export async function runGetCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/run-list.ts
+++ b/packages/cli/src/commands/run-list.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -135,15 +136,7 @@ export async function runListCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/run-start.ts
+++ b/packages/cli/src/commands/run-start.ts
@@ -1,8 +1,9 @@
 import { readFile } from 'node:fs/promises';
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -177,15 +178,7 @@ export async function runStartCommand(input: CommandInput): Promise<number> {
     input.output.stdout(`Follow with: mediforce run get ${result.instanceId}`);
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/secret-delete.ts
+++ b/packages/cli/src/commands/secret-delete.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -97,11 +98,7 @@ export async function secretDeleteCommand(input: CommandInput): Promise<number> 
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/secret-list.ts
+++ b/packages/cli/src/commands/secret-list.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -100,11 +101,7 @@ export async function secretListCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/secret-set.ts
+++ b/packages/cli/src/commands/secret-set.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -142,11 +143,7 @@ export async function secretSetCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/system-credits.ts
+++ b/packages/cli/src/commands/system-credits.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -94,11 +95,7 @@ export async function systemCreditsCommand(input: CommandInput): Promise<number>
     input.output.stdout(`  Limit:      $${data.limit.toFixed(2)}`);
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(input.output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-    } else {
-      printError(input.output, { error: err instanceof Error ? err.message : String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/system-status.ts
+++ b/packages/cli/src/commands/system-status.ts
@@ -1,8 +1,9 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import type { DockerInfoResponse } from '@mediforce/platform-api/contract';
-import { resolveConfig } from '../config.js';
+import { resolveBaseUrl, resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -51,12 +52,13 @@ function parseFlags(input: CommandInput): { flags: { 'base-url'?: string; json?:
   }
 }
 
-function handleApiError(err: unknown, output: OutputSink, jsonMode: boolean): number {
-  if (err instanceof ApiError) {
-    printError(output, { error: err.message, status: err.status, body: err.body }, jsonMode);
-  } else {
-    printError(output, { error: err instanceof Error ? err.message : String(err) }, jsonMode);
-  }
+function handleApiError(
+  err: unknown,
+  output: OutputSink,
+  jsonMode: boolean,
+  baseUrl: string,
+): number {
+  printError(output, formatCliError(err, { baseUrl, jsonMode }), jsonMode);
   return 1;
 }
 
@@ -90,7 +92,12 @@ export async function systemStatusCommand(input: CommandInput): Promise<number> 
     printDisk(input.output, data);
     return 0;
   } catch (err) {
-    return handleApiError(err, input.output, jsonMode);
+    return handleApiError(
+      err,
+      input.output,
+      jsonMode,
+      resolveBaseUrl({ flagBaseUrl: flags['base-url'], env: input.env }),
+    );
   }
 }
 
@@ -121,7 +128,12 @@ export async function systemImagesCommand(input: CommandInput): Promise<number> 
     printImages(input.output, data);
     return 0;
   } catch (err) {
-    return handleApiError(err, input.output, jsonMode);
+    return handleApiError(
+      err,
+      input.output,
+      jsonMode,
+      resolveBaseUrl({ flagBaseUrl: flags['base-url'], env: input.env }),
+    );
   }
 }
 
@@ -163,7 +175,12 @@ export async function systemRmiCommand(input: CommandInput): Promise<number> {
     input.output.stdout(`Deleted: ${result.deleted}`);
     return 0;
   } catch (err) {
-    return handleApiError(err, input.output, jsonMode);
+    return handleApiError(
+      err,
+      input.output,
+      jsonMode,
+      resolveBaseUrl({ flagBaseUrl: flags['base-url'], env: input.env }),
+    );
   }
 }
 
@@ -194,6 +211,11 @@ export async function systemDiskCommand(input: CommandInput): Promise<number> {
     printDisk(input.output, data);
     return 0;
   } catch (err) {
-    return handleApiError(err, input.output, jsonMode);
+    return handleApiError(
+      err,
+      input.output,
+      jsonMode,
+      resolveBaseUrl({ flagBaseUrl: flags['base-url'], env: input.env }),
+    );
   }
 }

--- a/packages/cli/src/commands/workflow-archive.ts
+++ b/packages/cli/src/commands/workflow-archive.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -131,15 +132,7 @@ export async function workflowArchiveCommand(input: CommandInput): Promise<numbe
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/workflow-copy.ts
+++ b/packages/cli/src/commands/workflow-copy.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -110,15 +111,7 @@ export async function workflowCopyCommand(input: CommandInput): Promise<number> 
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/workflow-get.ts
+++ b/packages/cli/src/commands/workflow-get.ts
@@ -1,8 +1,9 @@
 import { parseArgs } from 'node:util';
 import { writeFile } from 'node:fs/promises';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -131,15 +132,7 @@ export async function workflowGetCommand(input: CommandInput): Promise<number> {
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/workflow-list.ts
+++ b/packages/cli/src/commands/workflow-list.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -84,15 +85,7 @@ export async function workflowListCommand(input: CommandInput): Promise<number> 
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/workflow-register.ts
+++ b/packages/cli/src/commands/workflow-register.ts
@@ -2,7 +2,7 @@ import { parseArgs } from 'node:util';
 import { readFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import {
   RegisterWorkflowInputSchema,
   type RegisterWorkflowInput,
@@ -10,6 +10,7 @@ import {
 import { parseWorkflowDefinitionForCreation } from '@mediforce/platform-core';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -223,15 +224,7 @@ export async function workflowRegisterCommand(input: CommandInput): Promise<numb
     await warnMissingImages(body, input.output, jsonMode);
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/commands/workflow-set-visibility.ts
+++ b/packages/cli/src/commands/workflow-set-visibility.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce } from '@mediforce/platform-api/client';
 import { resolveConfig } from '../config.js';
 import { printJson, printError, type OutputSink } from '../output.js';
+import { formatCliError } from '../errors.js';
 
 interface CommandInput {
   argv: string[];
@@ -93,15 +94,7 @@ export async function workflowSetVisibilityCommand(input: CommandInput): Promise
     }
     return 0;
   } catch (err) {
-    if (err instanceof ApiError) {
-      printError(
-        input.output,
-        { error: err.message, status: err.status, body: err.body },
-        jsonMode,
-      );
-    } else {
-      printError(input.output, { error: String(err) }, jsonMode);
-    }
+    printError(input.output, formatCliError(err, { baseUrl: config.baseUrl, jsonMode }), jsonMode);
     return 1;
   }
 }

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -34,7 +34,7 @@ export function formatCliError(
     return {
       error: `Cannot reach Mediforce API${input.baseUrl ? ` at ${input.baseUrl}` : ''}`,
       cause: { message: 'server unreachable, took too long' },
-      hints: networkHints(),
+      hints: networkHints(input.baseUrl),
     };
   }
 
@@ -74,7 +74,7 @@ function formatNetworkError(systemError: SystemErrorShape, baseUrl?: string): Er
         address: systemError.address,
         port: systemError.port,
       },
-      hints: networkHints(),
+      hints: networkHints(baseUrl),
     };
   }
 
@@ -86,7 +86,7 @@ function formatNetworkError(systemError: SystemErrorShape, baseUrl?: string): Er
         message: 'hostname not resolvable',
         hostname: systemError.hostname,
       },
-      hints: networkHints(),
+      hints: networkHints(baseUrl),
     };
   }
 
@@ -94,7 +94,7 @@ function formatNetworkError(systemError: SystemErrorShape, baseUrl?: string): Er
     return {
       error: `Cannot reach Mediforce API${target}`,
       cause: { code, message: 'server unreachable, took too long' },
-      hints: networkHints(),
+      hints: networkHints(baseUrl),
     };
   }
 
@@ -102,23 +102,28 @@ function formatNetworkError(systemError: SystemErrorShape, baseUrl?: string): Er
     return {
       error: `Certificate problem reaching Mediforce API${target}`,
       cause: { code, message: 'certificate problem' },
-      hints: networkHints(),
+      hints: networkHints(baseUrl),
     };
   }
 
   return {
     error: `Cannot reach Mediforce API${target}`,
     cause: { code, message: systemError.message ?? 'network error' },
-    hints: networkHints(),
+    hints: networkHints(baseUrl),
   };
 }
 
-function networkHints(): string[] {
-  return [
-    'Is the dev server running? Start with: pnpm dev:local',
-    'To use a different host: export MEDIFORCE_BASE_URL=https://staging.mediforce.ai',
-    'Or pass --base-url https://staging.mediforce.ai to this command.',
-  ];
+function networkHints(baseUrl?: string): string[] {
+  const hints: string[] = [];
+
+  if (isLocalBaseUrl(baseUrl) === true) {
+    hints.push('Is the dev server running? Start with: pnpm dev:local');
+  }
+
+  hints.push('To use a different host: export MEDIFORCE_BASE_URL=https://staging.mediforce.ai');
+  hints.push('Or pass --base-url https://staging.mediforce.ai to this command.');
+
+  return hints;
 }
 
 
@@ -151,6 +156,15 @@ function isFetchFailure(err: unknown): boolean {
       return true;
     }
 
+    const nestedErrors = current['errors'];
+    if (Array.isArray(nestedErrors)) {
+      for (const nestedError of nestedErrors) {
+        if (isFetchFailure(nestedError)) {
+          return true;
+        }
+      }
+    }
+
     current = current['cause'];
   }
 
@@ -181,6 +195,16 @@ function findSystemError(err: unknown): SystemErrorShape | null {
         hostname: typeof current['hostname'] === 'string' ? current['hostname'] : undefined,
       };
     }
+    const nestedErrors = current['errors'];
+    if (Array.isArray(nestedErrors)) {
+      for (const nestedError of nestedErrors) {
+        const candidate = findSystemError(nestedError);
+        if (candidate !== null) {
+          return candidate;
+        }
+      }
+    }
+
     current = current['cause'];
   }
 
@@ -202,6 +226,20 @@ function findAbortError(err: unknown): unknown | null {
 
 function looksLikeNonJson404(body: unknown): boolean {
   return isRecord(body) && Object.keys(body).length === 0;
+}
+
+
+function isLocalBaseUrl(baseUrl: string | undefined): boolean {
+  if (typeof baseUrl !== 'string' || baseUrl.length === 0) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(baseUrl);
+    return parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,173 @@
+import { ApiError } from '@mediforce/platform-api/client';
+import type { ErrorPayload } from './output.js';
+
+export interface FormatCliErrorInput {
+  baseUrl?: string;
+  jsonMode?: boolean;
+}
+
+const DNS_CODES = new Set(['ENOTFOUND', 'EAI_AGAIN']);
+const TIMEOUT_CODES = new Set(['UND_ERR_CONNECT_TIMEOUT', 'ETIMEDOUT']);
+const TLS_CODES = new Set([
+  'CERT_HAS_EXPIRED',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+]);
+
+export function formatCliError(
+  err: unknown,
+  input: FormatCliErrorInput = {},
+): ErrorPayload {
+  if (err instanceof ApiError) {
+    return formatApiError(err);
+  }
+
+  const systemError = findSystemError(err);
+  if (systemError !== null) {
+    return formatNetworkError(systemError, input.baseUrl);
+  }
+
+  const abortError = findAbortError(err);
+  if (abortError !== null) {
+    return {
+      error: `Cannot reach Mediforce API${input.baseUrl ? ` at ${input.baseUrl}` : ''}`,
+      cause: { message: 'server unreachable, took too long' },
+      hints: networkHints(),
+    };
+  }
+
+  return { error: String(err) };
+}
+
+function formatApiError(err: ApiError): ErrorPayload {
+  const payload: ErrorPayload = {
+    error: err.message,
+    status: err.status,
+    body: err.body,
+  };
+
+  if (err.status === 401) {
+    payload.hints = ['Set MEDIFORCE_API_KEY to a valid API key.'];
+  } else if (err.status === 403) {
+    payload.hints = ['Check that MEDIFORCE_API_KEY is valid for this workspace.'];
+  } else if (err.status === 404 && looksLikeNonJson404(err.body)) {
+    payload.hints = [
+      'The base URL may be wrong. Point MEDIFORCE_BASE_URL at a Mediforce API host.',
+    ];
+  }
+
+  return payload;
+}
+
+function formatNetworkError(systemError: SystemErrorShape, baseUrl?: string): ErrorPayload {
+  const code = systemError.code;
+  const target = baseUrl ? ` at ${baseUrl}` : '';
+
+  if (code === 'ECONNREFUSED') {
+    return {
+      error: `Cannot reach Mediforce API${target}`,
+      cause: {
+        code,
+        message: 'connection refused',
+        address: systemError.address,
+        port: systemError.port,
+      },
+      hints: networkHints(),
+    };
+  }
+
+  if (DNS_CODES.has(code)) {
+    return {
+      error: `Cannot resolve Mediforce API host${baseUrl ? ` for ${baseUrl}` : ''}`,
+      cause: {
+        code,
+        message: 'hostname not resolvable',
+        hostname: systemError.hostname,
+      },
+      hints: networkHints(),
+    };
+  }
+
+  if (TIMEOUT_CODES.has(code)) {
+    return {
+      error: `Cannot reach Mediforce API${target}`,
+      cause: { code, message: 'server unreachable, took too long' },
+      hints: networkHints(),
+    };
+  }
+
+  if (TLS_CODES.has(code)) {
+    return {
+      error: `Certificate problem reaching Mediforce API${target}`,
+      cause: { code, message: 'certificate problem' },
+      hints: networkHints(),
+    };
+  }
+
+  return {
+    error: `Cannot reach Mediforce API${target}`,
+    cause: { code, message: systemError.message ?? 'network error' },
+    hints: networkHints(),
+  };
+}
+
+function networkHints(): string[] {
+  return [
+    'Is the dev server running? Start with: pnpm dev:local',
+    'To use a different host: export MEDIFORCE_BASE_URL=https://staging.mediforce.ai',
+    'Or pass --base-url https://staging.mediforce.ai to this command.',
+  ];
+}
+
+interface SystemErrorShape {
+  code: string;
+  message?: string;
+  address?: string;
+  port?: number;
+  hostname?: string;
+}
+
+function findSystemError(err: unknown): SystemErrorShape | null {
+  let current: unknown = err;
+  const seen = new Set<unknown>();
+
+  while (isRecord(current) && !seen.has(current)) {
+    seen.add(current);
+    const code = current['code'];
+    if (typeof code === 'string') {
+      return {
+        code,
+        message: typeof current['message'] === 'string' ? current['message'] : undefined,
+        address: typeof current['address'] === 'string' ? current['address'] : undefined,
+        port: typeof current['port'] === 'number' ? current['port'] : undefined,
+        hostname: typeof current['hostname'] === 'string' ? current['hostname'] : undefined,
+      };
+    }
+    current = current['cause'];
+  }
+
+  return null;
+}
+
+function findAbortError(err: unknown): unknown | null {
+  let current: unknown = err;
+  const seen = new Set<unknown>();
+
+  while (isRecord(current) && !seen.has(current)) {
+    seen.add(current);
+    if (current['name'] === 'AbortError') return current;
+    current = current['cause'];
+  }
+
+  return null;
+}
+
+function looksLikeNonJson404(body: unknown): boolean {
+  return isRecord(body) && Object.keys(body).length === 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -38,6 +38,10 @@ export function formatCliError(
     };
   }
 
+  if (err instanceof Error) {
+    return { error: err.message };
+  }
+
   return { error: String(err) };
 }
 
@@ -217,7 +221,9 @@ function findAbortError(err: unknown): unknown | null {
 
   while (isRecord(current) && !seen.has(current)) {
     seen.add(current);
-    if (current['name'] === 'AbortError') return current;
+    if (current['name'] === 'AbortError') {
+      return current;
+    }
     current = current['cause'];
   }
 
@@ -225,6 +231,7 @@ function findAbortError(err: unknown): unknown | null {
 }
 
 function looksLikeNonJson404(body: unknown): boolean {
+  // parseJsonOrThrow normalizes non-JSON 404 response bodies to {} in ApiError.body.
   return isRecord(body) && Object.keys(body).length === 0;
 }
 

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -24,7 +24,7 @@ export function formatCliError(
     return formatApiError(err);
   }
 
-  const systemError = findSystemError(err);
+  const systemError = findFetchSystemError(err);
   if (systemError !== null) {
     return formatNetworkError(systemError, input.baseUrl);
   }
@@ -119,6 +119,42 @@ function networkHints(): string[] {
     'To use a different host: export MEDIFORCE_BASE_URL=https://staging.mediforce.ai',
     'Or pass --base-url https://staging.mediforce.ai to this command.',
   ];
+}
+
+
+function findFetchSystemError(err: unknown): SystemErrorShape | null {
+  if (!isFetchFailure(err)) {
+    return null;
+  }
+
+  return findSystemError(err);
+}
+
+function isFetchFailure(err: unknown): boolean {
+  let current: unknown = err;
+  const seen = new Set<unknown>();
+
+  while (isRecord(current) && !seen.has(current)) {
+    seen.add(current);
+
+    if (current['name'] === 'AbortError') {
+      return true;
+    }
+
+    const message = current['message'];
+    if (
+      typeof current['name'] === 'string' &&
+      current['name'] === 'TypeError' &&
+      typeof message === 'string' &&
+      message.toLowerCase() === 'fetch failed'
+    ) {
+      return true;
+    }
+
+    current = current['cause'];
+  }
+
+  return false;
 }
 
 interface SystemErrorShape {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -23,6 +23,14 @@ export interface ErrorPayload {
   error: string;
   status?: number;
   body?: unknown;
+  cause?: {
+    code?: string;
+    message: string;
+    address?: string;
+    port?: number;
+    hostname?: string;
+  };
+  hints?: string[];
 }
 
 export function printJson(sink: OutputSink, payload: unknown): void {
@@ -64,4 +72,25 @@ export function printError(
   const suffix =
     payload.status !== undefined ? ` (HTTP ${String(payload.status)})` : '';
   sink.stderr(`Error${suffix}: ${payload.error}`);
+  if (payload.cause !== undefined) {
+    sink.stderr(`  Reason: ${formatCause(payload.cause)}`);
+  }
+  if (payload.hints !== undefined && payload.hints.length > 0) {
+    sink.stderr('');
+    sink.stderr('Hints:');
+    for (const hint of payload.hints) {
+      sink.stderr(`  - ${hint}`);
+    }
+  }
+}
+
+function formatCause(cause: NonNullable<ErrorPayload['cause']>): string {
+  const details: string[] = [];
+  if (cause.code !== undefined) details.push(cause.code);
+  if (cause.address !== undefined && cause.port !== undefined) {
+    details.push(`${cause.address}:${String(cause.port)}`);
+  } else if (cause.hostname !== undefined) {
+    details.push(cause.hostname);
+  }
+  return details.length > 0 ? `${cause.message} (${details.join(' ')})` : cause.message;
 }


### PR DESCRIPTION
Closes #397

## Summary
- Adds shared CLI error formatting for network failures and API auth errors.
- Replaces duplicated command catch blocks with `formatCliError(...)`.
- Preserves JSON-mode error output on stdout while adding structured `cause` and `hints`.
- Adds regression tests for formatter classification and workflow-list network errors.

## Testing
- pnpm typecheck
- pnpm test:affected
- pnpm test
- MEDIFORCE_API_KEY=k pnpm exec mediforce workflow list --base-url http://127.0.0.1:65534

## Manual examples
Connection refused:
\`\`\`bash
MEDIFORCE_API_KEY=k pnpm exec mediforce workflow list --base-url http://127.0.0.1:65534
\`\`\`

DNS failure:
\`\`\`bash
MEDIFORCE_API_KEY=k pnpm exec mediforce workflow list --base-url https://does-not-exist.invalid
\`\`\`

TLS certificate problem:
\`\`\`bash
MEDIFORCE_API_KEY=k pnpm exec mediforce workflow list --base-url https://expired.badssl.com
\`\`\`

JSON mode:
\`\`\`bash
MEDIFORCE_API_KEY=k pnpm exec mediforce workflow list --base-url https://does-not-exist.invalid --json
\`\`\`