### PR TITLE
docs(adr): ADR-0001 — Firestore to self-hosted Postgres

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,266 @@
+# Mediforce
+
+Mediforce is a single-tenant, on-prem-capable workflow + agent orchestration
+platform for pharma. This document is the glossary — canonical names for the
+concepts. **Not a spec, not implementation guide.**
+
+## Language
+
+### Deployment shape
+
+**Deployment**:
+A single running Mediforce installation. Typically dedicated to one customer
+(single-tenant). Contains many Namespaces.
+
+**Namespace** *(today canonical; rename to Workspace proposed in ADR-001)*:
+An isolated scope of work inside a Deployment. Owns workflow definitions,
+process instances, agent definitions, OAuth providers, secrets, tool catalog,
+cowork sessions. Identified by a URL-safe `handle`. Two types: `personal`
+(auto-created per user, linked via `linkedUserId`) and `organization`
+(multi-member, shared — e.g. a department inside the customer tenant).
+_Avoid_: Workspace (UI term in transition — see note below), Tenant (= the
+whole Deployment, not an isolated scope inside it).
+
+**Handle**:
+URL-safe identifier for a Namespace (e.g. `acme-onco-trial`). Globally unique
+inside a Deployment. Used in URL paths (`/{handle}/…`) and as Namespace's
+storage key.
+
+### Workflow domain
+
+**Workflow Definition**:
+Authoritative template for a runnable workflow. Versioned (integer), immutable
+once created. Belongs to one Namespace. Contains steps, transitions,
+triggers, declared roles, env, optional git workspace. Has
+`visibility: public | private` — `public` discoverable read-only across
+Namespaces, `private` members-only.
+_Avoid_: Process Definition (legacy schema, replaced by Workflow Definition),
+"Workflow" used loosely for a running instance — that is a Workflow Run.
+
+**Workflow Run** *(today's `ProcessInstance` — rename to `WorkflowRun` proposed)*:
+One execution of a Workflow Definition. Tracks current step, status,
+accumulated variables, trigger payload, total cost, deleted/archived flags.
+**"Run" is the canonical term** — used everywhere in the UI, URLs
+(`/workflows/{name}/runs/{runId}`), API routes (`/api/runs/{runId}`), schema
+comments ("new runs", "archived runs", git branch `run/<runId>`), and
+neighbour entities (`AgentRun`). The `ProcessInstance` schema name is
+implementation legacy and renames to `WorkflowRun` in ADR-0001.
+_Avoid_: "Workflow Instance" (briefly proposed but inconsistent with the
+project's own "Run" vocabulary), "Process Instance" (legacy schema name
+only), "Workflow" alone (ambiguous — Definition or Run?).
+
+**Workflow Step** *(config; static)*:
+A node in a Workflow Definition's DAG. Defines `executor: human | agent |
+script | cowork | action`, optional autonomy level (agent steps),
+allowed roles, verdicts, params.
+_Avoid_: "Step" alone (ambiguous — config or runtime instance?).
+
+**Step Execution** *(runtime; one attempt)*:
+One attempt to execute one Workflow Step inside a Workflow Run. Captures
+input, output, verdict, gate result, iteration number, error. Optionally has
+0..1 Agent Run, 0..1 Cowork Session, 0..N Human Tasks attached.
+
+### What an agent / human / cowork produces
+
+**Output** (`StepExecution.output`):
+Immediate result of one Step Execution. Polymorphic — shape depends on
+executor (form submission, agent envelope, gate decision).
+
+**Variables** (`ProcessInstance.variables`):
+Accumulated outputs across all completed Step Executions of one Process
+Instance. The carry-forward state used to resolve `${steps.stepId.output.key}`
+in subsequent steps and transitions.
+
+**Artifact** (`CoworkSession.artifact`):
+Structured deliverable that a human and an agent build collaboratively across
+the turns of a Cowork Session. **Not** the same as Output or Variables —
+finalized artifact is promoted to Output only when the cowork step completes.
+
+### Agent + human work
+
+**Agent Run**:
+One autonomous (L0–L4) execution of an agent for a Step Execution.
+Result: an Agent Output Envelope. Immutable once created.
+
+**Cowork Session**:
+A real-time, human-in-the-loop session attached to a Step Execution where
+executor=`cowork`. Modes: `chat` (text via SSE) or `voice-realtime` (OpenAI
+Realtime). Has turns and an Artifact.
+_Avoid_: "Cowork" as a standalone noun without context (`Cowork Session`,
+`Cowork Step` are the precise terms).
+
+**Conversation Turn**:
+A single message in a Cowork Session. Three role-discriminated subtypes:
+`human`, `agent`, `tool` (MCP tool execution result).
+
+**Human Task**:
+Work item assigned to a human role inside a Workflow Run. Created when
+`executor=human` or as L3 agent-review. Has soft claim (`assignedUserId: null`
+visible to all role-matching users until claimed).
+
+**Handoff**:
+Structured escalation from an Agent Run to a human (low confidence, error,
+explicit escalation). Distinct from Human Task — Handoff has agent context,
+question, resolution. Lifecycle: `created → acknowledged → resolved`.
+
+### Plugin / Skill / MCP
+
+**Plugin** *(runtime strategy)*:
+A pluggable agent runtime implementation. Today: `claude-code`, `opencode`,
+`script-container`, plus mocks. Each implements `BaseContainerAgentPlugin` and
+declares roles (`executor`, `reviewer`). Registered in PluginRegistry.
+
+**Skill** *(code payload)*:
+A code artifact (script or git repo) consumed by an agent at spawn time
+(e.g. Claude Code loads it into the container).
+_Avoid_: Conflating with Plugin — Plugin is the runtime; Skill is data.
+
+**Agent Definition** *(template)*:
+Reusable spec for an agent runtime (Claude Code / OpenCode / cowork-chat /
+voice-realtime) including system prompt, model, MCP bindings, skills.
+Referenced by Workflow Step via `agentId`. Decoupled from steps so the same
+agent can power many steps.
+
+**MCP Server**:
+External tool host (stdio or HTTP) accessible to an agent via Model Context
+Protocol. Attached to an Agent Definition via Agent MCP Binding; narrowed
+per-step via Step MCP Restriction (subtractive).
+
+**Tool Catalog Entry**:
+Admin-curated stdio MCP server definition that agents reference by `catalogId`
+(prevents inline RCE). Namespace-scoped.
+
+### Identity / auth
+
+**User**:
+A human (or service account) authenticated to a Deployment. Identity owned by
+the auth library (NextAuth tables `auth_users` + `auth_accounts` + `auth_sessions`
+after ADR-0002). Mediforce-side fields live in `user_profiles`.
+
+**Session**:
+A server-side, DB-backed record proving a User is currently signed in. Carries
+a `session_token` (cookie value), `user_id`, `expires`. Revocable
+immediately by deleting the row.
+_Avoid_: "JWT" (we explicitly chose database sessions, not JWT).
+
+**Membership** *(workspace governance level)*:
+The kind of seat a User holds inside one Workspace: `owner | admin | member`.
+Stored on `workspace_members.membership`. Owners can delete the Workspace and
+manage other owners; admins can manage members and workspace settings; members
+can use the Workspace.
+_Avoid_: "Role" alone — that's overloaded with process-domain roles below.
+
+**Roles** *(process-domain, plural)*:
+Functional roles a User holds inside one Workspace for workflow purposes —
+e.g. `reviewer`, `PI`, `approver`. Stored on `workspace_members.roles` as
+`text[]`. Drive `HumanTask.assignedRole` and `CoworkSession.assignedRole`
+gating, and `WorkflowStep.allowedRoles` access control.
+_Avoid_: confusing with Membership above. Roles are per-workspace today
+(per-deployment in legacy Firebase custom claims; migrated to per-workspace
+in ADR-0002).
+
+**Deployment admin**:
+A boolean on `user_profiles.deployment_admin`. The Deployment-wide
+superuser bit (formerly Firebase custom claim `role: 'admin'`). Rare —
+typically one sysadmin per Deployment. Cross-Workspace operational power.
+
+**OAuth Provider Config** *(per-Namespace)*:
+Authorization-server endpoint + credentials. GitHub / Google built-in; custom
+OIDC supported.
+
+**Agent OAuth Token** *(per Namespace + Agent + Server)*:
+Persisted token used by one Agent Definition to authenticate to one MCP
+server. Two Agents needing GitHub connect twice — by design.
+
+**Namespace Secret** *(broader scope)*:
+Key-value secrets visible to all workflows in a Namespace. Resolved via
+`{{SECRET:name}}` template at runtime.
+
+**Workflow Secret** *(narrower scope)*:
+Secrets scoped to one Workflow Definition. Wins over Namespace Secret if
+same key exists (precedence).
+
+### Audit / observability
+
+**Audit Event**:
+Immutable, human-readable log entry. Captures actor (user/agent/system),
+action, basis (rule that triggered), input/output snapshot, entity context,
+process+step context. The compliance backbone (21 CFR Part 11).
+
+**Agent Event**:
+Operational telemetry emitted during an Agent Run (status changes, custom
+events). Distinct from Audit Event — Agent Event is internal; Audit Event is
+the user-facing immutable log.
+
+## Relationships
+
+- A **Deployment** contains many **Namespaces**.
+- A **Namespace** owns its **Workflow Definitions**, **Workflow Runs**,
+  **Agent Definitions**, **OAuth Providers**, **Secrets**, **Tool Catalog**.
+- A **Workflow Definition** has many versioned revisions; its `visibility`
+  controls cross-Namespace read access.
+- A **Workflow Run** belongs to exactly one **Workflow Definition**
+  (`name`+`version`).
+- A **Workflow Run** has many **Step Executions**.
+- A **Step Execution** has 0..1 **Agent Run**, 0..1 **Cowork Session**,
+  0..N **Human Tasks** attached.
+- An **Agent Run** may produce 0..N **Handoffs**.
+- An **Agent Definition** has many **Agent MCP Bindings** (per server) and
+  many **Agent OAuth Tokens** (per server).
+
+## Flagged ambiguities
+
+- **Namespace vs Workspace** *(active rename in flight)*: Code uses
+  `namespace` everywhere — schema fields, repos, Firestore collection,
+  Postgres columns (post-migration). UI uses "Workspace" in user-facing
+  strings (placeholders, redirect paths, hook names). **Today's canonical
+  domain term: `Namespace`.** ADR-001 proposes the inverse — flip to
+  `Workspace` as the canonical user-facing term, with `namespace` retiring to
+  a storage-level synonym at most. Decision deferred to ADR-001 review.
+- **Process vs Workflow** *(legacy)*: `Process*` is legacy naming. `Workflow*`
+  is the present canonical. Some repos still named `ProcessRepository`
+  while managing `WorkflowDefinitions`; `processInstanceId` field name
+  ubiquitous. ADR-001 renames at storage level only (column names);
+  follow-up PRs rename repositories and types incrementally. New code
+  uses Workflow.
+- **Output vs Variables vs Artifact**: three distinct concepts, often
+  confused. Output = one step's immediate result. Variables = accumulated
+  outputs forwarded across steps. Artifact = collaboratively built
+  deliverable inside a cowork session (promoted to Output only on cowork
+  finalize). Keep the distinction in storage too.
+- **Workflow visibility (`public` vs `private`)**: Defined in PR #346 — a
+  `public` Workflow Definition is **read-discoverable from other
+  Namespaces**; `private` is members-only. **Workflow Runs (runs) are
+  always members-only**, regardless of the parent definition's visibility.
+  Default changed to `private` later. Postgres needs same semantic — most
+  natural: app-layer filter today, RLS policy `USING (namespace IN (member of)
+  OR (table = workflow_definitions AND visibility = 'public'))` in the
+  future RLS ADR. Resolved 2026-05-19: `public` stays a live cross-workspace
+  feature — teams can publish, platform ships examples — no pharma-deployment
+  disable. Access goes through an **explicit repo method**
+  (`discoverPublicWorkflows()`); default `list()` stays workspace-scoped.
+- **L0 vs L2 with `result: null`**: Both allow null result. L0 = Silent
+  Observer (annotations only, no decision attempted). L2 = Informed Agent
+  (decision made, but confidence below threshold → null + fallback path).
+  Storage shape identical; semantics differ.
+- **`workspace` name collision** *(resolved 2026-05-19)*: With the
+  Namespace → Workspace rename proposed in ADR-001, the existing
+  `WorkflowDefinition.workspace` field (git working-tree config) collides.
+  Resolution: rename that field to **`gitWorkspace`**. The schema type
+  `WorkflowWorkspaceSchema` becomes `WorkflowGitWorkspaceSchema`,
+  `WorkflowWorkspace` type becomes `WorkflowGitWorkspace`.
+- **Fail-proof repository scoping** *(resolved 2026-05-19, applies to
+  ADR-001 implementation)*: Two invariants on every repo query:
+  (1) workspace/namespace scoping enforced at the repo base class — caller
+  cannot construct a query that crosses workspaces by accident;
+  (2) soft-delete filter (`deleted_at IS NULL AND archived_at IS NULL`)
+  enforced at the repo base class — caller cannot accidentally read
+  tombstones. Both have explicit opt-out methods (`crossWorkspacePublic()`,
+  `includeArchived()`, `includeDeleted()`) used only at audited call sites
+  (admin, public workflow discovery, cleanup jobs). Postgres RLS in the
+  later Phase 2 ADR adds belt-and-suspenders enforcement.
+- **Retention policy** *(resolved 2026-05-19)*: Soft-delete is **forever**
+  for now — no automatic hard-delete purge after N days. A later ADR may
+  introduce retention windows if a customer asks. Operational implication:
+  storage grows monotonically; partial indexes on `deleted_at IS NULL`
+  keep query cost flat.

--- a/docs/adr/0001-firestore-to-postgres.md
+++ b/docs/adr/0001-firestore-to-postgres.md
@@ -47,7 +47,7 @@ Move the primary datastore to **self-hosted Postgres 16**, accessed via
    for routes that pin to one `/{handle}/…` segment. The wrapper layer that
    consumes this base class — `CallerScope` plus per-entity
    `Authorized<Entity>Repository` types — lands ahead of the Postgres swap;
-   see [ADR-0003](./0003-scoped-data-access-authorization.md) for the
+   see [ADR-0004](./0004-scoped-data-access-authorization.md) for the
    wrapper layer's design and timing.
 4. **Soft-delete via timestamps.** Replace existing `deleted: boolean` and
    `archived: boolean` flags with `deleted_at timestamptz` and

--- a/docs/adr/0001-firestore-to-postgres.md
+++ b/docs/adr/0001-firestore-to-postgres.md
@@ -1,0 +1,140 @@
+# 0001 — Move primary datastore from Firestore to self-hosted Postgres
+
+- **Status:** Proposed
+- **Date:** 2026-05-19
+- **Authors:** Marek Rogala (@marekrogala)
+- **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
+- **Implementation plan:** [PLAN-0001.md](./PLAN-0001.md)
+
+## Context
+
+Mediforce uses Firestore for all persistent state. Firestore is a managed Google
+service and cannot be deployed on customer premises — a hard requirement for
+every pharma customer Mediforce targets. The Firebase Emulator dependency also
+hurts local-dev and demo-deploy onboarding.
+
+The repository pattern is already in place across
+`packages/platform-core/src/interfaces/` (contracts),
+`packages/platform-infra/src/firestore/` (Firestore implementations) and
+`packages/platform-core/src/testing/` (in-memory test doubles). The migration is
+bounded to those surfaces plus the small number of UI hooks that bypass
+repositories to read Firestore directly via `onSnapshot`.
+
+Domain terms used below — Namespace (today's canonical scope), Workspace
+(proposed canonical user-facing alias), Workflow Definition, Process Instance,
+Step Execution, Agent Run, Cowork Session — are defined in
+[`CONTEXT.md`](../../CONTEXT.md).
+
+## Decision
+
+Move the primary datastore to **self-hosted Postgres 16**, accessed via
+**Drizzle ORM**, with the following architectural commitments:
+
+1. **Datastore.** Self-hosted Postgres 16, deployable as a single container via
+   `docker-compose`. The customer's IT operates it; we ship a backup recipe.
+2. **Access layer.** Drizzle ORM (typed query builder, TypeScript schemas,
+   `drizzle-kit` migrations). Repository interfaces in
+   `packages/platform-core/src/interfaces/` stay unchanged; the in-memory test
+   doubles remain the L2 path.
+3. **Fail-proof repository scoping.** Every concrete repository inherits from a
+   `WorkspaceScopedRepository` base that enforces, on every default read path:
+   (a) workspace scoping (`WHERE workspace = $me`) and (b) soft-delete
+   filtering (`WHERE deleted_at IS NULL AND archived_at IS NULL`). Crossing
+   those filters requires an explicit, audit-logged opt-out method (e.g.
+   `discoverPublicWorkflows()`, `includeDeleted()`, `includeArchived()`).
+4. **Soft-delete via timestamps.** Replace existing `deleted: boolean` and
+   `archived: boolean` flags with `deleted_at timestamptz` and
+   `archived_at timestamptz` columns. NULL = active. Soft-delete is **forever**
+   for now; a later ADR may introduce a retention purge.
+5. **Realtime swap.** All `onSnapshot` listeners are removed. Lists move to
+   **SWR polling** (2–10 s interval). Live agent run logs and cowork text chat
+   move to **Server-Sent Events**. No WebSockets are introduced.
+6. **Cross-workspace public discovery.** `WorkflowDefinition.visibility =
+   'public'` remains a live, cross-Workspace feature — teams may publish,
+   platform examples ship as public. Access goes through an explicit repo
+   method (`discoverPublicWorkflows()`); the default scoped `list()` never
+   crosses workspaces.
+7. **Domain term cleanup, storage level only.** Rename the storage field
+   `namespace` → `workspace`. Rename the colliding
+   `WorkflowDefinition.workspace` field (git working-tree config) to
+   `gitWorkspace`. Repository/class renames (`ProcessRepository` →
+   `WorkflowDefinitionRepository`, `ProcessInstance` → `WorkflowRun`) are
+   **out of scope here** and land in follow-up PRs. New code uses Workflow
+   / Run. "Run" is the canonical user-facing term — already in the UI, URLs
+   (`/workflows/{name}/runs/{runId}`), schema comments, and neighbour
+   `AgentRun` — so "Workflow Run" wins over "Workflow Instance".
+8. **Cutover.** **Big-bang with planned downtime** during a low-traffic window:
+   a one-shot Python script exports Firestore, transforms it, and bulk-inserts
+   into Postgres; we verify counts + sample diffs, flip the application's
+   datastore env, and restart. Rollback path: restore Firestore from backup,
+   retry next window. Mediforce is in platform-creation phase, not 24/7
+   maintenance — downtime is acceptable.
+
+## Considered alternatives
+
+- **Stay on Firestore.** Rejected: blocks pharma on-prem GTM; the migration
+  surface only grows as new collections accrue.
+- **Supabase self-hosted stack** (Postgres + PostgREST + GoTrue + Realtime +
+  Storage). Rejected: 8–10-container stack widens the customer's operational
+  surface; "just Postgres" is easier to defend in a vendor review. We can
+  adopt individual Supabase services later if needed; the schema is portable.
+- **DB-agnostic ORM (Prisma, TypeORM).** Rejected: the existing repository
+  pattern already provides the abstraction that matters (in-memory ↔ real
+  database swap). Forcing the lowest-common-denominator across DBs sacrifices
+  the Postgres-specific features (`jsonb` paths, RLS, partial indexes,
+  `LISTEN/NOTIFY`, `pgvector`) where the real wins live.
+- **Postgres + Prisma.** Considered; rejected for heavier runtime, awkward
+  `jsonb` support, higher exit cost. Drizzle stays close to SQL.
+- **Per-workspace dual-write cutover.** Rejected as overengineering for our
+  scale and life-cycle stage. Big-bang is lower-kit-cost and matches a
+  platform still being shaped, not one with a 24/7 SLA.
+
+## Consequences
+
+- Pharma on-prem deployment unblocked. Single new dependency every IT
+  department already supports.
+- Demo and local dev simplify to a single `docker-compose` container; Firebase
+  Emulators retire.
+- Strongly consistent reads/writes replace Firestore's eventual consistency,
+  removing a class of race-condition workarounds (notably the personal-
+  namespace bootstrap dance in `auth-context.tsx`).
+- One-time migration effort, estimated 2 focused engineering weeks.
+- ~14 UI hook sites + 3 page-component sites are rewired from `onSnapshot` to
+  SWR / SSE. Mostly mechanical.
+- New operational responsibility for self-hosted customers: Postgres backup.
+  Standard tooling; documented as part of this migration.
+- Cross-workspace public-workflow discovery is the **single permitted scope
+  exception** and is funnelled through one explicit repo method, audit-logged.
+
+## Enterprise / pharma fit
+
+- "Your data lives in your Postgres" is a one-line answer in every IT
+  vendor review.
+- Future Postgres Row-Level Security (Phase 2, separate ADR) gives
+  database-level Workspace isolation — the strongest possible answer to
+  "tenants cannot see each other's data".
+- 21 CFR Part 11-relevant features (audit triggers, point-in-time recovery,
+  write-ahead log) are off-the-shelf in Postgres.
+- A single `docker-compose up` for evaluators and demo-deploy operators
+  replaces the current multi-piece Firebase-Emulator setup.
+
+## Out of scope
+
+- **Firebase Auth → NextAuth** — separate ADR (`0002`), deferred for now.
+- **Firebase Storage → object storage** — separate ADR when a customer asks.
+- **Vercel AI SDK for cowork streaming** — separate ADR, post-migration.
+- **Postgres Row-Level Security** for namespace isolation — Phase 2, separate
+  ADR; this ADR enforces scoping in the application layer via the
+  fail-proof repository base class.
+
+## Open questions for review
+
+- **Drizzle (this ADR) vs raw `postgres.js` + Zod.** Drizzle wins for ~20
+  repositories; confirm in PR review.
+- **Rename `namespace` → `workspace` at the storage layer in this ADR** vs a
+  separate prior PR. Confirm in PR review.
+- **`type: 'organization' | 'personal'`** on Workspace — we keep
+  `'organization'` (departments inside a tenant), no rename. Confirm in PR
+  review.
+- **`public` cross-workspace discovery** — keep as a live feature, no
+  per-deployment disable flag. Confirm in PR review.

--- a/docs/adr/0001-firestore-to-postgres.md
+++ b/docs/adr/0001-firestore-to-postgres.md
@@ -79,22 +79,63 @@ Move the primary datastore to **self-hosted Postgres 16**, accessed via
 
 ## Considered alternatives
 
+### Datastore engine
+
 - **Stay on Firestore.** Rejected: blocks pharma on-prem GTM; the migration
   surface only grows as new collections accrue.
+- **MySQL / MariaDB.** Considered — many pharma IT shops already operate
+  one. Rejected because: weaker JSON / `jsonb` story (no native `jsonb`
+  path operators and partial indexes are more limited); no native
+  publish-subscribe equivalent of `LISTEN / NOTIFY`; weaker row-level
+  security primitives that the future RLS ADR will rely on; the vector,
+  full-text, and extension ecosystem (`pgvector`, FTS) trails Postgres.
+  Postgres is the more capable target at no extra operational cost.
+- **SQLite (+ Litestream for backups).** Considered — irresistibly simple.
+  Rejected because: a single-writer concurrency model bottlenecks the
+  workflow engine + UI + worker writing concurrently; no usable network
+  protocol, so the worker and the Next.js process must share a filesystem;
+  no RLS path; mediocre support for `bytea`-sized rows we'll store for
+  skills and attachments (see ADR-0003). Fine as a future "tiny demo"
+  side-target if we ever ship a personal-use SKU, not a fit for the main
+  product.
+- **MongoDB or another document store.** Rejected — it preserves the
+  document-DB ergonomics that drove us off Firestore (poor joins, awkward
+  multi-collection consistency, weaker SQL tooling, identical vendor-risk
+  conversation in pharma reviews).
+- **CockroachDB / YugabyteDB / TiDB (distributed Postgres-compatible).**
+  Rejected as overkill for single-tenant pharma deployments. They solve
+  multi-region HA we don't need; in exchange they add deployment
+  complexity (multiple nodes, gossip, raft), operational cost, and
+  occasional Postgres incompatibility (transactional ergonomics, certain
+  extensions). Postgres scales vertically far past where any pharma
+  customer's mediforce instance will land.
 - **Supabase self-hosted stack** (Postgres + PostgREST + GoTrue + Realtime +
   Storage). Rejected: 8–10-container stack widens the customer's operational
   surface; "just Postgres" is easier to defend in a vendor review. We can
-  adopt individual Supabase services later if needed; the schema is portable.
+  adopt individual Supabase services later if needed; the schema is
+  portable. If a customer specifically asks for Supabase, the same schema
+  lights up on top of theirs.
+
+### Access layer / ORM
+
 - **DB-agnostic ORM (Prisma, TypeORM).** Rejected: the existing repository
   pattern already provides the abstraction that matters (in-memory ↔ real
-  database swap). Forcing the lowest-common-denominator across DBs sacrifices
-  the Postgres-specific features (`jsonb` paths, RLS, partial indexes,
-  `LISTEN/NOTIFY`, `pgvector`) where the real wins live.
+  database swap). Forcing the lowest-common-denominator across DBs
+  sacrifices the Postgres-specific features (`jsonb` paths, RLS, partial
+  indexes, `LISTEN/NOTIFY`, `pgvector`) where the real wins live.
 - **Postgres + Prisma.** Considered; rejected for heavier runtime, awkward
   `jsonb` support, higher exit cost. Drizzle stays close to SQL.
-- **Per-workspace dual-write cutover.** Rejected as overengineering for our
-  scale and life-cycle stage. Big-bang is lower-kit-cost and matches a
-  platform still being shaped, not one with a 24/7 SLA.
+- **Postgres + raw `postgres.js` + Zod** (no ORM at all). Considered;
+  Drizzle wins for ~20 repositories because typed query builders catch
+  column-typo and join-shape bugs at compile time and keep migrations in
+  one tool. We can drop Drizzle later and the hand-written SQL underneath
+  stays valid — exit cost is low.
+
+### Migration approach
+
+- **Per-workspace dual-write cutover.** Rejected as overengineering for
+  our scale and life-cycle stage. Big-bang is lower-kit-cost and matches
+  a platform still being shaped, not one with a 24/7 SLA.
 
 ## Consequences
 

--- a/docs/adr/0001-firestore-to-postgres.md
+++ b/docs/adr/0001-firestore-to-postgres.md
@@ -36,12 +36,19 @@ Move the primary datastore to **self-hosted Postgres 16**, accessed via
    `drizzle-kit` migrations). Repository interfaces in
    `packages/platform-core/src/interfaces/` stay unchanged; the in-memory test
    doubles remain the L2 path.
-3. **Fail-proof repository scoping.** Every concrete repository inherits from a
-   `WorkspaceScopedRepository` base that enforces, on every default read path:
-   (a) workspace scoping (`WHERE workspace = $me`) and (b) soft-delete
-   filtering (`WHERE deleted_at IS NULL AND archived_at IS NULL`). Crossing
-   those filters requires an explicit, audit-logged opt-out method (e.g.
+3. **Fail-proof repository scoping.** Every concrete repository inherits from an
+   `AuthorizedRepository` base that enforces, on every default read and write
+   path: (a) workspace scoping (`WHERE workspace IN $callerWorkspaces`, or
+   unrestricted for `caller.kind === 'apiKey'`) and (b) soft-delete filtering
+   (`WHERE deleted_at IS NULL AND archived_at IS NULL`). Crossing those
+   filters requires an explicit, audit-logged opt-out method (e.g.
    `discoverPublicWorkflows()`, `includeDeleted()`, `includeArchived()`).
+   A URL-driven single-workspace variant (`scopedTo(handle)`) is available
+   for routes that pin to one `/{handle}/…` segment. The wrapper layer that
+   consumes this base class — `CallerScope` plus per-entity
+   `Authorized<Entity>Repository` types — lands ahead of the Postgres swap;
+   see [ADR-0003](./0003-scoped-data-access-authorization.md) for the
+   wrapper layer's design and timing.
 4. **Soft-delete via timestamps.** Replace existing `deleted: boolean` and
    `archived: boolean` flags with `deleted_at timestamptz` and
    `archived_at timestamptz` columns. NULL = active. Soft-delete is **forever**

--- a/docs/adr/PLAN-0001.md
+++ b/docs/adr/PLAN-0001.md
@@ -343,23 +343,52 @@ OpenRouter.
 
 ### 2.1 Base class sketch
 
+The base class is reshaped from the original singular-workspace sketch to
+take a `CallerIdentity` value (see
+[ADR-0003](./0003-scoped-data-access-authorization.md) §7), so the same
+filter form maps onto both today's multi-workspace endpoints (e.g.
+`GET /api/tasks?role=…` lists tasks from every workspace the caller
+belongs to) and the future Postgres RLS policy
+(`workspace IN (SELECT workspace FROM workspace_members WHERE user_id = current_user_id())`).
+A `scopedTo(handle)` mode covers URL-driven `/{handle}/…` routes after the
+middleware has confirmed membership of `handle`.
+
 ```ts
 // packages/platform-infra/src/postgres/repositories/base.ts
-export abstract class WorkspaceScopedRepository<TRow extends { workspace: string }> {
+export abstract class AuthorizedRepository<TRow extends { workspace: string }> {
   constructor(
     protected readonly db: Database,
     protected readonly table: PgTable,
-    protected readonly workspace: string,
+    protected readonly caller: CallerIdentity,
   ) {}
 
-  /** Default scoped read — workspace-bound and excludes tombstones. */
+  /** Default scoped read — caller-bound and excludes tombstones. */
   protected scoped() {
+    const base = this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          isNull(this.table.deletedAt),
+          isNull(this.table.archivedAt),
+        ),
+      );
+    if (this.caller.kind === 'apiKey') return base;
+    return base.where(inArray(this.table.workspace, [...this.caller.workspaces]));
+  }
+
+  /** Pin to a single workspace — used by /{handle}/… routes after middleware
+   * has verified the caller is a member of `handle`. */
+  protected scopedTo(handle: string) {
+    if (this.caller.kind !== 'apiKey' && !this.caller.workspaces.has(handle)) {
+      throw new ForbiddenError();
+    }
     return this.db
       .select()
       .from(this.table)
       .where(
         and(
-          eq(this.table.workspace, this.workspace),
+          eq(this.table.workspace, handle),
           isNull(this.table.deletedAt),
           isNull(this.table.archivedAt),
         ),
@@ -396,11 +425,13 @@ export abstract class WorkspaceScopedRepository<TRow extends { workspace: string
 
 | Layer | What it does |
 |---|---|
-| App middleware | Resolves the calling user → list of member workspaces. Rejects any request whose `:handle` URL segment is not in that list. |
-| Repository base class | Filters every default read/write by `workspace = $myWorkspace`. |
+| App middleware | Resolves the calling user → `CallerIdentity` (uid + the set of member workspaces). Rejects any request whose `:handle` URL segment is not in that set. |
+| Repository base class | Filters every default read/write by `workspace IN $callerWorkspaces` (unrestricted for `caller.kind === 'apiKey'`). |
 | Postgres RLS (Phase 2, separate ADR) | Belt-and-suspenders: even a bug in the repo cannot leak across workspaces. |
 
-This ADR delivers the first two; RLS is a later, additive change.
+This ADR delivers the first two; RLS is a later, additive change. The
+caller-set form maps directly onto the eventual RLS policy
+(`workspace IN (SELECT workspace FROM workspace_members WHERE user_id = current_user_id())`).
 
 ---
 

--- a/docs/adr/PLAN-0001.md
+++ b/docs/adr/PLAN-0001.md
@@ -1,0 +1,723 @@
+# PLAN-0001 — Implementation plan for ADR-0001
+
+Companion to [`0001-firestore-to-postgres.md`](./0001-firestore-to-postgres.md).
+This document is **exhaustive** — the implementing agent should follow it
+step-by-step and never assume something can be skipped because "it's obvious".
+
+Cross-reference for domain language: [`../../CONTEXT.md`](../../CONTEXT.md).
+
+---
+
+## 1. Storage shape decisions (per aggregate)
+
+### 1.1 General conventions
+
+- Every table has:
+  - `id uuid primary key default gen_random_uuid()`
+  - `created_at timestamptz not null default now()`
+  - `updated_at timestamptz not null default now()` with a trigger to bump on `UPDATE`
+  - Any tenant-scoped table also has `workspace text not null` (replaces today's `namespace` column; same semantic, new name).
+  - Soft-delete tables also have `deleted_at timestamptz` and (where the schema currently has `archived`) `archived_at timestamptz`. Active rows have both `NULL`.
+- All indexes on tenant-scoped tables lead with `workspace` (e.g. `(workspace, status, created_at desc)`).
+- Soft-delete tables get a `WHERE deleted_at IS NULL AND archived_at IS NULL` partial index for hot read paths.
+- Polymorphic / "schemaless" data lives in `jsonb` columns. Query-worthy fields are expanded into typed columns (the **hybrid pattern**).
+
+### 1.2 Per-aggregate sketches
+
+#### `workspaces` (renamed from `namespaces`)
+
+```sql
+create table workspaces (
+  handle text primary key,                 -- URL-safe slug; today's PK
+  type text not null,                      -- 'personal' | 'organization' (kept; departments map to organization)
+  display_name text,
+  avatar_url text,
+  icon text,
+  linked_user_id text,                     -- non-null for personal
+  bio text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table workspace_members (
+  workspace text not null references workspaces(handle) on delete cascade,
+  uid text not null,
+  role text not null,                      -- 'owner' | 'admin' | 'member'
+  display_name text,
+  avatar_url text,
+  joined_at timestamptz not null default now(),
+  primary key (workspace, uid)
+);
+create index on workspace_members (uid);   -- replaces the Firestore collectionGroup query
+```
+
+#### `workflow_definitions` (+ `workflow_meta`)
+
+```sql
+create table workflow_definitions (
+  id uuid primary key default gen_random_uuid(),
+  workspace text not null references workspaces(handle) on delete cascade,
+  name text not null,
+  version int not null,
+  title text,
+  description text,
+  preamble text,
+  visibility text not null default 'private',  -- 'public' | 'private'
+  steps jsonb not null,                        -- entire steps[] (read whole, mutated rarely)
+  transitions jsonb not null,                  -- entire transitions[]
+  triggers jsonb not null,
+  trigger_input jsonb,
+  roles jsonb,
+  env jsonb,
+  notifications jsonb,
+  git_workspace jsonb,                         -- renamed from 'workspace' to avoid collision
+  metadata jsonb,
+  copied_from text,
+  input_for_next_run jsonb,
+  archived_at timestamptz,
+  deleted_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (workspace, name, version)
+);
+create index on workflow_definitions (workspace, name, version desc)
+  where deleted_at is null and archived_at is null;
+create index on workflow_definitions (visibility, workspace, name)
+  where deleted_at is null and visibility = 'public';
+
+create table workflow_meta (
+  workspace text not null references workspaces(handle) on delete cascade,
+  name text not null,
+  default_version int,
+  hidden boolean not null default false,
+  updated_at timestamptz not null default now(),
+  primary key (workspace, name)
+);
+```
+
+#### `process_instances` (+ `step_executions`, `agent_events`)
+
+```sql
+create table process_instances (
+  id uuid primary key default gen_random_uuid(),
+  workspace text not null references workspaces(handle) on delete cascade,
+  definition_name text not null,
+  definition_version int not null,
+  status text not null,                    -- 'created' | 'running' | 'paused' | 'completed' | 'failed'
+  current_step_id text,
+  variables jsonb not null default '{}',   -- accumulator; read/written as a whole
+  trigger_type text not null,
+  trigger_payload jsonb,
+  pause_reason text,
+  error jsonb,
+  assigned_roles text[],
+  previous_run jsonb,
+  previous_run_source_id uuid,
+  total_cost_usd numeric(12,6),
+  created_by text,
+  archived_at timestamptz,
+  deleted_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  foreign key (workspace, definition_name, definition_version)
+    references workflow_definitions(workspace, name, version)
+);
+create index on process_instances (workspace, status, created_at desc)
+  where deleted_at is null and archived_at is null;
+create index on process_instances (workspace, definition_name, status, updated_at desc)
+  where deleted_at is null and archived_at is null;
+
+create table step_executions (
+  id uuid primary key default gen_random_uuid(),
+  process_instance_id uuid not null references process_instances(id) on delete cascade,
+  step_id text not null,
+  status text not null,                    -- pending|running|completed|failed|escalated|paused
+  iteration_number int not null default 1,
+  input jsonb,
+  output jsonb,                            -- polymorphic per step type
+  verdict text,
+  gate_result jsonb,
+  error jsonb,
+  review_verdicts jsonb,                   -- array of ReviewVerdict (rarely queried individually)
+  agent_output jsonb,                      -- snapshot of AgentOutputEnvelope (display copy)
+  executed_by text,
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+create index on step_executions (process_instance_id, step_id, started_at desc);
+
+create table agent_events (
+  id uuid primary key default gen_random_uuid(),
+  process_instance_id uuid not null references process_instances(id) on delete cascade,
+  step_id text not null,
+  type text not null,
+  payload jsonb,
+  sequence bigint not null,                -- stable ordering across distributed emitters
+  timestamp timestamptz not null
+);
+create index on agent_events (process_instance_id, step_id, sequence);
+```
+
+#### `agent_runs` (hybrid: query columns + envelope_payload)
+
+```sql
+create table agent_runs (
+  id uuid primary key default gen_random_uuid(),
+  process_instance_id uuid not null references process_instances(id) on delete cascade,
+  step_id text not null,
+  plugin_id text not null,
+  autonomy_level text not null,
+  status text not null,
+  fallback_reason text,
+  -- expanded from envelope (query-worthy)
+  confidence numeric,
+  model text,
+  duration_ms int,
+  prompt_tokens int,
+  completion_tokens int,
+  cost_usd numeric(12,6),
+  -- everything else
+  envelope_payload jsonb,                  -- reasoning_summary, reasoning_chain, annotations, gitMetadata, presentation, deliverableFile, result
+  executor_type text,
+  reviewer_type text,
+  started_at timestamptz not null default now(),
+  completed_at timestamptz
+);
+create index on agent_runs (process_instance_id, step_id, started_at desc);
+create index on agent_runs (model, started_at) where cost_usd is not null;
+```
+
+#### `cowork_sessions` (+ normalized `cowork_turns`)
+
+```sql
+create table cowork_sessions (
+  id uuid primary key default gen_random_uuid(),
+  workspace text not null references workspaces(handle) on delete cascade,
+  process_instance_id uuid not null references process_instances(id) on delete cascade,
+  step_id text not null,
+  assigned_role text not null,
+  assigned_user_id text,                   -- soft claim
+  status text not null,                    -- 'active' | 'finalized' | 'abandoned'
+  agent text not null,                     -- 'chat' | 'voice-realtime'
+  model text,
+  system_prompt text,
+  output_schema jsonb,
+  voice_config jsonb,
+  artifact jsonb,                          -- collaboratively built deliverable
+  mcp_servers jsonb,
+  finalized_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index on cowork_sessions (workspace, status, created_at);
+create index on cowork_sessions (assigned_role, status, created_at);
+create index on cowork_sessions (process_instance_id, step_id);
+
+-- Turns normalized — append-only, per-turn status updates are cheap.
+create table cowork_turns (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references cowork_sessions(id) on delete cascade,
+  idx int not null,                        -- ordinal within session
+  role text not null,                      -- 'human' | 'agent' | 'tool'
+  content text not null,
+  artifact_delta jsonb,
+  -- tool-only fields
+  tool_name text,
+  tool_args jsonb,
+  tool_result text,
+  tool_status text,                        -- 'running' | 'success' | 'error'
+  server_name text,
+  timestamp timestamptz not null,
+  unique (session_id, idx)
+);
+```
+
+#### `human_tasks`
+
+```sql
+create table human_tasks (
+  id uuid primary key default gen_random_uuid(),
+  workspace text not null references workspaces(handle) on delete cascade,
+  process_instance_id uuid not null references process_instances(id) on delete cascade,
+  step_id text not null,
+  assigned_role text not null,
+  assigned_user_id text,                   -- soft claim
+  status text not null,                    -- 'pending' | 'claimed' | 'completed' | 'cancelled'
+  deadline timestamptz,
+  completion_data jsonb,
+  ui jsonb,
+  params jsonb,
+  creation_reason text not null,           -- 'human_executor' | 'agent_review_l3'
+  selection jsonb,
+  options jsonb,
+  verdicts jsonb,                          -- resolved verdict descriptors (array)
+  deleted_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index on human_tasks (assigned_role, status, created_at)
+  where deleted_at is null;
+create index on human_tasks (process_instance_id, step_id);
+```
+
+#### `handoff_entities`
+
+```sql
+create table handoff_entities (
+  id uuid primary key default gen_random_uuid(),
+  workspace text not null references workspaces(handle) on delete cascade,
+  type text not null,
+  process_instance_id uuid not null references process_instances(id) on delete cascade,
+  step_id text not null,
+  agent_run_id uuid not null references agent_runs(id) on delete cascade,
+  assigned_role text not null,
+  assigned_user_id text,
+  status text not null,                    -- 'created' | 'acknowledged' | 'resolved'
+  agent_work jsonb,
+  agent_reasoning text,
+  agent_question text,
+  payload jsonb,
+  resolution jsonb,
+  resolved_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index on handoff_entities (workspace, status, created_at);
+create index on handoff_entities (assigned_role, status);
+```
+
+#### `audit_events` (hybrid: query columns + payload)
+
+```sql
+create table audit_events (
+  id uuid primary key default gen_random_uuid(),
+  workspace text not null references workspaces(handle) on delete cascade,
+  -- queryable
+  actor_id text,
+  actor_type text not null,                -- 'user' | 'agent' | 'system'
+  actor_role text,
+  action text not null,
+  entity_type text not null,
+  entity_id text not null,
+  process_instance_id uuid,
+  step_id text,
+  process_definition_version int,
+  executor_type text,
+  reviewer_type text,
+  timestamp timestamptz not null,
+  server_timestamp timestamptz not null default now(),
+  -- everything else
+  payload jsonb                            -- description, basis, input_snapshot, output_snapshot
+);
+create index on audit_events (workspace, entity_type, entity_id, timestamp desc);
+create index on audit_events (workspace, process_instance_id, timestamp asc);
+```
+
+#### `agent_definitions`, `agent_oauth_tokens`, `oauth_providers`
+
+Composite-key tables, all workspace-scoped. Schemas mirror today's Zod
+schemas with no behavioural change. Storage shape: lift small primitive
+fields to columns, keep large optional structures (e.g.
+`mcp_servers`, `agent_work`) as `jsonb`.
+
+#### `namespace_secrets`, `workflow_secrets`, `tool_catalog_entries`, `cron_trigger_states`, `model_registry`
+
+Direct one-to-one ports of today's documents. Secrets keep their precedence
+rule (workflow wins over namespace on key collision). `model_registry` is
+deployment-global (not workspace-scoped); a sync job keeps it in step with
+OpenRouter.
+
+### 1.3 What we explicitly do NOT change
+
+- `WorkflowDefinition.steps` and `.transitions` stay as `jsonb` blobs. They are
+  read whole, mutated through a single "publish new version" path.
+- `ProcessInstance.variables` stays as one `jsonb` blob. Resolution path
+  `${steps.X.output.Y}` reads the whole map; per-key indexing would be premature.
+- `StepExecution.output` stays polymorphic (`jsonb`). Different step types yield
+  different shapes.
+
+---
+
+## 2. Fail-proof repository pattern
+
+### 2.1 Base class sketch
+
+```ts
+// packages/platform-infra/src/postgres/repositories/base.ts
+export abstract class WorkspaceScopedRepository<TRow extends { workspace: string }> {
+  constructor(
+    protected readonly db: Database,
+    protected readonly table: PgTable,
+    protected readonly workspace: string,
+  ) {}
+
+  /** Default scoped read — workspace-bound and excludes tombstones. */
+  protected scoped() {
+    return this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.workspace, this.workspace),
+          isNull(this.table.deletedAt),
+          isNull(this.table.archivedAt),
+        ),
+      );
+  }
+
+  /** Audit-logged opt-out for cross-workspace public discovery. */
+  protected crossWorkspacePublic(condition: SQL) {
+    auditLog({ action: 'cross_workspace_public_read', condition: String(condition) });
+    return this.db.select().from(this.table).where(condition);
+  }
+
+  /** Audit-logged opt-out for admin / cleanup use. */
+  protected includeDeleted() { /* … */ }
+  protected includeArchived() { /* … */ }
+}
+```
+
+### 2.2 Rules of use
+
+- Repositories **never** expose `this.db` outside themselves. The base class
+  closes the `db` member as `protected`.
+- Caller code (services, route handlers) **never** imports Drizzle's `db` and
+  **never** writes SQL by hand. It calls repository methods.
+- Adding a new repository method that has to ignore the default filters
+  requires:
+  - Naming it explicitly (`discoverPublic…`, `…IncludingDeleted`, etc.)
+  - Calling one of the base-class opt-outs (which emits an `audit_event`)
+- Linter rule (custom ESLint or a `grep` pre-commit hook): forbid `db.select`,
+  `db.insert`, `db.update`, `db.delete` outside
+  `packages/platform-infra/src/postgres/repositories/`.
+
+### 2.3 Multi-tenancy enforcement layers
+
+| Layer | What it does |
+|---|---|
+| App middleware | Resolves the calling user → list of member workspaces. Rejects any request whose `:handle` URL segment is not in that list. |
+| Repository base class | Filters every default read/write by `workspace = $myWorkspace`. |
+| Postgres RLS (Phase 2, separate ADR) | Belt-and-suspenders: even a bug in the repo cannot leak across workspaces. |
+
+This ADR delivers the first two; RLS is a later, additive change.
+
+---
+
+## 3. Realtime swap
+
+### 3.1 Lists → SWR polling
+
+Each hook listed below moves from `onSnapshot` to `useSWR(url, { refreshInterval: N })`,
+where the URL points at a new (or existing) JSON GET endpoint that returns the
+same list shape.
+
+| Hook | Refresh interval | Notes |
+|---|---|---|
+| [`use-process-instances.ts`](../../packages/platform-ui/src/hooks/use-process-instances.ts) | 2 s | High-attention list |
+| [`use-tasks.ts`](../../packages/platform-ui/src/hooks/use-tasks.ts) | 2 s | High-attention list |
+| [`use-monitoring.ts`](../../packages/platform-ui/src/hooks/use-monitoring.ts) | 2 s | Composite |
+| [`use-audit-events.ts`](../../packages/platform-ui/src/hooks/use-audit-events.ts) | 5 s | |
+| [`use-agent-runs.ts`](../../packages/platform-ui/src/hooks/use-agent-runs.ts) | Collection: 5 s. **Single run: SSE** | Live run gets a stream; the index is polled |
+| [`use-all-user-namespaces.ts`](../../packages/platform-ui/src/hooks/use-all-user-namespaces.ts) | 10 s | Changes rarely |
+| [`use-namespace.ts`](../../packages/platform-ui/src/hooks/use-namespace.ts) | 10 s | |
+| [`use-namespace-role.ts`](../../packages/platform-ui/src/hooks/use-namespace-role.ts) | 10 s | |
+| [`use-collection.ts`](../../packages/platform-ui/src/hooks/use-collection.ts) | n/a — **delete** | Generic adapter no longer needed; each call site is explicit |
+| [`use-workflow-definitions.ts`](../../packages/platform-ui/src/hooks/use-workflow-definitions.ts) | 10 s | Verify listener pattern when migrating |
+
+`onSnapshot` calls in **page components** (not hooks) — move into hooks first,
+then convert per the table above:
+
+- [`packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx) — member list listener
+- [`packages/platform-ui/src/app/(app)/[handle]/tasks/[taskId]/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/tasks/[taskId]/page.tsx) — single task listener
+- [`packages/platform-ui/src/app/(app)/[handle]/cowork/[sessionId]/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/cowork/[sessionId]/page.tsx) — cowork session listener → **SSE**
+
+### 3.2 Live agent run logs → SSE
+
+- New endpoint: `GET /api/agent-runs/:id/stream` returns `text/event-stream`.
+- Backend reads from Redis pub/sub (the `container-worker` already publishes
+  log lines for live BullMQ jobs).
+- Simple SSE format: `data: {"timestamp":"…","line":"…","type":"log|status"}`.
+- No AI SDK needed for this path; raw `ReadableStream` + `TextEncoder` is enough.
+
+### 3.3 Cowork text-chat streaming
+
+Today: [`packages/platform-ui/src/app/api/cowork/[sessionId]/message/route.ts`](../../packages/platform-ui/src/app/api/cowork/[sessionId]/message/route.ts)
+hand-parses OpenRouter SSE. This ADR leaves that endpoint as-is. A future ADR
+proposes Vercel AI SDK as a helper library.
+
+### 3.4 Cowork voice (OpenAI Realtime)
+
+Out of scope. Stays as-is.
+
+---
+
+## 4. Renames in scope
+
+| Today (Firestore / TypeScript) | After this migration (Postgres / TypeScript) | Notes |
+|---|---|---|
+| Firestore collection `namespaces` | Postgres table `workspaces` | Storage rename |
+| Column / schema field `namespace` | Column `workspace`, Zod field `workspace` | Storage rename, full repo + API |
+| `Namespace.type === 'organization'` | unchanged | Organization stays — departments inside a tenant |
+| `WorkflowDefinition.workspace` (git config) | `WorkflowDefinition.gitWorkspace` | Avoids collision with new canonical `workspace` |
+| `WorkflowWorkspaceSchema` (Zod) | `WorkflowGitWorkspaceSchema` | Type rename |
+| Type alias `WorkflowWorkspace` | `WorkflowGitWorkspace` | Type rename |
+| Class `ProcessRepository` | `WorkflowDefinitionRepository` | **Not in this ADR** — follow-up |
+| Type `ProcessInstance` | `WorkflowRun` | **Not in this ADR** — follow-up. "Run" is the canonical user-facing term (UI, URLs, comments, `AgentRun`); "Workflow Run" wins over "Workflow Instance". |
+| Field `processInstanceId` | `workflowRunId` | **Not in this ADR** — follow-up |
+
+Follow-up Process→Workflow rename PRs land **after** this migration to keep
+this ADR's diff focused. New code written during the migration uses Workflow
+terminology where it does not break compatibility.
+
+---
+
+## 5. Repositories — implementation checklist
+
+### 5.1 Repos with no existing interface (extract first)
+
+These six Firestore repos have no `platform-core/src/interfaces/` contract.
+Add an interface for each **before** writing the Postgres implementation; the
+interface is shared by the in-memory double and both backends.
+
+- [`agent-definition-repository`](../../packages/platform-infra/src/firestore/agent-definition-repository.ts)
+- [`model-registry-repository`](../../packages/platform-infra/src/firestore/model-registry-repository.ts)
+- [`namespace-repository`](../../packages/platform-infra/src/firestore/namespace-repository.ts)
+- [`namespace-secrets-repository`](../../packages/platform-infra/src/firestore/namespace-secrets-repository.ts)
+- [`oauth-provider-repository`](../../packages/platform-infra/src/firestore/oauth-provider-repository.ts)
+- [`workflow-secrets-repository`](../../packages/platform-infra/src/firestore/workflow-secrets-repository.ts)
+
+`cron-trigger-state-repository` and `tool-catalog-repository` already have
+interfaces — no extraction needed.
+
+### 5.2 Build order (Postgres implementations)
+
+Roughly small/leaf → large/root, so each step is independently testable.
+
+1. `tool-catalog`
+2. `audit`
+3. `agent-oauth-token` + `oauth-provider` (mutually referencing)
+4. `cron-trigger-state`
+5. `agent-run`
+6. `human-task`
+7. `handoff`
+8. `cowork-session` + `cowork-turns` (one repo, two tables)
+9. `process-instance` (+ `step-executions`, `agent-events`)
+10. `workflow-definition` (+ `workflow-meta`)
+11. `agent-definition`
+12. `model-registry`
+13. `workspace` (+ `workspace-members`)
+14. `namespace-secrets`
+15. `workflow-secrets`
+
+Each step's PR ships:
+- Drizzle schema + `drizzle-kit generate` migration file (committed SQL)
+- Postgres repo implementing the existing interface
+- L2 parity test: in-memory double + Postgres-in-testcontainer run the same
+  test suite
+- L3 API E2E: at least one route handler exercises the Postgres path
+
+### 5.3 Direct Firestore usage to refactor through repos
+
+- [`packages/platform-ui/src/app/actions/definitions.ts:233-247`](../../packages/platform-ui/src/app/actions/definitions.ts) — namespace migration query via `getAdminFirestore()`
+- [`packages/platform-ui/src/app/actions/tasks.ts`](../../packages/platform-ui/src/app/actions/tasks.ts) — direct write to `humanTasks` via client SDK
+- [`packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx) — member ops via `updateDoc`/`deleteDoc`/`writeBatch` (client SDK)
+- [`packages/platform-ui/src/contexts/auth-context.tsx`](../../packages/platform-ui/src/contexts/auth-context.tsx) — personal namespace bootstrap circular logic
+
+Refactor target: move the logic into a server action / repository method that
+holds the workspace + auth context. The personal-namespace bootstrap becomes a
+single transactional server action.
+
+---
+
+## 6. Schema & code translation crib sheet
+
+| Firestore-ism | Postgres equivalent |
+|---|---|
+| `FieldValue.serverTimestamp()` | `default now()` on insert; `now()` in `UPDATE … SET updated_at = now()` |
+| `FieldValue.arrayUnion(turn)` (cowork) | `INSERT INTO cowork_turns …` (normalized) |
+| `Timestamp` coercion to ISO string | `timestamptz` is native — no coercion |
+| `batch.commit()` (`writeBatch`) | `BEGIN … COMMIT` transaction |
+| `runTransaction(async tx => …)` (secrets) | `BEGIN ISOLATION LEVEL SERIALIZABLE … COMMIT` |
+| `where('foo', 'in', [arr])` capped at 30 | Native `WHERE foo = ANY($1)` — drop the chunking loop |
+| `collectionGroup('members').where('uid', …)` (with fallback when index missing) | `SELECT … FROM workspace_members WHERE uid = $1` — drop the fallback |
+| Firestore composite indexes (`firestore.indexes.json`) | Equivalent btree indexes on the new tables (sketched in §1.2) |
+
+---
+
+## 7. Bugs fixed in flight (no separate PR needed)
+
+- **BUG-03** (`firestore.rules:152`): process instances are readable by any
+  authenticated user. Fixed by the fail-proof repository scoping (§2) —
+  default `list()` filters by `workspace = $me`.
+- **BUG-04** (`firestore.rules:27`): audit events are readable by any
+  authenticated user. Same fix: scoped repo.
+
+---
+
+## 8. Cutover (big-bang)
+
+### 8.1 Pre-cutover
+
+1. All Postgres-backed repositories shipped behind a `STORAGE_BACKEND=firestore|postgres`
+   feature flag. Default `firestore` during the implementation phase.
+2. CI runs the L2 parity suite + L3 E2E suite against **both** backends. Green
+   on both is a merge prerequisite for each repo migration PR.
+3. Postgres production instance provisioned in the target environment; backup
+   tooling configured.
+
+### 8.2 Cutover window (planned downtime)
+
+1. Announce maintenance window (low-traffic time).
+2. Mark the app read-only via a feature flag.
+3. Snapshot Firestore (export to GCS).
+4. Run the migration script (`scripts/migrate-firestore-to-postgres/main.py`):
+   - Streams the Firestore export.
+   - Maps each document to the target Postgres row.
+   - `INSERT … ON CONFLICT DO NOTHING` for idempotency.
+   - Updates per-table counts + writes them to `migration_log` for audit.
+5. Run the verification step (`scripts/migrate-firestore-to-postgres/verify.py`):
+   - Row counts match per table.
+   - 50 random rows per table sampled and compared field-by-field.
+6. Flip `STORAGE_BACKEND=postgres` in env. Restart application + workers.
+7. Smoke test: log in, list workflows, run one workflow end-to-end, open one
+   cowork session, send one human task, see one audit row.
+8. Clear the read-only flag. End maintenance window.
+
+### 8.3 Rollback
+
+If verification or smoke fails:
+
+1. Set `STORAGE_BACKEND=firestore` again, restart.
+2. Restore Firestore from the snapshot if any writes leaked to Postgres after
+   the cut.
+3. Triage with full `migration_log` + sample diffs. Retry next window.
+
+### 8.4 Post-cutover (within 2 weeks)
+
+- Delete `packages/platform-infra/src/firestore/`.
+- Remove the `STORAGE_BACKEND` flag (always Postgres).
+- Drop `firestore.rules`, `firestore.indexes.json`, and the Firestore stanza
+  of `firebase.json` (keep `firebase.json` for the still-active Firebase Auth
+  flow until ADR-0002 lands).
+- Remove all `NEXT_PUBLIC_FIREBASE_*` and `FIRESTORE_EMULATOR_HOST` env vars
+  associated with data, keeping only those required by Firebase Auth.
+- Update `README.md`, `.env.example`, and `CHANGELOG.md`.
+
+---
+
+## 9. Demo & local dev story
+
+- `docker-compose.yml` at the repo root boots: app (Next.js, port 9003),
+  Postgres 16 (port 5432), Redis (port 6379), nothing else. Single
+  `docker-compose up` is the new "I want to try Mediforce" flow.
+- `pnpm dev:local` runs the app against the dockerised Postgres + Redis.
+- A seed script (`scripts/seed-dev-data.ts`) creates a personal Workspace,
+  a `demo` Organization Workspace, a sample Workflow Definition, and one
+  running Process Instance.
+- L4 UI E2E (Playwright) starts the same docker-compose stack via
+  `webServer.command` in `playwright.config.ts`. Firebase Emulators are
+  removed from the test setup (replaced by Postgres).
+
+---
+
+## 10. Verification
+
+A migration is "done" when **all** of the below are true:
+
+1. `grep -r "onSnapshot" packages/` returns zero matches.
+2. `grep -r "firebase/firestore\|firebase-admin/firestore" packages/` returns
+   zero matches.
+3. `pnpm test` and `pnpm test:e2e` pass with **no Firebase Emulators** in the
+   test environment.
+4. A fresh clone, `docker-compose up`, `pnpm dev` completes the full demo
+   flow (login → create Workspace → create Workflow → run instance → human
+   task → cowork → finalize) with no external Firebase project configured.
+5. The migration script's verification mode reports 0 diffs across all tables
+   for the last test run.
+
+---
+
+## 11. Open follow-up PRs (after this migration lands)
+
+- Rename `ProcessRepository` → `WorkflowDefinitionRepository`,
+  `ProcessInstance` → `WorkflowRun`, `processInstanceId` → `workflowRunId`.
+  Multiple small PRs. "Run" matches the existing UI / URL / schema-comment
+  vocabulary.
+- Add Postgres RLS policies (Phase 2, separate ADR).
+- Vercel AI SDK adoption for cowork streaming (separate ADR).
+- Firebase Auth → NextAuth (ADR-0002).
+- Firebase Storage → S3-compatible object storage (separate ADR).
+- pgvector for agent memory / semantic search.
+
+---
+
+## 12. Implementation inventory checklist
+
+The implementing agent must touch every row below. This is the exhaustive list
+extracted from a two-pass codebase audit.
+
+### Firestore collections → Postgres tables
+
+- `agentDefinitions` → `agent_definitions`
+- `agentRuns` → `agent_runs`
+- `auditEvents` → `audit_events`
+- `coworkSessions` → `cowork_sessions` (+ `cowork_turns` from `turns` array)
+- `humanTasks` → `human_tasks`
+- `handoffEntities` → `handoff_entities`
+- `modelRegistry` → `model_registry`
+- `namespaces` → `workspaces`
+- `processInstances` → `process_instances` (+ `step_executions`, `agent_events` from sub-collections)
+- `users` → `users` (still consumed by `auth-context.tsx`; minimal port now,
+  fuller restructure with NextAuth in ADR-0002)
+- `workflowDefinitions` → `workflow_definitions`
+- `workflowMeta` → `workflow_meta`
+- `agentOAuthTokens` → `agent_oauth_tokens`
+- `oauthProviders` → `oauth_providers`
+- `namespaceSecrets` → `namespace_secrets`
+- `workflowSecrets` → `workflow_secrets`
+- `cronTriggerState` → `cron_trigger_states`
+- `namespaces/{handle}/members` → `workspace_members`
+- `namespaces/{handle}/workflowSecrets` → folded into `workflow_secrets` with `workspace` column
+- `namespaces/{handle}/toolCatalog` → `tool_catalog_entries` with `workspace` column
+- `processInstances/{id}/stepExecutions` → `step_executions`
+- `processInstances/{id}/agentEvents` → `agent_events`
+
+### Indexes — mapped from `firestore.indexes.json`
+
+Replicated as btree indexes per §1.2. All compound indexes lead with
+`workspace`.
+
+### Realtime call sites — see §3
+
+### Direct Firestore usage bypassing repos — see §5.3
+
+### Firestore-specific features → Postgres equivalents — see §6
+
+### Bugs fixed in flight — see §7
+
+### Env variables
+
+**Remove:**
+- `NEXT_PUBLIC_FIREBASE_API_KEY`
+- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` (until ADR-0002)
+- `NEXT_PUBLIC_FIREBASE_PROJECT_ID` (until ADR-0002)
+- `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` (until Storage ADR)
+- `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`
+- `NEXT_PUBLIC_FIREBASE_APP_ID`
+- `NEXT_PUBLIC_USE_EMULATORS`
+- `FIRESTORE_EMULATOR_HOST`
+
+**Add:**
+- `DATABASE_URL` (e.g. `postgresql://mediforce:password@postgres:5432/mediforce`)
+- `DATABASE_POOL_MAX` (default 10)
+- `REDIS_URL` (already exists; required now for SSE pub/sub of agent run logs)
+- `STORAGE_BACKEND` (`firestore | postgres`, removed after cutover)
+
+### Test infrastructure
+
+- L2 / L3 use a Postgres container provisioned via `testcontainers` per test
+  file (cheap), or a shared instance with per-test schemas (faster).
+- L4 UI E2E moves to the docker-compose stack from §9.
+- The shared `WorkspaceScopedRepositoryContract` test suite ensures every
+  Postgres repo passes the same tests as its in-memory double.

--- a/docs/adr/PLAN-0001.md
+++ b/docs/adr/PLAN-0001.md
@@ -345,7 +345,7 @@ OpenRouter.
 
 The base class is reshaped from the original singular-workspace sketch to
 take a `CallerIdentity` value (see
-[ADR-0003](./0003-scoped-data-access-authorization.md) §7), so the same
+[ADR-0004](./0004-scoped-data-access-authorization.md) §7), so the same
 filter form maps onto both today's multi-workspace endpoints (e.g.
 `GET /api/tasks?role=…` lists tasks from every workspace the caller
 belongs to) and the future Postgres RLS policy

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,40 @@
+# Architectural Decision Records
+
+Short documents capturing significant architectural decisions, the rejected
+alternatives, and the rationale.
+
+## Process
+
+1. Propose an ADR as a PR (status: `Proposed`). Discussion happens in PR review.
+2. Merge once the team agrees (status: `Accepted`). The ADR becomes the source
+   of truth.
+3. To change a decision, open a new ADR that **supersedes** the old one. The
+   old one stays in place with status `Superseded by NNNN` — full audit trail.
+4. Implementation lives in separate PRs that reference the ADR.
+
+## Format
+
+Every ADR is short and focused on the decision itself. Implementation detail
+goes into a separate `PLAN-NNNN.md` companion file when it would otherwise
+crowd the ADR.
+
+See [grill-with-docs/ADR-FORMAT.md](../../.claude/skills/grill-with-docs/ADR-FORMAT.md)
+for the template.
+
+Domain language used in ADRs is defined in [`../../CONTEXT.md`](../../CONTEXT.md).
+
+## Numbering
+
+Sequential, zero-padded to four digits (`0001`, `0002`, …). Never reuse a number.
+
+## Status values
+
+- `Proposed` — under discussion in a PR
+- `Accepted` — merged, decision is binding
+- `Deprecated` — no longer applies, kept for history
+- `Superseded by NNNN` — replaced by a later ADR
+
+## Index
+
+- [0001 — Move primary datastore from Firestore to self-hosted Postgres](./0001-firestore-to-postgres.md) (+ [PLAN](./PLAN-0001.md))
+- [0002 — Move authentication from Firebase Auth to NextAuth (Auth.js v5)](./0002-firebase-auth-to-nextauth.md) (+ [PLAN](./PLAN-0002.md))


### PR DESCRIPTION
## Summary

- Propose **ADR-0001** — migrate primary datastore from Firestore to self-hosted Postgres 16 with Drizzle.
- Add companion **PLAN-0001.md** with exhaustive implementation checklist (schemas, fail-proof repo pattern, realtime swap, big-bang cutover).
- Add project-wide **CONTEXT.md** glossary defining canonical domain terms (Workspace, Workflow Definition, Process Instance, Step Execution, Agent Run, Cowork Session, …).

ADR is short and decision-focused (8 architectural commitments). PLAN is the place to look for SQL sketches and the file-by-file checklist.

## Why now

Pharma customers need on-prem deployment. Firestore is a managed Google service and blocks the GTM. Demo / local-dev complexity (Firebase Emulators) also slows onboarding. The repository pattern is already in place so the surface to refactor is bounded.

## Open questions for review (also flagged at the bottom of the ADR)

- Drizzle vs raw `postgres.js` + Zod — Drizzle wins for ~20 repos; confirm.
- Storage-level rename `namespace` → `workspace` inside ADR-0001 vs a separate prior PR — confirm.
- Keep `Workspace.type = 'organization' | 'personal'` (organizations represent departments inside a tenant) — confirm no rename to `'team'`.
- Keep `WorkflowDefinition.visibility = 'public'` as a live cross-workspace feature, no per-deployment disable flag — confirm.

## Out of scope

- Firebase Auth → NextAuth (separate ADR coming next)
- Firebase Storage migration
- Vercel AI SDK adoption
- Postgres Row-Level Security (Phase 2)
- Process → Workflow class renames (follow-up PRs)

## Test plan

This PR is documentation-only — no code changes. Review consists of:
- [ ] Read the ADR (`docs/adr/0001-firestore-to-postgres.md`) and confirm the eight decisions are sound.
- [ ] Skim PLAN (`docs/adr/PLAN-0001.md`) — flag any aggregate whose storage shape is wrong (jsonb vs columns), any missed Firestore-ism, any wrong file path.
- [ ] Read CONTEXT.md and call out any term whose definition does not match how you use it in conversation.
- [ ] Answer the four open questions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)