### PR TITLE
docs(adr): ADR-0002 — Firebase Auth to NextAuth (Auth.js v5)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -233,18 +233,38 @@ can use the Workspace.
 _Avoid_: "Role" alone — that's overloaded with process-domain roles below.
 
 **Roles** *(process-domain, plural)*:
-Functional roles a User holds inside one Workspace for workflow purposes —
-e.g. `reviewer`, `PI`, `approver`. Stored on `workspace_members.roles` as
-`text[]`. Drive `HumanTask.assignedRole` and `CoworkSession.assignedRole`
-gating, and `WorkflowStep.allowedRoles` access control.
-_Avoid_: confusing with Membership above. Roles are per-workspace today
-(per-deployment in legacy Firebase custom claims; migrated to per-workspace
-in ADR-0002).
+Functional roles a User holds for workflow purposes — e.g. `reviewer`, `PI`,
+`approver`. **Deployment-global**, stored in the `user_roles(uid, role)` table.
+Drive `HumanTask.assignedRole` and `CoworkSession.assignedRole` gating,
+`WorkflowStep.allowedRoles` access control, and `getUsersByRole` notification
+targeting (which resolves a role to Users with **no** Workspace context).
+_Avoid_: confusing with Membership above. Roles are **global**, not
+per-Workspace — they were global Firebase custom claims and ADR-0002 keeps
+that semantics (a `user_roles` table, not a per-membership array; making them
+per-Workspace would silently rescope notification targeting). Per-Workspace
+functional roles can return later as a deliberate product decision.
 
 **Deployment admin**:
 A boolean on `user_profiles.deployment_admin`. The Deployment-wide
 superuser bit (formerly Firebase custom claim `role: 'admin'`). Rare —
 typically one sysadmin per Deployment. Cross-Workspace operational power.
+
+**Caller Identity** *(per-request authorization subject)*:
+The resolved subject of one API request, produced by `resolveCallerIdentity`.
+Two kinds: a **user** caller (a signed-in User — `uid` + Workspace memberships)
+or an **apiKey** caller (a system actor: CLI / agents / cron, full access).
+Browser users resolve from the Session cookie; machine callers from
+`X-Api-Key`. Feeds the caller-set repository base (ADR-0004).
+_Avoid_: conflating with User (the human/account) or Session (the sign-in
+record) — Caller Identity is the per-request derivative used for scoping.
+
+**Account linking** *(by verified email)*:
+Attaching a new sign-in provider (e.g. Google) to an existing User when the
+provider asserts the **same verified email**. Used so migration-seeded Users
+(ADR-0002) log in via Google onto their pre-existing `uid` with no remap.
+Enabled only for verified-email providers (`allowDangerousEmailAccountLinking`
+on Google), gated by the email-domain allowlist.
+_Avoid_: the old `pendingGoogleLink` password-link dance (dropped in ADR-0002).
 
 **OAuth Provider Config** *(per-Namespace)*:
 Authorization-server endpoint + credentials. GitHub / Google built-in; custom

--- a/docs/adr/0002-firebase-auth-to-nextauth.md
+++ b/docs/adr/0002-firebase-auth-to-nextauth.md
@@ -1,0 +1,183 @@
+# 0002 — Move authentication from Firebase Auth to NextAuth (Auth.js v5)
+
+- **Status:** Proposed
+- **Date:** 2026-05-19
+- **Authors:** Marek Rogala (@marekrogala)
+- **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
+- **Depends on:** [ADR-0001](./0001-firestore-to-postgres.md) (Postgres + Drizzle is the adapter target)
+- **Implementation plan:** [PLAN-0002.md](./PLAN-0002.md)
+
+## Context
+
+Mediforce uses Firebase Auth for identity. Firebase Auth is a Google SaaS — it
+cannot run on customer premises, which blocks the same pharma on-prem GTM that
+motivates [ADR-0001](./0001-firestore-to-postgres.md). Pharma customers also
+expect SSO via their corporate IdP (Microsoft Entra ID, Okta, Keycloak) and
+Firebase Auth's OIDC integration is awkward — credentials still flow through
+Google's identity layer.
+
+Today's auth surface in Mediforce:
+
+- Browser sign-in via `firebase/auth` SDK: Google OAuth popup + email/password.
+- Server-side ID-token verification in `packages/platform-ui/src/middleware.ts`.
+- Admin SDK `getAuth()` server-side for invites and user directory.
+- **Custom claims** carry two distinct concepts: `role: 'admin'` (deployment
+  superuser) and `roles: string[]` (process-domain functional roles).
+- A flat `users/{uid}` Firestore doc holds `handle` (current Workspace),
+  `mustChangePassword` and profile fields — no formal Zod schema.
+- CLI / cron / scripts authenticate via a shared `PLATFORM_API_KEY` env. This
+  path is **out of scope** for this ADR (Filip's work-in-progress on Personal
+  Access Tokens covers it).
+
+Domain terms — User, Workspace, Workspace member, **membership** (governance
+level: `owner | admin | member`), **roles** (process-domain), deployment admin
+— are defined in [`CONTEXT.md`](../../CONTEXT.md).
+
+## Decision
+
+Replace Firebase Auth with **NextAuth (Auth.js v5)**, backed by the Postgres
+introduced in ADR-0001 via `@auth/drizzle-adapter`. Specifics:
+
+1. **Library.** `next-auth@5` plus `@auth/drizzle-adapter`. Self-hosted, MIT,
+   no SaaS in the path.
+
+2. **Adapter target.** Drizzle, writing to the same Postgres database
+   established by ADR-0001. New tables: `auth_users`, `auth_accounts`,
+   `auth_sessions`, `auth_verification_tokens`. A Mediforce-side
+   `user_profiles` table joins by `user_id` and owns domain fields
+   (`current_workspace`, `deployment_admin`, `must_change_password`).
+   This **split** (auth tables vs domain profile) is the standard NextAuth
+   pattern and keeps schema changes from the upstream library separated from
+   Mediforce concerns.
+
+3. **Session strategy.** **Database sessions**, not JWT. Server-side
+   revocation works in one HTTP round-trip; session create/destroy is a row
+   we can audit; the per-request DB read is indexed (millisecond-scale) and
+   negligible for our scale.
+
+4. **Providers, env-gated and additive.** A single configuration ships
+   four providers, each enabled by an env var:
+
+   - **Google OAuth** (`GOOGLE_CLIENT_ID`) — parity with today's
+     `signInWithPopup(googleProvider)`. The default for the current
+     Mediforce user base.
+   - **Credentials / email + password** (`ENABLE_PASSWORD_AUTH=true`) —
+     real password auth (bcrypt-hashed in `auth_users`). Optional. Useful
+     when Google/OIDC aren't available, plus for testing and self-hosted
+     installs.
+   - **Email magic link** (`SMTP_HOST` set) — passwordless via SendGrid
+     (we already operate it in `platform-infra/src/email`). Staging / fallback.
+   - **OIDC** (`OIDC_ISSUER` set) — pharma SSO to a customer's Keycloak /
+     Entra / Okta / generic OIDC server. **One IdP per deployment**;
+     mediforce is single-tenant per deployment so per-workspace IdPs are
+     out of scope.
+
+5. **Role / claim resolution.** Firebase custom claims map onto three
+   different storage locations:
+
+   - `customClaims.role === 'admin'` → `user_profiles.deployment_admin: boolean`
+   - `customClaims.roles: string[]` → **per-workspace** `workspace_members.roles: text[]`
+     (today these claims are global; the migration **copies them onto every
+     workspace membership** the user holds, then admins can fine-tune
+     separately).
+   - Workspace governance (`owner | admin | member`) lives on
+     `workspace_members.membership` (renamed from today's `members.role`
+     to remove the naming collision with process-domain roles).
+
+6. **Middleware.** `hasValidFirebaseToken()` in
+   `packages/platform-ui/src/middleware.ts` is removed. Browser requests
+   carry NextAuth's `authjs.session-token` httpOnly cookie; the middleware
+   resolves the user via `await auth()`. `hasValidApiKey()` (the
+   `PLATFORM_API_KEY` path for CLI / cron) **stays untouched** — out of
+   scope of this ADR.
+
+7. **Existing-user migration.** Google users migrate **seamlessly**: a
+   Python script seeds them into `auth_users` keyed by email; the first
+   NextAuth Google sign-in matches the pre-seeded row, links the account,
+   and they're in. **Password users do not have their hashes migrated** —
+   Firebase password hashes are not exportable in any form NextAuth can
+   accept. Active production users are mostly Google; the few password
+   accounts are internal/testing and re-enroll via the magic-link or
+   password provider (whichever the deployment has enabled).
+
+8. **Cutover.** **Sequential after ADR-0001**, not bundled. ADR-0001 lands
+   first; mediforce runs on Postgres + Firebase Auth for a stable interval
+   (hybrid is fine — Firebase Auth talks to Google, doesn't touch our DB).
+   Then ADR-0002 runs its own planned-downtime cutover: deploy NextAuth
+   code, run user migration script, flip `AUTH_BACKEND=nextauth`, restart,
+   smoke-test. Rollback path: flip back to `AUTH_BACKEND=firebase`,
+   investigate. Splitting cutovers isolates failure modes.
+
+## Considered alternatives
+
+- **Stay on Firebase Auth.** Rejected — blocks pharma on-prem, blocks SSO
+  story.
+- **Lucia.** Lighter, but loses NextAuth's mature provider library (Entra,
+  Okta, generic OIDC are 10 lines of config each). Ecosystem smaller, more
+  code we own.
+- **Ory Kratos.** Separate Go service, separate DB, separate operations.
+  Overkill for a single-app installation.
+- **Clerk / WorkOS / Auth0 / Stytch.** SaaS — same on-prem block as
+  Firebase. Rejected.
+- **Keycloak run-our-own.** A separate Java service we'd operate. Some
+  pharma customers run Keycloak themselves; we connect to *theirs* via the
+  OIDC provider above rather than running ours.
+- **NextAuth with JWT sessions.** Simpler operationally (no session
+  table), but loses immediate server-side revocation. Pharma cares.
+  Rejected.
+
+## Consequences
+
+- Pharma on-prem deployment unblocked on the auth side.
+- One codebase / one configuration covers demo, staging, customer pharma
+  deployments — different deployments enable different providers via env.
+- Session revocation is immediate (deactivate a user → next request 401).
+- Auth state lives in our Postgres — visible in our backups, audit log,
+  monitoring.
+- We own more auth surface than before: email verification, magic link
+  flow, password policy (if enabled), account recovery. NextAuth handles
+  the heavy lifting; we own the configuration.
+- The currently-undocumented `users/{uid}` Firestore shape gets a real
+  schema (`auth_users` + `user_profiles`).
+
+## Enterprise / pharma fit
+
+- **SSO via the customer's IdP** is config-only: `OIDC_ISSUER` /
+  `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` set, callback URL registered with
+  the IdP, done.
+- **No SaaS in the auth path** when the customer uses OIDC against their
+  IdP — credentials never leave their infrastructure.
+- **Audit trail** — every session create/destroy is a row we control. Add
+  per-event audit rows in callbacks (`signIn`, `signOut`) if the customer
+  asks.
+- **21 CFR Part 11**: access control is auditable, sessions are revocable,
+  user lifecycle is transparent.
+- **Demo simplicity** — a `docker-compose up`, click "Sign in with Google"
+  (or pre-seed a password user) and you're in. No external Firebase
+  project required.
+
+## Out of scope
+
+- **CLI / API key auth** (`PLATFORM_API_KEY` + Personal Access Tokens) —
+  Filip's separate WIP.
+- **2FA / TOTP / WebAuthn passkeys** — future ADR. NextAuth v5 has no
+  built-in 2FA; we'd add `@simplewebauthn` for passkeys and/or
+  `otplib` for TOTP. Trigger: first pharma customer asks.
+- **SCIM** — automatic user provisioning from customer IdP. Future ADR
+  when a customer with >100 users asks.
+- **Federated logout / single sign-out** — supported by NextAuth for OIDC
+  but needs wiring. Future ADR.
+- **Firebase Auth password hash migration** — explicitly deferred. Active
+  password users re-enroll via magic link or the (optional) Credentials
+  provider.
+
+## Open questions for review
+
+- Single OIDC config per deployment vs per workspace — recommended single
+  per deployment given Mediforce's single-tenant model. Confirm.
+- Real password provider toggle (`ENABLE_PASSWORD_AUTH=true`) — confirm
+  this stays a supported option, not "demo only".
+- Session strategy `database` vs `jwt` — confirm `database` for revocation
+  and audit.
+- Cutover sequencing — confirm ADR-0001 lands first, then ADR-0002, not
+  bundled.

