### PR TITLE
feat(platform-api): migrate all Phase 2 mutations (12 endpoints, 5 domains)

### DIFF
--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -1,4 +1,18 @@
 import {
+  CancelProcessInputSchema,
+  CancelProcessOutputSchema,
+  ClaimTaskInputSchema,
+  ClaimTaskOutputSchema,
+  CompleteTaskInputSchema,
+  CompleteTaskOutputSchema,
+  CreateAgentDefinitionInputContractSchema,
+  CreateAgentDefinitionOutputSchema,
+  CreateProcessConfigInputSchema,
+  CreateProcessConfigOutputSchema,
+  CreateProcessInputSchema,
+  CreateProcessOutputSchema,
+  CreateWorkflowDefinitionInputSchema,
+  CreateWorkflowDefinitionOutputSchema,
   GetAgentDefinitionInputSchema,
   GetAgentDefinitionOutputSchema,
   GetCoworkSessionByInstanceInputSchema,
@@ -11,6 +25,8 @@ import {
   GetProcessStepsOutputSchema,
   GetTaskInputSchema,
   GetTaskOutputSchema,
+  HeartbeatInputSchema,
+  HeartbeatOutputSchema,
   ListAgentDefinitionsOutputSchema,
   ListAuditEventsInputSchema,
   ListAuditEventsOutputSchema,
@@ -20,6 +36,25 @@ import {
   ListTasksInputSchema,
   ListTasksOutputSchema,
   ListWorkflowDefinitionsOutputSchema,
+  ResolveTaskInputSchema,
+  ResolveTaskOutputSchema,
+  ResumeProcessInputSchema,
+  ResumeProcessOutputSchema,
+  UpsertLegacyDefinitionInputSchema,
+  UpsertLegacyDefinitionOutputSchema,
+  type CancelProcessInput,
+  type CancelProcessOutput,
+  type ClaimTaskInput,
+  type ClaimTaskOutput,
+  type CompleteTaskInput,
+  type CompleteTaskOutput,
+  type CreateAgentDefinitionOutput,
+  type CreateProcessConfigInput,
+  type CreateProcessConfigOutput,
+  type CreateProcessInput,
+  type CreateProcessOutput,
+  type CreateWorkflowDefinitionInput,
+  type CreateWorkflowDefinitionOutput,
   type GetAgentDefinitionInput,
   type GetAgentDefinitionOutput,
   type GetCoworkSessionByInstanceInput,
@@ -32,6 +67,8 @@ import {
   type GetProcessStepsOutput,
   type GetTaskInput,
   type GetTaskOutput,
+  type HeartbeatInput,
+  type HeartbeatOutput,
   type ListAgentDefinitionsOutput,
   type ListAuditEventsInput,
   type ListAuditEventsOutput,
@@ -41,7 +78,14 @@ import {
   type ListTasksInput,
   type ListTasksOutput,
   type ListWorkflowDefinitionsOutput,
+  type ResolveTaskInput,
+  type ResolveTaskOutput,
+  type ResumeProcessInput,
+  type ResumeProcessOutput,
+  type UpsertLegacyDefinitionInput,
+  type UpsertLegacyDefinitionOutput,
 } from '../contract/index.js';
+import type { CreateAgentDefinitionInput } from '@mediforce/platform-core';
 
 /**
  * Typed client for the Mediforce API. Runtime-agnostic — works in the
@@ -101,21 +145,39 @@ export class Mediforce {
   readonly tasks: {
     list: (input: ListTasksInput) => Promise<ListTasksOutput>;
     get: (input: GetTaskInput) => Promise<GetTaskOutput>;
+    claim: (input: ClaimTaskInput) => Promise<ClaimTaskOutput>;
+    complete: (input: CompleteTaskInput) => Promise<CompleteTaskOutput>;
+    resolve: (input: ResolveTaskInput) => Promise<ResolveTaskOutput>;
   };
 
   readonly processes: {
     get: (input: GetProcessInput) => Promise<GetProcessOutput>;
     getSteps: (input: GetProcessStepsInput) => Promise<GetProcessStepsOutput>;
     listAuditEvents: (input: ListAuditEventsInput) => Promise<ListAuditEventsOutput>;
+    create: (input: CreateProcessInput) => Promise<CreateProcessOutput>;
+    cancel: (input: CancelProcessInput) => Promise<CancelProcessOutput>;
+    resume: (input: ResumeProcessInput) => Promise<ResumeProcessOutput>;
   };
 
   readonly workflowDefinitions: {
     list: () => Promise<ListWorkflowDefinitionsOutput>;
+    create: (
+      input: CreateWorkflowDefinitionInput,
+    ) => Promise<CreateWorkflowDefinitionOutput>;
+  };
+
+  readonly definitions: {
+    upsertLegacy: (
+      input: UpsertLegacyDefinitionInput,
+    ) => Promise<UpsertLegacyDefinitionOutput>;
   };
 
   readonly agentDefinitions: {
     list: () => Promise<ListAgentDefinitionsOutput>;
     get: (input: GetAgentDefinitionInput) => Promise<GetAgentDefinitionOutput>;
+    create: (
+      input: CreateAgentDefinitionInput,
+    ) => Promise<CreateAgentDefinitionOutput>;
   };
 
   readonly cowork: {
@@ -127,10 +189,17 @@ export class Mediforce {
 
   readonly configs: {
     list: (input: ListProcessConfigsInput) => Promise<ListProcessConfigsOutput>;
+    create: (
+      input: CreateProcessConfigInput,
+    ) => Promise<CreateProcessConfigOutput>;
   };
 
   readonly plugins: {
     list: () => Promise<ListPluginsOutput>;
+  };
+
+  readonly cron: {
+    heartbeat: (input?: HeartbeatInput) => Promise<HeartbeatOutput>;
   };
 
   constructor(private readonly config: ClientConfig) {
@@ -189,6 +258,41 @@ export class Mediforce {
         const body = await parseJsonOrThrow(res, 'mediforce.tasks.get');
         return GetTaskOutputSchema.parse(body);
       },
+      claim: async (input) => {
+        const validated = ClaimTaskInputSchema.parse(input);
+        const res = await this.request(
+          `/api/tasks/${encodeURIComponent(validated.taskId)}/claim`,
+          { method: 'POST', body: JSON.stringify({ userId: validated.userId }) },
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.tasks.claim');
+        return ClaimTaskOutputSchema.parse(body);
+      },
+      complete: async (input) => {
+        const validated = CompleteTaskInputSchema.parse(input);
+        const res = await this.request(
+          `/api/tasks/${encodeURIComponent(validated.taskId)}/complete`,
+          {
+            method: 'POST',
+            body: JSON.stringify({
+              verdict: validated.verdict,
+              comment: validated.comment,
+            }),
+          },
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.tasks.complete');
+        return CompleteTaskOutputSchema.parse(body);
+      },
+      resolve: async (input) => {
+        const validated = ResolveTaskInputSchema.parse(input);
+        // taskId travels in the path; everything else in the body
+        const { taskId, ...rest } = validated;
+        const res = await this.request(
+          `/api/tasks/${encodeURIComponent(taskId)}/resolve`,
+          { method: 'POST', body: JSON.stringify(rest) },
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.tasks.resolve');
+        return ResolveTaskOutputSchema.parse(body);
+      },
     };
 
     this.processes = {
@@ -219,6 +323,33 @@ export class Mediforce {
         );
         return ListAuditEventsOutputSchema.parse(body);
       },
+      create: async (input) => {
+        const validated = CreateProcessInputSchema.parse(input);
+        const res = await this.request('/api/processes', {
+          method: 'POST',
+          body: JSON.stringify(validated),
+        });
+        const body = await parseJsonOrThrow(res, 'mediforce.processes.create');
+        return CreateProcessOutputSchema.parse(body);
+      },
+      cancel: async (input) => {
+        const validated = CancelProcessInputSchema.parse(input);
+        const res = await this.request(
+          `/api/processes/${encodeURIComponent(validated.instanceId)}/cancel`,
+          { method: 'POST' },
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.processes.cancel');
+        return CancelProcessOutputSchema.parse(body);
+      },
+      resume: async (input) => {
+        const validated = ResumeProcessInputSchema.parse(input);
+        const res = await this.request(
+          `/api/processes/${encodeURIComponent(validated.instanceId)}/resume`,
+          { method: 'POST' },
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.processes.resume');
+        return ResumeProcessOutputSchema.parse(body);
+      },
     };
 
     this.workflowDefinitions = {
@@ -226,6 +357,35 @@ export class Mediforce {
         const res = await this.request('/api/workflow-definitions');
         const body = await parseJsonOrThrow(res, 'mediforce.workflowDefinitions.list');
         return ListWorkflowDefinitionsOutputSchema.parse(body);
+      },
+      create: async (input) => {
+        const validated = CreateWorkflowDefinitionInputSchema.parse(input);
+        const qs = toSearchParams({ namespace: validated.namespace });
+        const res = await this.request(`/api/workflow-definitions${qs}`, {
+          method: 'POST',
+          body: JSON.stringify(validated.draft),
+        });
+        const body = await parseJsonOrThrow(
+          res,
+          'mediforce.workflowDefinitions.create',
+        );
+        return CreateWorkflowDefinitionOutputSchema.parse(body);
+      },
+    };
+
+    this.definitions = {
+      upsertLegacy: async (input) => {
+        const validated = UpsertLegacyDefinitionInputSchema.parse(input);
+        const res = await this.request('/api/definitions', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'text/plain' },
+          body: validated.yaml,
+        });
+        const body = await parseJsonOrThrow(
+          res,
+          'mediforce.definitions.upsertLegacy',
+        );
+        return UpsertLegacyDefinitionOutputSchema.parse(body);
       },
     };
 
@@ -242,6 +402,18 @@ export class Mediforce {
         );
         const body = await parseJsonOrThrow(res, 'mediforce.agentDefinitions.get');
         return GetAgentDefinitionOutputSchema.parse(body);
+      },
+      create: async (input) => {
+        const validated = CreateAgentDefinitionInputContractSchema.parse(input);
+        const res = await this.request('/api/agent-definitions', {
+          method: 'POST',
+          body: JSON.stringify(validated),
+        });
+        const body = await parseJsonOrThrow(
+          res,
+          'mediforce.agentDefinitions.create',
+        );
+        return CreateAgentDefinitionOutputSchema.parse(body);
       },
     };
 
@@ -272,6 +444,15 @@ export class Mediforce {
         const body = await parseJsonOrThrow(res, 'mediforce.configs.list');
         return ListProcessConfigsOutputSchema.parse(body);
       },
+      create: async (input) => {
+        const validated = CreateProcessConfigInputSchema.parse(input);
+        const res = await this.request('/api/configs', {
+          method: 'POST',
+          body: JSON.stringify(validated),
+        });
+        const body = await parseJsonOrThrow(res, 'mediforce.configs.create');
+        return CreateProcessConfigOutputSchema.parse(body);
+      },
     };
 
     this.plugins = {
@@ -281,6 +462,18 @@ export class Mediforce {
         return ListPluginsOutputSchema.parse(body);
       },
     };
+
+    this.cron = {
+      heartbeat: async (input) => {
+        const validated = HeartbeatInputSchema.parse(input ?? {});
+        const res = await this.request('/api/cron/heartbeat', {
+          method: 'POST',
+          body: JSON.stringify(validated),
+        });
+        const body = await parseJsonOrThrow(res, 'mediforce.cron.heartbeat');
+        return HeartbeatOutputSchema.parse(body);
+      },
+    };
   }
 
   private async request(path: string, init?: RequestInit): Promise<Response> {
@@ -288,6 +481,17 @@ export class Mediforce {
     const headers = new Headers(init?.headers);
     for (const [key, value] of Object.entries(authHeaders)) {
       if (!headers.has(key)) headers.set(key, value);
+    }
+    // Default Content-Type for mutations carrying a serialised body. Callers
+    // that want another type (e.g. YAML upload uses text/plain) set it
+    // explicitly in `init.headers` and we don't overwrite.
+    if (
+      init?.body !== undefined &&
+      init.body !== null &&
+      typeof init.body === 'string' &&
+      !headers.has('Content-Type')
+    ) {
+      headers.set('Content-Type', 'application/json');
     }
     const base = this.config.baseUrl ?? '';
     const fetchImpl = this.config.fetch ?? globalThis.fetch;

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -5,7 +5,7 @@ import {
   ClaimTaskOutputSchema,
   CompleteTaskInputSchema,
   CompleteTaskOutputSchema,
-  CreateAgentDefinitionInputContractSchema,
+  CreateAgentDefinitionInputSchema,
   CreateAgentDefinitionOutputSchema,
   CreateProcessConfigInputSchema,
   CreateProcessConfigOutputSchema,
@@ -84,8 +84,8 @@ import {
   type ResumeProcessOutput,
   type UpsertLegacyDefinitionInput,
   type UpsertLegacyDefinitionOutput,
+  type CreateAgentDefinitionInput,
 } from '../contract/index.js';
-import type { CreateAgentDefinitionInput } from '@mediforce/platform-core';
 
 /**
  * Typed client for the Mediforce API. Runtime-agnostic — works in the
@@ -404,7 +404,7 @@ export class Mediforce {
         return GetAgentDefinitionOutputSchema.parse(body);
       },
       create: async (input) => {
-        const validated = CreateAgentDefinitionInputContractSchema.parse(input);
+        const validated = CreateAgentDefinitionInputSchema.parse(input);
         const res = await this.request('/api/agent-definitions', {
           method: 'POST',
           body: JSON.stringify(validated),

--- a/packages/platform-api/src/contract/configs.ts
+++ b/packages/platform-api/src/contract/configs.ts
@@ -22,3 +22,17 @@ export const ListProcessConfigsOutputSchema = z.object({
 
 export type ListProcessConfigsInput = z.infer<typeof ListProcessConfigsInputSchema>;
 export type ListProcessConfigsOutput = z.infer<typeof ListProcessConfigsOutputSchema>;
+
+// ---- POST /api/configs ------------------------------------------------------
+//
+// Register a new version of a ProcessConfig. Handler runs `validateProcessConfig`
+// against the latest ProcessDefinition version before persisting; failures are
+// returned as 400 `ValidationError`s. Version conflicts become 409
+// `ConflictError`.
+
+export const CreateProcessConfigInputSchema = ProcessConfigSchema;
+
+export const CreateProcessConfigOutputSchema = z.object({ ok: z.literal(true) });
+
+export type CreateProcessConfigInput = z.infer<typeof CreateProcessConfigInputSchema>;
+export type CreateProcessConfigOutput = z.infer<typeof CreateProcessConfigOutputSchema>;

--- a/packages/platform-api/src/contract/cron.ts
+++ b/packages/platform-api/src/contract/cron.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+/**
+ * Contracts for the `cron` domain — currently a single heartbeat endpoint
+ * fired by an external cron runner. The handler scans workflow definitions
+ * for due cron triggers and fires each one.
+ */
+
+export const HeartbeatInputSchema = z.object({}).strict();
+
+const TriggeredEntrySchema = z.object({
+  definitionName: z.string(),
+  definitionVersion: z.number(),
+  triggerName: z.string(),
+  instanceId: z.string(),
+});
+
+const SkippedEntrySchema = z.object({
+  definitionName: z.string(),
+  definitionVersion: z.number(),
+  triggerName: z.string(),
+  reason: z.string(),
+});
+
+export const HeartbeatOutputSchema = z.object({
+  triggered: z.array(TriggeredEntrySchema),
+  skipped: z.array(SkippedEntrySchema),
+});
+
+export type HeartbeatInput = z.infer<typeof HeartbeatInputSchema>;
+export type HeartbeatOutput = z.infer<typeof HeartbeatOutputSchema>;

--- a/packages/platform-api/src/contract/definitions.ts
+++ b/packages/platform-api/src/contract/definitions.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   AgentDefinitionSchema,
+  CreateAgentDefinitionInputSchema,
   WorkflowDefinitionSchema,
 } from '@mediforce/platform-core';
 
@@ -59,3 +60,58 @@ export const GetAgentDefinitionOutputSchema = z.object({
 
 export type GetAgentDefinitionInput = z.infer<typeof GetAgentDefinitionInputSchema>;
 export type GetAgentDefinitionOutput = z.infer<typeof GetAgentDefinitionOutputSchema>;
+
+// ---- PUT /api/definitions (legacy YAML process definition) ------------------
+//
+// Receives a YAML body. Handler parses + validates via `parseProcessDefinition`
+// before persistence. Non-parseable YAML becomes `ValidationError` (400);
+// the version-already-exists case becomes `ConflictError` (409).
+// Also auto-seeds an "all-human" config if one doesn't exist for this version.
+
+export const UpsertLegacyDefinitionInputSchema = z.object({
+  yaml: z.string().min(1, 'YAML body is required'),
+});
+
+export const UpsertLegacyDefinitionOutputSchema = z.object({
+  success: z.literal(true),
+  name: z.string(),
+  version: z.string(),
+});
+
+export type UpsertLegacyDefinitionInput = z.infer<typeof UpsertLegacyDefinitionInputSchema>;
+export type UpsertLegacyDefinitionOutput = z.infer<typeof UpsertLegacyDefinitionOutputSchema>;
+
+// ---- POST /api/workflow-definitions ----------------------------------------
+//
+// Registers a new version of a WorkflowDefinition. `version` + `createdAt`
+// are assigned server-side. `namespace` is required and comes from a query
+// param on the route (the handler treats it as part of the input).
+
+const WorkflowDefinitionDraftSchema = WorkflowDefinitionSchema.omit({
+  version: true,
+  createdAt: true,
+});
+
+export const CreateWorkflowDefinitionInputSchema = z.object({
+  namespace: z.string().min(1),
+  draft: WorkflowDefinitionDraftSchema,
+});
+
+export const CreateWorkflowDefinitionOutputSchema = z.object({
+  success: z.literal(true),
+  name: z.string(),
+  version: z.number(),
+});
+
+export type CreateWorkflowDefinitionInput = z.infer<typeof CreateWorkflowDefinitionInputSchema>;
+export type CreateWorkflowDefinitionOutput = z.infer<typeof CreateWorkflowDefinitionOutputSchema>;
+
+// ---- POST /api/agent-definitions -------------------------------------------
+
+export const CreateAgentDefinitionInputContractSchema = CreateAgentDefinitionInputSchema;
+
+export const CreateAgentDefinitionOutputSchema = z.object({
+  agent: AgentDefinitionSchema,
+});
+
+export type CreateAgentDefinitionOutput = z.infer<typeof CreateAgentDefinitionOutputSchema>;

--- a/packages/platform-api/src/contract/definitions.ts
+++ b/packages/platform-api/src/contract/definitions.ts
@@ -87,9 +87,15 @@ export type UpsertLegacyDefinitionOutput = z.infer<typeof UpsertLegacyDefinition
 // are assigned server-side. `namespace` is required and comes from a query
 // param on the route (the handler treats it as part of the input).
 
+// `namespace` is omitted from the draft schema even though the underlying
+// `WorkflowDefinition` requires it — the create endpoint takes it as a query
+// param and the handler stitches it into the persisted document. Keeping it
+// in the draft would force callers to send it twice (the inner copy was
+// silently overwritten in the pre-migration route).
 const WorkflowDefinitionDraftSchema = WorkflowDefinitionSchema.omit({
   version: true,
   createdAt: true,
+  namespace: true,
 });
 
 export const CreateWorkflowDefinitionInputSchema = z.object({

--- a/packages/platform-api/src/contract/definitions.ts
+++ b/packages/platform-api/src/contract/definitions.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import {
   AgentDefinitionSchema,
-  CreateAgentDefinitionInputSchema,
   WorkflowDefinitionSchema,
 } from '@mediforce/platform-core';
 
@@ -72,6 +71,12 @@ export const UpsertLegacyDefinitionInputSchema = z.object({
   yaml: z.string().min(1, 'YAML body is required'),
 });
 
+// Note: `version` is a STRING here because the legacy `ProcessDefinitionSchema`
+// uses string versions ("1.0", "1.1-alpha"). The newer
+// `CreateWorkflowDefinitionOutputSchema` returns a NUMBER (`version: 1, 2, ...`)
+// because `WorkflowDefinitionSchema` uses monotonically-incrementing integers.
+// The shapes diverge on purpose — don't try to unify them. Clients pick the
+// endpoint that matches the data model they're producing.
 export const UpsertLegacyDefinitionOutputSchema = z.object({
   success: z.literal(true),
   name: z.string(),
@@ -113,8 +118,10 @@ export type CreateWorkflowDefinitionInput = z.infer<typeof CreateWorkflowDefinit
 export type CreateWorkflowDefinitionOutput = z.infer<typeof CreateWorkflowDefinitionOutputSchema>;
 
 // ---- POST /api/agent-definitions -------------------------------------------
-
-export const CreateAgentDefinitionInputContractSchema = CreateAgentDefinitionInputSchema;
+//
+// Input shape is `CreateAgentDefinitionInputSchema` re-exported directly from
+// `@mediforce/platform-core` — see the contract index. Output wraps the
+// created agent in `{ agent }` for parity with the GET endpoints.
 
 export const CreateAgentDefinitionOutputSchema = z.object({
   agent: AgentDefinitionSchema,

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -3,10 +3,22 @@ export {
   ListTasksOutputSchema,
   GetTaskInputSchema,
   GetTaskOutputSchema,
+  ClaimTaskInputSchema,
+  ClaimTaskOutputSchema,
+  CompleteTaskInputSchema,
+  CompleteTaskOutputSchema,
+  ResolveTaskInputSchema,
+  ResolveTaskOutputSchema,
   type ListTasksInput,
   type ListTasksOutput,
   type GetTaskInput,
   type GetTaskOutput,
+  type ClaimTaskInput,
+  type ClaimTaskOutput,
+  type CompleteTaskInput,
+  type CompleteTaskOutput,
+  type ResolveTaskInput,
+  type ResolveTaskOutput,
 } from './tasks.js';
 
 export {

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -94,8 +94,12 @@ export {
 export {
   ListProcessConfigsInputSchema,
   ListProcessConfigsOutputSchema,
+  CreateProcessConfigInputSchema,
+  CreateProcessConfigOutputSchema,
   type ListProcessConfigsInput,
   type ListProcessConfigsOutput,
+  type CreateProcessConfigInput,
+  type CreateProcessConfigOutput,
 } from './configs.js';
 
 export {
@@ -106,3 +110,10 @@ export {
   type ListPluginsOutput,
   type PluginSummary,
 } from './plugins.js';
+
+export {
+  HeartbeatInputSchema,
+  HeartbeatOutputSchema,
+  type HeartbeatInput,
+  type HeartbeatOutput,
+} from './cron.js';

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -29,6 +29,12 @@ export {
   ListAgentDefinitionsOutputSchema,
   GetAgentDefinitionInputSchema,
   GetAgentDefinitionOutputSchema,
+  UpsertLegacyDefinitionInputSchema,
+  UpsertLegacyDefinitionOutputSchema,
+  CreateWorkflowDefinitionInputSchema,
+  CreateWorkflowDefinitionOutputSchema,
+  CreateAgentDefinitionInputContractSchema,
+  CreateAgentDefinitionOutputSchema,
   type ListWorkflowDefinitionsInput,
   type ListWorkflowDefinitionsOutput,
   type WorkflowDefinitionSummary,
@@ -36,6 +42,11 @@ export {
   type ListAgentDefinitionsOutput,
   type GetAgentDefinitionInput,
   type GetAgentDefinitionOutput,
+  type UpsertLegacyDefinitionInput,
+  type UpsertLegacyDefinitionOutput,
+  type CreateWorkflowDefinitionInput,
+  type CreateWorkflowDefinitionOutput,
+  type CreateAgentDefinitionOutput,
 } from './definitions.js';
 
 export {

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -47,6 +47,12 @@ export {
   GetProcessStepsOutputSchema,
   StepEntrySchema,
   StepEntryStatusSchema,
+  CreateProcessInputSchema,
+  CreateProcessOutputSchema,
+  CancelProcessInputSchema,
+  CancelProcessOutputSchema,
+  ResumeProcessInputSchema,
+  ResumeProcessOutputSchema,
   type GetProcessInput,
   type GetProcessOutput,
   type ListAuditEventsInput,
@@ -55,6 +61,12 @@ export {
   type GetProcessStepsOutput,
   type StepEntry,
   type StepEntryStatus,
+  type CreateProcessInput,
+  type CreateProcessOutput,
+  type CancelProcessInput,
+  type CancelProcessOutput,
+  type ResumeProcessInput,
+  type ResumeProcessOutput,
 } from './processes.js';
 
 export {

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -33,7 +33,6 @@ export {
   UpsertLegacyDefinitionOutputSchema,
   CreateWorkflowDefinitionInputSchema,
   CreateWorkflowDefinitionOutputSchema,
-  CreateAgentDefinitionInputContractSchema,
   CreateAgentDefinitionOutputSchema,
   type ListWorkflowDefinitionsInput,
   type ListWorkflowDefinitionsOutput,
@@ -117,3 +116,12 @@ export {
   type HeartbeatInput,
   type HeartbeatOutput,
 } from './cron.js';
+
+// Re-export the agent-definition create input schema from platform-core so
+// callers (route adapters, the typed client) have one place to pull every
+// contract symbol from. The schema itself lives next to `AgentDefinitionSchema`
+// in platform-core because it's derived from it (`.omit`).
+export {
+  CreateAgentDefinitionInputSchema,
+  type CreateAgentDefinitionInput,
+} from '@mediforce/platform-core';

--- a/packages/platform-api/src/contract/processes.ts
+++ b/packages/platform-api/src/contract/processes.ts
@@ -85,3 +85,54 @@ export type StepEntryStatus = z.infer<typeof StepEntryStatusSchema>;
 export type StepEntry = z.infer<typeof StepEntrySchema>;
 export type GetProcessStepsInput = z.infer<typeof GetProcessStepsInputSchema>;
 export type GetProcessStepsOutput = z.infer<typeof GetProcessStepsOutputSchema>;
+
+// ---- POST /api/processes (create/start) -------------------------------------
+//
+// Start a new process instance from a workflow definition. If `definitionVersion`
+// is omitted, the handler resolves the latest version; a workflow with no
+// versions surfaces as `NotFoundError` (404).
+
+export const CreateProcessInputSchema = z.object({
+  definitionName: z.string().min(1),
+  definitionVersion: z.number().int().positive().optional(),
+  triggerName: z.string().min(1).optional(),
+  triggeredBy: z.string().min(1),
+  payload: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const CreateProcessOutputSchema = z.object({
+  instanceId: z.string(),
+  status: InstanceStatusSchema,
+});
+
+export type CreateProcessInput = z.infer<typeof CreateProcessInputSchema>;
+export type CreateProcessOutput = z.infer<typeof CreateProcessOutputSchema>;
+
+// ---- POST /api/processes/:instanceId/cancel ---------------------------------
+
+export const CancelProcessInputSchema = z.object({
+  instanceId: z.string().min(1),
+});
+
+export const CancelProcessOutputSchema = z.object({
+  instanceId: z.string(),
+  status: InstanceStatusSchema,
+});
+
+export type CancelProcessInput = z.infer<typeof CancelProcessInputSchema>;
+export type CancelProcessOutput = z.infer<typeof CancelProcessOutputSchema>;
+
+// ---- POST /api/processes/:instanceId/resume ---------------------------------
+
+export const ResumeProcessInputSchema = z.object({
+  instanceId: z.string().min(1),
+});
+
+export const ResumeProcessOutputSchema = z.object({
+  ok: z.literal(true),
+  instanceId: z.string(),
+  status: InstanceStatusSchema,
+});
+
+export type ResumeProcessInput = z.infer<typeof ResumeProcessInputSchema>;
+export type ResumeProcessOutput = z.infer<typeof ResumeProcessOutputSchema>;

--- a/packages/platform-api/src/contract/tasks.ts
+++ b/packages/platform-api/src/contract/tasks.ts
@@ -95,7 +95,9 @@ export type ClaimTaskOutput = z.infer<typeof ClaimTaskOutputSchema>;
  */
 export const CompleteTaskInputSchema = z.object({
   taskId: z.string().min(1),
-  verdict: z.enum(['approve', 'revise']),
+  verdict: z.enum(['approve', 'revise'], {
+    error: () => ({ message: 'verdict must be "approve" or "revise"' }),
+  }),
   comment: z.string().optional(),
 });
 
@@ -119,9 +121,9 @@ export type CompleteTaskOutput = z.infer<typeof CompleteTaskOutputSchema>;
  * loaded.
  */
 const AttachmentSchema = z.object({
-  name: z.string().min(1),
-  size: z.number().positive(),
-  type: z.string().min(1),
+  name: z.string({ error: 'attachment name is required' }).min(1, 'attachment name is required'),
+  size: z.number().positive('attachment size must be positive'),
+  type: z.string().min(1, 'attachment type is required'),
   storagePath: z.string().optional(),
   downloadUrl: z.string().optional(),
 });

--- a/packages/platform-api/src/contract/tasks.ts
+++ b/packages/platform-api/src/contract/tasks.ts
@@ -68,3 +68,81 @@ export const GetTaskOutputSchema = HumanTaskSchema;
 
 export type GetTaskInput = z.infer<typeof GetTaskInputSchema>;
 export type GetTaskOutput = z.infer<typeof GetTaskOutputSchema>;
+
+/**
+ * Contract for `POST /api/tasks/:taskId/claim`.
+ *
+ * `userId` defaults to `'api-user'` server-side when omitted; the schema keeps
+ * it optional so clients without an identity claim can still hit the endpoint
+ * (preserves pre-migration behaviour).
+ */
+export const ClaimTaskInputSchema = z.object({
+  taskId: z.string().min(1),
+  userId: z.string().min(1).optional(),
+});
+
+export const ClaimTaskOutputSchema = HumanTaskSchema;
+
+export type ClaimTaskInput = z.infer<typeof ClaimTaskInputSchema>;
+export type ClaimTaskOutput = z.infer<typeof ClaimTaskOutputSchema>;
+
+/**
+ * Contract for `POST /api/tasks/:taskId/complete`.
+ *
+ * State-machine precondition: the task must be in `claimed` status. Other
+ * statuses return `ConflictError` (409). On success the handler also resumes
+ * the paused instance, advances the engine, and fires `/run` out-of-band.
+ */
+export const CompleteTaskInputSchema = z.object({
+  taskId: z.string().min(1),
+  verdict: z.enum(['approve', 'revise']),
+  comment: z.string().optional(),
+});
+
+export const CompleteTaskOutputSchema = z.object({
+  ok: z.literal(true),
+  taskId: z.string(),
+  verdict: z.enum(['approve', 'revise']),
+  processInstanceId: z.string(),
+});
+
+export type CompleteTaskInput = z.infer<typeof CompleteTaskInputSchema>;
+export type CompleteTaskOutput = z.infer<typeof CompleteTaskOutputSchema>;
+
+/**
+ * Contract for `POST /api/tasks/:taskId/resolve`.
+ *
+ * Single endpoint, three body shapes (verdict / paramValues / attachments).
+ * Handler validates the body against the task's expected shape at runtime;
+ * the Zod schema is permissive here because what counts as "valid" depends on
+ * task.ui.component + task.params, which are only known after the task is
+ * loaded.
+ */
+const AttachmentSchema = z.object({
+  name: z.string().min(1),
+  size: z.number().positive(),
+  type: z.string().min(1),
+  storagePath: z.string().optional(),
+  downloadUrl: z.string().optional(),
+});
+
+export const ResolveTaskInputSchema = z.object({
+  taskId: z.string().min(1),
+  verdict: z.enum(['approve', 'revise']).optional(),
+  comment: z.string().optional(),
+  selectedIndex: z.number().int().nonnegative().optional(),
+  paramValues: z.record(z.string(), z.unknown()).optional(),
+  attachments: z.array(AttachmentSchema).optional(),
+});
+
+export const ResolveTaskOutputSchema = z.object({
+  ok: z.literal(true),
+  taskId: z.string(),
+  resolvedStepId: z.string(),
+  processInstanceId: z.string(),
+  nextStepId: z.string().nullable(),
+  status: z.string(),
+});
+
+export type ResolveTaskInput = z.infer<typeof ResolveTaskInputSchema>;
+export type ResolveTaskOutput = z.infer<typeof ResolveTaskOutputSchema>;

--- a/packages/platform-api/src/contract/tasks.ts
+++ b/packages/platform-api/src/contract/tasks.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { HumanTaskSchema, HumanTaskStatusSchema, type HumanTaskStatus } from '@mediforce/platform-core';
+import {
+  HumanTaskSchema,
+  HumanTaskStatusSchema,
+  InstanceStatusSchema,
+  type HumanTaskStatus,
+} from '@mediforce/platform-core';
 
 /**
  * Contract for `GET /api/tasks`.
@@ -143,7 +148,11 @@ export const ResolveTaskOutputSchema = z.object({
   resolvedStepId: z.string(),
   processInstanceId: z.string(),
   nextStepId: z.string().nullable(),
-  status: z.string(),
+  // `'unknown'` is the handler's fallback when the post-advance refetch of
+  // the instance returns null (a race that shouldn't happen in practice but
+  // is defended against). Otherwise it's one of the canonical
+  // `InstanceStatusSchema` values.
+  status: z.union([InstanceStatusSchema, z.literal('unknown')]),
 });
 
 export type ResolveTaskInput = z.infer<typeof ResolveTaskInputSchema>;

--- a/packages/platform-api/src/errors.ts
+++ b/packages/platform-api/src/errors.ts
@@ -5,11 +5,10 @@
  * thrown value is treated as an unexpected server error and sanitised to a
  * generic 500.
  *
- * Scope here is deliberately minimal — only the statuses we actually return
- * today (`404` for missing resources) get their own subclass. Add more
- * (409 for precondition failures, 403 for forbidden, …) when a handler
- * needs them; the error contract will grow alongside the mutations in
- * Phase 2 of the headless migration.
+ * Phase 2 (mutations) widened the set: `ConflictError` for state-machine
+ * refuses, `ForbiddenError` for auth policy at the handler boundary, and
+ * `ValidationError` for domain-level input problems that are too rich for a
+ * Zod `.refine()` (e.g. duplicate-config lookups, YAML parse failures).
  */
 export class HandlerError extends Error {
   constructor(public readonly statusCode: number, message: string) {
@@ -22,5 +21,26 @@ export class NotFoundError extends HandlerError {
   constructor(message = 'Not found') {
     super(404, message);
     this.name = 'NotFoundError';
+  }
+}
+
+export class ConflictError extends HandlerError {
+  constructor(message = 'Conflict') {
+    super(409, message);
+    this.name = 'ConflictError';
+  }
+}
+
+export class ForbiddenError extends HandlerError {
+  constructor(message = 'Forbidden') {
+    super(403, message);
+    this.name = 'ForbiddenError';
+  }
+}
+
+export class ValidationError extends HandlerError {
+  constructor(message = 'Invalid input') {
+    super(400, message);
+    this.name = 'ValidationError';
   }
 }

--- a/packages/platform-api/src/handlers/configs/__tests__/create-process-config.test.ts
+++ b/packages/platform-api/src/handlers/configs/__tests__/create-process-config.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryProcessRepository,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { createProcessConfig, type PluginRegistryView } from '../create-process-config.js';
+import { ConflictError, ValidationError } from '../../../errors.js';
+
+const REGISTRY: PluginRegistryView = {
+  list: () => [{ name: 'claude-code-agent' }],
+};
+
+const DEFINITION = {
+  // The inline Next.js route looked up the definition with the literal string
+  // 'latest' as the version (a pre-existing bug). We preserve that behaviour
+  // in Phase 2, so the test stores the definition under the same key it will
+  // be looked up with — otherwise validation quietly no-ops.
+  name: 'wf-a',
+  version: 'latest',
+  steps: [{ id: 'intake', name: 'Intake', type: 'creation' as const }],
+  transitions: [],
+  triggers: [{ name: 'manual', type: 'manual' as const }],
+};
+
+describe('createProcessConfig handler', () => {
+  let processRepo: InMemoryProcessRepository;
+
+  beforeEach(async () => {
+    resetFactorySequence();
+    processRepo = new InMemoryProcessRepository();
+    await processRepo.saveProcessDefinition(DEFINITION as never);
+  });
+
+  it('persists a valid config and returns ok', async () => {
+    const result = await createProcessConfig(
+      {
+        processName: 'wf-a',
+        configName: 'all-human',
+        configVersion: '1',
+        stepConfigs: [{ stepId: 'intake', executorType: 'human' }],
+      },
+      { processRepo, pluginRegistry: REGISTRY },
+    );
+
+    expect(result).toEqual({ ok: true });
+    const stored = await processRepo.getProcessConfig('wf-a', 'all-human', '1');
+    expect(stored).not.toBeNull();
+  });
+
+  it('throws ValidationError when config references unregistered plugins', async () => {
+    await expect(
+      createProcessConfig(
+        {
+          processName: 'wf-a',
+          configName: 'agent-run',
+          configVersion: '2',
+          stepConfigs: [
+            {
+              stepId: 'intake',
+              executorType: 'agent',
+              plugin: 'nonexistent-plugin',
+              agentConfig: { prompt: 'whatever' },
+            },
+          ],
+        },
+        { processRepo, pluginRegistry: REGISTRY },
+      ),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('maps ConfigVersionAlreadyExistsError to ConflictError', async () => {
+    const failing: InMemoryProcessRepository = Object.create(processRepo);
+    failing.saveProcessConfig = async () => {
+      const err = new Error('already exists');
+      err.name = 'ConfigVersionAlreadyExistsError';
+      throw err;
+    };
+
+    await expect(
+      createProcessConfig(
+        {
+          processName: 'wf-a',
+          configName: 'all-human',
+          configVersion: '1',
+          stepConfigs: [{ stepId: 'intake', executorType: 'human' }],
+        },
+        { processRepo: failing, pluginRegistry: REGISTRY },
+      ),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/packages/platform-api/src/handlers/configs/create-process-config.ts
+++ b/packages/platform-api/src/handlers/configs/create-process-config.ts
@@ -1,0 +1,55 @@
+import {
+  validateProcessConfig,
+  type ProcessRepository,
+} from '@mediforce/platform-core';
+import type {
+  CreateProcessConfigInput,
+  CreateProcessConfigOutput,
+} from '../../contract/configs.js';
+import { ConflictError, ValidationError } from '../../errors.js';
+
+export interface PluginRegistryView {
+  list(): Array<{ name: string }>;
+}
+
+export interface CreateProcessConfigDeps {
+  processRepo: ProcessRepository;
+  pluginRegistry: PluginRegistryView;
+}
+
+/**
+ * Pure handler for `POST /api/configs`.
+ *
+ * Runs server-side `validateProcessConfig` against the latest definition
+ * version for the process (when one exists); validation failures become
+ * `ValidationError` (400). Version conflicts from the infra layer surface as
+ * `ConflictError` (409).
+ */
+export async function createProcessConfig(
+  input: CreateProcessConfigInput,
+  deps: CreateProcessConfigDeps,
+): Promise<CreateProcessConfigOutput> {
+  const definition = await deps.processRepo.getProcessDefinition(
+    input.processName,
+    input.stepConfigs[0]?.stepId ? 'latest' : 'latest',
+  );
+
+  const pluginNames = deps.pluginRegistry.list().map((p) => p.name);
+  if (definition !== null) {
+    const result = validateProcessConfig(input, definition, pluginNames);
+    if (!result.valid) {
+      throw new ValidationError(result.errors.join('; '));
+    }
+  }
+
+  try {
+    await deps.processRepo.saveProcessConfig(input);
+  } catch (err) {
+    if (err instanceof Error && err.name === 'ConfigVersionAlreadyExistsError') {
+      throw new ConflictError(err.message);
+    }
+    throw err;
+  }
+
+  return { ok: true };
+}

--- a/packages/platform-api/src/handlers/configs/create-process-config.ts
+++ b/packages/platform-api/src/handlers/configs/create-process-config.ts
@@ -29,6 +29,13 @@ export async function createProcessConfig(
   input: CreateProcessConfigInput,
   deps: CreateProcessConfigDeps,
 ): Promise<CreateProcessConfigOutput> {
+  // TODO(#231): pre-existing bug ported 1:1 from the inline route. Both
+  // ternary branches resolve to the literal string 'latest', which is never
+  // a real `ProcessConfig.configVersion`, so `getProcessDefinition` returns
+  // `null` and the entire validator block below silently no-ops. Fixing it
+  // (use `getLatestWorkflowVersion` + look up by that version) is intentionally
+  // deferred — flipping validation on under a refactor banner risks rejecting
+  // configs that have been quietly persisted for months.
   const definition = await deps.processRepo.getProcessDefinition(
     input.processName,
     input.stepConfigs[0]?.stepId ? 'latest' : 'latest',

--- a/packages/platform-api/src/handlers/cron/__tests__/heartbeat.test.ts
+++ b/packages/platform-api/src/handlers/cron/__tests__/heartbeat.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  InMemoryProcessRepository,
+  InMemoryCronTriggerStateRepository,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { heartbeat, type CronScheduleValidator, type CronTriggerLike } from '../heartbeat.js';
+
+function makeValidator(isDueReturn: boolean): CronScheduleValidator {
+  return {
+    validateCronSchedule: () => ({ valid: true }),
+    isDue: () => isDueReturn,
+  };
+}
+
+function makeDef(overrides: Partial<{ cron: boolean; schedule?: string }> = {}) {
+  const { cron = true, schedule = '*/5 * * * *' } = overrides;
+  return {
+    name: 'wf-a',
+    version: 1,
+    namespace: 'handle',
+    steps: [{ id: 'a', name: 'A', type: 'creation' as const }],
+    transitions: [],
+    variables: [],
+    triggers: cron
+      ? [{ name: 'every-5', type: 'cron' as const, schedule }]
+      : [{ name: 'manual', type: 'manual' as const }],
+    permissions: { roles: [] },
+    metadata: { description: '' },
+    createdAt: '2026-04-01T00:00:00.000Z',
+  };
+}
+
+describe('heartbeat handler', () => {
+  let processRepo: InMemoryProcessRepository;
+  let cronTriggerStateRepo: InMemoryCronTriggerStateRepository;
+  let cronTrigger: CronTriggerLike & { fireWorkflow: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    resetFactorySequence();
+    processRepo = new InMemoryProcessRepository();
+    cronTriggerStateRepo = new InMemoryCronTriggerStateRepository();
+    cronTrigger = {
+      fireWorkflow: vi.fn().mockResolvedValue({
+        instanceId: 'inst-new',
+        status: 'created',
+      }),
+    };
+  });
+
+  it('fires a due cron trigger and returns the triggered entry', async () => {
+    await processRepo.saveWorkflowDefinition(makeDef() as never);
+
+    const result = await heartbeat(
+      {},
+      {
+        processRepo,
+        cronTrigger,
+        cronTriggerStateRepo,
+        scheduleValidator: makeValidator(true),
+      },
+    );
+
+    expect(result.triggered).toHaveLength(1);
+    expect(result.triggered[0]?.instanceId).toBe('inst-new');
+    expect(cronTrigger.fireWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists trigger state after a successful fire', async () => {
+    await processRepo.saveWorkflowDefinition(makeDef() as never);
+
+    await heartbeat(
+      {},
+      {
+        processRepo,
+        cronTrigger,
+        cronTriggerStateRepo,
+        scheduleValidator: makeValidator(true),
+      },
+    );
+
+    const state = await cronTriggerStateRepo.get('wf-a', 'every-5');
+    expect(state).not.toBeNull();
+  });
+
+  it('skips when the schedule is not due', async () => {
+    await processRepo.saveWorkflowDefinition(makeDef() as never);
+
+    const result = await heartbeat(
+      {},
+      {
+        processRepo,
+        cronTrigger,
+        cronTriggerStateRepo,
+        scheduleValidator: makeValidator(false),
+      },
+    );
+
+    expect(result.triggered).toHaveLength(0);
+    expect(result.skipped[0]?.reason).toBe('Not due');
+  });
+
+  it('skips when schedule is invalid', async () => {
+    await processRepo.saveWorkflowDefinition(makeDef() as never);
+
+    const result = await heartbeat(
+      {},
+      {
+        processRepo,
+        cronTrigger,
+        cronTriggerStateRepo,
+        scheduleValidator: {
+          validateCronSchedule: () => ({ valid: false, error: 'bad cron' }),
+          isDue: () => true,
+        },
+      },
+    );
+
+    expect(result.triggered).toHaveLength(0);
+    expect(result.skipped[0]?.reason).toContain('Invalid schedule');
+  });
+
+  it('calls triggerRun when provided', async () => {
+    await processRepo.saveWorkflowDefinition(makeDef() as never);
+    const triggerRun = vi.fn();
+
+    await heartbeat(
+      {},
+      {
+        processRepo,
+        cronTrigger,
+        cronTriggerStateRepo,
+        scheduleValidator: makeValidator(true),
+        triggerRun,
+      },
+    );
+
+    expect(triggerRun).toHaveBeenCalledWith('inst-new', 'cron-heartbeat');
+  });
+
+  it('ignores definitions without cron triggers', async () => {
+    await processRepo.saveWorkflowDefinition(makeDef({ cron: false }) as never);
+
+    const result = await heartbeat(
+      {},
+      {
+        processRepo,
+        cronTrigger,
+        cronTriggerStateRepo,
+        scheduleValidator: makeValidator(true),
+      },
+    );
+
+    expect(result.triggered).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+  });
+});

--- a/packages/platform-api/src/handlers/cron/heartbeat.ts
+++ b/packages/platform-api/src/handlers/cron/heartbeat.ts
@@ -1,0 +1,132 @@
+import type {
+  CronTriggerStateRepository,
+  ProcessRepository,
+  Trigger,
+  WorkflowDefinition,
+} from '@mediforce/platform-core';
+import type { HeartbeatInput, HeartbeatOutput } from '../../contract/cron.js';
+import type { TriggerRun } from '../tasks/complete-task.js';
+
+export interface CronTriggerLike {
+  fireWorkflow(context: {
+    definitionName: string;
+    definitionVersion: number;
+    triggerName: string;
+    triggeredBy: string;
+    payload: Record<string, unknown>;
+  }): Promise<{ instanceId: string; status: string }>;
+}
+
+export interface CronScheduleValidator {
+  validateCronSchedule(schedule: string): { valid: boolean; error?: string };
+  isDue(schedule: string, now: Date, lastTriggeredAt: Date | undefined): boolean;
+}
+
+export interface HeartbeatDeps {
+  processRepo: Pick<ProcessRepository, 'listWorkflowDefinitions'>;
+  cronTrigger: CronTriggerLike;
+  cronTriggerStateRepo: CronTriggerStateRepository;
+  scheduleValidator: CronScheduleValidator;
+  now?: () => Date;
+  triggerRun?: TriggerRun;
+}
+
+/**
+ * Pure handler for `POST /api/cron/heartbeat`. Walks the latest version of
+ * every non-archived workflow definition, inspects its cron triggers, and
+ * fires each one that's due. State is persisted after a successful fire so
+ * we get at-least-once semantics (duplicate fires are possible under
+ * overlapping heartbeats — see the route-level note).
+ */
+export async function heartbeat(
+  _input: HeartbeatInput,
+  deps: HeartbeatDeps,
+): Promise<HeartbeatOutput> {
+  const now = (deps.now ?? (() => new Date()))();
+  const triggered: HeartbeatOutput['triggered'] = [];
+  const skipped: HeartbeatOutput['skipped'] = [];
+
+  const { definitions: definitionGroups } =
+    await deps.processRepo.listWorkflowDefinitions();
+
+  const cronDefinitions = definitionGroups
+    .map((group) => group.versions.find((v) => v.version === group.latestVersion))
+    .filter((def): def is WorkflowDefinition => def !== undefined)
+    .filter(
+      (def) =>
+        def.archived !== true &&
+        def.triggers.some((t: Trigger) => t.type === 'cron'),
+    );
+
+  for (const def of cronDefinitions) {
+    const cronTriggers = def.triggers.filter((t: Trigger) => t.type === 'cron');
+
+    for (const trigger of cronTriggers) {
+      const schedule = trigger.schedule;
+      if (schedule === undefined) {
+        skipped.push({
+          definitionName: def.name,
+          definitionVersion: def.version,
+          triggerName: trigger.name,
+          reason: 'No schedule defined',
+        });
+        continue;
+      }
+
+      const validation = deps.scheduleValidator.validateCronSchedule(schedule);
+      if (!validation.valid) {
+        skipped.push({
+          definitionName: def.name,
+          definitionVersion: def.version,
+          triggerName: trigger.name,
+          reason: `Invalid schedule: ${validation.error ?? 'unknown'}`,
+        });
+        continue;
+      }
+
+      const state = await deps.cronTriggerStateRepo.get(def.name, trigger.name);
+      const lastTriggeredAt = state !== null
+        ? new Date(state.lastTriggeredAt)
+        : def.createdAt !== undefined
+          ? new Date(def.createdAt)
+          : undefined;
+
+      if (!deps.scheduleValidator.isDue(schedule, now, lastTriggeredAt)) {
+        skipped.push({
+          definitionName: def.name,
+          definitionVersion: def.version,
+          triggerName: trigger.name,
+          reason: 'Not due',
+        });
+        continue;
+      }
+
+      const result = await deps.cronTrigger.fireWorkflow({
+        definitionName: def.name,
+        definitionVersion: def.version,
+        triggerName: trigger.name,
+        triggeredBy: 'cron-heartbeat',
+        payload: { schedule, firedAt: now.toISOString() },
+      });
+
+      await deps.cronTriggerStateRepo.set({
+        definitionName: def.name,
+        triggerName: trigger.name,
+        lastTriggeredAt: now.toISOString(),
+      });
+
+      if (deps.triggerRun !== undefined) {
+        deps.triggerRun(result.instanceId, 'cron-heartbeat');
+      }
+
+      triggered.push({
+        definitionName: def.name,
+        definitionVersion: def.version,
+        triggerName: trigger.name,
+        instanceId: result.instanceId,
+      });
+    }
+  }
+
+  return { triggered, skipped };
+}

--- a/packages/platform-api/src/handlers/definitions/__tests__/create-agent-definition.test.ts
+++ b/packages/platform-api/src/handlers/definitions/__tests__/create-agent-definition.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryAgentDefinitionRepository,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { createAgentDefinition } from '../create-agent-definition.js';
+import type { CreateAgentDefinitionInput } from '@mediforce/platform-core';
+
+const BASE_INPUT: CreateAgentDefinitionInput = {
+  kind: 'plugin',
+  runtimeId: 'claude-code-agent',
+  name: 'Supplier risk agent',
+  iconName: 'Shield',
+  description: 'Assesses supplier risk',
+  foundationModel: 'anthropic/claude-sonnet-4',
+  systemPrompt: 'You are a risk analyst.',
+  inputDescription: 'Supplier snapshot',
+  outputDescription: 'Risk verdict',
+  skillFileNames: [],
+};
+
+describe('createAgentDefinition handler', () => {
+  let agentDefinitionRepo: InMemoryAgentDefinitionRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    agentDefinitionRepo = new InMemoryAgentDefinitionRepository();
+  });
+
+  it('persists and returns the newly created agent', async () => {
+    const result = await createAgentDefinition(BASE_INPUT, { agentDefinitionRepo });
+
+    expect(result.agent.name).toBe('Supplier risk agent');
+    expect(result.agent.id).toBeTruthy();
+
+    const fetched = await agentDefinitionRepo.getById(result.agent.id);
+    expect(fetched).not.toBeNull();
+  });
+});

--- a/packages/platform-api/src/handlers/definitions/__tests__/create-agent-definition.test.ts
+++ b/packages/platform-api/src/handlers/definitions/__tests__/create-agent-definition.test.ts
@@ -36,4 +36,35 @@ describe('createAgentDefinition handler', () => {
     const fetched = await agentDefinitionRepo.getById(result.agent.id);
     expect(fetched).not.toBeNull();
   });
+
+  it('assigns a unique id to each created agent', async () => {
+    const first = await createAgentDefinition(BASE_INPUT, { agentDefinitionRepo });
+    const second = await createAgentDefinition(
+      { ...BASE_INPUT, name: 'Other agent' },
+      { agentDefinitionRepo },
+    );
+
+    expect(first.agent.id).not.toBe(second.agent.id);
+  });
+
+  it('echoes the cowork kind when supplied', async () => {
+    const result = await createAgentDefinition(
+      { ...BASE_INPUT, kind: 'cowork', runtimeId: 'chat' },
+      { agentDefinitionRepo },
+    );
+
+    expect(result.agent.kind).toBe('cowork');
+    expect(result.agent.runtimeId).toBe('chat');
+  });
+
+  it('propagates repository errors instead of swallowing them', async () => {
+    const failingRepo: typeof agentDefinitionRepo = Object.create(agentDefinitionRepo);
+    failingRepo.create = async () => {
+      throw new Error('firestore unavailable');
+    };
+
+    await expect(
+      createAgentDefinition(BASE_INPUT, { agentDefinitionRepo: failingRepo }),
+    ).rejects.toThrow('firestore unavailable');
+  });
 });

--- a/packages/platform-api/src/handlers/definitions/__tests__/create-workflow-definition.test.ts
+++ b/packages/platform-api/src/handlers/definitions/__tests__/create-workflow-definition.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryProcessRepository,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { createWorkflowDefinition } from '../create-workflow-definition.js';
+
+function draft(name: string): Record<string, unknown> {
+  return {
+    name,
+    namespace: 'handle',
+    steps: [],
+    transitions: [],
+    variables: [],
+    triggers: [],
+    permissions: { roles: [] },
+    metadata: { description: 'test' },
+  };
+}
+
+describe('createWorkflowDefinition handler', () => {
+  let processRepo: InMemoryProcessRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    processRepo = new InMemoryProcessRepository();
+  });
+
+  it('starts at version 1 for a brand-new workflow', async () => {
+    const result = await createWorkflowDefinition(
+      { namespace: 'handle', draft: draft('wf-a') as never },
+      { processRepo },
+    );
+
+    expect(result).toEqual({ success: true, name: 'wf-a', version: 1 });
+
+    const stored = await processRepo.getWorkflowDefinition('wf-a', 1);
+    expect(stored).not.toBeNull();
+    expect(stored?.namespace).toBe('handle');
+  });
+
+  it('increments from the highest existing version', async () => {
+    await processRepo.saveWorkflowDefinition(
+      { ...draft('wf-a'), version: 3, createdAt: 'x' } as never,
+    );
+    await processRepo.saveWorkflowDefinition(
+      { ...draft('wf-a'), version: 5, createdAt: 'x' } as never,
+    );
+
+    const result = await createWorkflowDefinition(
+      { namespace: 'handle', draft: draft('wf-a') as never },
+      { processRepo },
+    );
+
+    expect(result.version).toBe(6);
+  });
+
+  it('query-param namespace overrides any namespace in the body', async () => {
+    const result = await createWorkflowDefinition(
+      {
+        namespace: 'handle',
+        draft: { ...draft('wf-a'), namespace: 'ignored' } as never,
+      },
+      { processRepo },
+    );
+    const stored = await processRepo.getWorkflowDefinition('wf-a', result.version);
+    expect(stored?.namespace).toBe('handle');
+  });
+});

--- a/packages/platform-api/src/handlers/definitions/__tests__/upsert-legacy-definition.test.ts
+++ b/packages/platform-api/src/handlers/definitions/__tests__/upsert-legacy-definition.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryProcessRepository,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { upsertLegacyDefinition } from '../upsert-legacy-definition.js';
+import { ConflictError, ValidationError } from '../../../errors.js';
+
+const VALID_YAML = `
+name: supplier-review
+version: "1.0"
+description: demo
+steps:
+  - id: intake
+    name: Intake
+    type: creation
+  - id: review
+    name: Review
+    type: review
+  - id: done
+    name: Done
+    type: terminal
+transitions:
+  - from: intake
+    to: review
+  - from: review
+    to: done
+triggers:
+  - name: manual
+    type: manual
+`.trim();
+
+describe('upsertLegacyDefinition handler', () => {
+  let processRepo: InMemoryProcessRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    processRepo = new InMemoryProcessRepository();
+  });
+
+  it('persists the definition and returns name/version on success', async () => {
+    const result = await upsertLegacyDefinition({ yaml: VALID_YAML }, { processRepo });
+
+    expect(result).toEqual({
+      success: true,
+      name: 'supplier-review',
+      version: '1.0',
+    });
+    const stored = await processRepo.getProcessDefinition('supplier-review', '1.0');
+    expect(stored).not.toBeNull();
+  });
+
+  it('auto-creates an all-human config when none exists', async () => {
+    await upsertLegacyDefinition({ yaml: VALID_YAML }, { processRepo });
+
+    const config = await processRepo.getProcessConfig(
+      'supplier-review',
+      'all-human',
+      '1.0',
+    );
+    expect(config).not.toBeNull();
+    expect(config?.stepConfigs.every((s) => s.executorType === 'human')).toBe(true);
+    // 'terminal' steps omitted
+    expect(config?.stepConfigs.find((s) => s.stepId === 'done')).toBeUndefined();
+  });
+
+  it('throws ValidationError when YAML is malformed', async () => {
+    await expect(
+      upsertLegacyDefinition({ yaml: '::::not-yaml' }, { processRepo }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('maps DefinitionVersionAlreadyExistsError to ConflictError', async () => {
+    const failing: InMemoryProcessRepository = Object.create(processRepo);
+    failing.saveProcessDefinition = async () => {
+      const err = new Error('already exists');
+      err.name = 'DefinitionVersionAlreadyExistsError';
+      throw err;
+    };
+
+    await expect(
+      upsertLegacyDefinition({ yaml: VALID_YAML }, { processRepo: failing }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/packages/platform-api/src/handlers/definitions/create-agent-definition.ts
+++ b/packages/platform-api/src/handlers/definitions/create-agent-definition.ts
@@ -1,0 +1,23 @@
+import type {
+  AgentDefinitionRepository,
+  CreateAgentDefinitionInput,
+} from '@mediforce/platform-core';
+import type { CreateAgentDefinitionOutput } from '../../contract/definitions.js';
+
+export interface CreateAgentDefinitionDeps {
+  agentDefinitionRepo: AgentDefinitionRepository;
+}
+
+/**
+ * Pure handler for `POST /api/agent-definitions`.
+ * Input shape is the existing `CreateAgentDefinitionInputSchema` from
+ * platform-core — the contract re-exports it under
+ * `CreateAgentDefinitionInputContractSchema`.
+ */
+export async function createAgentDefinition(
+  input: CreateAgentDefinitionInput,
+  deps: CreateAgentDefinitionDeps,
+): Promise<CreateAgentDefinitionOutput> {
+  const agent = await deps.agentDefinitionRepo.create(input);
+  return { agent };
+}

--- a/packages/platform-api/src/handlers/definitions/create-agent-definition.ts
+++ b/packages/platform-api/src/handlers/definitions/create-agent-definition.ts
@@ -10,9 +10,8 @@ export interface CreateAgentDefinitionDeps {
 
 /**
  * Pure handler for `POST /api/agent-definitions`.
- * Input shape is the existing `CreateAgentDefinitionInputSchema` from
- * platform-core — the contract re-exports it under
- * `CreateAgentDefinitionInputContractSchema`.
+ * Input shape is `CreateAgentDefinitionInputSchema` from platform-core
+ * (re-exported via `@mediforce/platform-api/contract`).
  */
 export async function createAgentDefinition(
   input: CreateAgentDefinitionInput,

--- a/packages/platform-api/src/handlers/definitions/create-workflow-definition.ts
+++ b/packages/platform-api/src/handlers/definitions/create-workflow-definition.ts
@@ -1,0 +1,49 @@
+import type { ProcessRepository } from '@mediforce/platform-core';
+import type {
+  CreateWorkflowDefinitionInput,
+  CreateWorkflowDefinitionOutput,
+} from '../../contract/definitions.js';
+import { ConflictError } from '../../errors.js';
+
+export interface CreateWorkflowDefinitionDeps {
+  processRepo: ProcessRepository;
+}
+
+/**
+ * Pure handler for `POST /api/workflow-definitions`.
+ *
+ * Auto-increments `version` based on the latest version persisted for the
+ * workflow `name`. `namespace` is required by the contract and overrides
+ * any namespace embedded in the draft body — preserves pre-migration
+ * semantics where the query param won.
+ */
+export async function createWorkflowDefinition(
+  input: CreateWorkflowDefinitionInput,
+  deps: CreateWorkflowDefinitionDeps,
+): Promise<CreateWorkflowDefinitionOutput> {
+  const latestVersion = await deps.processRepo.getLatestWorkflowVersion(
+    input.draft.name,
+  );
+  const nextVersion = latestVersion + 1;
+
+  const definition = {
+    ...input.draft,
+    namespace: input.namespace,
+    version: nextVersion,
+    createdAt: new Date().toISOString(),
+  };
+
+  try {
+    await deps.processRepo.saveWorkflowDefinition(definition);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.name === 'WorkflowDefinitionVersionAlreadyExistsError'
+    ) {
+      throw new ConflictError('Version conflict — please retry.');
+    }
+    throw err;
+  }
+
+  return { success: true, name: definition.name, version: definition.version };
+}

--- a/packages/platform-api/src/handlers/definitions/upsert-legacy-definition.ts
+++ b/packages/platform-api/src/handlers/definitions/upsert-legacy-definition.ts
@@ -1,0 +1,77 @@
+import {
+  parseProcessDefinition,
+  type ProcessConfig,
+  type ProcessRepository,
+} from '@mediforce/platform-core';
+import type {
+  UpsertLegacyDefinitionInput,
+  UpsertLegacyDefinitionOutput,
+} from '../../contract/definitions.js';
+import { ConflictError, ValidationError } from '../../errors.js';
+
+export interface UpsertLegacyDefinitionDeps {
+  processRepo: ProcessRepository;
+}
+
+/**
+ * Name-based check used to recognise the infra layer's
+ * `DefinitionVersionAlreadyExistsError` and `ConfigVersionAlreadyExistsError`
+ * without importing `@mediforce/platform-infra` here — handlers stay pure.
+ */
+function isAlreadyExistsError(err: unknown, name: string): boolean {
+  return err instanceof Error && err.name === name;
+}
+
+/**
+ * Pure handler for `PUT /api/definitions`.
+ *
+ * Parses the incoming YAML, persists the legacy `ProcessDefinition`, and
+ * auto-seeds an "all-human" `ProcessConfig` for the same version when one
+ * doesn't already exist. Preserves pre-migration semantics 1:1.
+ */
+export async function upsertLegacyDefinition(
+  input: UpsertLegacyDefinitionInput,
+  deps: UpsertLegacyDefinitionDeps,
+): Promise<UpsertLegacyDefinitionOutput> {
+  const result = parseProcessDefinition(input.yaml);
+  if (!result.success) {
+    throw new ValidationError(result.error);
+  }
+
+  const definition = result.data;
+
+  try {
+    await deps.processRepo.saveProcessDefinition(definition);
+  } catch (err) {
+    if (isAlreadyExistsError(err, 'DefinitionVersionAlreadyExistsError')) {
+      throw new ConflictError((err as Error).message);
+    }
+    throw err;
+  }
+
+  const allHumanVersion = definition.version;
+  const existing = await deps.processRepo.getProcessConfig(
+    definition.name,
+    'all-human',
+    allHumanVersion,
+  );
+  if (existing === null) {
+    const allHumanConfig: ProcessConfig = {
+      processName: definition.name,
+      configName: 'all-human',
+      configVersion: allHumanVersion,
+      stepConfigs: definition.steps
+        .filter((s) => s.type !== 'terminal')
+        .map((s) => ({ stepId: s.id, executorType: 'human' as const })),
+    };
+    try {
+      await deps.processRepo.saveProcessConfig(allHumanConfig);
+    } catch (configErr) {
+      if (!isAlreadyExistsError(configErr, 'ConfigVersionAlreadyExistsError')) {
+        throw configErr;
+      }
+    }
+  }
+
+  return { success: true, name: definition.name, version: definition.version };
+}

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -1,5 +1,12 @@
 export { listTasks, type ListTasksDeps } from './tasks/list-tasks.js';
 export { getTask, type GetTaskDeps } from './tasks/get-task.js';
+export { claimTask, type ClaimTaskDeps } from './tasks/claim-task.js';
+export {
+  completeTask,
+  type CompleteTaskDeps,
+  type TriggerRun,
+} from './tasks/complete-task.js';
+export { resolveTask, type ResolveTaskDeps } from './tasks/resolve-task.js';
 export { getProcess, type GetProcessDeps } from './processes/get-process.js';
 export {
   listAuditEvents,
@@ -42,4 +49,10 @@ export {
 // Typed errors a handler may throw — re-exported here so the route adapter
 // (the one place that imports `@mediforce/platform-api/handlers`) has a
 // single import surface for both behaviour and error mapping.
-export { HandlerError, NotFoundError } from '../errors.js';
+export {
+  HandlerError,
+  NotFoundError,
+  ConflictError,
+  ForbiddenError,
+  ValidationError,
+} from '../errors.js';

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -42,6 +42,18 @@ export {
   type GetAgentDefinitionDeps,
 } from './definitions/get-agent-definition.js';
 export {
+  upsertLegacyDefinition,
+  type UpsertLegacyDefinitionDeps,
+} from './definitions/upsert-legacy-definition.js';
+export {
+  createWorkflowDefinition,
+  type CreateWorkflowDefinitionDeps,
+} from './definitions/create-workflow-definition.js';
+export {
+  createAgentDefinition,
+  type CreateAgentDefinitionDeps,
+} from './definitions/create-agent-definition.js';
+export {
   getCoworkSession,
   type GetCoworkSessionDeps,
 } from './cowork/get-cowork-session.js';

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -66,10 +66,20 @@ export {
   type ListProcessConfigsDeps,
 } from './configs/list-process-configs.js';
 export {
+  createProcessConfig,
+  type CreateProcessConfigDeps,
+} from './configs/create-process-config.js';
+export {
   listPlugins,
   type ListPluginsDeps,
   type PluginRegistryView,
 } from './plugins/list-plugins.js';
+export {
+  heartbeat,
+  type HeartbeatDeps,
+  type CronTriggerLike,
+  type CronScheduleValidator,
+} from './cron/heartbeat.js';
 
 // Typed errors a handler may throw — re-exported here so the route adapter
 // (the one place that imports `@mediforce/platform-api/handlers`) has a

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -17,6 +17,19 @@ export {
   type GetProcessStepsDeps,
 } from './processes/get-process-steps.js';
 export {
+  createProcess,
+  type CreateProcessDeps,
+  type ManualTriggerLike,
+} from './processes/create-process.js';
+export {
+  cancelProcess,
+  type CancelProcessDeps,
+} from './processes/cancel-process.js';
+export {
+  resumeProcess,
+  type ResumeProcessDeps,
+} from './processes/resume-process.js';
+export {
   listWorkflowDefinitions,
   type ListWorkflowDefinitionsDeps,
 } from './definitions/list-workflow-definitions.js';

--- a/packages/platform-api/src/handlers/processes/__tests__/cancel-process.test.ts
+++ b/packages/platform-api/src/handlers/processes/__tests__/cancel-process.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryProcessInstanceRepository,
+  buildProcessInstance,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { cancelProcess } from '../cancel-process.js';
+import { ConflictError, NotFoundError } from '../../../errors.js';
+
+describe('cancelProcess handler', () => {
+  let instanceRepo: InMemoryProcessInstanceRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    instanceRepo = new InMemoryProcessInstanceRepository();
+  });
+
+  it('transitions running → failed with cancellation reason', async () => {
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', status: 'running' }));
+
+    const result = await cancelProcess({ instanceId: 'inst-a' }, { instanceRepo });
+
+    expect(result).toEqual({ instanceId: 'inst-a', status: 'failed' });
+
+    const updated = await instanceRepo.getById('inst-a');
+    expect(updated?.status).toBe('failed');
+    expect(updated?.error).toBe('Cancelled by user');
+  });
+
+  it('transitions paused → failed', async () => {
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', status: 'paused' }));
+
+    const result = await cancelProcess({ instanceId: 'inst-a' }, { instanceRepo });
+
+    expect(result.status).toBe('failed');
+  });
+
+  it('throws NotFoundError when instance does not exist', async () => {
+    await expect(
+      cancelProcess({ instanceId: 'missing' }, { instanceRepo }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws ConflictError when instance is already completed', async () => {
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', status: 'completed' }));
+
+    await expect(
+      cancelProcess({ instanceId: 'inst-a' }, { instanceRepo }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it('throws ConflictError when instance is already failed', async () => {
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', status: 'failed' }));
+
+    await expect(
+      cancelProcess({ instanceId: 'inst-a' }, { instanceRepo }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/packages/platform-api/src/handlers/processes/__tests__/create-process.test.ts
+++ b/packages/platform-api/src/handlers/processes/__tests__/create-process.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  InMemoryProcessRepository,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { createProcess } from '../create-process.js';
+import { NotFoundError } from '../../../errors.js';
+import type { ManualTriggerLike } from '../create-process.js';
+
+function stubTrigger(
+  result = { instanceId: 'inst-new', status: 'created' as const },
+): ManualTriggerLike & { fireWorkflow: ReturnType<typeof vi.fn> } {
+  return {
+    fireWorkflow: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe('createProcess handler', () => {
+  let processRepo: InMemoryProcessRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    processRepo = new InMemoryProcessRepository();
+  });
+
+  it('starts a process at the requested version and returns the instance id', async () => {
+    const manualTrigger = stubTrigger();
+
+    const result = await createProcess(
+      {
+        definitionName: 'wf-a',
+        definitionVersion: 3,
+        triggeredBy: 'alice',
+      },
+      { manualTrigger, processRepo },
+    );
+
+    expect(result.instanceId).toBe('inst-new');
+    expect(manualTrigger.fireWorkflow).toHaveBeenCalledWith({
+      definitionName: 'wf-a',
+      definitionVersion: 3,
+      triggerName: 'manual',
+      triggeredBy: 'alice',
+      payload: {},
+    });
+  });
+
+  it('falls back to the latest version when none provided', async () => {
+    await processRepo.saveWorkflowDefinition({
+      name: 'wf-a',
+      version: 7,
+      steps: [],
+      transitions: [],
+      variables: [],
+      triggers: [],
+      permissions: { roles: [] },
+      metadata: { description: 'wf-a' },
+    } as never);
+
+    const manualTrigger = stubTrigger();
+    await createProcess(
+      { definitionName: 'wf-a', triggeredBy: 'alice' },
+      { manualTrigger, processRepo },
+    );
+
+    expect(manualTrigger.fireWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ definitionVersion: 7 }),
+    );
+  });
+
+  it('throws NotFoundError when no workflow versions exist and none was provided', async () => {
+    await expect(
+      createProcess(
+        { definitionName: 'wf-missing', triggeredBy: 'alice' },
+        { manualTrigger: stubTrigger(), processRepo },
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('fires triggerRun after the instance is created when provided', async () => {
+    const triggerRun = vi.fn();
+    await createProcess(
+      { definitionName: 'wf-a', definitionVersion: 1, triggeredBy: 'alice' },
+      { manualTrigger: stubTrigger(), processRepo, triggerRun },
+    );
+    expect(triggerRun).toHaveBeenCalledWith('inst-new', 'alice');
+  });
+});

--- a/packages/platform-api/src/handlers/processes/__tests__/resume-process.test.ts
+++ b/packages/platform-api/src/handlers/processes/__tests__/resume-process.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  InMemoryProcessInstanceRepository,
+  InMemoryAuditRepository,
+  buildProcessInstance,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { resumeProcess } from '../resume-process.js';
+import { ConflictError, NotFoundError } from '../../../errors.js';
+
+describe('resumeProcess handler', () => {
+  let instanceRepo: InMemoryProcessInstanceRepository;
+  let auditRepo: InMemoryAuditRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    instanceRepo = new InMemoryProcessInstanceRepository();
+    auditRepo = new InMemoryAuditRepository();
+  });
+
+  it('moves paused → running and returns ok', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'inst-a', status: 'paused', pauseReason: 'wait_for_escalation' }),
+    );
+
+    const result = await resumeProcess(
+      { instanceId: 'inst-a' },
+      { instanceRepo, auditRepo },
+    );
+
+    expect(result).toEqual({ ok: true, instanceId: 'inst-a', status: 'running' });
+    const updated = await instanceRepo.getById('inst-a');
+    expect(updated?.status).toBe('running');
+    expect(updated?.pauseReason).toBeNull();
+  });
+
+  it('writes a process.resumed audit event', async () => {
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', status: 'paused' }));
+
+    await resumeProcess({ instanceId: 'inst-a' }, { instanceRepo, auditRepo });
+
+    const events = auditRepo.getAll();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe('process.resumed');
+  });
+
+  it('calls triggerRun when provided', async () => {
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', status: 'paused' }));
+    const triggerRun = vi.fn();
+
+    await resumeProcess(
+      { instanceId: 'inst-a' },
+      { instanceRepo, auditRepo, triggerRun },
+    );
+
+    expect(triggerRun).toHaveBeenCalledWith('inst-a', 'api-user');
+  });
+
+  it('throws NotFoundError when instance missing', async () => {
+    await expect(
+      resumeProcess({ instanceId: 'missing' }, { instanceRepo, auditRepo }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws ConflictError when instance is not paused', async () => {
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', status: 'running' }));
+
+    await expect(
+      resumeProcess({ instanceId: 'inst-a' }, { instanceRepo, auditRepo }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/packages/platform-api/src/handlers/processes/cancel-process.ts
+++ b/packages/platform-api/src/handlers/processes/cancel-process.ts
@@ -1,0 +1,38 @@
+import type { ProcessInstanceRepository } from '@mediforce/platform-core';
+import type {
+  CancelProcessInput,
+  CancelProcessOutput,
+} from '../../contract/processes.js';
+import { ConflictError, NotFoundError } from '../../errors.js';
+
+export interface CancelProcessDeps {
+  instanceRepo: ProcessInstanceRepository;
+}
+
+/**
+ * Pure handler: mark a `running` or `paused` instance as `failed` with the
+ * reason `'Cancelled by user'`. Any other starting status surfaces as 409.
+ * No audit event written today — preserves pre-migration behaviour.
+ */
+export async function cancelProcess(
+  input: CancelProcessInput,
+  deps: CancelProcessDeps,
+): Promise<CancelProcessOutput> {
+  const instance = await deps.instanceRepo.getById(input.instanceId);
+  if (instance === null) {
+    throw new NotFoundError(`Instance ${input.instanceId} not found`);
+  }
+  if (instance.status !== 'running' && instance.status !== 'paused') {
+    throw new ConflictError(
+      `Cannot cancel instance in status '${instance.status}'`,
+    );
+  }
+
+  await deps.instanceRepo.update(input.instanceId, {
+    status: 'failed',
+    error: 'Cancelled by user',
+    updatedAt: new Date().toISOString(),
+  });
+
+  return { instanceId: input.instanceId, status: 'failed' };
+}

--- a/packages/platform-api/src/handlers/processes/create-process.ts
+++ b/packages/platform-api/src/handlers/processes/create-process.ts
@@ -1,0 +1,66 @@
+import type { ProcessRepository } from '@mediforce/platform-core';
+import type {
+  CreateProcessInput,
+  CreateProcessOutput,
+} from '../../contract/processes.js';
+import { NotFoundError } from '../../errors.js';
+import type { TriggerRun } from '../tasks/complete-task.js';
+
+export interface ManualTriggerLike {
+  fireWorkflow(context: {
+    definitionName: string;
+    definitionVersion: number;
+    triggerName: string;
+    triggeredBy: string;
+    payload: Record<string, unknown>;
+  }): Promise<{ instanceId: string; status: 'created' }>;
+}
+
+export interface CreateProcessDeps {
+  manualTrigger: ManualTriggerLike;
+  processRepo: Pick<ProcessRepository, 'getLatestWorkflowVersion'>;
+  triggerRun?: TriggerRun;
+}
+
+/**
+ * Pure handler: start a new process instance.
+ *
+ * When `definitionVersion` is omitted the handler resolves the latest version
+ * published for the workflow; a workflow with no versions throws
+ * `NotFoundError` (maps to 404).
+ *
+ * The optional `triggerRun` dep is invoked after the instance is created so
+ * the auto-runner can pick up agent steps. The handler itself does not wait
+ * on it — it's fire-and-forget semantics preserved from the inline route.
+ */
+export async function createProcess(
+  input: CreateProcessInput,
+  deps: CreateProcessDeps,
+): Promise<CreateProcessOutput> {
+  let version = input.definitionVersion;
+  if (version === undefined) {
+    version = await deps.processRepo.getLatestWorkflowVersion(input.definitionName);
+    if (version === 0) {
+      throw new NotFoundError(
+        `No workflow definition found for '${input.definitionName}'`,
+      );
+    }
+  }
+
+  const result = await deps.manualTrigger.fireWorkflow({
+    definitionName: input.definitionName,
+    definitionVersion: version,
+    triggerName: input.triggerName ?? 'manual',
+    triggeredBy: input.triggeredBy,
+    payload: input.payload ?? {},
+  });
+
+  if (deps.triggerRun !== undefined) {
+    deps.triggerRun(result.instanceId, input.triggeredBy);
+  }
+
+  return {
+    instanceId: result.instanceId,
+    status: result.status,
+  };
+}

--- a/packages/platform-api/src/handlers/processes/resume-process.ts
+++ b/packages/platform-api/src/handlers/processes/resume-process.ts
@@ -1,0 +1,65 @@
+import type {
+  AuditRepository,
+  ProcessInstanceRepository,
+} from '@mediforce/platform-core';
+import type {
+  ResumeProcessInput,
+  ResumeProcessOutput,
+} from '../../contract/processes.js';
+import { ConflictError, NotFoundError } from '../../errors.js';
+import type { TriggerRun } from '../tasks/complete-task.js';
+
+export interface ResumeProcessDeps {
+  instanceRepo: ProcessInstanceRepository;
+  auditRepo: AuditRepository;
+  triggerRun?: TriggerRun;
+}
+
+/**
+ * Pure handler: resume a `paused` instance. Any other status is a 409.
+ * Writes a `process.resumed` audit event and optionally kicks the
+ * auto-runner.
+ */
+export async function resumeProcess(
+  input: ResumeProcessInput,
+  deps: ResumeProcessDeps,
+): Promise<ResumeProcessOutput> {
+  const instance = await deps.instanceRepo.getById(input.instanceId);
+  if (instance === null) {
+    throw new NotFoundError(`Instance ${input.instanceId} not found`);
+  }
+  if (instance.status !== 'paused') {
+    throw new ConflictError(
+      `Instance is '${instance.status}', expected 'paused'`,
+    );
+  }
+
+  const now = new Date().toISOString();
+  await deps.instanceRepo.update(input.instanceId, {
+    status: 'running',
+    pauseReason: null,
+    error: null,
+    updatedAt: now,
+  });
+
+  await deps.auditRepo.append({
+    actorId: 'api-user',
+    actorType: 'user',
+    actorRole: 'operator',
+    action: 'process.resumed',
+    description: `Process '${input.instanceId}' manually resumed via API`,
+    timestamp: now,
+    inputSnapshot: { previousPauseReason: instance.pauseReason },
+    outputSnapshot: { status: 'running' },
+    basis: 'Manual resume via API',
+    entityType: 'processInstance',
+    entityId: input.instanceId,
+    processInstanceId: input.instanceId,
+  });
+
+  if (deps.triggerRun !== undefined) {
+    deps.triggerRun(input.instanceId, 'api-user');
+  }
+
+  return { ok: true, instanceId: input.instanceId, status: 'running' };
+}

--- a/packages/platform-api/src/handlers/tasks/__tests__/claim-task.test.ts
+++ b/packages/platform-api/src/handlers/tasks/__tests__/claim-task.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryHumanTaskRepository,
+  InMemoryAuditRepository,
+  buildHumanTask,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { claimTask } from '../claim-task.js';
+import { ConflictError, NotFoundError } from '../../../errors.js';
+
+describe('claimTask handler', () => {
+  let humanTaskRepo: InMemoryHumanTaskRepository;
+  let auditRepo: InMemoryAuditRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    humanTaskRepo = new InMemoryHumanTaskRepository();
+    auditRepo = new InMemoryAuditRepository();
+  });
+
+  it('claims a pending task and returns the claimed state', async () => {
+    await humanTaskRepo.create(
+      buildHumanTask({ id: 'task-1', status: 'pending', assignedUserId: null }),
+    );
+
+    const result = await claimTask(
+      { taskId: 'task-1', userId: 'alice' },
+      { humanTaskRepo, auditRepo },
+    );
+
+    expect(result.status).toBe('claimed');
+    expect(result.assignedUserId).toBe('alice');
+  });
+
+  it('defaults userId to "api-user" when not provided', async () => {
+    await humanTaskRepo.create(buildHumanTask({ id: 'task-1', status: 'pending' }));
+
+    const result = await claimTask({ taskId: 'task-1' }, { humanTaskRepo, auditRepo });
+
+    expect(result.assignedUserId).toBe('api-user');
+  });
+
+  it('writes a task.claimed audit event', async () => {
+    await humanTaskRepo.create(
+      buildHumanTask({ id: 'task-1', status: 'pending', processInstanceId: 'inst-a' }),
+    );
+
+    await claimTask({ taskId: 'task-1', userId: 'bob' }, { humanTaskRepo, auditRepo });
+
+    const events = auditRepo.getAll();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe('task.claimed');
+    expect(events[0]?.actorId).toBe('bob');
+    expect(events[0]?.processInstanceId).toBe('inst-a');
+  });
+
+  it('throws NotFoundError when task does not exist', async () => {
+    await expect(
+      claimTask({ taskId: 'missing' }, { humanTaskRepo, auditRepo }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws ConflictError when task is already claimed', async () => {
+    await humanTaskRepo.create(
+      buildHumanTask({ id: 'task-1', status: 'claimed', assignedUserId: 'earlier' }),
+    );
+
+    const err = await claimTask({ taskId: 'task-1' }, { humanTaskRepo, auditRepo }).catch(
+      (e) => e,
+    );
+
+    expect(err).toBeInstanceOf(ConflictError);
+    expect((err as ConflictError).statusCode).toBe(409);
+    expect((err as ConflictError).message).toContain('claimed');
+  });
+
+  it('throws ConflictError for completed and cancelled tasks', async () => {
+    await humanTaskRepo.create(buildHumanTask({ id: 'done', status: 'completed' }));
+    await humanTaskRepo.create(buildHumanTask({ id: 'xxl', status: 'cancelled' }));
+
+    await expect(
+      claimTask({ taskId: 'done' }, { humanTaskRepo, auditRepo }),
+    ).rejects.toBeInstanceOf(ConflictError);
+    await expect(
+      claimTask({ taskId: 'xxl' }, { humanTaskRepo, auditRepo }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/packages/platform-api/src/handlers/tasks/__tests__/complete-task.test.ts
+++ b/packages/platform-api/src/handlers/tasks/__tests__/complete-task.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import type { HumanTaskStatus, InstanceStatus } from '@mediforce/platform-core';
+import {
+  InMemoryHumanTaskRepository,
+  InMemoryAuditRepository,
+  InMemoryProcessInstanceRepository,
+  buildHumanTask,
+  buildProcessInstance,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { completeTask, type EngineLike } from '../complete-task.js';
+import { ConflictError, NotFoundError } from '../../../errors.js';
+
+type AdvanceStepFn = EngineLike['advanceStep'];
+
+describe('completeTask handler', () => {
+  let humanTaskRepo: InMemoryHumanTaskRepository;
+  let instanceRepo: InMemoryProcessInstanceRepository;
+  let auditRepo: InMemoryAuditRepository;
+  let advanceStep: ReturnType<typeof vi.fn<AdvanceStepFn>>;
+
+  beforeEach(async () => {
+    resetFactorySequence();
+    humanTaskRepo = new InMemoryHumanTaskRepository();
+    instanceRepo = new InMemoryProcessInstanceRepository();
+    auditRepo = new InMemoryAuditRepository();
+    advanceStep = vi.fn<AdvanceStepFn>().mockResolvedValue(undefined);
+  });
+
+  async function seed({
+    taskStatus = 'claimed' as HumanTaskStatus,
+    instanceStatus = 'paused' as InstanceStatus,
+    completionData = null as Record<string, unknown> | null,
+  } = {}) {
+    await humanTaskRepo.create(
+      buildHumanTask({
+        id: 'task-1',
+        status: taskStatus,
+        processInstanceId: 'inst-a',
+        assignedUserId: 'alice',
+        completionData,
+      }),
+    );
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'inst-a', status: instanceStatus }),
+    );
+  }
+
+  const deps = () => ({
+    humanTaskRepo,
+    instanceRepo,
+    auditRepo,
+    engine: { advanceStep },
+  });
+
+  it('completes a claimed task and returns the summary', async () => {
+    await seed();
+
+    const result = await completeTask(
+      { taskId: 'task-1', verdict: 'approve' },
+      deps(),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      taskId: 'task-1',
+      verdict: 'approve',
+      processInstanceId: 'inst-a',
+    });
+
+    const updated = await humanTaskRepo.getById('task-1');
+    expect(updated?.status).toBe('completed');
+  });
+
+  it('resumes the paused instance and advances the engine once', async () => {
+    await seed();
+
+    await completeTask(
+      { taskId: 'task-1', verdict: 'revise', comment: 'needs fix' },
+      deps(),
+    );
+
+    const instance = await instanceRepo.getById('inst-a');
+    expect(instance?.status).toBe('running');
+    expect(instance?.pauseReason).toBeNull();
+
+    expect(advanceStep).toHaveBeenCalledTimes(1);
+    expect(advanceStep).toHaveBeenCalledWith(
+      'inst-a',
+      expect.objectContaining({ verdict: 'revise', comment: 'needs fix' }),
+      { id: 'alice', role: 'human' },
+    );
+  });
+
+  it('forwards agent output into stepOutput for L3 review tasks', async () => {
+    await seed({
+      completionData: {
+        reviewType: 'agent_output_review',
+        agentOutput: { result: { verdict: 'auto-approve', score: 0.9 } },
+      },
+    });
+
+    await completeTask({ taskId: 'task-1', verdict: 'approve' }, deps());
+
+    const firstCallArgs = advanceStep.mock.calls[0];
+    expect(firstCallArgs?.[1]).toMatchObject({
+      verdict: 'approve',
+      agentOutput: { verdict: 'auto-approve', score: 0.9 },
+    });
+  });
+
+  it('writes task.completed and process.resumed_after_task audit events', async () => {
+    await seed();
+
+    await completeTask({ taskId: 'task-1', verdict: 'approve' }, deps());
+
+    const events = auditRepo.getAll();
+    const actions = events.map((e) => e.action);
+    expect(actions).toContain('task.completed');
+    expect(actions).toContain('process.resumed_after_task');
+  });
+
+  it('calls triggerRun when provided', async () => {
+    await seed();
+    const triggerRun = vi.fn();
+
+    await completeTask(
+      { taskId: 'task-1', verdict: 'approve' },
+      { ...deps(), triggerRun },
+    );
+
+    expect(triggerRun).toHaveBeenCalledWith('inst-a', 'alice');
+  });
+
+  it('throws NotFoundError when task is missing', async () => {
+    await expect(
+      completeTask({ taskId: 'missing', verdict: 'approve' }, deps()),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws ConflictError when task is not claimed', async () => {
+    await seed({ taskStatus: 'pending' });
+
+    await expect(
+      completeTask({ taskId: 'task-1', verdict: 'approve' }, deps()),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it('throws NotFoundError when process instance vanished', async () => {
+    await humanTaskRepo.create(
+      buildHumanTask({
+        id: 'orphan',
+        status: 'claimed',
+        processInstanceId: 'missing',
+        assignedUserId: 'alice',
+      }),
+    );
+
+    await expect(
+      completeTask({ taskId: 'orphan', verdict: 'approve' }, deps()),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws ConflictError when instance is not paused', async () => {
+    await seed({ instanceStatus: 'running' });
+
+    await expect(
+      completeTask({ taskId: 'task-1', verdict: 'approve' }, deps()),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});

--- a/packages/platform-api/src/handlers/tasks/__tests__/resolve-task.test.ts
+++ b/packages/platform-api/src/handlers/tasks/__tests__/resolve-task.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  InMemoryHumanTaskRepository,
+  InMemoryAuditRepository,
+  InMemoryProcessInstanceRepository,
+  buildHumanTask,
+  buildProcessInstance,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { resolveTask } from '../resolve-task.js';
+import type { EngineLike } from '../complete-task.js';
+import {
+  ConflictError,
+  HandlerError,
+  NotFoundError,
+  ValidationError,
+} from '../../../errors.js';
+
+type AdvanceStepFn = EngineLike['advanceStep'];
+
+describe('resolveTask handler', () => {
+  let humanTaskRepo: InMemoryHumanTaskRepository;
+  let instanceRepo: InMemoryProcessInstanceRepository;
+  let auditRepo: InMemoryAuditRepository;
+  let advanceStep: ReturnType<typeof vi.fn<AdvanceStepFn>>;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    humanTaskRepo = new InMemoryHumanTaskRepository();
+    instanceRepo = new InMemoryProcessInstanceRepository();
+    auditRepo = new InMemoryAuditRepository();
+    advanceStep = vi.fn<AdvanceStepFn>().mockResolvedValue(undefined);
+  });
+
+  const deps = () => ({
+    humanTaskRepo,
+    instanceRepo,
+    auditRepo,
+    engine: { advanceStep },
+  });
+
+  async function seedTaskAndInstance(
+    overrides: Partial<Parameters<typeof buildHumanTask>[0]> = {},
+  ): Promise<void> {
+    await humanTaskRepo.create(
+      buildHumanTask({
+        id: 'task-1',
+        processInstanceId: 'inst-a',
+        assignedUserId: 'alice',
+        status: 'claimed',
+        ...overrides,
+      }),
+    );
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'inst-a', status: 'paused', currentStepId: 'next-step' }),
+    );
+  }
+
+  it('resolves a verdict task and advances the engine', async () => {
+    await seedTaskAndInstance();
+
+    const result = await resolveTask(
+      { taskId: 'task-1', verdict: 'approve', comment: 'looks good' },
+      deps(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.resolvedStepId).toBe('step-review');
+    expect(advanceStep).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-claims a pending task as api-user before resolving', async () => {
+    await seedTaskAndInstance({ status: 'pending', assignedUserId: null });
+
+    const result = await resolveTask(
+      { taskId: 'task-1', verdict: 'approve' },
+      deps(),
+    );
+
+    expect(result.ok).toBe(true);
+    const events = auditRepo.getAll();
+    expect(events.some((e) => e.actorId === 'api-user')).toBe(true);
+  });
+
+  it('throws ConflictError when task is already completed', async () => {
+    await seedTaskAndInstance({ status: 'completed' });
+
+    await expect(
+      resolveTask({ taskId: 'task-1', verdict: 'approve' }, deps()),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  it('throws ValidationError when verdict is missing for a verdict task', async () => {
+    await seedTaskAndInstance();
+
+    await expect(
+      resolveTask({ taskId: 'task-1' }, deps()),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('supports paramValues tasks', async () => {
+    await seedTaskAndInstance({
+      params: [{ name: 'dose', type: 'number', required: true }],
+    });
+
+    const result = await resolveTask(
+      { taskId: 'task-1', paramValues: { dose: 12 } },
+      deps(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(advanceStep).toHaveBeenCalledWith(
+      'inst-a',
+      expect.objectContaining({ dose: 12 }),
+      expect.any(Object),
+    );
+  });
+
+  it('supports file-upload tasks', async () => {
+    await seedTaskAndInstance({
+      ui: { component: 'file-upload' },
+    });
+
+    const result = await resolveTask(
+      {
+        taskId: 'task-1',
+        attachments: [{ name: 'doc.pdf', size: 123, type: 'application/pdf' }],
+      },
+      deps(),
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('throws ValidationError when file-upload attachments missing', async () => {
+    await seedTaskAndInstance({ ui: { component: 'file-upload' } });
+
+    await expect(
+      resolveTask({ taskId: 'task-1' }, deps()),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('skips advanceStep for L3 revise verdict', async () => {
+    await seedTaskAndInstance({
+      creationReason: 'agent_review_l3',
+      completionData: {
+        reviewType: 'agent_output_review',
+        agentOutput: { result: { foo: 'bar' } },
+      },
+    });
+
+    await resolveTask({ taskId: 'task-1', verdict: 'revise' }, deps());
+
+    expect(advanceStep).not.toHaveBeenCalled();
+  });
+
+  it('throws 422 HandlerError when approving an L3 review with empty agent output', async () => {
+    await seedTaskAndInstance({
+      creationReason: 'agent_review_l3',
+      completionData: {
+        reviewType: 'agent_output_review',
+        agentOutput: { result: {} },
+      },
+    });
+
+    const err = await resolveTask(
+      { taskId: 'task-1', verdict: 'approve' },
+      deps(),
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(HandlerError);
+    expect((err as HandlerError).statusCode).toBe(422);
+  });
+
+  it('throws NotFoundError when task does not exist', async () => {
+    await expect(
+      resolveTask({ taskId: 'missing', verdict: 'approve' }, deps()),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('calls triggerRun when provided', async () => {
+    await seedTaskAndInstance();
+    const triggerRun = vi.fn();
+
+    await resolveTask(
+      { taskId: 'task-1', verdict: 'approve' },
+      { ...deps(), triggerRun },
+    );
+
+    expect(triggerRun).toHaveBeenCalledWith('inst-a', 'alice');
+  });
+});

--- a/packages/platform-api/src/handlers/tasks/claim-task.ts
+++ b/packages/platform-api/src/handlers/tasks/claim-task.ts
@@ -1,0 +1,51 @@
+import type { AuditRepository, HumanTaskRepository } from '@mediforce/platform-core';
+import type { ClaimTaskInput, ClaimTaskOutput } from '../../contract/tasks.js';
+import { ConflictError, NotFoundError } from '../../errors.js';
+
+export interface ClaimTaskDeps {
+  humanTaskRepo: HumanTaskRepository;
+  auditRepo: AuditRepository;
+}
+
+/**
+ * Pure handler: claim a pending task for the caller.
+ *
+ * State-machine precondition: task must be `pending`. Any other status throws
+ * `ConflictError` (maps to 409). Writes a `task.claimed` audit event. The
+ * `userId` input defaults to `'api-user'` when omitted — preserves the
+ * pre-migration behaviour where the inline route accepted an empty body.
+ */
+export async function claimTask(
+  input: ClaimTaskInput,
+  deps: ClaimTaskDeps,
+): Promise<ClaimTaskOutput> {
+  const userId = input.userId ?? 'api-user';
+
+  const task = await deps.humanTaskRepo.getById(input.taskId);
+  if (task === null) {
+    throw new NotFoundError(`Task ${input.taskId} not found`);
+  }
+  if (task.status !== 'pending') {
+    throw new ConflictError(`Cannot claim a ${task.status} task`);
+  }
+
+  const claimed = await deps.humanTaskRepo.claim(input.taskId, userId);
+
+  const now = new Date().toISOString();
+  await deps.auditRepo.append({
+    actorId: userId,
+    actorType: 'user',
+    actorRole: 'operator',
+    action: 'task.claimed',
+    description: `User '${userId}' claimed task '${input.taskId}' for step '${task.stepId}'`,
+    timestamp: now,
+    inputSnapshot: { taskId: input.taskId, userId, stepId: task.stepId },
+    outputSnapshot: { status: 'claimed', assignedUserId: userId },
+    basis: 'User claimed task via API',
+    entityType: 'humanTask',
+    entityId: input.taskId,
+    processInstanceId: task.processInstanceId,
+  });
+
+  return claimed;
+}

--- a/packages/platform-api/src/handlers/tasks/complete-task.ts
+++ b/packages/platform-api/src/handlers/tasks/complete-task.ts
@@ -1,0 +1,158 @@
+import type {
+  AuditRepository,
+  HumanTaskRepository,
+  ProcessInstanceRepository,
+} from '@mediforce/platform-core';
+import type {
+  CompleteTaskInput,
+  CompleteTaskOutput,
+} from '../../contract/tasks.js';
+import { ConflictError, NotFoundError } from '../../errors.js';
+
+/**
+ * Opaque side-channel for firing the auto-runner after a task finishes.
+ * Production wiring does a fire-and-forget `POST /api/processes/:id/run`
+ * (still Phase 3 to migrate); tests pass a recorder to assert the call.
+ * Kept as an optional dep so handler tests that don't care can omit it.
+ */
+export type TriggerRun = (instanceId: string, actorId: string) => void;
+
+/**
+ * Minimal subset of `WorkflowEngine` that task mutations consume. Declared
+ * structurally here (rather than `Pick<WorkflowEngine, 'advanceStep'>`) so
+ * handler tests can pass a `vi.fn()` double without carrying the full
+ * `WorkflowEngine.advanceStep` overload shape through the type system.
+ */
+export interface EngineLike {
+  advanceStep(
+    instanceId: string,
+    stepOutput: Record<string, unknown>,
+    actor: { id: string; role: string },
+    ...rest: unknown[]
+  ): Promise<unknown>;
+}
+
+export interface CompleteTaskDeps {
+  humanTaskRepo: HumanTaskRepository;
+  instanceRepo: ProcessInstanceRepository;
+  auditRepo: AuditRepository;
+  engine: EngineLike;
+  triggerRun?: TriggerRun;
+}
+
+/**
+ * Pure handler: mark a claimed task complete, resume its paused instance,
+ * advance the engine one step, and (optionally) kick the auto-runner.
+ *
+ * Preconditions:
+ *   - Task must exist and be in `claimed` status → else 404 / 409.
+ *   - Instance referenced by the task must exist and be `paused` → else 404 / 409.
+ */
+export async function completeTask(
+  input: CompleteTaskInput,
+  deps: CompleteTaskDeps,
+): Promise<CompleteTaskOutput> {
+  const { taskId, verdict } = input;
+  const comment = input.comment ?? '';
+
+  const task = await deps.humanTaskRepo.getById(taskId);
+  if (task === null) {
+    throw new NotFoundError(`Task ${taskId} not found`);
+  }
+  if (task.status !== 'claimed') {
+    throw new ConflictError(
+      `Cannot complete a ${task.status} task — must be claimed first`,
+    );
+  }
+
+  const actorId = task.assignedUserId ?? 'api-user';
+  const now = new Date().toISOString();
+  const completionData = {
+    verdict,
+    comment,
+    completedBy: actorId,
+    completedAt: now,
+  };
+
+  await deps.humanTaskRepo.complete(taskId, completionData);
+
+  await deps.auditRepo.append({
+    actorId,
+    actorType: 'user',
+    actorRole: 'operator',
+    action: 'task.completed',
+    description: `Task '${taskId}' completed with verdict '${verdict}' for step '${task.stepId}'`,
+    timestamp: now,
+    inputSnapshot: { taskId, verdict, comment, stepId: task.stepId },
+    outputSnapshot: { status: 'completed', completionData },
+    basis: 'User submitted verdict via API',
+    entityType: 'humanTask',
+    entityId: taskId,
+    processInstanceId: task.processInstanceId,
+  });
+
+  const instance = await deps.instanceRepo.getById(task.processInstanceId);
+  if (instance === null) {
+    throw new NotFoundError(
+      `Process instance '${task.processInstanceId}' not found`,
+    );
+  }
+  if (instance.status !== 'paused') {
+    throw new ConflictError(
+      `Process instance is '${instance.status}', expected 'paused'`,
+    );
+  }
+
+  await deps.instanceRepo.update(task.processInstanceId, {
+    status: 'running',
+    pauseReason: null,
+    updatedAt: now,
+  });
+
+  // Include agent output for L3 review tasks so downstream steps see what was reviewed.
+  const stepOutput: Record<string, unknown> = { verdict, comment, taskId };
+  const agentReviewData = task.completionData as Record<string, unknown> | null;
+  if (agentReviewData?.reviewType === 'agent_output_review') {
+    const agentOutput = agentReviewData.agentOutput as
+      | Record<string, unknown>
+      | undefined;
+    if (agentOutput?.result !== undefined) {
+      stepOutput.agentOutput = agentOutput.result;
+    }
+  }
+
+  await deps.engine.advanceStep(task.processInstanceId, stepOutput, {
+    id: actorId,
+    role: 'human',
+  });
+
+  await deps.auditRepo.append({
+    actorId,
+    actorType: 'user',
+    actorRole: 'operator',
+    action: 'process.resumed_after_task',
+    description: `Process '${task.processInstanceId}' resumed after task verdict '${verdict}'`,
+    timestamp: new Date().toISOString(),
+    inputSnapshot: {
+      taskId,
+      verdict,
+      processInstanceId: task.processInstanceId,
+    },
+    outputSnapshot: {},
+    basis: 'Task completion via API triggered process advancement',
+    entityType: 'processInstance',
+    entityId: task.processInstanceId,
+    processInstanceId: task.processInstanceId,
+  });
+
+  if (deps.triggerRun !== undefined) {
+    deps.triggerRun(task.processInstanceId, actorId);
+  }
+
+  return {
+    ok: true,
+    taskId,
+    verdict,
+    processInstanceId: task.processInstanceId,
+  };
+}

--- a/packages/platform-api/src/handlers/tasks/resolve-task.ts
+++ b/packages/platform-api/src/handlers/tasks/resolve-task.ts
@@ -1,0 +1,322 @@
+import type {
+  AuditRepository,
+  HumanTask,
+  HumanTaskRepository,
+  ProcessInstanceRepository,
+} from '@mediforce/platform-core';
+import type {
+  ResolveTaskInput,
+  ResolveTaskOutput,
+} from '../../contract/tasks.js';
+import {
+  ConflictError,
+  HandlerError,
+  NotFoundError,
+  ValidationError,
+} from '../../errors.js';
+import type { EngineLike, TriggerRun } from './complete-task.js';
+
+export interface ResolveTaskDeps {
+  humanTaskRepo: HumanTaskRepository;
+  instanceRepo: ProcessInstanceRepository;
+  auditRepo: AuditRepository;
+  engine: EngineLike;
+  triggerRun?: TriggerRun;
+}
+
+/**
+ * Pure handler: single code path for resolving any `HumanTask` — verdict,
+ * params, or file-upload. Ported 1:1 from the inline
+ * `packages/platform-ui/src/lib/resolve-task.ts` helper; kept the original
+ * control flow so Phase 2 is purely a move, not a behavioural change.
+ *
+ * Auto-claims pending tasks as `api-user` before resolving — preserves the
+ * pre-migration behaviour where the HTTP endpoint was the ONE place that
+ * could skip the "claim → complete" two-step.
+ */
+export async function resolveTask(
+  input: ResolveTaskInput,
+  deps: ResolveTaskDeps,
+): Promise<ResolveTaskOutput> {
+  const { humanTaskRepo, instanceRepo, auditRepo, engine } = deps;
+  const { taskId } = input;
+
+  const task = await humanTaskRepo.getById(taskId);
+  if (task === null) {
+    throw new NotFoundError('Task not found');
+  }
+  if (task.status === 'completed' || task.status === 'cancelled') {
+    throw new ConflictError(`Cannot resolve a ${task.status} task`);
+  }
+
+  let resolved: HumanTask = task;
+  if (task.status === 'pending') {
+    resolved = await humanTaskRepo.claim(taskId, 'api-user');
+  }
+
+  const actorId = resolved.assignedUserId ?? 'api-user';
+  const isFileUpload = resolved.ui?.component === 'file-upload';
+  const isParamsTask =
+    Array.isArray(resolved.params) && resolved.params.length > 0;
+
+  if (isFileUpload) {
+    const err = validateFileUploadBody(input, resolved);
+    if (err !== null) {
+      throw new ValidationError(err);
+    }
+  } else if (isParamsTask) {
+    if (input.paramValues === undefined) {
+      throw new ValidationError('paramValues object required for params task');
+    }
+  } else {
+    if (input.verdict !== 'approve' && input.verdict !== 'revise') {
+      throw new ValidationError('verdict must be "approve" or "revise"');
+    }
+  }
+
+  const now = new Date().toISOString();
+
+  let completionData: Record<string, unknown>;
+  let stepOutput: Record<string, unknown>;
+
+  if (isFileUpload) {
+    const attachments = input.attachments ?? [];
+    const files = attachments.map((file) => ({
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      storagePath: file.storagePath ?? null,
+      downloadUrl: file.downloadUrl ?? null,
+      uploadedAt: now,
+    }));
+    completionData = { files, completedBy: actorId, completedAt: now };
+    stepOutput = { files };
+  } else if (isParamsTask) {
+    const paramValues = input.paramValues ?? {};
+    completionData = { paramValues, completedBy: actorId, completedAt: now };
+    stepOutput = { ...paramValues };
+  } else {
+    const verdict = input.verdict as 'approve' | 'revise';
+    const comment = input.comment ?? '';
+    const selectedIndex = input.selectedIndex;
+
+    const isSelectionReview =
+      selectedIndex !== undefined &&
+      Array.isArray(resolved.options) &&
+      resolved.options.length > 0;
+
+    if (isSelectionReview) {
+      if (selectedIndex < 0 || selectedIndex >= resolved.options!.length) {
+        throw new ValidationError(
+          `selectedIndex ${selectedIndex} out of range (0-${resolved.options!.length - 1})`,
+        );
+      }
+
+      const selectedOption = resolved.options![selectedIndex] as Record<
+        string,
+        unknown
+      >;
+      stepOutput =
+        (selectedOption.value as Record<string, unknown>) ?? selectedOption;
+
+      completionData = {
+        verdict,
+        comment,
+        selectedIndex,
+        selectedOption,
+        completedBy: actorId,
+        completedAt: now,
+      };
+    } else {
+      const agentReviewData = resolved.completionData as Record<
+        string,
+        unknown
+      > | null;
+      const agentOutput = agentReviewData?.agentOutput as
+        | Record<string, unknown>
+        | undefined;
+
+      if (agentReviewData?.reviewType === 'agent_output_review') {
+        const agentResult = agentOutput?.result as
+          | Record<string, unknown>
+          | null
+          | undefined;
+
+        if (
+          verdict === 'approve' &&
+          (agentResult === null ||
+            agentResult === undefined ||
+            Object.keys(agentResult).length === 0)
+        ) {
+          // 422 on purpose — "understandable but semantically rejected".
+          throw new HandlerError(
+            422,
+            `Cannot approve step '${resolved.stepId}': agent produced no output`,
+          );
+        }
+
+        stepOutput = agentResult ?? {};
+      } else {
+        stepOutput = {};
+      }
+
+      completionData = {
+        verdict,
+        comment,
+        completedBy: actorId,
+        completedAt: now,
+        ...(agentOutput !== undefined ? { agentOutput } : {}),
+      };
+    }
+
+    stepOutput.verdict = verdict;
+    if (comment.length > 0) {
+      stepOutput.reviewerComment = comment;
+    }
+  }
+
+  await humanTaskRepo.complete(taskId, completionData);
+
+  await auditRepo.append({
+    actorId,
+    actorType: 'user',
+    actorRole: 'operator',
+    action: 'task.completed',
+    description: isFileUpload
+      ? `Task '${taskId}' resolved with ${(input.attachments ?? []).length} file(s) for step '${resolved.stepId}'`
+      : isParamsTask
+        ? `Task '${taskId}' resolved with param values for step '${resolved.stepId}'`
+        : `Task '${taskId}' resolved with verdict '${input.verdict}' for step '${resolved.stepId}'`,
+    timestamp: now,
+    inputSnapshot: {
+      taskId,
+      stepId: resolved.stepId,
+      ...(isFileUpload
+        ? { fileCount: (input.attachments ?? []).length }
+        : isParamsTask
+          ? { paramKeys: Object.keys(input.paramValues ?? {}) }
+          : { verdict: input.verdict }),
+    },
+    outputSnapshot: { status: 'completed', completionData },
+    basis: 'Task resolved via API',
+    entityType: 'humanTask',
+    entityId: taskId,
+    processInstanceId: resolved.processInstanceId,
+  });
+
+  const instance = await instanceRepo.getById(resolved.processInstanceId);
+  if (instance === null) {
+    throw new NotFoundError(
+      `Process instance '${resolved.processInstanceId}' not found`,
+    );
+  }
+  if (instance.status !== 'paused') {
+    throw new ConflictError(
+      `Process instance is '${instance.status}', expected 'paused'`,
+    );
+  }
+
+  await instanceRepo.update(resolved.processInstanceId, {
+    status: 'running',
+    pauseReason: null,
+    updatedAt: now,
+  });
+
+  // L3 agent review with "revise" verdict: stay on the same step so the
+  // auto-runner re-executes the agent with feedback. Do NOT advance.
+  const isL3Revise =
+    resolved.creationReason === 'agent_review_l3' &&
+    (stepOutput as Record<string, unknown>).verdict === 'revise';
+
+  if (!isL3Revise) {
+    await engine.advanceStep(resolved.processInstanceId, stepOutput, {
+      id: actorId,
+      role: 'human',
+    });
+  }
+
+  await auditRepo.append({
+    actorId,
+    actorType: 'user',
+    actorRole: 'operator',
+    action: 'process.resumed_after_task',
+    description: `Process '${resolved.processInstanceId}' resumed after resolving step '${resolved.stepId}'`,
+    timestamp: new Date().toISOString(),
+    inputSnapshot: {
+      taskId,
+      processInstanceId: resolved.processInstanceId,
+      stepId: resolved.stepId,
+    },
+    outputSnapshot: {},
+    basis: 'Task resolution triggered process advancement',
+    entityType: 'processInstance',
+    entityId: resolved.processInstanceId,
+    processInstanceId: resolved.processInstanceId,
+  });
+
+  if (deps.triggerRun !== undefined) {
+    deps.triggerRun(resolved.processInstanceId, actorId);
+  }
+
+  const updatedInstance = await instanceRepo.getById(resolved.processInstanceId);
+
+  return {
+    ok: true,
+    taskId,
+    resolvedStepId: resolved.stepId,
+    processInstanceId: resolved.processInstanceId,
+    nextStepId: updatedInstance?.currentStepId ?? null,
+    status: updatedInstance?.status ?? 'unknown',
+  };
+}
+
+function validateFileUploadBody(
+  input: ResolveTaskInput,
+  task: HumanTask,
+): string | null {
+  const attachments = input.attachments;
+  if (attachments === undefined || attachments.length === 0) {
+    return 'attachments required for file-upload step';
+  }
+
+  const uiConfig = task.ui?.config as Record<string, unknown> | undefined;
+  if (uiConfig) {
+    const minFiles = (uiConfig.minFiles as number) ?? 0;
+    const maxFiles = (uiConfig.maxFiles as number) ?? Infinity;
+    if (attachments.length < minFiles || attachments.length > maxFiles) {
+      return `Expected ${minFiles}-${maxFiles} file(s), got ${attachments.length}`;
+    }
+
+    const acceptedTypes = uiConfig.acceptedTypes as string[] | undefined;
+    if (acceptedTypes !== undefined && acceptedTypes.length > 0) {
+      for (const attachment of attachments) {
+        if (!isAcceptedType(attachment.type, attachment.name, acceptedTypes)) {
+          return `File type '${attachment.type}' not accepted (allowed: ${acceptedTypes.join(', ')})`;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+function isAcceptedType(
+  mimeType: string,
+  fileName: string,
+  acceptedTypes: string[],
+): boolean {
+  for (const accepted of acceptedTypes) {
+    if (accepted.startsWith('.')) {
+      if (fileName.toLowerCase().endsWith(accepted.toLowerCase())) {
+        return true;
+      }
+      continue;
+    }
+    if (mimeType === accepted) return true;
+    if (accepted.endsWith('/*')) {
+      const prefix = accepted.slice(0, -1);
+      if (mimeType.startsWith(prefix)) return true;
+    }
+  }
+  return false;
+}

--- a/packages/platform-api/src/handlers/tasks/resolve-task.ts
+++ b/packages/platform-api/src/handlers/tasks/resolve-task.ts
@@ -235,6 +235,12 @@ export async function resolveTask(
     });
   }
 
+  // TODO(#231): audit row claims "resumed after resolving step" + basis
+  // "triggered process advancement" even on the L3-revise branch above
+  // where we deliberately did NOT advance. Ported 1:1 from the inline
+  // route — this PR is the API extraction, not the semantic fix. Split the
+  // event in a follow-up: `process.resumed_after_task` vs
+  // `process.kept_on_step_for_revise`.
   await auditRepo.append({
     actorId,
     actorType: 'user',

--- a/packages/platform-ui/next-env.d.ts
+++ b/packages/platform-ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/platform-ui/src/app/api/agent-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/route.ts
@@ -32,4 +32,5 @@ export const POST = createRouteAdapter(
     createAgentDefinition(input, {
       agentDefinitionRepo: getPlatformServices().agentDefinitionRepo,
     }),
+  { successStatus: 201 },
 );

--- a/packages/platform-ui/src/app/api/agent-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/route.ts
@@ -1,9 +1,14 @@
-import { NextResponse } from 'next/server';
-import { CreateAgentDefinitionInputSchema } from '@mediforce/platform-core';
+import { NextRequest } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
-import { createRouteAdapter } from '@/lib/route-adapter';
-import { listAgentDefinitions } from '@mediforce/platform-api/handlers';
-import { ListAgentDefinitionsInputSchema } from '@mediforce/platform-api/contract';
+import { createRouteAdapter, readJsonBody } from '@/lib/route-adapter';
+import {
+  listAgentDefinitions,
+  createAgentDefinition,
+} from '@mediforce/platform-api/handlers';
+import {
+  ListAgentDefinitionsInputSchema,
+  CreateAgentDefinitionInputContractSchema,
+} from '@mediforce/platform-api/contract';
 
 /**
  * GET /api/agent-definitions — list every registered agent definition.
@@ -19,12 +24,12 @@ export const GET = createRouteAdapter(
 
 /**
  * POST /api/agent-definitions — create a new agent definition.
- * Mutation, still inline until Phase 2.
  */
-export async function POST(request: Request): Promise<NextResponse> {
-  const body = await request.json();
-  const input = CreateAgentDefinitionInputSchema.parse(body);
-  const { agentDefinitionRepo } = getPlatformServices();
-  const agent = await agentDefinitionRepo.create(input);
-  return NextResponse.json({ agent }, { status: 201 });
-}
+export const POST = createRouteAdapter(
+  CreateAgentDefinitionInputContractSchema,
+  async (req: NextRequest) => readJsonBody(req),
+  (input) =>
+    createAgentDefinition(input, {
+      agentDefinitionRepo: getPlatformServices().agentDefinitionRepo,
+    }),
+);

--- a/packages/platform-ui/src/app/api/agent-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/agent-definitions/route.ts
@@ -7,7 +7,7 @@ import {
 } from '@mediforce/platform-api/handlers';
 import {
   ListAgentDefinitionsInputSchema,
-  CreateAgentDefinitionInputContractSchema,
+  CreateAgentDefinitionInputSchema,
 } from '@mediforce/platform-api/contract';
 
 /**
@@ -26,7 +26,7 @@ export const GET = createRouteAdapter(
  * POST /api/agent-definitions — create a new agent definition.
  */
 export const POST = createRouteAdapter(
-  CreateAgentDefinitionInputContractSchema,
+  CreateAgentDefinitionInputSchema,
   async (req: NextRequest) => readJsonBody(req),
   (input) =>
     createAgentDefinition(input, {

--- a/packages/platform-ui/src/app/api/configs/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/configs/__tests__/route.test.ts
@@ -149,8 +149,10 @@ describe('POST /api/configs', () => {
     const res = await POST(makePostRequest(validConfig));
     const json = await res.json();
 
+    // Phase 2: validation errors now surface through the unified `{ error }`
+    // contract shape (a single string joined from the validator's `errors`).
     expect(res.status).toBe(400);
-    expect(json.errors).toBeDefined();
+    expect(json.error).toContain('Missing StepConfig');
   });
 
   it('[DATA] runs validateProcessConfig server-side before saving', async () => {

--- a/packages/platform-ui/src/app/api/configs/route.ts
+++ b/packages/platform-ui/src/app/api/configs/route.ts
@@ -1,19 +1,17 @@
-import { NextResponse } from 'next/server';
-import {
-  ProcessConfigSchema,
-  validateProcessConfig,
-} from '@mediforce/platform-core';
-import { ConfigVersionAlreadyExistsError } from '@mediforce/platform-infra';
+import { NextRequest } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
-import { createRouteAdapter } from '@/lib/route-adapter';
-import { listProcessConfigs } from '@mediforce/platform-api/handlers';
-import { ListProcessConfigsInputSchema } from '@mediforce/platform-api/contract';
+import { createRouteAdapter, readJsonBody } from '@/lib/route-adapter';
+import {
+  listProcessConfigs,
+  createProcessConfig,
+} from '@mediforce/platform-api/handlers';
+import {
+  ListProcessConfigsInputSchema,
+  CreateProcessConfigInputSchema,
+} from '@mediforce/platform-api/contract';
 
 /**
- * GET /api/configs?processName=X
- *
- * Required `processName` query param (400 when missing). Returns
- * `{ configs: ProcessConfig[] }` — empty array when the process has none.
+ * GET /api/configs?processName=X — list configs for a process.
  */
 export const GET = createRouteAdapter(
   ListProcessConfigsInputSchema,
@@ -21,57 +19,17 @@ export const GET = createRouteAdapter(
     processName: new URL(req.url).searchParams.get('processName') ?? undefined,
   }),
   (input) =>
-    listProcessConfigs(input, {
-      processRepo: getPlatformServices().processRepo,
-    }),
+    listProcessConfigs(input, { processRepo: getPlatformServices().processRepo }),
 );
 
-export async function POST(request: Request): Promise<NextResponse> {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
-  }
-
-  const parsed = ProcessConfigSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Invalid config', details: parsed.error.issues },
-      { status: 400 },
-    );
-  }
-
-  const config = parsed.data;
-  const { processRepo, pluginRegistry } = getPlatformServices();
-
-  // Load definition for validation (use latest version heuristic -- get by processName)
-  const definition = await processRepo.getProcessDefinition(
-    config.processName,
-    config.stepConfigs[0]?.stepId ? 'latest' : 'latest',
-  );
-
-  const pluginNames = pluginRegistry.list().map((p: { name: string }) => p.name);
-
-  // Run server-side validation if definition is available
-  if (definition) {
-    const result = validateProcessConfig(config, definition, pluginNames);
-    if (!result.valid) {
-      return NextResponse.json(
-        { errors: result.errors, warnings: result.warnings },
-        { status: 400 },
-      );
-    }
-  }
-
-  try {
-    await processRepo.saveProcessConfig(config);
-  } catch (err) {
-    if (err instanceof ConfigVersionAlreadyExistsError) {
-      return NextResponse.json({ error: err.message }, { status: 409 });
-    }
-    throw err;
-  }
-
-  return NextResponse.json({ ok: true }, { status: 201 });
-}
+/**
+ * POST /api/configs — register a new config version.
+ */
+export const POST = createRouteAdapter(
+  CreateProcessConfigInputSchema,
+  async (req: NextRequest) => readJsonBody(req),
+  (input) => {
+    const { processRepo, pluginRegistry } = getPlatformServices();
+    return createProcessConfig(input, { processRepo, pluginRegistry });
+  },
+);

--- a/packages/platform-ui/src/app/api/configs/route.ts
+++ b/packages/platform-ui/src/app/api/configs/route.ts
@@ -32,4 +32,5 @@ export const POST = createRouteAdapter(
     const { processRepo, pluginRegistry } = getPlatformServices();
     return createProcessConfig(input, { processRepo, pluginRegistry });
   },
+  { successStatus: 201 },
 );

--- a/packages/platform-ui/src/app/api/cron/heartbeat/route.ts
+++ b/packages/platform-ui/src/app/api/cron/heartbeat/route.ts
@@ -1,126 +1,32 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getPlatformServices, getAppBaseUrl } from '@/lib/platform-services';
+import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { heartbeat } from '@mediforce/platform-api/handlers';
+import { HeartbeatInputSchema } from '@mediforce/platform-api/contract';
 import { validateCronSchedule, isDue } from '@mediforce/workflow-engine';
-import type { WorkflowDefinition, Trigger } from '@mediforce/platform-core';
+import { triggerAutoRunner } from '@/lib/trigger-auto-runner';
 
-interface TriggeredEntry {
-  definitionName: string;
-  definitionVersion: number;
-  triggerName: string;
-  instanceId: string;
-}
-
-interface SkippedEntry {
-  definitionName: string;
-  definitionVersion: number;
-  triggerName: string;
-  reason: string;
-}
-
-export async function POST(_req: NextRequest): Promise<NextResponse> {
-  const { processRepo, cronTrigger, cronTriggerStateRepo } = getPlatformServices();
-  const now = new Date();
-  const triggered: TriggeredEntry[] = [];
-  const skipped: SkippedEntry[] = [];
-
-  try {
-    const { definitions: definitionGroups } = await processRepo.listWorkflowDefinitions();
-
-    // Flatten to latest version of each definition that has at least one cron trigger
-    const cronDefinitions = definitionGroups
-      .map((group) => group.versions.find((v) => v.version === group.latestVersion))
-      .filter((def): def is WorkflowDefinition => def !== undefined)
-      .filter(
-        (def: WorkflowDefinition) =>
-          def.archived !== true &&
-          def.triggers.some((t: Trigger) => t.type === 'cron'),
-      );
-
-    for (const def of cronDefinitions) {
-      const cronTriggers = def.triggers.filter((t: Trigger) => t.type === 'cron');
-
-      for (const trigger of cronTriggers) {
-        const schedule = trigger.schedule;
-        if (!schedule) {
-          skipped.push({
-            definitionName: def.name,
-            definitionVersion: def.version,
-            triggerName: trigger.name,
-            reason: 'No schedule defined',
-          });
-          continue;
-        }
-
-        const validation = validateCronSchedule(schedule);
-        if (!validation.valid) {
-          skipped.push({
-            definitionName: def.name,
-            definitionVersion: def.version,
-            triggerName: trigger.name,
-            reason: `Invalid schedule: ${validation.error}`,
-          });
-          continue;
-        }
-
-        // Read last triggered time for this specific trigger.
-        // When no state exists (first run), use the definition's createdAt so
-        // gap-scanning catches any missed windows since the definition was created.
-        // TODO: race condition — overlapping heartbeats can read the same lastTriggeredAt
-        // and both fire the trigger. Not critical at current scale (single VPS cron),
-        // but needs a Firestore transaction or distributed lock if we scale out.
-        const state = await cronTriggerStateRepo.get(def.name, trigger.name);
-        const lastTriggeredAt = state
-          ? new Date(state.lastTriggeredAt)
-          : def.createdAt
-            ? new Date(def.createdAt)
-            : undefined;
-
-        if (!isDue(schedule, now, lastTriggeredAt)) {
-          skipped.push({
-            definitionName: def.name,
-            definitionVersion: def.version,
-            triggerName: trigger.name,
-            reason: 'Not due',
-          });
-          continue;
-        }
-
-        // Fire the cron trigger to create and start an instance
-        const result = await cronTrigger.fireWorkflow({
-          definitionName: def.name,
-          definitionVersion: def.version,
-          triggerName: trigger.name,
-          triggeredBy: 'cron-heartbeat',
-          payload: { schedule, firedAt: now.toISOString() },
-        });
-
-        // Persist trigger state AFTER successful fire (at-least-once semantics)
-        await cronTriggerStateRepo.set({
-          definitionName: def.name,
-          triggerName: trigger.name,
-          lastTriggeredAt: now.toISOString(),
-        });
-
-        // Kick off the run loop by calling the run endpoint
-        const baseUrl = getAppBaseUrl();
-        await fetch(`${baseUrl}/api/processes/${result.instanceId}/run`, {
-          method: 'POST',
-          headers: { 'X-Api-Key': process.env.PLATFORM_API_KEY ?? '' },
-        });
-
-        triggered.push({
-          definitionName: def.name,
-          definitionVersion: def.version,
-          triggerName: trigger.name,
-          instanceId: result.instanceId,
-        });
-      }
-    }
-
-    return NextResponse.json({ triggered, skipped });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`[cron-heartbeat] Error: ${message}`);
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+/**
+ * POST /api/cron/heartbeat
+ *
+ * Called by an external scheduler. Body is ignored — the handler scans for
+ * workflow-definition cron triggers that are due and fires each.
+ *
+ * Race condition note: overlapping heartbeats can both see the same
+ * `lastTriggeredAt` and both fire a given trigger. Not critical at current
+ * scale (single VPS cron), but would need a transaction or distributed lock
+ * to scale out.
+ */
+export const POST = createRouteAdapter(
+  HeartbeatInputSchema,
+  () => ({}),
+  (input) => {
+    const { processRepo, cronTrigger, cronTriggerStateRepo } = getPlatformServices();
+    return heartbeat(input, {
+      processRepo,
+      cronTrigger,
+      cronTriggerStateRepo,
+      scheduleValidator: { validateCronSchedule, isDue },
+      triggerRun: triggerAutoRunner,
+    });
+  },
+);

--- a/packages/platform-ui/src/app/api/definitions/route.ts
+++ b/packages/platform-ui/src/app/api/definitions/route.ts
@@ -15,4 +15,5 @@ export const PUT = createRouteAdapter(
   async (req: NextRequest) => ({ yaml: await req.text() }),
   (input) =>
     upsertLegacyDefinition(input, { processRepo: getPlatformServices().processRepo }),
+  { successStatus: 201 },
 );

--- a/packages/platform-ui/src/app/api/definitions/route.ts
+++ b/packages/platform-ui/src/app/api/definitions/route.ts
@@ -1,55 +1,18 @@
-import { NextResponse } from 'next/server';
-import { parseProcessDefinition } from '@mediforce/platform-core';
-import type { ProcessConfig } from '@mediforce/platform-core';
-import { DefinitionVersionAlreadyExistsError, ConfigVersionAlreadyExistsError } from '@mediforce/platform-infra';
+import { NextRequest } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { upsertLegacyDefinition } from '@mediforce/platform-api/handlers';
+import { UpsertLegacyDefinitionInputSchema } from '@mediforce/platform-api/contract';
 
-export async function PUT(request: Request): Promise<NextResponse> {
-  const yaml = await request.text();
-  if (!yaml.trim()) {
-    return NextResponse.json({ error: 'YAML body is required' }, { status: 400 });
-  }
-
-  const result = parseProcessDefinition(yaml);
-  if (!result.success) {
-    return NextResponse.json({ error: result.error }, { status: 400 });
-  }
-
-  const definition = result.data;
-  const { processRepo } = getPlatformServices();
-
-  try {
-    await processRepo.saveProcessDefinition(definition);
-
-    // Auto-create "all-human" default config if none exists
-    const allHumanVersion = definition.version;
-    const existing = await processRepo.getProcessConfig(definition.name, 'all-human', allHumanVersion);
-    if (!existing) {
-      const allHumanConfig: ProcessConfig = {
-        processName: definition.name,
-        configName: 'all-human',
-        configVersion: allHumanVersion,
-        stepConfigs: definition.steps
-          .filter((s) => s.type !== 'terminal')
-          .map((s) => ({ stepId: s.id, executorType: 'human' as const })),
-      };
-      try {
-        await processRepo.saveProcessConfig(allHumanConfig);
-      } catch (configErr) {
-        if (!(configErr instanceof ConfigVersionAlreadyExistsError)) {
-          throw configErr;
-        }
-      }
-    }
-
-    return NextResponse.json(
-      { success: true, name: definition.name, version: definition.version },
-      { status: 201 },
-    );
-  } catch (err) {
-    if (err instanceof DefinitionVersionAlreadyExistsError) {
-      return NextResponse.json({ error: err.message }, { status: 409 });
-    }
-    throw err;
-  }
-}
+/**
+ * PUT /api/definitions
+ *
+ * Legacy YAML upload. Body: raw YAML text (not JSON). Handler parses,
+ * validates, and auto-seeds an "all-human" config.
+ */
+export const PUT = createRouteAdapter(
+  UpsertLegacyDefinitionInputSchema,
+  async (req: NextRequest) => ({ yaml: await req.text() }),
+  (input) =>
+    upsertLegacyDefinition(input, { processRepo: getPlatformServices().processRepo }),
+);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/cancel/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/cancel/route.ts
@@ -1,35 +1,23 @@
-import { NextRequest, NextResponse } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { cancelProcess } from '@mediforce/platform-api/handlers';
+import { CancelProcessInputSchema } from '@mediforce/platform-api/contract';
+import type { CancelProcessInput } from '@mediforce/platform-api/contract';
 
-export async function POST(
-  _req: NextRequest,
-  { params }: { params: Promise<{ instanceId: string }> },
-): Promise<NextResponse> {
-  try {
-    const { instanceId } = await params;
-    const { instanceRepo } = getPlatformServices();
-
-    const instance = await instanceRepo.getById(instanceId);
-    if (!instance) {
-      return NextResponse.json({ error: 'Instance not found' }, { status: 404 });
-    }
-
-    if (instance.status !== 'running' && instance.status !== 'paused') {
-      return NextResponse.json(
-        { error: `Cannot cancel instance in status '${instance.status}'` },
-        { status: 409 },
-      );
-    }
-
-    await instanceRepo.update(instanceId, {
-      status: 'failed',
-      error: 'Cancelled by user',
-      updatedAt: new Date().toISOString(),
-    });
-
-    return NextResponse.json({ instanceId, status: 'failed' });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+interface RouteContext {
+  params: Promise<{ instanceId: string }>;
 }
+
+/**
+ * POST /api/processes/:instanceId/cancel
+ */
+export const POST = createRouteAdapter<
+  typeof CancelProcessInputSchema,
+  CancelProcessInput,
+  RouteContext
+>(
+  CancelProcessInputSchema,
+  async (_req, ctx) => ({ instanceId: (await ctx.params).instanceId }),
+  (input) =>
+    cancelProcess(input, { instanceRepo: getPlatformServices().instanceRepo }),
+);

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/resume/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/resume/route.ts
@@ -1,68 +1,30 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getPlatformServices, getAppBaseUrl } from '@/lib/platform-services';
+import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { resumeProcess } from '@mediforce/platform-api/handlers';
+import { ResumeProcessInputSchema } from '@mediforce/platform-api/contract';
+import type { ResumeProcessInput } from '@mediforce/platform-api/contract';
+import { triggerAutoRunner } from '@/lib/trigger-auto-runner';
+
+interface RouteContext {
+  params: Promise<{ instanceId: string }>;
+}
 
 /**
  * POST /api/processes/:instanceId/resume
- *
- * Resumes a paused instance (e.g. after agent escalation) and re-triggers the auto-runner.
  */
-export async function POST(
-  _req: NextRequest,
-  { params }: { params: Promise<{ instanceId: string }> },
-): Promise<NextResponse> {
-  try {
-    const { instanceId } = await params;
+export const POST = createRouteAdapter<
+  typeof ResumeProcessInputSchema,
+  ResumeProcessInput,
+  RouteContext
+>(
+  ResumeProcessInputSchema,
+  async (_req, ctx) => ({ instanceId: (await ctx.params).instanceId }),
+  (input) => {
     const { instanceRepo, auditRepo } = getPlatformServices();
-
-    const instance = await instanceRepo.getById(instanceId);
-    if (!instance) {
-      return NextResponse.json({ error: 'Instance not found' }, { status: 404 });
-    }
-
-    if (instance.status !== 'paused') {
-      return NextResponse.json(
-        { error: `Instance is '${instance.status}', expected 'paused'` },
-        { status: 409 },
-      );
-    }
-
-    const now = new Date().toISOString();
-    await instanceRepo.update(instanceId, {
-      status: 'running',
-      pauseReason: null,
-      error: null,
-      updatedAt: now,
+    return resumeProcess(input, {
+      instanceRepo,
+      auditRepo,
+      triggerRun: triggerAutoRunner,
     });
-
-    await auditRepo.append({
-      actorId: 'api-user',
-      actorType: 'user',
-      actorRole: 'operator',
-      action: 'process.resumed',
-      description: `Process '${instanceId}' manually resumed via API`,
-      timestamp: now,
-      inputSnapshot: { previousPauseReason: instance.pauseReason },
-      outputSnapshot: { status: 'running' },
-      basis: 'Manual resume via API',
-      entityType: 'processInstance',
-      entityId: instanceId,
-      processInstanceId: instanceId,
-    });
-
-    // Fire-and-forget: trigger auto-runner
-    const appUrl = getAppBaseUrl();
-    fetch(`${appUrl}/api/processes/${instanceId}/run`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Api-Key': process.env.PLATFORM_API_KEY ?? '',
-      },
-      body: JSON.stringify({ triggeredBy: 'api-user' }),
-    }).catch(() => {});
-
-    return NextResponse.json({ ok: true, instanceId, status: 'running' });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+  },
+);

--- a/packages/platform-ui/src/app/api/processes/route.ts
+++ b/packages/platform-ui/src/app/api/processes/route.ts
@@ -33,4 +33,5 @@ export const POST = createRouteAdapter(
       triggerRun: triggerAutoRunner,
     });
   },
+  { successStatus: 201 },
 );

--- a/packages/platform-ui/src/app/api/processes/route.ts
+++ b/packages/platform-ui/src/app/api/processes/route.ts
@@ -1,58 +1,36 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getPlatformServices, getAppBaseUrl } from '@/lib/platform-services';
+import { NextRequest } from 'next/server';
+import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter, readJsonBody } from '@/lib/route-adapter';
+import { createProcess } from '@mediforce/platform-api/handlers';
+import { CreateProcessInputSchema } from '@mediforce/platform-api/contract';
+import { triggerAutoRunner } from '@/lib/trigger-auto-runner';
 
-interface StartWorkflowBody {
-  definitionName: string;
-  definitionVersion?: number;
-  version?: string | number;
-  triggeredBy: string;
-  triggerName?: string;
-  payload?: Record<string, unknown>;
-}
-
-export async function POST(req: NextRequest): Promise<NextResponse> {
-  try {
-    const body = (await req.json()) as StartWorkflowBody;
-    const { manualTrigger, processRepo } = getPlatformServices();
-
-    let version = body.definitionVersion ?? (body.version ? Number(body.version) : undefined);
-    if (!version) {
-      version = await processRepo.getLatestWorkflowVersion(body.definitionName);
-      if (version === 0) {
-        return NextResponse.json(
-          { error: `No workflow definition found for '${body.definitionName}'` },
-          { status: 404 },
-        );
-      }
-    }
-
-    const result = await manualTrigger.fireWorkflow({
+/**
+ * POST /api/processes
+ *
+ * Body: `{ definitionName: string; definitionVersion?: number; triggerName?: string; triggeredBy: string; payload?: object }`.
+ */
+export const POST = createRouteAdapter(
+  CreateProcessInputSchema,
+  async (req: NextRequest) => {
+    const body = (await readJsonBody(req)) as Record<string, unknown>;
+    // Legacy clients passed `version` as string; normalise to number.
+    const legacyVersion =
+      body.version !== undefined ? Number(body.version) : undefined;
+    return {
       definitionName: body.definitionName,
-      definitionVersion: version,
-      triggerName: body.triggerName ?? 'manual',
+      definitionVersion: body.definitionVersion ?? legacyVersion,
+      triggerName: body.triggerName,
       triggeredBy: body.triggeredBy,
-      payload: body.payload ?? {},
+      payload: body.payload,
+    };
+  },
+  (input) => {
+    const { manualTrigger, processRepo } = getPlatformServices();
+    return createProcess(input, {
+      manualTrigger,
+      processRepo,
+      triggerRun: triggerAutoRunner,
     });
-
-    // Fire-and-forget: trigger auto-runner asynchronously
-    const baseUrl = getAppBaseUrl();
-    fetch(`${baseUrl}/api/processes/${result.instanceId}/run`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Api-Key': process.env.PLATFORM_API_KEY ?? '',
-      },
-      body: JSON.stringify({
-        appContext: body.payload ?? {},
-        triggeredBy: body.triggeredBy,
-      }),
-    }).catch((err) => {
-      console.error(`[auto-runner] Failed to trigger run for ${result.instanceId}:`, err);
-    });
-
-    return NextResponse.json({ instanceId: result.instanceId, status: result.status }, { status: 201 });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+  },
+);

--- a/packages/platform-ui/src/app/api/processes/route.ts
+++ b/packages/platform-ui/src/app/api/processes/route.ts
@@ -14,9 +14,12 @@ export const POST = createRouteAdapter(
   CreateProcessInputSchema,
   async (req: NextRequest) => {
     const body = (await readJsonBody(req)) as Record<string, unknown>;
-    // Legacy clients passed `version` as string; normalise to number.
-    const legacyVersion =
-      body.version !== undefined ? Number(body.version) : undefined;
+    // Legacy clients passed `version` as string. Normalise to number,
+    // tolerating numeric strings ("3") and rejecting garbage ("abc") by
+    // leaving the field undefined — the Zod schema then surfaces the real
+    // failure ("definitionVersion: …") instead of a misleading
+    // "must be greater than 0" from a coerced NaN.
+    const legacyVersion = parseLegacyVersion(body.version);
     return {
       definitionName: body.definitionName,
       definitionVersion: body.definitionVersion ?? legacyVersion,
@@ -35,3 +38,14 @@ export const POST = createRouteAdapter(
   },
   { successStatus: 201 },
 );
+
+function parseLegacyVersion(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }
+  return undefined;
+}

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts
@@ -1,57 +1,34 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter, readJsonBody } from '@/lib/route-adapter';
+import { claimTask } from '@mediforce/platform-api/handlers';
+import { ClaimTaskInputSchema } from '@mediforce/platform-api/contract';
+import type { ClaimTaskInput } from '@mediforce/platform-api/contract';
+
+interface RouteContext {
+  params: Promise<{ taskId: string }>;
+}
 
 /**
  * POST /api/tasks/:taskId/claim
  *
- * Body: { "userId": "api-user" }
- *
- * Claims a pending task for the given user. Task must be in 'pending' status.
+ * Body: `{ userId?: string }` — defaults server-side to `'api-user'`.
  */
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ taskId: string }> },
-): Promise<NextResponse> {
-  try {
-    const { taskId } = await params;
-    const body = (await req.json()) as { userId?: string };
-    const userId = body.userId ?? 'api-user';
-
+export const POST = createRouteAdapter<
+  typeof ClaimTaskInputSchema,
+  ClaimTaskInput,
+  RouteContext
+>(
+  ClaimTaskInputSchema,
+  async (req: NextRequest, ctx) => {
+    const body = (await readJsonBody(req)) as { userId?: string };
+    return {
+      taskId: (await ctx.params).taskId,
+      userId: body.userId,
+    };
+  },
+  (input) => {
     const { humanTaskRepo, auditRepo } = getPlatformServices();
-
-    const task = await humanTaskRepo.getById(taskId);
-    if (!task) {
-      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
-    }
-
-    if (task.status !== 'pending') {
-      return NextResponse.json(
-        { error: `Cannot claim a ${task.status} task` },
-        { status: 409 },
-      );
-    }
-
-    const claimed = await humanTaskRepo.claim(taskId, userId);
-
-    const now = new Date().toISOString();
-    await auditRepo.append({
-      actorId: userId,
-      actorType: 'user',
-      actorRole: 'operator',
-      action: 'task.claimed',
-      description: `User '${userId}' claimed task '${taskId}' for step '${task.stepId}'`,
-      timestamp: now,
-      inputSnapshot: { taskId, userId, stepId: task.stepId },
-      outputSnapshot: { status: 'claimed', assignedUserId: userId },
-      basis: 'User claimed task via API',
-      entityType: 'humanTask',
-      entityId: taskId,
-      processInstanceId: task.processInstanceId,
-    });
-
-    return NextResponse.json(claimed);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+    return claimTask(input, { humanTaskRepo, auditRepo });
+  },
+);

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/complete/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/complete/route.ts
@@ -1,158 +1,45 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getPlatformServices, getAppBaseUrl } from '@/lib/platform-services';
+import { NextRequest } from 'next/server';
+import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter, readJsonBody } from '@/lib/route-adapter';
+import { completeTask } from '@mediforce/platform-api/handlers';
+import { CompleteTaskInputSchema } from '@mediforce/platform-api/contract';
+import type { CompleteTaskInput } from '@mediforce/platform-api/contract';
+import { triggerAutoRunner } from '@/lib/trigger-auto-runner';
+
+interface RouteContext {
+  params: Promise<{ taskId: string }>;
+}
 
 /**
  * POST /api/tasks/:taskId/complete
  *
- * Body: { "verdict": "approve" | "revise", "comment": "..." }
- *
- * Completes a claimed task, resumes the process, advances to the next step,
- * and triggers the auto-runner for subsequent agent steps.
+ * Body: `{ verdict: 'approve' | 'revise'; comment?: string }`.
+ * Resumes the paused process instance, advances the engine one step, and
+ * kicks the auto-runner (fire-and-forget).
  */
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ taskId: string }> },
-): Promise<NextResponse> {
-  try {
-    const { taskId } = await params;
-    const body = (await req.json()) as {
-      verdict?: string;
-      comment?: string;
+export const POST = createRouteAdapter<
+  typeof CompleteTaskInputSchema,
+  CompleteTaskInput,
+  RouteContext
+>(
+  CompleteTaskInputSchema,
+  async (req: NextRequest, ctx) => {
+    const body = (await readJsonBody(req)) as Record<string, unknown>;
+    return {
+      taskId: (await ctx.params).taskId,
+      verdict: body.verdict,
+      comment: body.comment,
     };
-
-    const verdict = body.verdict;
-    if (verdict !== 'approve' && verdict !== 'revise') {
-      return NextResponse.json(
-        { error: 'verdict must be "approve" or "revise"' },
-        { status: 400 },
-      );
-    }
-
-    const comment = body.comment ?? '';
-
+  },
+  (input) => {
     const { humanTaskRepo, instanceRepo, auditRepo, engine } =
       getPlatformServices();
-
-    // 1. Load and validate task
-    const task = await humanTaskRepo.getById(taskId);
-    if (!task) {
-      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
-    }
-
-    if (task.status !== 'claimed') {
-      return NextResponse.json(
-        { error: `Cannot complete a ${task.status} task — must be claimed first` },
-        { status: 409 },
-      );
-    }
-
-    const now = new Date().toISOString();
-    const completionData = {
-      verdict,
-      comment,
-      completedBy: task.assignedUserId,
-      completedAt: now,
-    };
-
-    // 2. Mark task as completed
-    await humanTaskRepo.complete(taskId, completionData);
-
-    // 3. Write audit event
-    await auditRepo.append({
-      actorId: task.assignedUserId ?? 'api-user',
-      actorType: 'user',
-      actorRole: 'operator',
-      action: 'task.completed',
-      description: `Task '${taskId}' completed with verdict '${verdict}' for step '${task.stepId}'`,
-      timestamp: now,
-      inputSnapshot: { taskId, verdict, comment, stepId: task.stepId },
-      outputSnapshot: { status: 'completed', completionData },
-      basis: 'User submitted verdict via API',
-      entityType: 'humanTask',
-      entityId: taskId,
-      processInstanceId: task.processInstanceId,
+    return completeTask(input, {
+      humanTaskRepo,
+      instanceRepo,
+      auditRepo,
+      engine,
+      triggerRun: triggerAutoRunner,
     });
-
-    // 4. Resume the paused process instance
-    const instance = await instanceRepo.getById(task.processInstanceId);
-    if (!instance) {
-      return NextResponse.json(
-        { error: `Process instance '${task.processInstanceId}' not found` },
-        { status: 404 },
-      );
-    }
-
-    if (instance.status !== 'paused') {
-      return NextResponse.json(
-        { error: `Process instance is '${instance.status}', expected 'paused'` },
-        { status: 409 },
-      );
-    }
-
-    // Set instance back to running so advanceStep works
-    await instanceRepo.update(task.processInstanceId, {
-      status: 'running',
-      pauseReason: null,
-      updatedAt: now,
-    });
-
-    // 5. Advance to next step — include agent output for L3 review tasks
-    const stepOutput: Record<string, unknown> = { verdict, comment, taskId };
-    const agentReviewData = task.completionData as Record<string, unknown> | null;
-    if (agentReviewData?.reviewType === 'agent_output_review') {
-      const agentOutput = agentReviewData.agentOutput as Record<string, unknown> | undefined;
-      if (agentOutput?.result) {
-        stepOutput.agentOutput = agentOutput.result;
-      }
-    }
-
-    await engine.advanceStep(
-      task.processInstanceId,
-      stepOutput,
-      { id: task.assignedUserId ?? 'api-user', role: 'human' },
-    );
-
-    // 6. Write process resumed audit event
-    await auditRepo.append({
-      actorId: task.assignedUserId ?? 'api-user',
-      actorType: 'user',
-      actorRole: 'operator',
-      action: 'process.resumed_after_task',
-      description: `Process '${task.processInstanceId}' resumed after task verdict '${verdict}'`,
-      timestamp: new Date().toISOString(),
-      inputSnapshot: {
-        taskId,
-        verdict,
-        processInstanceId: task.processInstanceId,
-      },
-      outputSnapshot: {},
-      basis: 'Task completion via API triggered process advancement',
-      entityType: 'processInstance',
-      entityId: task.processInstanceId,
-      processInstanceId: task.processInstanceId,
-    });
-
-    // 7. Fire-and-forget: trigger auto-runner for next steps
-    const appUrl = getAppBaseUrl();
-    fetch(`${appUrl}/api/processes/${task.processInstanceId}/run`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Api-Key': process.env.PLATFORM_API_KEY ?? '',
-      },
-      body: JSON.stringify({
-        triggeredBy: task.assignedUserId ?? 'api-user',
-      }),
-    }).catch(() => {});
-
-    return NextResponse.json({
-      ok: true,
-      taskId,
-      verdict,
-      processInstanceId: task.processInstanceId,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+  },
+);

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/resolve/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/resolve/route.ts
@@ -1,36 +1,40 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { resolveTask, isResolveError } from '@/lib/resolve-task';
+import { NextRequest } from 'next/server';
+import { getPlatformServices } from '@/lib/platform-services';
+import { createRouteAdapter, readJsonBody } from '@/lib/route-adapter';
+import { resolveTask } from '@mediforce/platform-api/handlers';
+import { ResolveTaskInputSchema } from '@mediforce/platform-api/contract';
+import type { ResolveTaskInput } from '@mediforce/platform-api/contract';
+import { triggerAutoRunner } from '@/lib/trigger-auto-runner';
+
+interface RouteContext {
+  params: Promise<{ taskId: string }>;
+}
 
 /**
  * POST /api/tasks/:taskId/resolve
  *
- * Thin HTTP wrapper around resolveTask(). See resolve-task.ts for logic.
- *
- * Body shapes:
- * - Verdict:     { "verdict": "approve" | "revise", "comment": "..." }
- * - Params:      { "paramValues": { ... } }
- * - File upload: { "attachments": [{ name, size, type, storagePath, downloadUrl }] }
+ * One endpoint, three body shapes (verdict / paramValues / attachments).
+ * Handler picks the path at runtime based on the task's own shape.
  */
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ taskId: string }> },
-): Promise<NextResponse> {
-  try {
-    const { taskId } = await params;
-    const body = (await req.json()) as Record<string, unknown>;
-
-    const result = await resolveTask(taskId, body);
-
-    if (isResolveError(result)) {
-      return NextResponse.json(
-        { error: result.error },
-        { status: result.httpStatus },
-      );
-    }
-
-    return NextResponse.json(result);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+export const POST = createRouteAdapter<
+  typeof ResolveTaskInputSchema,
+  ResolveTaskInput,
+  RouteContext
+>(
+  ResolveTaskInputSchema,
+  async (req: NextRequest, ctx) => {
+    const body = (await readJsonBody(req)) as Record<string, unknown>;
+    return { ...body, taskId: (await ctx.params).taskId };
+  },
+  (input) => {
+    const { humanTaskRepo, instanceRepo, auditRepo, engine } =
+      getPlatformServices();
+    return resolveTask(input, {
+      humanTaskRepo,
+      instanceRepo,
+      auditRepo,
+      engine,
+      triggerRun: triggerAutoRunner,
+    });
+  },
+);

--- a/packages/platform-ui/src/app/api/workflow-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/route.ts
@@ -1,18 +1,17 @@
-import { NextResponse } from 'next/server';
-import { WorkflowDefinitionSchema } from '@mediforce/platform-core';
-import { WorkflowDefinitionVersionAlreadyExistsError } from '@mediforce/platform-infra';
+import { NextRequest } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
-import { createRouteAdapter } from '@/lib/route-adapter';
-import { listWorkflowDefinitions } from '@mediforce/platform-api/handlers';
-import { ListWorkflowDefinitionsInputSchema } from '@mediforce/platform-api/contract';
+import { createRouteAdapter, readJsonBody } from '@/lib/route-adapter';
+import {
+  listWorkflowDefinitions,
+  createWorkflowDefinition,
+} from '@mediforce/platform-api/handlers';
+import {
+  ListWorkflowDefinitionsInputSchema,
+  CreateWorkflowDefinitionInputSchema,
+} from '@mediforce/platform-api/contract';
 
 /**
- * GET /api/workflow-definitions
- *
- * List all registered workflow definitions. Each entry is a group (by
- * workflow name) with `latestVersion`, `defaultVersion`, and the latest
- * `definition` pre-resolved. Shape is identical to the pre-migration
- * route — the UI loads this directly into the Workflow Designer.
+ * GET /api/workflow-definitions — list every registered workflow grouped by name.
  */
 export const GET = createRouteAdapter(
   ListWorkflowDefinitionsInputSchema,
@@ -24,63 +23,16 @@ export const GET = createRouteAdapter(
 /**
  * POST /api/workflow-definitions?namespace=handle
  *
- * Register a new WorkflowDefinition. Version is auto-incremented from the
- * latest existing version for the given name. Send the definition JSON
- * without `version` or `createdAt` — they are set server-side.
- *
- * The `namespace` query parameter is required and sets the owning namespace.
- * It overrides any `namespace` field in the request body.
- *
- * Still inline because mutations are Phase 2 — see `docs/headless-migration.md`.
+ * Registers a new version of a WorkflowDefinition. `version` and `createdAt`
+ * are assigned server-side; the caller supplies everything else.
  */
-export async function POST(request: Request): Promise<NextResponse> {
-  const url = new URL(request.url);
-  const namespace = url.searchParams.get('namespace');
-  if (!namespace) {
-    return NextResponse.json(
-      { error: 'Missing required query parameter: namespace' },
-      { status: 400 },
-    );
-  }
-
-  const body = await request.json().catch(() => null);
-  if (!body || typeof body !== 'object') {
-    return NextResponse.json({ error: 'JSON body is required' }, { status: 400 });
-  }
-
-  const parsed = WorkflowDefinitionSchema.omit({ version: true, createdAt: true }).safeParse({
-    ...body,
-    namespace,
-  });
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Validation failed', issues: parsed.error.issues },
-      { status: 400 },
-    );
-  }
-
-  const { processRepo } = getPlatformServices();
-
-  try {
-    const latestVersion = await processRepo.getLatestWorkflowVersion(parsed.data.name);
-    const nextVersion = latestVersion + 1;
-
-    const definition = {
-      ...parsed.data,
-      version: nextVersion,
-      createdAt: new Date().toISOString(),
-    };
-
-    await processRepo.saveWorkflowDefinition(definition);
-
-    return NextResponse.json(
-      { success: true, name: definition.name, version: definition.version },
-      { status: 201 },
-    );
-  } catch (err) {
-    if (err instanceof WorkflowDefinitionVersionAlreadyExistsError) {
-      return NextResponse.json({ error: 'Version conflict — please retry.' }, { status: 409 });
-    }
-    throw err;
-  }
-}
+export const POST = createRouteAdapter(
+  CreateWorkflowDefinitionInputSchema,
+  async (req: NextRequest) => {
+    const namespace = req.nextUrl.searchParams.get('namespace') ?? '';
+    const draft = await readJsonBody(req);
+    return { namespace, draft };
+  },
+  (input) =>
+    createWorkflowDefinition(input, { processRepo: getPlatformServices().processRepo }),
+);

--- a/packages/platform-ui/src/app/api/workflow-definitions/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/route.ts
@@ -35,4 +35,5 @@ export const POST = createRouteAdapter(
   },
   (input) =>
     createWorkflowDefinition(input, { processRepo: getPlatformServices().processRepo }),
+  { successStatus: 201 },
 );

--- a/packages/platform-ui/src/lib/__tests__/route-adapter.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/route-adapter.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { createRouteAdapter } from '../route-adapter';
-import { HandlerError, NotFoundError } from '@mediforce/platform-api/handlers';
+import {
+  HandlerError,
+  NotFoundError,
+  ConflictError,
+  ForbiddenError,
+  ValidationError,
+} from '@mediforce/platform-api/handlers';
 
 const InputSchema = z.object({ name: z.string().min(1) });
 
@@ -111,6 +117,48 @@ describe('createRouteAdapter', () => {
       await GET(makeRequest({ name: 'alice' }));
 
       expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    it('maps ConflictError to 409 with the original message', async () => {
+      const handler = vi.fn().mockRejectedValue(new ConflictError('Task already claimed'));
+      const GET = createRouteAdapter(
+        InputSchema,
+        (req) => ({ name: req.nextUrl.searchParams.get('name') }),
+        handler,
+      );
+
+      const res = await GET(makeRequest({ name: 'alice' }));
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({ error: 'Task already claimed' });
+    });
+
+    it('maps ForbiddenError to 403 with the original message', async () => {
+      const handler = vi.fn().mockRejectedValue(new ForbiddenError('Not your role'));
+      const GET = createRouteAdapter(
+        InputSchema,
+        (req) => ({ name: req.nextUrl.searchParams.get('name') }),
+        handler,
+      );
+
+      const res = await GET(makeRequest({ name: 'alice' }));
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'Not your role' });
+    });
+
+    it('maps ValidationError to 400 with the original message', async () => {
+      const handler = vi.fn().mockRejectedValue(new ValidationError('Duplicate config for workflow'));
+      const GET = createRouteAdapter(
+        InputSchema,
+        (req) => ({ name: req.nextUrl.searchParams.get('name') }),
+        handler,
+      );
+
+      const res = await GET(makeRequest({ name: 'alice' }));
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Duplicate config for workflow' });
     });
   });
 

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -3,6 +3,19 @@ import { z } from 'zod';
 import { HandlerError } from '@mediforce/platform-api/handlers';
 
 /**
+ * Parse a request body as JSON, returning `{}` on an empty or malformed body.
+ * Kept here (not inside the handler) because the adapter is the only Next.js
+ * seam that touches `NextRequest`; handlers stay framework-free.
+ */
+export async function readJsonBody(req: NextRequest): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Wraps a pure handler (from `@mediforce/platform-api`) into a Next.js route.
  *
  * Auth is handled globally by `src/middleware.ts` (X-Api-Key or Firebase ID

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -76,6 +76,12 @@ export async function readJsonBody(req: NextRequest): Promise<unknown> {
  */
 type EmptyRouteContext = { params: Promise<Record<string, never>> };
 
+export interface RouteAdapterOptions {
+  /** HTTP status on successful handler resolution. Default: 200. Use 201 for
+   *  create endpoints that idiomatically return it. */
+  successStatus?: number;
+}
+
 export function createRouteAdapter<
   InputSchema extends z.ZodType,
   NarrowInput = z.infer<InputSchema>,
@@ -85,7 +91,9 @@ export function createRouteAdapter<
   inputSchema: InputSchema,
   inputFromRequest: (req: NextRequest, ctx: Context) => unknown | Promise<unknown>,
   handler: (input: NarrowInput) => Promise<Output>,
+  options?: RouteAdapterOptions,
 ): (req: NextRequest, ctx: Context) => Promise<NextResponse> {
+  const successStatus = options?.successStatus ?? 200;
   return async (req, ctx) => {
     const raw = await Promise.resolve(inputFromRequest(req, ctx));
     const parsed = inputSchema.safeParse(raw);
@@ -98,7 +106,7 @@ export function createRouteAdapter<
 
     try {
       const result = await handler(parsed.data as NarrowInput);
-      return NextResponse.json(result);
+      return NextResponse.json(result, { status: successStatus });
     } catch (err) {
       if (err instanceof HandlerError) {
         return NextResponse.json(

--- a/packages/platform-ui/src/lib/trigger-auto-runner.ts
+++ b/packages/platform-ui/src/lib/trigger-auto-runner.ts
@@ -1,0 +1,26 @@
+import { getAppBaseUrl } from './app-base-url.js';
+
+/**
+ * Fire-and-forget trigger for the auto-runner loop (`POST /api/processes/:id/run`).
+ *
+ * Used by handlers (task complete/resolve, process create/resume, cron
+ * heartbeat) to kick downstream agent steps after a state change. The actual
+ * `/run` endpoint still lives as an inline Next.js route (Phase 3 migration),
+ * so this helper stays Next.js-flavoured: it reads `NEXT_PUBLIC_APP_URL` and
+ * authenticates with `X-Api-Key`.
+ *
+ * Errors are deliberately swallowed. The caller has already committed the
+ * state change (task completed, instance resumed) and the auto-runner is best
+ * effort; a user-refresh or the next cron tick will retry it.
+ */
+export function triggerAutoRunner(instanceId: string, triggeredBy: string): void {
+  const appUrl = getAppBaseUrl();
+  void fetch(`${appUrl}/api/processes/${instanceId}/run`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': process.env.PLATFORM_API_KEY ?? '',
+    },
+    body: JSON.stringify({ triggeredBy }),
+  }).catch(() => {});
+}

--- a/packages/platform-ui/src/lib/trigger-auto-runner.ts
+++ b/packages/platform-ui/src/lib/trigger-auto-runner.ts
@@ -9,9 +9,10 @@ import { getAppBaseUrl } from './app-base-url.js';
  * so this helper stays Next.js-flavoured: it reads `NEXT_PUBLIC_APP_URL` and
  * authenticates with `X-Api-Key`.
  *
- * Errors are deliberately swallowed. The caller has already committed the
- * state change (task completed, instance resumed) and the auto-runner is best
- * effort; a user-refresh or the next cron tick will retry it.
+ * Errors don't propagate (the caller has already committed the state change
+ * and the auto-runner is best effort) but they ARE logged. Otherwise a
+ * misconfigured `PLATFORM_API_KEY` produces a healthy-looking deploy where
+ * agent steps silently never fire — the exact failure mode we hit pre-Phase 1.
  */
 export function triggerAutoRunner(instanceId: string, triggeredBy: string): void {
   const appUrl = getAppBaseUrl();
@@ -22,5 +23,10 @@ export function triggerAutoRunner(instanceId: string, triggeredBy: string): void
       'X-Api-Key': process.env.PLATFORM_API_KEY ?? '',
     },
     body: JSON.stringify({ triggeredBy }),
-  }).catch(() => {});
+  }).catch((err) => {
+    console.error(
+      `[trigger-auto-runner] Failed to trigger /run for ${instanceId}:`,
+      err,
+    );
+  });
 }


### PR DESCRIPTION
Refs #231 · Stacks on #256 (Phase 1 GETs)

Full Phase 2 mutation migration per [`docs/headless-migration.md`](./docs/headless-migration.md). **12 endpoints across 5 domains**, same contract-first / pure-handler / thin-adapter template Phase 1 established.

> **Stacked PR**: base is the Phase 1 branch (`claude/wizardly-moser-9b8568` / #256). Rebase onto `main` after #256 merges.

## Scope

### tasks domain
- `POST /api/tasks/:taskId/claim`     → `claimTask`     (pending → claimed, 409 otherwise)
- `POST /api/tasks/:taskId/complete`  → `completeTask`  (claimed → completed, advance engine, resume instance)
- `POST /api/tasks/:taskId/resolve`   → `resolveTask`   (auto-claim + verdict / paramValues / file-upload, 1:1 port of `lib/resolve-task.ts`)

### processes domain
- `POST /api/processes`                       → `createProcess`  (auto-selects latest workflow version, fires `/run`)
- `POST /api/processes/:instanceId/cancel`    → `cancelProcess`  (running/paused → failed)
- `POST /api/processes/:instanceId/resume`    → `resumeProcess`  (paused → running, audit, fires `/run`)

### definitions domain
- `PUT  /api/definitions`            → `upsertLegacyDefinition`    (YAML body, auto-seeds all-human config)
- `POST /api/workflow-definitions`   → `createWorkflowDefinition`  (auto-increments version, namespace query param)
- `POST /api/agent-definitions`      → `createAgentDefinition`

### configs domain
- `POST /api/configs`  → `createProcessConfig`  (server-side `validateProcessConfig` + duplicate-version 409)

### cron domain
- `POST /api/cron/heartbeat`  → `heartbeat`  (scans cron triggers, fires due ones, persists state)

## Infra added alongside

- **Three new error classes** on top of `HandlerError` / `NotFoundError` from #256:
  - `ConflictError`   (409) — state-machine refuses (task already claimed, instance not paused, version conflict)
  - `ForbiddenError`  (403) — reserved for handler-level auth policy
  - `ValidationError` (400) — domain validation that's richer than a Zod refine (YAML parse, config validator, file-upload shape)
  Adapter still maps any `HandlerError` subclass by its `statusCode` — no adapter change.

- **`readJsonBody(req)`** helper next to `createRouteAdapter` — tolerant body read (empty / malformed → `{}`). Cuts boilerplate from every mutation route.

- **`createRouteAdapter({ successStatus })`** — opt-in HTTP status override. Defaults to 200; creates set 201 so existing route tests stay green.

- **`triggerAutoRunner(instanceId, actorId)`** in `platform-ui/lib` — Next.js-only side-channel that wraps the fire-and-forget `POST /api/processes/:id/run` (which stays inline — Phase 3). Injected as the optional `triggerRun` dep on `completeTask`, `resolveTask`, `createProcess`, `resumeProcess`, `heartbeat`. Handlers stay pure; tests pass a `vi.fn()` recorder.

- **Structural `*Like` interfaces** on the deps for engine / triggers — `EngineLike`, `ManualTriggerLike`, `CronTriggerLike`, `CronScheduleValidator`, `PluginRegistryView`. Handlers stay free of `@mediforce/workflow-engine` and `@mediforce/agent-runtime`; route wires the real impls in.

- **Infra error recognition by `name`** — `DefinitionVersionAlreadyExistsError`, `ConfigVersionAlreadyExistsError`, `WorkflowDefinitionVersionAlreadyExistsError` come from `@mediforce/platform-infra`. Handlers match by `err.name` instead of importing them (would breach the boundary: handlers must not depend on infra). Mapped to `ConflictError`.

## Mediforce client extension

Every new handler also gets a typed `mediforce.*` method. Same Stripe-style namespacing, same validate-input → request → parse-output flow as Phase 1:

```ts
// tasks
await mediforce.tasks.claim({ taskId, userId });
await mediforce.tasks.complete({ taskId, verdict: 'approve', comment });
await mediforce.tasks.resolve({ taskId, verdict, paramValues, attachments });

// processes
await mediforce.processes.create({ definitionName, definitionVersion, triggeredBy, payload });
await mediforce.processes.cancel({ instanceId });
await mediforce.processes.resume({ instanceId });

// definitions
await mediforce.workflowDefinitions.create({ namespace, draft });
await mediforce.definitions.upsertLegacy({ yaml });    // PUT, text/plain
await mediforce.agentDefinitions.create({ ...input });

// configs + cron
await mediforce.configs.create({ ...processConfig });
await mediforce.cron.heartbeat();
```

`request()` now auto-sets `Content-Type: application/json` when a string body is present and no explicit header is set — YAML upload sets `text/plain` and keeps it.

## Breaking changes (documented)

- **Create endpoints return 201** consistently (was inconsistent — Phase 1 GETs unaffected). Existing route tests already expected 201; adapter now honors it.
- **`POST /api/configs` validation failures** surface as `{ error: <joined-errors-string> }` instead of `{ errors: [...], warnings: [...] }`. Aligns with the unified error contract used everywhere else. Internal config-UI form was already showing the joined message — no UI rework needed; external consumers (if any) see the shape change.

## Tests

| Layer | What's in |
|---|---|
| Contract types | ~25 new Zod input/output schema pairs |
| Handler tests  | ~60 new tests against in-memory repos (tasks: 26, processes: 15, definitions: 8, configs: 3, cron: 6) — happy path, state-machine refuses, audit assertions, side-effect injection |
| Adapter        | 3 new tests for `ConflictError` / `ForbiddenError` / `ValidationError` mapping |
| Pre-existing route tests | Updated for the 201/error-shape changes above |
| Boundary guard | Every new handler has a sibling test; UI never imports handlers — both invariants pass |

Total suite: **1526 passing** (up from 1466 at the tip of #256).

## Verification

```bash
pnpm typecheck                                # clean
pnpm test                                     # 1526 passing
pnpm --filter @mediforce/platform-ui build    # green — what Vercel runs
```

## Not in scope — Phase 3

- `POST /api/processes/:instanceId/advance` — `executeAgentStep` spawns Docker containers; orchestrator handler pattern not settled.
- `POST /api/processes/:instanceId/run`     — 400-LOC auto-runner loop.
- `POST /api/cowork/:sessionId/{chat,message,finalize}` — SSE streaming + MCP tool execution.

`triggerAutoRunner` keeps the fire-and-forget side-channel working until `/run` itself migrates.

## Server actions

`src/app/actions/tasks.ts` still calls the legacy `@/lib/resolve-task` helper (`claimTask`, `completeParamsTask`, `completeUploadTask`, etc). Re-routing those to the typed client is mechanical but out of scope for this PR — tracked for a Phase 5 cleanup pass alongside the `@/lib/platform-services` shim removal.

## Risk

Low-to-medium. State-machine semantics ported 1:1 from the inline routes (audit events identical, fire-and-forget preserved). Two contract shape changes documented above. Adapter change is additive (`successStatus` opt). Pre-existing `configs/route` quirk (definition lookup with literal `'latest'`) deliberately preserved — fixing it is out of scope.