### PR TITLE
ci(vercel): skip preview deploys when only docs/skills/configs change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
 
+# NOTE: The `paths-ignore` lists below are mirrored in
+# `packages/platform-ui/vercel.json` (`ignoreCommand`) so Vercel skips
+# preview deploys for the same docs-only changes that skip CI. Keep both
+# lists in sync — adding an entry here without updating Vercel means
+# extra preview builds; the reverse means CI runs on changes Vercel
+# already skipped.
 on:
   pull_request:
     paths-ignore:

--- a/packages/platform-ui/vercel.json
+++ b/packages/platform-ui/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "ignoreCommand": "cd \"$(git rev-parse --show-toplevel)\" && git diff --quiet HEAD^ HEAD -- . ':!docs' ':!skills' ':!.claude' ':!agents' ':!.planning' ':!LICENSE' ':(exclude,glob)*.md'"
 }


### PR DESCRIPTION
## Summary

Vercel currently builds a preview deploy on every push, even when the diff is docs-only (e.g., a CHANGELOG entry, an `AGENTS.md` tweak, or an edit to `skills/`). That's wasted build minutes and a "preview" link that didn't actually change.

This PR adds an `ignoreCommand` to `packages/platform-ui/vercel.json` that mirrors the existing `paths-ignore` in `.github/workflows/ci.yml` — Vercel skips the deploy under the same conditions CI skips its checks. Cross-reference comment added at the top of `ci.yml` so anyone editing one is reminded to update the other.

## Why mirror CI instead of writing a separate rule?

We already maintain "what counts as a docs-only change" in `ci.yml`. Duplicating that list with different paths would mean two sources of truth that drift. Same list → same semantics → predictable: if a change is small enough that CI skips it, Vercel skips it too.

## Why an inline one-liner in `vercel.json` instead of a script?

The list is short. A `scripts/vercel-ignore.sh` would be a separate file for two shell commands — over-engineering. Tradeoff accepted: the JSON line is dense but it's the implementation of an existing rule, not a new one.

## How it works

```bash
cd "$(git rev-parse --show-toplevel)" \
  && git diff --quiet HEAD^ HEAD -- . \
       ':!docs' ':!skills' ':!.claude' ':!agents' ':!.planning' ':!LICENSE' \
       ':(exclude,glob)*.md'
```

- `cd` to repo root so pathspecs are repo-relative regardless of where Vercel sets cwd
- `:!path` shorthand excludes each directory (matches GHA `path/**` semantics)
- `:(exclude,glob)*.md` excludes root-level `.md` files only (matches GHA `*.md` which does NOT match `**/*.md`)
- Exit 0 → Vercel skips deploy; exit 1 → Vercel builds
- Fail-open: if `HEAD^` doesn't exist (shallow clone, first commit on branch), `git diff` exits non-zero and Vercel builds — preferring an extra deploy to a missed one

## Test plan

Two real-commit tests against `origin`:

- [x] **Skip case**: HEAD of #444 (docs/skills-only refactor branch) — `exit: 0` ✓
- [x] **Deploy case**: Renovate vitest bump #440 (touches `pnpm-lock.yaml`) — `exit: 1` ✓
- [ ] **Live confirmation**: this PR itself touches `packages/platform-ui/vercel.json` and `.github/workflows/ci.yml`, both outside the exclude list → Vercel will build a preview for this PR. That's correct: the change to `vercel.json` IS a build input.

## What still triggers a build

Any change to `packages/*` (including the platform-ui itself), `apps/*`, root-level `package.json` / `pnpm-lock.yaml` / `tsconfig*.json`, or anything else not in the exclude list.

## Companion to

Goes well with #444 (slim AGENTS.md + composable skills refactor) — that PR ships purely doc/skill changes and would be the first beneficiary of this rule once both merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_015nXyUPhdndfaypfN5NFXd4)_