--- a/docs/adr/0002-firebase-auth-to-nextauth.md
+++ b/docs/adr/0002-firebase-auth-to-nextauth.md
@@ -5,7 +5,7 @@
 - **Authors:** Marek Rogala (@marekrogala)
 - **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
 - **Depends on:** [ADR-0001](./0001-firestore-to-postgres.md) (Postgres + Drizzle is the adapter target)
-- **Coordinates with:** [ADR-0004](./0004-scoped-data-access-authorization.md) (the `CallerIdentity` and session resolver this ADR defines feed the caller-set repository base from ADR-0004) and the headless migration's Phase 4 typed `apiClient` (the browser `Mediforce` client's `bearerToken` callback flips from `auth.currentUser.getIdToken()` to a NextAuth session resolver — `await getSession()` — when this ADR lands; tracked in [`docs/headless-migration.md`](../headless-migration.md))
+- **Coordinates with:** [ADR-0004](./0004-scoped-data-access-authorization.md) (the `CallerIdentity` this ADR resolves feeds the caller-set repository base from ADR-0004 — the carrier change is orthogonal to that shape, as [ADR-0005](./0005-headless-platform-api-ui-separation.md) already noted) and the headless Phase 1–4 auth boundary (`proxy.ts` + `lib/api-auth.ts`). The browser `Mediforce` client / `apiFetch` **stop attaching an `Authorization` header for same-origin `/api/*` calls** — the NextAuth httpOnly session cookie rides automatically (see §6). Tracked in [`docs/headless-migration.md`](../headless-migration.md).
 - **Implementation plan:** [PLAN-0002.md](./PLAN-0002.md)
 
 ## Context
@@ -20,7 +20,21 @@ Google's identity layer.
 Today's auth surface in Mediforce:
 
 - Browser sign-in via `firebase/auth` SDK: Google OAuth popup + email/password.
-- Server-side ID-token verification in `packages/platform-ui/src/middleware.ts`.
+- **Two-stage server-side ID-token verification** (the headless Phase 1–4
+  boundary — there is no `middleware.ts`):
+  1. `packages/platform-ui/src/proxy.ts` (`matcher: '/api/:path*'`) — coarse
+     gate accepting **either** `X-Api-Key` (`hasValidApiKey`, server-to-server)
+     **or** `Authorization: Bearer <Firebase ID token>`
+     (`hasValidFirebaseToken`, verified via `jose` + Firebase JWKS). Proves the
+     caller is authenticated, not what they may touch.
+  2. `packages/platform-ui/src/lib/api-auth.ts` (`resolveCallerIdentity`) —
+     per-route, re-verifies the Bearer via Admin SDK `verifyIdToken`, then
+     loads workspace memberships from Postgres into `CallerIdentity`.
+- The browser is today **just another Bearer client**: `lib/firebase-id-token.ts`
+  → `lib/mediforce.ts` / `lib/api-fetch.ts` attach `auth.currentUser.getIdToken()`.
+  This Bearer-in-browser shape is a Firebase-SDK artifact (client-first token
+  minting), not a deliberate architectural goal; this ADR returns the browser
+  to the standard same-origin cookie model (§6).
 - Admin SDK `getAuth()` server-side for invites and user directory.
 - **Custom claims** carry two distinct concepts: `role: 'admin'` (deployment
   superuser) and `roles: string[]` (process-domain functional roles).
@@ -56,22 +70,47 @@ introduced in ADR-0001 via `@auth/drizzle-adapter`. Specifics:
    we can audit; the per-request DB read is indexed (millisecond-scale) and
    negligible for our scale.
 
-4. **Providers, env-gated and additive.** A single configuration ships
-   four providers, each enabled by an env var:
+4. **Providers, env-gated and additive (MVP scope set 2026-06-16).** A single
+   configuration ships providers, each enabled by an env var. The MVP ships
+   **three**; magic-link is deferred:
 
    - **Google OAuth** (`GOOGLE_CLIENT_ID`) — parity with today's
      `signInWithPopup(googleProvider)`. The default for the current
      Mediforce user base.
    - **Credentials / email + password** (`ENABLE_PASSWORD_AUTH=true`) —
-     real password auth (bcrypt-hashed in `auth_users`). Optional. Useful
-     when Google/OIDC aren't available, plus for testing and self-hosted
-     installs.
-   - **Email magic link** (`SMTP_HOST` set) — passwordless via SendGrid
-     (we already operate it in `platform-infra/src/email`). Staging / fallback.
+     real password auth (bcrypt-hashed in `auth_users`). A first-class,
+     production-supported option (not demo-only) — it is also load-bearing
+     for local dev, E2E, and air-gapped demos, replacing today's Firebase
+     Auth emulator password users. **Heavy password policy** (complexity,
+     rotation, lockout, history) is **deferred to a future ADR** — built
+     when a real password-in-production deployment needs 21 CFR-grade
+     controls. The MVP provider is honest, not crippled, but minimal.
    - **OIDC** (`OIDC_ISSUER` set) — pharma SSO to a customer's Keycloak /
      Entra / Okta / generic OIDC server. **One IdP per deployment**;
      mediforce is single-tenant per deployment so per-workspace IdPs are
-     out of scope.
+     out of scope. **Included now but dormant**: it is ~15 lines of
+     env-gated config that ship even with no IdP wired. Real per-customer
+     integration (client registration, callback URL, claim mapping,
+     end-to-end test against the customer's IdP) happens when a customer
+     lands; the MVP at most carries one smoke test against a local Keycloak.
+     Shipped now because it *is* the on-prem SSO GTM story and costs almost
+     nothing dormant.
+   - **Email magic link** — **deferred** (was a fourth provider in the
+     draft). Needs SMTP wiring + the verification-token flow, which nobody
+     needs today. Add when a deployment without Google/OIDC/password asks.
+
+4a. **Email-domain allowlist (decision 2026-06-16).** A deployment-level
+   `ALLOWED_EMAIL_DOMAINS` env (comma-separated, e.g. `appsilon.com`) is
+   enforced in the NextAuth `signIn` callback across **all** providers: a
+   sign-in whose `user.email` domain is not in the list is rejected; an unset
+   value means no restriction. This is **not** optional polish — with Google
+   enabled, *any* Google account on earth could otherwise sign in, so the
+   allowlist is what closes that open door (staging restricts to
+   `appsilon.com`; a customer deployment restricts to its domain, or relies on
+   its OIDC IdP). It is a deployment-operator security policy (env var,
+   boot-validated in `instrumentation.ts`, enforced in the same `signIn`
+   callback as the personal-workspace bootstrap), never a per-workspace
+   in-app setting.
 
 5. **Role / claim resolution.** Firebase custom claims map onto three
    different storage locations:
@@ -85,29 +124,69 @@ introduced in ADR-0001 via `@auth/drizzle-adapter`. Specifics:
      `workspace_members.membership` (renamed from today's `members.role`
      to remove the naming collision with process-domain roles).
 
-6. **Middleware.** `hasValidFirebaseToken()` in
-   `packages/platform-ui/src/middleware.ts` is removed. Browser requests
-   carry NextAuth's `authjs.session-token` httpOnly cookie; the middleware
-   resolves the user via `await auth()`. `hasValidApiKey()` (the
-   `PLATFORM_API_KEY` path for CLI / cron) **stays untouched** — out of
-   scope of this ADR.
+6. **Auth boundary — cookie for the browser, key/token for machines.**
+   The carrier splits cleanly by client kind, which is the industry-standard
+   shape for a same-origin Next.js app whose `/api/*` routes are also consumed
+   by non-browser clients (browser → cookie session; CLI / agents / MCP →
+   API key or PAT). Concretely:
 
-7. **Existing-user migration.** Google users migrate **seamlessly**: a
-   Python script seeds them into `auth_users` keyed by email; the first
-   NextAuth Google sign-in matches the pre-seeded row, links the account,
-   and they're in. **Password users do not have their hashes migrated** —
-   Firebase password hashes are not exportable in any form NextAuth can
-   accept. Active production users are mostly Google; the few password
-   accounts are internal/testing and re-enroll via the magic-link or
-   password provider (whichever the deployment has enabled).
+   - `hasValidFirebaseToken()` in `proxy.ts` is **replaced** by a NextAuth
+     session-cookie check (`auth()` / session-token lookup). The browser
+     carries NextAuth's `authjs.session-token` httpOnly cookie; no
+     `Authorization` header on same-origin `/api/*` calls.
+   - `hasValidApiKey()` in `proxy.ts` (the `PLATFORM_API_KEY` path, and the
+     per-user PATs from #376) **stays untouched** — out of scope of this ADR.
+   - `lib/api-auth.ts` `resolveCallerIdentity` resolves `uid` from the
+     NextAuth session instead of `verifyIdToken(Bearer)`; the
+     membership-load-into-`CallerIdentity` tail is unchanged.
+   - `lib/firebase-id-token.ts`, and the `Authorization`-attaching paths in
+     `lib/mediforce.ts` / `lib/api-fetch.ts`, are deleted — the same-origin
+     cookie rides automatically.
 
-8. **Cutover.** **Sequential after ADR-0001**, not bundled. ADR-0001 lands
-   first; mediforce runs on Postgres + Firebase Auth for a stable interval
-   (hybrid is fine — Firebase Auth talks to Google, doesn't touch our DB).
-   Then ADR-0002 runs its own planned-downtime cutover: deploy NextAuth
-   code, run user migration script, flip `AUTH_BACKEND=nextauth`, restart,
-   smoke-test. Rollback path: flip back to `AUTH_BACKEND=firebase`,
-   investigate. Splitting cutovers isolates failure modes.
+   **Same-origin assumption (decision 2026-06-16).** The target post-Firebase
+   deployment is a single self-hosted Next.js server (one origin for UI + API);
+   cookie sessions are the natural fit. The current `proxy.ts` CORS allowlist
+   + `*.hosted.app` pattern is a Firebase Hosting artifact that retires with
+   the Firebase exit. If a real cross-origin front (separate mobile / partner
+   SPA) ever lands, reconcile then via a same-site reverse proxy (preferred)
+   or `SameSite=None; Secure` cookies + a strict CORS allowlist — not by
+   reverting the browser to Bearer.
+
+7. **Existing-user migration — greenfield schema, one-time staging remap
+   (decision 2026-06-16).** There are **no production deployments**, so the
+   schema is written **greenfield** (the project default: build it as if from
+   scratch unless a concrete reason forbids it). `auth_users.id` is a fresh
+   adapter-generated `uuid` — no Firebase-uid baggage carried into the new
+   schema. Staging is the only environment with existing users + data, and we
+   keep it:
+
+   - **Structural changes ship as Drizzle migrations** (create `auth_*` +
+     `user_profiles` reshape; `workspace_members` rename `role` → `membership`
+     + add `roles text[]`).
+   - **The firebase_uid → uuid remap ships as a one-time script, not a SQL
+     migration** — building the mapping requires reading Firebase Auth
+     (`listUsers`), which a pure SQL migration cannot do. The script reads
+     Firebase Auth, inserts `auth_users` (fresh uuid), builds the map, and
+     rewrites the staging references (`workspace_members.uid`,
+     `audit_events.actor_id`, `human_tasks.*`, `cowork_sessions.*`,
+     `handoff.*`, `workspaces.linked_user_id`, `task_attachments.uploaded_by`
+     — the last added by ADR-0003, which lands first and writes it as a
+     Firebase-uid `text` column).
+   - No "seamless Google pre-seed" is required (zero production users to make
+     seamless). Dev / staging users re-enroll by signing in, or are placed by
+     the reworked seed (§Test infrastructure in PLAN).
+
+   _Supersedes the pre-2026-06-16 draft's seamless-Google-pre-seed +
+   password-re-enroll plan._
+
+8. **Cutover — straight swap, no dual-backend (decision 2026-06-16).** With
+   no production to protect (§7), there is no `AUTH_BACKEND` flag, no parallel
+   Firebase/NextAuth CI matrix, and no rollback-to-Firebase window. NextAuth
+   replaces Firebase Auth in one PR sequence; the one-time staging remap (§7)
+   preserves staging users; if something breaks, **fix forward**. ADR-0001
+   already landed, so this is simply the next change, not a bundled or flagged
+   cutover. **Lands after ADR-0003** (storage) so client-direct uploads do not
+   break when the Firebase Auth session disappears — see ADR-0003 §5.
 
 ## Considered alternatives
 
@@ -174,11 +253,30 @@ introduced in ADR-0001 via `@auth/drizzle-adapter`. Specifics:
 
 ## Open questions for review
 
-- Single OIDC config per deployment vs per workspace — recommended single
-  per deployment given Mediforce's single-tenant model. Confirm.
-- Real password provider toggle (`ENABLE_PASSWORD_AUTH=true`) — confirm
-  this stays a supported option, not "demo only".
-- Session strategy `database` vs `jwt` — confirm `database` for revocation
-  and audit.
-- Cutover sequencing — confirm ADR-0001 lands first, then ADR-0002, not
-  bundled.
+(None blocking. All review questions resolved in the 2026-06-16 grilling —
+see below.)
+
+### Resolved during the 2026-06-16 grilling
+
+- **OIDC scope.** Resolved: one IdP **per deployment** (single-tenant model),
+  and **included now but dormant** (env-gated, real integration per-customer
+  later). See §4.
+- **Password provider.** Resolved: **production-supported, not demo-only**,
+  env-gated; also the dev/E2E/demo auth path. Heavy 21 CFR password policy
+  deferred to a future ADR. See §4.
+- **Session strategy.** Resolved: **`database`** (immediate revocation +
+  audit; near-free given the Drizzle adapter is present for account linking
+  anyway). See §3.
+- **Email-domain allowlist.** Added: `ALLOWED_EMAIL_DOMAINS` enforced in the
+  `signIn` callback — mandatory in spirit once Google is on. See §4a.
+- **Magic-link provider.** Deferred (SMTP + verification-token flow; nobody
+  needs it today). See §4.
+
+- **Auth carrier (browser → API).** Resolved: cookie-native, same-origin
+  (decision §6). The browser uses the NextAuth httpOnly session cookie;
+  machines keep `X-Api-Key` / PAT. Reconciled with the headless `proxy.ts`
+  + `api-auth.ts` boundary that did not exist when this ADR was drafted.
+- **Cutover sequencing.** Moot: ADR-0001 already landed (Postgres cutover
+  completed 2026-05-31, PR #534). Mediforce now runs on Postgres + Firebase
+  Auth — exactly the stable hybrid this ADR's §8 assumed. ADR-0002 is the
+  next cutover; no bundling question remains.

--- a/docs/adr/0002-firebase-auth-to-nextauth.md
+++ b/docs/adr/0002-firebase-auth-to-nextauth.md
@@ -5,6 +5,7 @@
 - **Authors:** Marek Rogala (@marekrogala)
 - **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
 - **Depends on:** [ADR-0001](./0001-firestore-to-postgres.md) (Postgres + Drizzle is the adapter target)
+- **Coordinates with:** [ADR-0004](./0004-scoped-data-access-authorization.md) (the `CallerIdentity` and session resolver this ADR defines feed the caller-set repository base from ADR-0004) and the headless migration's Phase 4 typed `apiClient` (the browser `Mediforce` client's `bearerToken` callback flips from `auth.currentUser.getIdToken()` to a NextAuth session resolver — `await getSession()` — when this ADR lands; tracked in [`docs/headless-migration.md`](../headless-migration.md))
 - **Implementation plan:** [PLAN-0002.md](./PLAN-0002.md)
 
 ## Context

--- a/docs/adr/0002-firebase-auth-to-nextauth.md
+++ b/docs/adr/0002-firebase-auth-to-nextauth.md
@@ -1,7 +1,8 @@
 # 0002 — Move authentication from Firebase Auth to NextAuth (Auth.js v5)
 
-- **Status:** Proposed
-- **Date:** 2026-05-19
+- **Status:** Proposed (grilled & reshaped 2026-06-29; supersedes the
+  2026-06-16 greenfield-uuid + remap draft — see §7)
+- **Date:** 2026-05-19 (reshaped 2026-06-16, 2026-06-29)
 - **Authors:** Marek Rogala (@marekrogala)
 - **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
 - **Depends on:** [ADR-0001](./0001-firestore-to-postgres.md) (Postgres + Drizzle is the adapter target)
@@ -112,14 +113,32 @@ introduced in ADR-0001 via `@auth/drizzle-adapter`. Specifics:
    callback as the personal-workspace bootstrap), never a per-workspace
    in-app setting.
 
+4b. **Account linking by verified email (decision 2026-06-29).** A Google
+   sign-in whose email matches an existing `auth_users` row (a migration-seeded
+   user, §7) **links automatically** onto that user — `allowDangerousEmailAccountLinking:
+   true` set **on the Google provider only**. This is safe precisely because
+   Google emails are verified and `ALLOWED_EMAIL_DOMAINS` (§4a) already gates
+   the domain; it is what makes the seamless re-login work without a remap.
+   **Never** enable it for an unverified-email provider (the "dangerous" case —
+   account takeover). Today's explicit `pendingGoogleLink` password-link dance
+   (sign in with password to attach a same-email Google account) is **dropped** —
+   verified-email auto-link replaces it, and passwords are test-only anyway.
+
 5. **Role / claim resolution.** Firebase custom claims map onto three
    different storage locations:
 
    - `customClaims.role === 'admin'` → `user_profiles.deployment_admin: boolean`
-   - `customClaims.roles: string[]` → **per-workspace** `workspace_members.roles: text[]`
-     (today these claims are global; the migration **copies them onto every
-     workspace membership** the user holds, then admins can fine-tune
-     separately).
+   - `customClaims.roles: string[]` → a **global** `user_roles(uid, role)` table
+     (one indexed row per (user, role)). **These claims are global today and
+     `getUsersByRole(role)` is called with no namespace context**
+     (`workflow-engine.ts` escalation-notification targeting resolves a role to
+     users across the whole deployment). A global table is the faithful port —
+     the PG `UserDirectoryService` reads it with the same global semantics.
+     _(Decision 2026-06-29: rejected the earlier draft's per-workspace
+     `workspace_members.roles[]` — scoping role→user resolution to a workspace
+     would silently change notification targeting, a **regression** dressed as
+     a migration. Per-workspace functional roles can return later as a real
+     product decision if asked.)_
    - Workspace governance (`owner | admin | member`) lives on
      `workspace_members.membership` (renamed from today's `members.role`
      to remove the naming collision with process-domain roles).
@@ -152,41 +171,68 @@ introduced in ADR-0001 via `@auth/drizzle-adapter`. Specifics:
    or `SameSite=None; Secure` cookies + a strict CORS allowlist — not by
    reverting the browser to Bearer.
 
-7. **Existing-user migration — greenfield schema, one-time staging remap
-   (decision 2026-06-16).** There are **no production deployments**, so the
-   schema is written **greenfield** (the project default: build it as if from
-   scratch unless a concrete reason forbids it). `auth_users.id` is a fresh
-   adapter-generated `uuid` — no Firebase-uid baggage carried into the new
-   schema. Staging is the only environment with existing users + data, and we
-   keep it:
+7. **Existing-user migration — keep the uid, no remap (decision 2026-06-29).**
+   The Firebase uid is already the **canonical, opaque user id** stored as
+   `text` across the whole schema (`user_profiles.uid` PK, `workspace_members.uid`
+   PK, `workspaces.linked_user_id`, `{human_tasks,cowork_sessions,handoff}.assigned_user_id`,
+   `process_instances.created_by`, `audit_events` actor, `task_attachments.uploaded_by`).
+   Nothing parses a user id as a `uuid`. So `auth_users.id` **is the existing
+   Firebase uid** (the `@auth/drizzle-adapter` schema must declare `id` as
+   `text`, **not** `uuid` — the only impl constraint), and **every reference
+   stays valid with zero data rewrite**:
 
    - **Structural changes ship as Drizzle migrations** (create `auth_*` +
-     `user_profiles` reshape; `workspace_members` rename `role` → `membership`
-     + add `roles text[]`).
-   - **The firebase_uid → uuid remap ships as a one-time script, not a SQL
-     migration** — building the mapping requires reading Firebase Auth
-     (`listUsers`), which a pure SQL migration cannot do. The script reads
-     Firebase Auth, inserts `auth_users` (fresh uuid), builds the map, and
-     rewrites the staging references (`workspace_members.uid`,
-     `audit_events.actor_id`, `human_tasks.*`, `cowork_sessions.*`,
-     `handoff.*`, `workspaces.linked_user_id`, `task_attachments.uploaded_by`
-     — the last added by ADR-0003, which lands first and writes it as a
-     Firebase-uid `text` column).
-   - No "seamless Google pre-seed" is required (zero production users to make
-     seamless). Dev / staging users re-enroll by signing in, or are placed by
-     the reworked seed (§Test infrastructure in PLAN).
+     `user_profiles` reshape; `workspace_members` rename `role` → `membership`;
+     create the global `user_roles` table). The uid columns are **not** touched.
+   - **Migration = a tiny one-time seed**, not a remap: a script reads Firebase
+     Auth (`listUsers`) and inserts one `auth_users` row per existing user
+     (`id = uid`, `email`, `name`) so a Google sign-in **links by verified
+     email** (§4b) onto the pre-existing uid. It also seeds `user_roles` from
+     today's `customClaims.roles` and `user_profiles.deployment_admin` from
+     `customClaims.role === 'admin'`. No uid columns rewritten, no mapping
+     table, no `audit_events`/`human_tasks`/… churn.
+   - New users created after cutover get an adapter-generated `uuid` id —
+     mixed id shapes (Firebase strings + uuids) are harmless: both are opaque
+     `text`, no consumer cares.
+   - Passwords are not migrated (Firebase scrypt is proprietary; passwords are
+     test-only today). Email/password users reset if they want one — **not
+     forced** (§ password ceremony).
 
-   _Supersedes the pre-2026-06-16 draft's seamless-Google-pre-seed +
-   password-re-enroll plan._
+   _(Decision 2026-06-29, after grilling: **supersedes** the 2026-06-16
+   greenfield-uuid + remap-script plan. Keeping the uid was judged the
+   simpler-correct move — the uuid was cosmetic and the remap rewrote ~8
+   columns for no functional gain. This also **supersedes the "remap
+   uploaded_by to fresh uuids" line in [ADR-0003](./0003-remove-firebase-storage.md)
+   §5** — `uploaded_by` simply stays the Firebase-uid `text` it already is.)_
 
-8. **Cutover — straight swap, no dual-backend (decision 2026-06-16).** With
-   no production to protect (§7), there is no `AUTH_BACKEND` flag, no parallel
-   Firebase/NextAuth CI matrix, and no rollback-to-Firebase window. NextAuth
-   replaces Firebase Auth in one PR sequence; the one-time staging remap (§7)
-   preserves staging users; if something breaks, **fix forward**. ADR-0001
-   already landed, so this is simply the next change, not a bundled or flagged
-   cutover. **Lands after ADR-0003** (storage) so client-direct uploads do not
-   break when the Firebase Auth session disappears — see ADR-0003 §5.
+8. **Cutover — two PRs, no dual-run (decision 2026-06-29).** Auth is atomic —
+   you cannot half-authenticate — so there is no dual-backend window, no
+   `AUTH_BACKEND` flag, no parallel Firebase/NextAuth CI matrix, no
+   rollback-to-Firebase scaffolding. With no production to protect (§7) the
+   only cost of a bad cutover is "log in again," and the e2e auth-setup (now on
+   NextAuth) exercises the whole login→session→API flow in CI before deploy;
+   rollback is a redeploy. The work splits at a natural seam:
+
+   - **PR1 — user-management off Firebase-admin (additive, non-breaking).** The
+     global `user_roles` table + PG `UserDirectoryService` + PG invite impl,
+     behind the existing ports; one-time seed of `user_roles` from current
+     Firebase claims so `getUsersByRole` notifications keep working. Firebase
+     stays the auth source. De-risks PR2 by pulling role/directory complexity
+     out of the cutover.
+   - **PR2 — NextAuth atomic cutover.** `auth_*` tables + `user_profiles`
+     reshape + Google/Credentials providers + text-id drizzle adapter +
+     `resolveCallerIdentity`→cookie + client rewrite + login page + the §7
+     user seed on staging + e2e auth-setup → NextAuth + delete Firebase Auth /
+     firebase-admin / emulator. Gate: `grep firebase/auth → 0`.
+
+   A dual-run window (`resolveCallerIdentity` accepting both a Firebase Bearer
+   and a NextAuth cookie at once) was **considered and rejected**: ADR-0003's
+   migrate-before-flip protected data that would *vanish*; auth has no
+   equivalent data-loss risk, so the dual-path scaffolding (plus a teardown PR,
+   plus a wider security surface) buys nothing here.
+
+   **Lands after ADR-0003** (storage) so client-direct uploads do not break
+   when the Firebase Auth session disappears — see ADR-0003 §5.
 
 ## Considered alternatives
 

--- a/docs/adr/0003-remove-firebase-storage.md
+++ b/docs/adr/0003-remove-firebase-storage.md
@@ -81,8 +81,10 @@ filesystem implementation now.
    server-mediated **headless routes** (ADR-0005 / AGENTS.md §8 — never Server
    Actions) → `BlobStore`, severing the Firebase-Auth dependency, so it lands
    first. Consequently `task_attachments.uploaded_by` is a Firebase-uid `text`
-   column (no FK to ADR-0002's not-yet-existing `auth_users`); ADR-0002's
-   staging remap rewrites it when fresh uuids land.
+   column (no FK to ADR-0002's not-yet-existing `auth_users`). _(Update: ADR-0002
+   §7 supersedes the "staging remap rewrites it when fresh uuids land" plan —
+   `auth_users.id` keeps the Firebase uid, so `uploaded_by` stays this `text`
+   uid unchanged, no remap.)_
 
 6. **Firebase Storage removed via a standalone one-time migration.** ADR-0001's
    Firestore → Postgres cutover already shipped (#534), so this is a separate

--- a/docs/adr/PLAN-0002.md
+++ b/docs/adr/PLAN-0002.md
@@ -139,16 +139,9 @@ if (process.env.ENABLE_PASSWORD_AUTH === 'true') {
   }));
 }
 
-if (process.env.SMTP_HOST) {
-  providers.push(Email({
-    server: {
-      host: process.env.SMTP_HOST,
-      port: Number(process.env.SMTP_PORT),
-      auth: { user: process.env.SMTP_USER!, pass: process.env.SMTP_PASS! },
-    },
-    from: process.env.SMTP_FROM,
-  }));
-}
+// Magic-link (Email) provider is DEFERRED for the MVP (ADR-0002 §4) —
+// needs SMTP wiring + verification-token flow; add when a deployment
+// without Google/OIDC/password asks.
 
 if (process.env.OIDC_ISSUER) {
   providers.push({
@@ -167,6 +160,15 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
   providers,
   callbacks: {
     async signIn({ user }) {
+      // Deployment-level email-domain allowlist (ADR-0002 §4a). Unset =
+      // no restriction. With Google enabled this is what stops any Google
+      // account on earth from signing in (e.g. staging = 'appsilon.com').
+      const allowed = (process.env.ALLOWED_EMAIL_DOMAINS ?? '')
+        .split(',').map((d) => d.trim().toLowerCase()).filter(Boolean);
+      if (allowed.length > 0) {
+        const domain = (user.email ?? '').split('@')[1]?.toLowerCase() ?? '';
+        if (!allowed.includes(domain)) return false;
+      }
       // Ensure user_profiles row exists. Personal workspace bootstrap
       // happens here, in one transaction.
       await ensureUserProfile(user.id, user.email!);
@@ -212,9 +214,12 @@ import { auth as nextAuthMiddleware } from '@/auth';
 - `AUTH_URL` — full URL of deployment, e.g. `https://mediforce.acme.com`. Only required if not auto-detectable.
 - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` — for the Google provider.
 - `ENABLE_PASSWORD_AUTH=true` — to enable the Credentials provider.
-- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` — for the Email magic-link provider.
-- `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_DISPLAY_NAME` — for the customer SSO provider.
-- `AUTH_BACKEND` — `firebase` | `nextauth`. Set to `firebase` initially; flip to `nextauth` at cutover; removed after the migration is verified stable.
+- `ALLOWED_EMAIL_DOMAINS` — comma-separated email-domain allowlist (e.g. `appsilon.com`), enforced in the `signIn` callback (ADR-0002 §4a). Unset = no restriction. Boot-validated in `instrumentation.ts`.
+- `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_DISPLAY_NAME` — for the customer SSO provider (dormant until set).
+
+**Not added:** `SMTP_*` (magic-link deferred, ADR-0002 §4) and `AUTH_BACKEND`
+(no dual-backend flag — the migration is a straight swap, not a flagged
+cutover; see §5).
 
 ---
 
@@ -295,37 +300,34 @@ roles do they have) by replacing custom-claims lookups with reads from
 
 ---
 
-## 5. Cutover (sequential after ADR-0001)
+## 5. Cutover — straight swap (no dual-backend)
 
-### 5.1 Pre-cutover (over preceding sprint)
+No `AUTH_BACKEND` flag, no parallel Firebase/NextAuth CI matrix, no
+rollback-to-Firebase window. There is no production to protect (ADR-0002 §7),
+so the migration is a straight replacement, not a flagged cutover:
 
-1. NextAuth code shipped behind `AUTH_BACKEND` flag. `AUTH_BACKEND=firebase` keeps everything on Firebase.
-2. Schema migration (NextAuth tables + `user_profiles`) lands as a Drizzle migration. Empty tables in production until cutover.
-3. CI matrix runs L3 E2E against both `AUTH_BACKEND=firebase` and `AUTH_BACKEND=nextauth` (with a seeded user) so regressions surface in PR.
-4. OIDC integration smoke test against a sandbox IdP (Auth0 dev tenant or local Keycloak container) lands as an opt-in L3 test.
+1. Schema migration (`auth_*` + `user_profiles` + `workspace_members` reshape)
+   lands as a Drizzle migration.
+2. NextAuth replaces Firebase Auth in code: provider config, `proxy.ts`
+   session check, `api-auth.ts` resolver, `auth-context.tsx`,
+   login / change-password pages, invite + user-directory services. The
+   Firebase Auth client SDK and the Admin SDK auth path are removed.
+3. Run the one-time staging user remap (§4) so staging users + data survive.
+4. Smoke test: Google sign-in lands authenticated; `ALLOWED_EMAIL_DOMAINS`
+   rejects an out-of-domain email; password sign-in (if enabled) works;
+   sign-out → next request 401; deleting a row in `auth_sessions` → next
+   request 401.
+5. CI runs E2E against NextAuth only (no matrix). An OIDC smoke test against a
+   local Keycloak container is optional / opt-in.
 
-### 5.2 Cutover window (planned downtime, separate from ADR-0001's window)
+If something is wrong, **fix forward** — there is no live deployment to roll
+back to.
 
-1. Announce maintenance window.
-2. Run user migration script (steps in §4).
-3. Verify counts + sample.
-4. Set `AUTH_BACKEND=nextauth`, restart application.
-5. Smoke test: sign in with Google → land authenticated; (if password enabled) request magic link, click, set password, sign in; sign out → next request 401.
-6. End maintenance.
-
-### 5.3 Rollback
-
-If smoke fails:
-
-1. Set `AUTH_BACKEND=firebase`, restart.
-2. NextAuth tables remain but unused (no harm). Investigate.
-
-### 5.4 Post-cutover (within 2 weeks)
-
-- Remove `AUTH_BACKEND` flag (always NextAuth).
-- Uninstall `firebase` and `firebase-admin` packages from `packages/platform-ui` and `packages/platform-infra` if [ADR future] Firebase Storage migration has also landed; otherwise keep the Storage portion.
-- Delete the Auth emulator stanza from `firebase.json`.
-- Update `.env.example`, `README.md`, `CHANGELOG.md`.
+**Cleanup folded into the same work** (not a later phase): uninstall `firebase`
+and `firebase-admin` from `platform-ui` / `platform-infra` (the Storage half is
+already gone — ADR-0003 lands first), delete the Firebase Auth emulator stanza
+from `firebase.json` and the emulator-based dev seed / E2E setup (reworked to
+seed `auth_*` directly, §7), update `.env.example` / `README.md` / `CHANGELOG.md`.
 
 ---
 
@@ -378,10 +380,12 @@ The migration is "done" when **all** of the below are true:
 7. Role-based access: a user with `workspace_members.membership='admin'` can manage docker images / OAuth providers; with `'member'` cannot.
 8. Process-role gating: a user with `workspace_members.roles = ['reviewer']` can claim a human task with `assignedRole='reviewer'`; without the role cannot.
 
-### Rollback criteria
+### If something breaks
 
-- > 1% authentication failure rate over 1h sustained → flip `AUTH_BACKEND=firebase` and triage.
-- OIDC integration with a customer IdP fails and cannot be resolved in 24h → revert that customer's deployment to `AUTH_BACKEND=firebase` until fixed.
+Fix forward — there is no Firebase Auth backend to revert to (straight swap,
+§5). Staging is the only environment with users; if the remap or a provider
+misbehaves, re-run the idempotent remap (§4) or correct the config and
+redeploy. No production is at risk.
 
 ---
 

--- a/docs/adr/PLAN-0002.md
+++ b/docs/adr/PLAN-0002.md
@@ -5,7 +5,8 @@ Exhaustive checklist for the implementing agent. Cross-reference for domain
 language: [`../../CONTEXT.md`](../../CONTEXT.md).
 
 This plan **assumes ADR-0001 has landed**: Postgres is the live datastore,
-Drizzle is wired, `WorkspaceScopedRepository` base is in place.
+Drizzle is wired, and the caller-set repository base codified by
+[ADR-0004](./0004-scoped-data-access-authorization.md) is in place.
 
 ---
 
@@ -251,8 +252,10 @@ Grep for `verifyIdToken`, `getIdTokenResult`, `customClaims`, and any header-bas
 
 ### 3.5 Firestore-rules-derived application checks
 
-ADR-0001 already moves these into the application layer via the fail-proof
-repository base. ADR-0002 fills in the **decision** side (who's an admin, what
+ADR-0001 already moves these into the application layer via the caller-set
+repository base codified by
+[ADR-0004](./0004-scoped-data-access-authorization.md). ADR-0002 fills in
+the **decision** side (who's an admin, what
 roles do they have) by replacing custom-claims lookups with reads from
 `user_profiles` + `workspace_members`. Specifically:
 

--- a/docs/adr/PLAN-0002.md
+++ b/docs/adr/PLAN-0002.md
@@ -19,7 +19,7 @@ types must match the adapter's expectations — do not improvise.
 
 ```sql
 create table auth_users (
-  id uuid primary key default gen_random_uuid(),
+  id text primary key,                  -- NOT uuid: holds the existing Firebase uid for migrated users (ADR-0002 §7); the adapter mints a uuid-shaped string for new users. The @auth/drizzle-adapter schema MUST declare id as text.
   name text,
   email text unique not null,
   email_verified timestamptz,
@@ -32,7 +32,7 @@ create table auth_users (
 
 create table auth_accounts (
   id uuid primary key default gen_random_uuid(),
-  user_id uuid not null references auth_users(id) on delete cascade,
+  user_id text not null references auth_users(id) on delete cascade,  -- text: matches auth_users.id
   type text not null,                   -- 'oauth' | 'email' | 'credentials' | 'oidc'
   provider text not null,               -- 'google' | 'customer-sso' | 'email' | 'credentials'
   provider_account_id text not null,
@@ -49,7 +49,7 @@ create table auth_accounts (
 create table auth_sessions (
   id uuid primary key default gen_random_uuid(),
   session_token text unique not null,
-  user_id uuid not null references auth_users(id) on delete cascade,
+  user_id text not null references auth_users(id) on delete cascade,  -- text: matches auth_users.id
   expires timestamptz not null
 );
 create index on auth_sessions (user_id);
@@ -67,7 +67,7 @@ create table auth_verification_tokens (
 
 ```sql
 create table user_profiles (
-  user_id uuid primary key references auth_users(id) on delete cascade,
+  user_id text primary key references auth_users(id) on delete cascade,  -- text: matches auth_users.id
   current_workspace text references workspaces(handle),
   deployment_admin boolean not null default false,
   must_change_password boolean not null default false,
@@ -79,24 +79,34 @@ create table user_profiles (
 );
 ```
 
-### 1.3 Extensions to ADR-0001's `workspace_members`
+### 1.3 Rename on ADR-0001's `workspace_members`
 
-ADR-0001 introduces `workspace_members` with a single `role` column. ADR-0002
-**renames** that column to `membership` and **adds** a process-roles array:
+ADR-0001 introduces `workspace_members` with a single `role` column (workspace
+governance: `owner | admin | member`). ADR-0002 **renames** it to `membership`
+to remove the collision with process-domain roles:
 
 ```sql
 alter table workspace_members
   rename column role to membership;          -- 'owner' | 'admin' | 'member'
-
-alter table workspace_members
-  add column roles text[] not null default '{}';  -- process-domain roles (replaces Firebase customClaims.roles)
-
-create index on workspace_members using gin (roles);  -- "all reviewers in workspace W"
 ```
 
-If ADR-0001 has not yet shipped when ADR-0002 PR opens, fold the rename and the
-extra column directly into the ADR-0001 schema so it lands in one go. Otherwise
-do the `ALTER TABLE` here.
+No `roles[]` column is added — process-domain roles go in the **global**
+`user_roles` table (§1.4), matching today's global Firebase claims (ADR-0002 §5).
+
+### 1.4 Global process-domain roles
+
+```sql
+create table user_roles (
+  uid text not null references auth_users(id) on delete cascade,
+  role text not null,
+  primary key (uid, role)
+);
+create index on user_roles (role);          -- getUsersByRole(role): "all reviewers in the deployment"
+```
+
+Replaces Firebase `customClaims.roles` (global). `getUsersByRole(role)` is a
+deployment-wide query with no namespace context (ADR-0002 §5) — a global table
+is the faithful port. The PG `UserDirectoryService` reads it.
 
 ---
 
@@ -122,6 +132,10 @@ if (process.env.GOOGLE_CLIENT_ID) {
   providers.push(Google({
     clientId: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    // ADR-0002 §4b: link onto a migration-seeded user with the same (verified)
+    // email. Safe ONLY because Google verifies emails + ALLOWED_EMAIL_DOMAINS
+    // gates the domain. NEVER set this on an unverified-email provider.
+    allowDangerousEmailAccountLinking: true,
   }));
 }
 
@@ -228,7 +242,7 @@ cutover; see §5).
 ### 3.1 Server-side Firebase Admin SDK — replace
 
 - [`packages/platform-infra/src/auth/firebase-admin-init.ts`](../../packages/platform-infra/src/auth/firebase-admin-init.ts) — delete the `getAuth()` portion. (The `getFirestore()` portion is already gone from ADR-0001.)
-- [`packages/platform-infra/src/auth/firebase-invite-service.ts`](../../packages/platform-infra/src/auth/firebase-invite-service.ts) — rewrite as `NextAuthInviteService` that inserts an `auth_users` row and triggers a magic-link email.
+- [`packages/platform-infra/src/auth/firebase-invite-service.ts`](../../packages/platform-infra/src/auth/firebase-invite-service.ts) — rewrite as `PostgresInviteService`: an invite **pre-seeds an `auth_users` row** (email + name) plus the invitee's `workspace_members` membership and any `user_roles`. The invitee signs in with Google → verified-email auto-link (§4b) attaches to the seeded row. No temp password, no magic-link email (magic-link deferred, ADR-0002 §4).
 - [`packages/platform-infra/src/auth/firebase-user-directory-service.ts`](../../packages/platform-infra/src/auth/firebase-user-directory-service.ts) — rewrite as `PostgresUserDirectoryService`. Today uses `listUsers(1000)` and reads `customClaims.role` / `customClaims.roles`. After: `SELECT * FROM auth_users JOIN user_profiles …`.
 - [`packages/platform-ui/src/lib/resolve-agent-identity.ts`](../../packages/platform-ui/src/lib/resolve-agent-identity.ts) — keep, but stop using `firebase-admin/storage` for skill files only at the Storage ADR; auth-related code in here moves to NextAuth.
 
@@ -265,69 +279,63 @@ roles do they have) by replacing custom-claims lookups with reads from
 `user_profiles` + `workspace_members`. Specifically:
 
 - `isAdmin()` → `session.user.deploymentAdmin === true`
-- `hasProcessRole(assignedRoles)` → query `workspace_members.roles` for the
-  caller's `(workspace, uid)` and check `roles && assignedRoles` overlap
+- `hasProcessRole(assignedRoles)` → query the global `user_roles` for the
+  caller's `uid` and check overlap with `assignedRoles` (global, matching
+  today's Firebase-claims semantics — §1.4)
 - workspace governance (delete workspace, manage members, manage docker
   images, manage OAuth providers) → check `workspace_members.membership`
   for `owner` / `admin`
 
 ---
 
-## 4. User migration script
+## 4. User seed script (keep-uid — NOT a remap)
 
 `scripts/migrate-firebase-auth-to-postgres/main.py`. Idempotent; safe to re-run.
+Because `auth_users.id` **is** the Firebase uid (ADR-0002 §7), this is a small
+**seed**, not a reference remap — **no uid column is rewritten**, no mapping
+table.
 
 1. Use Firebase Admin SDK `listUsers()` to fetch every user (paginate).
-2. For each user:
-   - Determine `password_hash`: **null** (we do not migrate hashes).
-   - Determine providers from `providerData[]`:
-     - `google.com` → seed an `auth_accounts` row `(type='oauth', provider='google', provider_account_id=<google sub>)`. Google sign-in matches it on next sign-in.
-     - `password` → no `auth_accounts` row. User must re-enroll via magic link or Credentials if enabled.
-     - Other providers (`saml.*`, etc.) → handle case-by-case if found.
-   - Insert `auth_users (id=uuid_for_email, email, name=displayName, email_verified=now, image=photoURL)`.
-   - Insert `user_profiles (user_id, current_workspace=<from users/{uid}.handle>, deployment_admin=(customClaims.role==='admin'), must_change_password=<from users/{uid}.mustChangePassword>)`.
-3. Build a mapping table `firebase_uid_to_new_user_id (firebase_uid text primary key, user_id uuid)` and persist it. Used to migrate references.
-4. Walk Mediforce tables that reference Firebase uids and rewrite them via the mapping:
-   - `workspace_members.uid` (FK; needs to point at new `auth_users.id` if the column was uid-typed)
-   - `workspaces.linked_user_id`
-   - `audit_events.actor_id` (string, no FK, but still rewrite to keep audit consistent)
-   - `human_tasks.assigned_user_id`
-   - `cowork_sessions.assigned_user_id`
-   - `handoff_entities.assigned_user_id`
-   - any other table holding a uid (verified via `grep`)
-5. Copy `customClaims.roles` to **every** `workspace_members.roles` row the user has. Today's claims are global; after migration they become per-workspace, lossless on day one, admins fine-tune later.
-6. Verify: counts, sample row checks, foreign-key integrity.
+2. For each user (idempotent on `id = uid`):
+   - Insert `auth_users (id=uid, email, name=displayName, email_verified=now, image=photoURL)`. **`id` is the existing Firebase uid** — every `workspace_members.uid`, `*.assigned_user_id`, `created_by`, `uploaded_by`, `audit_events` actor already points here, untouched.
+   - `password_hash`: **null** (Firebase scrypt is proprietary; passwords are test-only). Email/password users reset if they want one — not forced.
+   - Do **not** pre-seed an `auth_accounts` Google row — first Google sign-in creates it and links by verified email (§4b) onto this `id`.
+   - Insert `user_profiles (user_id=uid, current_workspace=<from users/{uid}.handle>, deployment_admin=(customClaims.role==='admin'))`.
+   - Insert one `user_roles (uid, role)` row per entry in `customClaims.roles` (global — §1.4), so `getUsersByRole` notifications keep working.
+3. Verify: counts, sample row checks, FK integrity. **No reference rewrite step** — the uid columns are already correct.
 
 ---
 
-## 5. Cutover — straight swap (no dual-backend)
+## 5. Cutover — two PRs, no dual-run
 
 No `AUTH_BACKEND` flag, no parallel Firebase/NextAuth CI matrix, no
-rollback-to-Firebase window. There is no production to protect (ADR-0002 §7),
-so the migration is a straight replacement, not a flagged cutover:
+rollback-to-Firebase window, **no dual-run** (`resolveCallerIdentity` accepting
+both a Firebase Bearer and a NextAuth cookie at once was rejected — auth has no
+data-loss risk, unlike ADR-0003 storage). The work splits at a natural seam so
+the security-critical cutover reviews clean (ADR-0002 §8).
 
-1. Schema migration (`auth_*` + `user_profiles` + `workspace_members` reshape)
-   lands as a Drizzle migration.
-2. NextAuth replaces Firebase Auth in code: provider config, `proxy.ts`
-   session check, `api-auth.ts` resolver, `auth-context.tsx`,
-   login / change-password pages, invite + user-directory services. The
-   Firebase Auth client SDK and the Admin SDK auth path are removed.
-3. Run the one-time staging user remap (§4) so staging users + data survive.
-4. Smoke test: Google sign-in lands authenticated; `ALLOWED_EMAIL_DOMAINS`
-   rejects an out-of-domain email; password sign-in (if enabled) works;
-   sign-out → next request 401; deleting a row in `auth_sessions` → next
-   request 401.
-5. CI runs E2E against NextAuth only (no matrix). An OIDC smoke test against a
-   local Keycloak container is optional / opt-in.
+### PR1 — user-management off Firebase-admin (additive, non-breaking)
 
-If something is wrong, **fix forward** — there is no live deployment to roll
-back to.
+Firebase stays the auth source; this only swaps impls behind existing ports.
 
-**Cleanup folded into the same work** (not a later phase): uninstall `firebase`
-and `firebase-admin` from `platform-ui` / `platform-infra` (the Storage half is
-already gone — ADR-0003 lands first), delete the Firebase Auth emulator stanza
-from `firebase.json` and the emulator-based dev seed / E2E setup (reworked to
-seed `auth_*` directly, §7), update `.env.example` / `README.md` / `CHANGELOG.md`.
+1. Drizzle migration: create the global `user_roles` table (§1.4).
+2. `PostgresUserDirectoryService` (§3.1) reads `user_roles` + `auth_users`/`user_profiles` (the latter created here or in PR2 — if PR1 lands first, create a minimal `user_roles` + read current data; keep it simple). `getUsersByRole` stays global.
+3. `PostgresInviteService` (§3.1) — seed-based invites.
+4. One-time seed of `user_roles` from current Firebase `customClaims.roles` so `getUsersByRole` notification targeting keeps working.
+5. Consumers (`workflow-engine`, `caller-scope`) unchanged — same ports.
+
+Non-breaking: no auth-path change, no UI change.
+
+### PR2 — NextAuth atomic cutover
+
+1. Drizzle migration: `auth_*` tables + `user_profiles` + `workspace_members` rename (§1.1–1.3).
+2. NextAuth replaces Firebase Auth in code: provider config (§2.1), `proxy.ts` session check, `api-auth.ts` resolver (uid from session), `auth-context.tsx`, login / change-password pages. Delete `lib/firebase-id-token.ts` + the `Authorization`-attaching paths.
+3. Run the one-time user **seed** (§4) on staging so staging users + data survive (no remap — uid columns already correct).
+4. Rework e2e auth-setup (§7) onto NextAuth — this exercises login→session→API in CI before deploy.
+5. Smoke test: Google sign-in authenticated; `ALLOWED_EMAIL_DOMAINS` rejects out-of-domain; verified-email auto-link attaches to a seeded user; sign-out → next request 401; delete an `auth_sessions` row → next request 401.
+6. **Cleanup folded in** (not a later phase): uninstall `firebase` + `firebase-admin` from `platform-ui` / `platform-infra` (Storage half already gone — ADR-0003), delete the Firebase Auth emulator stanza from `firebase.json` + emulator-based dev seed, update `.env.example` / `README.md` / `CHANGELOG.md`. Gate: `grep firebase/auth → 0`.
+
+If something is wrong, **fix forward** — no live deployment to roll back to; rollback is a redeploy.
 
 ---
 
@@ -348,7 +356,7 @@ async function ensureUserProfile(userId: string, email: string) {
 
     const handle = await pickAvailableHandle(tx, email);  // 'alice', 'alice-2', …
     await tx.insert(workspaces).values({ handle, type: 'personal', linkedUserId: userId, displayName: email.split('@')[0] });
-    await tx.insert(workspaceMembers).values({ workspace: handle, uid: userId, membership: 'owner', roles: [] });
+    await tx.insert(workspaceMembers).values({ workspace: handle, uid: userId, membership: 'owner' });
     await tx.insert(userProfiles).values({ userId, currentWorkspace: handle, deploymentAdmin: false });
   });
 }
@@ -378,7 +386,7 @@ The migration is "done" when **all** of the below are true:
 5. OIDC smoke test: `OIDC_ISSUER` pointing at a Keycloak container, sign in via the IdP redirect, authenticated with `session.user.deploymentAdmin` populated.
 6. Session revocation: mark a row in `auth_sessions` deleted (or set `expires` to the past); the user's next request returns 401 with no other action.
 7. Role-based access: a user with `workspace_members.membership='admin'` can manage docker images / OAuth providers; with `'member'` cannot.
-8. Process-role gating: a user with `workspace_members.roles = ['reviewer']` can claim a human task with `assignedRole='reviewer'`; without the role cannot.
+8. Process-role gating: a user with `user_roles` row `(uid, 'reviewer')` can claim a human task with `assignedRole='reviewer'`; without the role cannot.
 
 ### If something breaks
 

--- a/docs/adr/PLAN-0002.md
+++ b/docs/adr/PLAN-0002.md
@@ -1,0 +1,391 @@
+# PLAN-0002 — Implementation plan for ADR-0002
+
+Companion to [`0002-firebase-auth-to-nextauth.md`](./0002-firebase-auth-to-nextauth.md).
+Exhaustive checklist for the implementing agent. Cross-reference for domain
+language: [`../../CONTEXT.md`](../../CONTEXT.md).
+
+This plan **assumes ADR-0001 has landed**: Postgres is the live datastore,
+Drizzle is wired, `WorkspaceScopedRepository` base is in place.
+
+---
+
+## 1. Schema additions
+
+### 1.1 NextAuth-managed tables
+
+These four tables are required by `@auth/drizzle-adapter`. Column names and
+types must match the adapter's expectations — do not improvise.
+
+```sql
+create table auth_users (
+  id uuid primary key default gen_random_uuid(),
+  name text,
+  email text unique not null,
+  email_verified timestamptz,
+  image text,
+  -- mediforce extensions (NextAuth tolerates extra columns)
+  password_hash text,                   -- only set when Credentials provider used
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table auth_accounts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth_users(id) on delete cascade,
+  type text not null,                   -- 'oauth' | 'email' | 'credentials' | 'oidc'
+  provider text not null,               -- 'google' | 'customer-sso' | 'email' | 'credentials'
+  provider_account_id text not null,
+  refresh_token text,
+  access_token text,
+  expires_at bigint,
+  token_type text,
+  scope text,
+  id_token text,
+  session_state text,
+  unique (provider, provider_account_id)
+);
+
+create table auth_sessions (
+  id uuid primary key default gen_random_uuid(),
+  session_token text unique not null,
+  user_id uuid not null references auth_users(id) on delete cascade,
+  expires timestamptz not null
+);
+create index on auth_sessions (user_id);
+create index on auth_sessions (expires);
+
+create table auth_verification_tokens (
+  identifier text not null,             -- usually the email
+  token text unique not null,
+  expires timestamptz not null,
+  primary key (identifier, token)
+);
+```
+
+### 1.2 Mediforce-managed table
+
+```sql
+create table user_profiles (
+  user_id uuid primary key references auth_users(id) on delete cascade,
+  current_workspace text references workspaces(handle),
+  deployment_admin boolean not null default false,
+  must_change_password boolean not null default false,
+  display_name text,
+  avatar_url text,
+  bio text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+```
+
+### 1.3 Extensions to ADR-0001's `workspace_members`
+
+ADR-0001 introduces `workspace_members` with a single `role` column. ADR-0002
+**renames** that column to `membership` and **adds** a process-roles array:
+
+```sql
+alter table workspace_members
+  rename column role to membership;          -- 'owner' | 'admin' | 'member'
+
+alter table workspace_members
+  add column roles text[] not null default '{}';  -- process-domain roles (replaces Firebase customClaims.roles)
+
+create index on workspace_members using gin (roles);  -- "all reviewers in workspace W"
+```
+
+If ADR-0001 has not yet shipped when ADR-0002 PR opens, fold the rename and the
+extra column directly into the ADR-0001 schema so it lands in one go. Otherwise
+do the `ALTER TABLE` here.
+
+---
+
+## 2. NextAuth configuration
+
+### 2.1 The auth file (one source of truth)
+
+```ts
+// packages/platform-ui/src/auth.ts
+import NextAuth from 'next-auth';
+import { DrizzleAdapter } from '@auth/drizzle-adapter';
+import Google from 'next-auth/providers/google';
+import Credentials from 'next-auth/providers/credentials';
+import Email from 'next-auth/providers/email';
+import bcrypt from 'bcryptjs';
+import { db } from '@mediforce/platform-infra/postgres';
+import { authUsers, userProfiles, workspaceMembers } from '@mediforce/platform-infra/postgres/schema';
+import { eq } from 'drizzle-orm';
+
+const providers = [];
+
+if (process.env.GOOGLE_CLIENT_ID) {
+  providers.push(Google({
+    clientId: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+  }));
+}
+
+if (process.env.ENABLE_PASSWORD_AUTH === 'true') {
+  providers.push(Credentials({
+    name: 'Password',
+    credentials: { email: { label: 'Email' }, password: { label: 'Password', type: 'password' } },
+    async authorize({ email, password }) {
+      if (typeof email !== 'string' || typeof password !== 'string') return null;
+      const user = await db.query.authUsers.findFirst({ where: eq(authUsers.email, email) });
+      if (!user || !user.passwordHash) return null;
+      const ok = await bcrypt.compare(password, user.passwordHash);
+      return ok ? user : null;
+    },
+  }));
+}
+
+if (process.env.SMTP_HOST) {
+  providers.push(Email({
+    server: {
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT),
+      auth: { user: process.env.SMTP_USER!, pass: process.env.SMTP_PASS! },
+    },
+    from: process.env.SMTP_FROM,
+  }));
+}
+
+if (process.env.OIDC_ISSUER) {
+  providers.push({
+    id: 'customer-sso',
+    name: process.env.OIDC_DISPLAY_NAME ?? 'Sign in with SSO',
+    type: 'oidc' as const,
+    issuer: process.env.OIDC_ISSUER,
+    clientId: process.env.OIDC_CLIENT_ID!,
+    clientSecret: process.env.OIDC_CLIENT_SECRET!,
+  });
+}
+
+export const { auth, handlers, signIn, signOut } = NextAuth({
+  adapter: DrizzleAdapter(db),
+  session: { strategy: 'database' },
+  providers,
+  callbacks: {
+    async signIn({ user }) {
+      // Ensure user_profiles row exists. Personal workspace bootstrap
+      // happens here, in one transaction.
+      await ensureUserProfile(user.id, user.email!);
+      return true;
+    },
+    async session({ session, user }) {
+      const profile = await db.query.userProfiles.findFirst({ where: eq(userProfiles.userId, user.id) });
+      session.user = {
+        ...session.user,
+        id: user.id,
+        currentWorkspace: profile?.currentWorkspace ?? null,
+        deploymentAdmin: profile?.deploymentAdmin ?? false,
+      };
+      return session;
+    },
+  },
+});
+```
+
+### 2.2 Routes & middleware
+
+```ts
+// packages/platform-ui/src/app/api/auth/[...nextauth]/route.ts
+export { GET, POST } from '@/auth';
+
+// packages/platform-ui/src/middleware.ts (simplified excerpt)
+import { auth as nextAuthMiddleware } from '@/auth';
+// keep hasValidApiKey() exactly as today
+// replace hasValidFirebaseToken() body with a NextAuth session lookup
+```
+
+### 2.3 Environment variables
+
+**Remove (Firebase Auth):**
+
+- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
+- `FIREBASE_AUTH_EMULATOR_HOST`
+- `NEXT_PUBLIC_FIREBASE_API_KEY` (if not used elsewhere after ADR-0001 takes down Firestore)
+
+**Add (NextAuth):**
+
+- `AUTH_SECRET` — 32-byte random hex. Required.
+- `AUTH_URL` — full URL of deployment, e.g. `https://mediforce.acme.com`. Only required if not auto-detectable.
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` — for the Google provider.
+- `ENABLE_PASSWORD_AUTH=true` — to enable the Credentials provider.
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` — for the Email magic-link provider.
+- `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, `OIDC_DISPLAY_NAME` — for the customer SSO provider.
+- `AUTH_BACKEND` — `firebase` | `nextauth`. Set to `firebase` initially; flip to `nextauth` at cutover; removed after the migration is verified stable.
+
+---
+
+## 3. Files touched
+
+### 3.1 Server-side Firebase Admin SDK — replace
+
+- [`packages/platform-infra/src/auth/firebase-admin-init.ts`](../../packages/platform-infra/src/auth/firebase-admin-init.ts) — delete the `getAuth()` portion. (The `getFirestore()` portion is already gone from ADR-0001.)
+- [`packages/platform-infra/src/auth/firebase-invite-service.ts`](../../packages/platform-infra/src/auth/firebase-invite-service.ts) — rewrite as `NextAuthInviteService` that inserts an `auth_users` row and triggers a magic-link email.
+- [`packages/platform-infra/src/auth/firebase-user-directory-service.ts`](../../packages/platform-infra/src/auth/firebase-user-directory-service.ts) — rewrite as `PostgresUserDirectoryService`. Today uses `listUsers(1000)` and reads `customClaims.role` / `customClaims.roles`. After: `SELECT * FROM auth_users JOIN user_profiles …`.
+- [`packages/platform-ui/src/lib/resolve-agent-identity.ts`](../../packages/platform-ui/src/lib/resolve-agent-identity.ts) — keep, but stop using `firebase-admin/storage` for skill files only at the Storage ADR; auth-related code in here moves to NextAuth.
+
+### 3.2 Client-side Firebase Web SDK — replace
+
+- [`packages/platform-ui/src/lib/firebase.ts`](../../packages/platform-ui/src/lib/firebase.ts) — delete the `getAuth()` initialization. Keep Storage init if Storage ADR has not landed.
+- [`packages/platform-ui/src/contexts/auth-context.tsx`](../../packages/platform-ui/src/contexts/auth-context.tsx) — **full rewrite**. Old → new:
+  - `onAuthStateChanged` → `useSession()` from `next-auth/react`
+  - `signInWithPopup(googleProvider)` → `signIn('google')`
+  - `signInWithEmailAndPassword` → `signIn('credentials', { email, password })`
+  - `fetchSignInMethodsForEmail` → drop (NextAuth picks the provider)
+  - `sendPasswordResetEmail` → `signIn('email', { email })` magic link
+  - `signOut` → `signOut()` from `next-auth/react`
+  - `linkWithCredential` → handled by NextAuth via `auth_accounts` row linking on matching verified email
+- [`packages/platform-ui/src/app/change-password/page.tsx`](../../packages/platform-ui/src/app/change-password/page.tsx) — rewrite to call a server action that updates `auth_users.password_hash` (bcrypt). Only meaningful when `ENABLE_PASSWORD_AUTH=true`.
+- [`packages/platform-ui/src/test/mocks/firebase.ts`](../../packages/platform-ui/src/test/mocks/firebase.ts) — delete the `firebase/auth` mocks; add `next-auth/react` mocks (`useSession`, `signIn`, `signOut`).
+- [`packages/platform-ui/src/app/(app)/[handle]/tasks/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/tasks/page.tsx) — `getIdTokenResult()` → `useSession()` (consume `session.user.deploymentAdmin` / `session.user.roles`).
+
+### 3.3 API middleware
+
+- [`packages/platform-ui/src/middleware.ts`](../../packages/platform-ui/src/middleware.ts) — replace `hasValidFirebaseToken()` with NextAuth session lookup. Keep `hasValidApiKey()` unchanged.
+
+### 3.4 Routes that read claims today
+
+Grep for `verifyIdToken`, `getIdTokenResult`, `customClaims`, and any header-based Bearer validation. Replace each with `await auth()` reading `session.user.deploymentAdmin` and (for workspace-scoped checks) a query on `workspace_members.membership` / `.roles`.
+
+### 3.5 Firestore-rules-derived application checks
+
+ADR-0001 already moves these into the application layer via the fail-proof
+repository base. ADR-0002 fills in the **decision** side (who's an admin, what
+roles do they have) by replacing custom-claims lookups with reads from
+`user_profiles` + `workspace_members`. Specifically:
+
+- `isAdmin()` → `session.user.deploymentAdmin === true`
+- `hasProcessRole(assignedRoles)` → query `workspace_members.roles` for the
+  caller's `(workspace, uid)` and check `roles && assignedRoles` overlap
+- workspace governance (delete workspace, manage members, manage docker
+  images, manage OAuth providers) → check `workspace_members.membership`
+  for `owner` / `admin`
+
+---
+
+## 4. User migration script
+
+`scripts/migrate-firebase-auth-to-postgres/main.py`. Idempotent; safe to re-run.
+
+1. Use Firebase Admin SDK `listUsers()` to fetch every user (paginate).
+2. For each user:
+   - Determine `password_hash`: **null** (we do not migrate hashes).
+   - Determine providers from `providerData[]`:
+     - `google.com` → seed an `auth_accounts` row `(type='oauth', provider='google', provider_account_id=<google sub>)`. Google sign-in matches it on next sign-in.
+     - `password` → no `auth_accounts` row. User must re-enroll via magic link or Credentials if enabled.
+     - Other providers (`saml.*`, etc.) → handle case-by-case if found.
+   - Insert `auth_users (id=uuid_for_email, email, name=displayName, email_verified=now, image=photoURL)`.
+   - Insert `user_profiles (user_id, current_workspace=<from users/{uid}.handle>, deployment_admin=(customClaims.role==='admin'), must_change_password=<from users/{uid}.mustChangePassword>)`.
+3. Build a mapping table `firebase_uid_to_new_user_id (firebase_uid text primary key, user_id uuid)` and persist it. Used to migrate references.
+4. Walk Mediforce tables that reference Firebase uids and rewrite them via the mapping:
+   - `workspace_members.uid` (FK; needs to point at new `auth_users.id` if the column was uid-typed)
+   - `workspaces.linked_user_id`
+   - `audit_events.actor_id` (string, no FK, but still rewrite to keep audit consistent)
+   - `human_tasks.assigned_user_id`
+   - `cowork_sessions.assigned_user_id`
+   - `handoff_entities.assigned_user_id`
+   - any other table holding a uid (verified via `grep`)
+5. Copy `customClaims.roles` to **every** `workspace_members.roles` row the user has. Today's claims are global; after migration they become per-workspace, lossless on day one, admins fine-tune later.
+6. Verify: counts, sample row checks, foreign-key integrity.
+
+---
+
+## 5. Cutover (sequential after ADR-0001)
+
+### 5.1 Pre-cutover (over preceding sprint)
+
+1. NextAuth code shipped behind `AUTH_BACKEND` flag. `AUTH_BACKEND=firebase` keeps everything on Firebase.
+2. Schema migration (NextAuth tables + `user_profiles`) lands as a Drizzle migration. Empty tables in production until cutover.
+3. CI matrix runs L3 E2E against both `AUTH_BACKEND=firebase` and `AUTH_BACKEND=nextauth` (with a seeded user) so regressions surface in PR.
+4. OIDC integration smoke test against a sandbox IdP (Auth0 dev tenant or local Keycloak container) lands as an opt-in L3 test.
+
+### 5.2 Cutover window (planned downtime, separate from ADR-0001's window)
+
+1. Announce maintenance window.
+2. Run user migration script (steps in §4).
+3. Verify counts + sample.
+4. Set `AUTH_BACKEND=nextauth`, restart application.
+5. Smoke test: sign in with Google → land authenticated; (if password enabled) request magic link, click, set password, sign in; sign out → next request 401.
+6. End maintenance.
+
+### 5.3 Rollback
+
+If smoke fails:
+
+1. Set `AUTH_BACKEND=firebase`, restart.
+2. NextAuth tables remain but unused (no harm). Investigate.
+
+### 5.4 Post-cutover (within 2 weeks)
+
+- Remove `AUTH_BACKEND` flag (always NextAuth).
+- Uninstall `firebase` and `firebase-admin` packages from `packages/platform-ui` and `packages/platform-infra` if [ADR future] Firebase Storage migration has also landed; otherwise keep the Storage portion.
+- Delete the Auth emulator stanza from `firebase.json`.
+- Update `.env.example`, `README.md`, `CHANGELOG.md`.
+
+---
+
+## 6. Personal workspace bootstrap
+
+Today's bootstrap in `auth-context.tsx:30-115` is a circular dance between
+`users/{uid}` doc, `namespaces/{handle}` doc, and the `members` subcollection.
+It's race-prone (the file has retry logic that suggests prior incidents).
+
+After migration, bootstrap moves to the `signIn` callback as a **single
+transaction**:
+
+```ts
+async function ensureUserProfile(userId: string, email: string) {
+  await db.transaction(async (tx) => {
+    const profile = await tx.query.userProfiles.findFirst({ where: eq(userProfiles.userId, userId) });
+    if (profile) return;
+
+    const handle = await pickAvailableHandle(tx, email);  // 'alice', 'alice-2', …
+    await tx.insert(workspaces).values({ handle, type: 'personal', linkedUserId: userId, displayName: email.split('@')[0] });
+    await tx.insert(workspaceMembers).values({ workspace: handle, uid: userId, membership: 'owner', roles: [] });
+    await tx.insert(userProfiles).values({ userId, currentWorkspace: handle, deploymentAdmin: false });
+  });
+}
+```
+
+One transaction, no race window.
+
+---
+
+## 7. Test infrastructure
+
+- Replace `packages/platform-ui/e2e/auth-setup.ts` Playwright global setup. Today seeds Firebase Auth users via the Admin SDK. After: insert directly into `auth_users` + `auth_sessions` (with a known session token cookie set by Playwright) — faster than navigating sign-in for every test.
+- Existing UI E2E tests that sign in via `test-login`: with `ENABLE_PASSWORD_AUTH=true` and seeded password users, the flow works unchanged.
+- Add at least one L3 E2E exercising the OIDC flow against a local Keycloak (`testcontainers/keycloak` image). Gated like L5 external tests.
+- Add L1/L2 unit tests for `ensureUserProfile` covering: new user (creates workspace), existing user (no-op), name collision (picks `email-N`).
+
+---
+
+## 8. Verification
+
+The migration is "done" when **all** of the below are true:
+
+1. `grep -r "from ['\"]firebase/auth\|from ['\"]firebase-admin/auth" packages/` returns zero matches.
+2. `grep -r "verifyIdToken\|getIdTokenResult\|customClaims" packages/` returns zero matches outside the migration script.
+3. `pnpm test` and `pnpm test:e2e` pass.
+4. Cold-clone smoke test: `docker-compose up`, `pnpm dev`, `localhost:9003`, click "Sign in with Google" (with `GOOGLE_CLIENT_ID` set in `.env.local`), authenticated end-to-end.
+5. OIDC smoke test: `OIDC_ISSUER` pointing at a Keycloak container, sign in via the IdP redirect, authenticated with `session.user.deploymentAdmin` populated.
+6. Session revocation: mark a row in `auth_sessions` deleted (or set `expires` to the past); the user's next request returns 401 with no other action.
+7. Role-based access: a user with `workspace_members.membership='admin'` can manage docker images / OAuth providers; with `'member'` cannot.
+8. Process-role gating: a user with `workspace_members.roles = ['reviewer']` can claim a human task with `assignedRole='reviewer'`; without the role cannot.
+
+### Rollback criteria
+
+- > 1% authentication failure rate over 1h sustained → flip `AUTH_BACKEND=firebase` and triage.
+- OIDC integration with a customer IdP fails and cannot be resolved in 24h → revert that customer's deployment to `AUTH_BACKEND=firebase` until fixed.
+
+---
+
+## 9. Open follow-ups (not blocking this ADR)
+
+- **0003+ Personal Access Tokens** — Filip's WIP. Replaces shared `PLATFORM_API_KEY` with per-user PATs.
+- **Future ADR 2FA / WebAuthn / TOTP** — when first pharma customer asks.
+- **Future ADR SCIM** — when first customer with >100 users asks for IdP-driven user provisioning.
+- **Future ADR federated logout (single sign-out)** — for OIDC, when a customer's IdP policy requires it.
+- **Audit event for every sign-in / sign-out** — straightforward addition in `signIn`/`signOut` callbacks; pencil in for the same PR or directly after.


### PR DESCRIPTION
## ADR-0002 — Firebase Auth → NextAuth (Auth.js v5)

Replace Firebase Auth with NextAuth (Auth.js v5) on Postgres via `@auth/drizzle-adapter`.

**Refreshed 2026-06-16** after a grilling pass against the *current* codebase (post ADR-0001 Postgres cutover #534 + headless Phase 1–4). The ADR + PLAN files in this PR are the source of truth; the decisions below supersede the original 2026-05-19 proposal.

### Key decisions (current)

1. **NextAuth v5 + `@auth/drizzle-adapter`**, **database sessions** (immediate revocation + audit).
2. **Auth boundary = `proxy.ts` + `lib/api-auth.ts`** — *not* `middleware.ts` (which no longer exists). Browser flips Firebase Bearer → **NextAuth same-origin cookie**; CLI / agents / MCP keep `X-Api-Key` / PAT.
3. **Greenfield fresh-uuid ids** (no production deployments). Staging users survive via a one-time remap script; schema changes via Drizzle migrations.
4. **MVP providers:** Google + Credentials (real password, production-supported) + **OIDC (one IdP per deployment, dormant / env-gated)**. **Magic-link deferred.** Heavy 21 CFR password policy deferred.
5. **`ALLOWED_EMAIL_DOMAINS`** allowlist enforced in the `signIn` callback — closes the "any Google account on earth can sign in" hole (e.g. staging = `appsilon.com`). Deployment-level env, not a per-workspace setting.
6. **Cutover = straight swap:** no `AUTH_BACKEND` flag, no dual-backend, no rollback (nothing in production). Fix-forward.

### Sequencing

ADR-0001 (data → Postgres) already merged (#534). Then **ADR-0003 (storage) → ADR-0002 (auth)**. Storage-first because today's uploads are client-direct and Firebase-Auth-gated; removing auth first would break them.

### Out of scope

CLI / API-key & PAT auth (#376), 2FA / WebAuthn, SCIM, federated logout, Firebase password-hash migration (users re-enroll), heavy password policy.

### Review

- [ ] Read `docs/adr/0002-firebase-auth-to-nextauth.md` + `PLAN-0002.md`.
- [ ] Confirm the decisions above map onto your model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pnjk1ySMuCwmoT873iqXTd