### PR TITLE
docs(adr): ADR-0003 — Remove Firebase Storage, no replacement

### DIFF
--- a/docs/adr/0003-remove-firebase-storage.md
+++ b/docs/adr/0003-remove-firebase-storage.md
@@ -1,146 +1,169 @@
-# 0003 — Remove Firebase Storage: skills to Postgres, attachments inline or via external link
+# 0003 — Remove Firebase Storage: delete uploaded-skills, task attachments to a BlobStore (filesystem now, S3 later)
 
-- **Status:** Proposed
-- **Date:** 2026-05-20
+- **Status:** Proposed (grilled & reshaped 2026-06-16; supersedes the
+  2026-05-20 "skills → Postgres bytea / attachments inline + DMS link" draft)
+- **Date:** 2026-05-20 (reshaped 2026-06-16)
 - **Authors:** Marek Rogala (@marekrogala)
 - **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
-- **Depends on:** [ADR-0001](./0001-firestore-to-postgres.md) (Postgres is the target for skill blobs and attachments)
+- **Depends on:** [ADR-0001](./0001-firestore-to-postgres.md) (Postgres for
+  attachment metadata) and the shared-filesystem precedent in
+  [ADR-0007](./0007-output-files-on-run-branch.md) (the `~/.mediforce` data
+  volume the API host already mounts).
+- **Lands before:** [ADR-0002](./0002-firebase-auth-to-nextauth.md) — see §5.
 - **Implementation plan:** [PLAN-0003.md](./PLAN-0003.md)
 
 ## Context
 
-Firebase Storage today holds two distinct things in Mediforce:
+Firebase Storage today holds two distinct things in Mediforce, both written
+**client-direct from the browser** and authorized by the Firebase Auth session
+(`storage.rules`: `allow write: if request.auth != null`):
 
-- **Skill files** attached to Agent Definitions — small (≤100KB cap), text /
-  markdown / scripts, occasionally binary. Read by the agent runtime at spawn
-  time. Used at the new-agent UI and at agent runtime via
-  `packages/platform-ui/src/lib/resolve-agent-identity.ts`.
-- **Task attachments** uploaded by humans inside a Human Task — `uploadBytesResumable`,
-  no explicit size cap, used in `packages/platform-ui/src/components/tasks/task-detail.tsx`
-  via the `FileUploadZone` component.
+- **Uploaded skill files** attached to Agent Definitions
+  (`AgentDefinition.skillFileNames` → `agentSkills/…`). At runtime
+  `resolve-agent-identity.ts` downloads them and concatenates their text into
+  the agent's system prompt. **This feature is dead:** every real app in
+  `apps/` loads skills via the git-native `skillsDir` mechanism (Claude-Code
+  `SKILL.md` files in the per-run worktree, PR #213); `skillFileNames` is
+  empty (`[]`) across all seeds, fixtures, and `.wd.json` files.
+- **Task attachments** uploaded by a human inside a Human Task
+  (`uploadBytesResumable` → `tasks/…`, in
+  `components/tasks/file-upload-view.tsx`). These are real and large workflow
+  files matter (datasets, PDFs) — the upload exists precisely to take big
+  files.
 
-Firebase Storage is a managed Google service. It has the same on-prem block as
+Firebase Storage is a managed Google service with the same on-prem block as
 Firestore (ADR-0001) and Firebase Auth (ADR-0002).
-
-A purpose-built object store (S3 / MinIO / Azure Blob) would replicate
-capability that pharma customers already own: every serious pharma org has a
-Document Management System (Veeva Vault, SharePoint Online, OpenText,
-Documentum) where regulated files **must** live for 21 CFR Part 11
-compliance — versioning, e-signature, retention, audit. Bundling another
-object store with mediforce duplicates that capability and widens the on-prem
-operational surface for no real benefit.
 
 Domain terms — Workspace, Agent Definition, Human Task — are defined in
 [`CONTEXT.md`](../../CONTEXT.md).
 
 ## Decision
 
-Eliminate object storage from Mediforce entirely. No S3, no MinIO, no
-replacement service.
+Remove Firebase Storage. Two moves: **delete the dead uploaded-skills
+feature**, and **move task attachments to a `BlobStore` abstraction** with a
+filesystem implementation now.
 
-1. **Skill files → Postgres `bytea`.** New child table
-   `agent_definition_skills (agent_definition_id, name, content_type, content bytea, ...)`
-   cascade-deleted with the parent Agent Definition. The 100KB per-file cap
-   stays. Embedded with the Agent Definition; one query loads everything an
-   agent needs at spawn time.
+1. **Delete the uploaded-skills feature entirely.** Drop
+   `AgentDefinition.skillFileNames` (Zod field + `agents.skill_file_names`
+   column), the skill-upload UI (`agents/new`, `agents/definitions/[id]`), and
+   the `downloadSkillFiles` / `## Skills` prompt-injection in
+   `resolve-agent-identity.ts`. The git-native **`skillsDir`** path is the
+   single remaining skill mechanism (a selected repo provides skills); extra
+   prompt text lives in the existing `systemPrompt` field. No data migration —
+   the field is empty everywhere. _(Decision 2026-06-16: the feature is being
+   reworked toward repo-selected skill loading; until then it is removed
+   rather than migrated.)_
 
-2. **Task attachments → dual mode, side by side in the UI.**
-   - **Inline upload up to 10MB.** Stored as Postgres `bytea` in a dedicated
-     table (`task_attachment_blobs`) keyed off `task_attachments.id` so the
-     hot `task_attachments` metadata table stays lean.
-   - **External link to a customer-controlled DMS** (paste URL of a file in
-     Veeva / SharePoint / Documentum / OpenText). Mediforce stores the
-     string + access audit. The DMS remains the source of truth and the
-     compliance owner.
-   - 10MB cap covers screenshots, short notes, sample exports, ad-hoc
-     work product. Larger / regulated files go through the DMS link path.
+2. **Task attachments → `BlobStore` interface; filesystem impl now,
+   S3-compatible later.** Bytes go through a `BlobStore` port
+   (`put` / `get` / `getStream` / `delete` by key). The default implementation
+   writes under the **`~/.mediforce` data volume the API host already mounts
+   for ADR-0007** — no new service, no new operational requirement. An
+   S3-compatible implementation is an env-selected drop-in for deployments
+   that already run object storage (deferred until a deployment asks; the
+   interface keeps it non-breaking). Attachment **metadata** (name,
+   content-type, size, workspace, task, uploader, blob key) lives in a
+   Postgres `task_attachments` table; **bytes never go into Postgres**.
 
-3. **No new infrastructure service** is added to the Mediforce stack.
-   It stays Next.js + Postgres + Redis + (per-step) container worker.
-   Single `docker-compose up` keeps working; air-gapped pharma deploys
-   need no extra configuration to start.
+3. **No object-storage service is mandatory.** Stack stays Next.js + Postgres
+   + Redis + worker + the existing `~/.mediforce` volume. `docker-compose up`
+   and air-gapped pharma deploys keep working with zero extra configuration.
 
-4. **Firebase Storage is removed end-to-end** during the storage cutover
-   for ADR-0001. The same Python migration script that moves Firestore
-   data to Postgres also reads every `agentSkills/…` and `tasks/…/…`
-   object from Firebase Storage, ingests them into Postgres, and stops
-   touching Firebase Storage thereafter.
+4. **Configurable size guard, not a hard 10MB cap.** Its own env,
+   `MEDIFORCE_ATTACHMENT_MAX_BYTES` (independent of any other size knob),
+   guards against disk exhaustion. It is an operational guard, not a design
+   constraint pushing files elsewhere — the filesystem backend handles large
+   files, which is the whole point of the upload.
+
+5. **Sequencing — Storage lands before Auth (ADR-0002).** Today's uploads are
+   client-direct and Firebase-Auth-authorized; removing Firebase Auth first
+   would null `request.auth` and break every upload. This ADR moves uploads to
+   server-mediated **headless routes** (ADR-0005 / AGENTS.md §8 — never Server
+   Actions) → `BlobStore`, severing the Firebase-Auth dependency, so it lands
+   first. Consequently `task_attachments.uploaded_by` is a Firebase-uid `text`
+   column (no FK to ADR-0002's not-yet-existing `auth_users`); ADR-0002's
+   staging remap rewrites it when fresh uuids land.
+
+6. **Firebase Storage removed via a standalone one-time migration.** ADR-0001's
+   Firestore → Postgres cutover already shipped (#534), so this is a separate
+   storage-only script, run once against staging: copy each `tasks/…` object
+   into the `BlobStore` and write its `task_attachments` row. `agentSkills/…`
+   objects are simply abandoned (feature deleted). New deployments start clean.
+
+**Dropped from the earlier draft:** the **DMS external-link** attachment mode.
+It was net-new (zero code today) and existed only to avoid hosting large files;
+with a real `BlobStore` it is unnecessary. A "reference a file already in the
+customer's Veeva / SharePoint" feature can return later as its own product
+decision, not a storage-infra necessity.
 
 ## Considered alternatives
 
-- **Self-hosted MinIO container.** Rejected — adds an extra service to the
-  stack we'd have to operate, monitor, back up. Pharma deploys typically
-  already have S3-compatible storage they'd prefer to point at, not a
-  bundled second one.
-- **Customer-provided S3-compatible bucket via env.** Considered — would
-  work in production but breaks the goal of a single-container demo and
-  air-gapped pharma footprint. Punt to a future ADR if a customer ever asks.
-- **Postgres `bytea` for all attachments without size cap.** Rejected —
-  large `bytea` rows bloat pg_dump, slow queries, hurt connection pooling.
-  10MB cap is a deliberate UX choice that nudges large content to the DMS
-  where it belongs.
-- **Git LFS via `gitWorkspace` for skill files.** Clever but mismatched
-  scope: skills are properties of an Agent Definition; `gitWorkspace` is a
-  per-workflow git working tree. Conflating them complicates ownership.
-- **External DMS only, no inline upload.** Rejected because it breaks the
-  demo experience — every evaluator would need to configure a DMS first.
-- **Drop task attachments as a feature.** Considered. Rejected — small
-  inline attachments are useful for screenshots, notes, sample data, and
-  cost nothing in the chosen design.
+- **Postgres `bytea` for attachment bytes** (the earlier draft). Rejected for
+  large files: `bytea` loads fully into memory (no streaming from PG), bloats
+  `pg_dump`, amplifies WAL, and holds a pooled connection for the whole
+  transfer. Fine for a few MB, wrong for the large workflow files this upload
+  exists to handle.
+- **Mandatory self-hosted MinIO / S3 container.** Rejected as the *default* —
+  an extra service to operate, monitor, back up, for a single-container demo
+  and air-gapped footprint. Kept available as the **optional** `BlobStore`
+  backend for deployments that want it.
+- **DMS external-link as the path for large files.** Rejected — breaks the
+  upload UX (every large file would require a pre-configured DMS); reintroduced
+  later only as an optional reference feature if a customer asks.
+- **Keep uploaded skills, migrate them to Postgres.** Rejected — the feature is
+  dead (all apps use `skillsDir`); migrating dead weight violates "do it
+  greenfield, simplest thing that's correct."
+- **Pluggable `BlobStore` deferred (just hardcode filesystem).** Partially
+  taken: we ship a **thin `BlobStore` port with only the filesystem
+  implementation** now (the in-memory test double is required anyway by the
+  repository-pattern test layer, so the port costs ~nothing). The S3 backend
+  is **not built** — it stays a non-breaking future add, not a hypothetical we
+  solve for the MVP. Speed over future-proofing (decision 2026-06-16).
 
 ## Consequences
 
-- Stack stays Postgres + Redis + Next.js + worker. Zero new SaaS or new
-  container.
-- Demo and local dev work out of the box; no Firebase project, no S3 bucket,
-  no MinIO container.
-- Pharma deploys do not need to configure storage to start. DMS integration
-  is a paste-a-URL feature, not an infrastructure setup.
-- `pg_dump` captures everything in one backup. PITR covers attachments too.
-- Postgres database size grows with attachment content. Estimate: 10MB cap,
-  ~thousands of attachments per workspace per year. Manageable. Future
-  retention policy in a separate ADR if a customer hits capacity limits.
-- The 10MB cap is a real product constraint. Users uploading clinical PDFs,
-  raw datasets, or long video must use the DMS link path. UI must surface
-  this clearly.
-- We give up the ability to serve files via a CDN-backed bucket URL.
-  Mediforce serves attachments via authenticated app routes. Slower for
-  very large or very frequent reads — fine at our scale.
+- Stack stays Postgres + Redis + Next.js + worker + the existing `~/.mediforce`
+  volume. Zero new mandatory SaaS or container.
+- Large workflow files are supported (filesystem streaming), removing the
+  earlier draft's 10MB ceiling.
+- Object storage is a non-breaking opt-in (`BlobStore` S3 impl) when a
+  deployment wants it.
+- `pg_dump` stays lean — only metadata in Postgres; bytes live on the volume
+  (backed up by volume snapshot, same as ADR-0007's bare repos).
+- Attachments are served via authenticated, workspace-scoped streaming app
+  routes — no public bucket URLs, no CDN (fine at our scale).
+- The Agent Definition surface shrinks (`skillFileNames` gone); the only skill
+  path is `skillsDir` from a selected repo.
+- The API host must share the `~/.mediforce` filesystem — already an ADR-0007
+  assumption, not new.
 
 ## Enterprise / pharma fit
 
-- DMS stays the source of truth for regulated files — exactly what 21 CFR
-  Part 11 expects: versioning, e-signature, retention, access audit all
-  live where the customer's QA team already runs them.
-- Mediforce orchestrates workflow around files; it does not try to be the
-  DMS. Clear separation of concerns in vendor-risk reviews.
-- Air-gapped pharma deploys (no internet egress, no SaaS) work end-to-end
-  with this design.
-- Inline 10MB covers ad-hoc / non-regulated work product (screenshots of
-  bugs, brief notes, mock data) without forcing every user through the
-  DMS for trivial attachments.
+- Air-gapped pharma deploys (no egress, no SaaS) work end-to-end: files on the
+  local volume, no Google bucket.
+- A deployment that standardizes on its own S3-compatible storage points the
+  `BlobStore` at it via env — no Mediforce-bundled object store to vendor-review.
+- `pg_dump` + volume snapshot is the whole backup story; PITR covers metadata.
+- Regulated-file handling (Veeva as system of record) returns later as an
+  optional reference-link feature if a customer's QA process requires it.
 
 ## Out of scope
 
-- **External DMS integration adapters** (Veeva Vault API, SharePoint
-  Graph API, Documentum REST) — future feature, not infrastructure.
-  Stored URLs work as opaque strings today; preview / metadata fetch can
-  come later.
-- **Encryption at rest beyond Postgres defaults** (TDE, customer-managed
-  keys) — future ADR if a customer asks.
-- **File scanning / antivirus** for inline uploads — future ADR.
+- **S3-compatible `BlobStore` implementation** — interface ships now, S3 impl
+  when a deployment asks. Non-breaking addition.
+- **External DMS reference-link attachments** (Veeva / SharePoint URL) —
+  future product feature, not storage infra.
+- **Antivirus / content scanning** of uploads — future ADR.
+- **Encryption at rest beyond volume/Postgres defaults** — future ADR.
 - **CDN serving of attachments** — not needed at current scale.
-- **Customer-provided S3 adapter** — future ADR if a deployment ever needs
-  more than the 10MB inline + DMS-link combo.
 
 ## Open questions for review
 
-- **10MB cap value** — confirm not 5 / 25 / 50. Trade-off: bigger inline
-  cap helps demos and small deployments; smaller cap protects Postgres
-  backups and connection pool. 10MB is the recommended starting point.
-- **Whether skill files realistically need to stay binary-capable** — today's
-  cap is 100KB and content is text/markdown/scripts in practice. Could
-  tighten to `text` column if confirmed never binary; `bytea` is safer.
-- **Whether attachments are stored on Tasks only, or also belong on
-  Process Instances / Cowork Sessions** — today only Tasks. Confirm we're
-  not pre-emptively adding the same on other entities.
+- **Default `MEDIFORCE_ATTACHMENT_MAX_BYTES`** — a generous default (e.g.
+  100 MiB) chosen on its own merit, not coupled to any other cap. Confirm it
+  is generous enough for the large workflow files the upload targets, or set
+  higher.
+- **`task_attachments.task_id` FK type** — match `human_tasks.id` (Firestore-
+  shaped `text` per the ADR-0001 "stay text" precedent). Confirm at impl time.
+- **Attachments scoped to Human Tasks only** — confirmed 2026-06-16: not added
+  to Process Instances / Cowork Sessions pre-emptively.

--- a/docs/adr/0003-remove-firebase-storage.md
+++ b/docs/adr/0003-remove-firebase-storage.md
@@ -1,0 +1,146 @@
+# 0003 — Remove Firebase Storage: skills to Postgres, attachments inline or via external link
+
+- **Status:** Proposed
+- **Date:** 2026-05-20
+- **Authors:** Marek Rogala (@marekrogala)
+- **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
+- **Depends on:** [ADR-0001](./0001-firestore-to-postgres.md) (Postgres is the target for skill blobs and attachments)
+- **Implementation plan:** [PLAN-0003.md](./PLAN-0003.md)
+
+## Context
+
+Firebase Storage today holds two distinct things in Mediforce:
+
+- **Skill files** attached to Agent Definitions — small (≤100KB cap), text /
+  markdown / scripts, occasionally binary. Read by the agent runtime at spawn
+  time. Used at the new-agent UI and at agent runtime via
+  `packages/platform-ui/src/lib/resolve-agent-identity.ts`.
+- **Task attachments** uploaded by humans inside a Human Task — `uploadBytesResumable`,
+  no explicit size cap, used in `packages/platform-ui/src/components/tasks/task-detail.tsx`
+  via the `FileUploadZone` component.
+
+Firebase Storage is a managed Google service. It has the same on-prem block as
+Firestore (ADR-0001) and Firebase Auth (ADR-0002).
+
+A purpose-built object store (S3 / MinIO / Azure Blob) would replicate
+capability that pharma customers already own: every serious pharma org has a
+Document Management System (Veeva Vault, SharePoint Online, OpenText,
+Documentum) where regulated files **must** live for 21 CFR Part 11
+compliance — versioning, e-signature, retention, audit. Bundling another
+object store with mediforce duplicates that capability and widens the on-prem
+operational surface for no real benefit.
+
+Domain terms — Workspace, Agent Definition, Human Task — are defined in
+[`CONTEXT.md`](../../CONTEXT.md).
+
+## Decision
+
+Eliminate object storage from Mediforce entirely. No S3, no MinIO, no
+replacement service.
+
+1. **Skill files → Postgres `bytea`.** New child table
+   `agent_definition_skills (agent_definition_id, name, content_type, content bytea, ...)`
+   cascade-deleted with the parent Agent Definition. The 100KB per-file cap
+   stays. Embedded with the Agent Definition; one query loads everything an
+   agent needs at spawn time.
+
+2. **Task attachments → dual mode, side by side in the UI.**
+   - **Inline upload up to 10MB.** Stored as Postgres `bytea` in a dedicated
+     table (`task_attachment_blobs`) keyed off `task_attachments.id` so the
+     hot `task_attachments` metadata table stays lean.
+   - **External link to a customer-controlled DMS** (paste URL of a file in
+     Veeva / SharePoint / Documentum / OpenText). Mediforce stores the
+     string + access audit. The DMS remains the source of truth and the
+     compliance owner.
+   - 10MB cap covers screenshots, short notes, sample exports, ad-hoc
+     work product. Larger / regulated files go through the DMS link path.
+
+3. **No new infrastructure service** is added to the Mediforce stack.
+   It stays Next.js + Postgres + Redis + (per-step) container worker.
+   Single `docker-compose up` keeps working; air-gapped pharma deploys
+   need no extra configuration to start.
+
+4. **Firebase Storage is removed end-to-end** during the storage cutover
+   for ADR-0001. The same Python migration script that moves Firestore
+   data to Postgres also reads every `agentSkills/…` and `tasks/…/…`
+   object from Firebase Storage, ingests them into Postgres, and stops
+   touching Firebase Storage thereafter.
+
+## Considered alternatives
+
+- **Self-hosted MinIO container.** Rejected — adds an extra service to the
+  stack we'd have to operate, monitor, back up. Pharma deploys typically
+  already have S3-compatible storage they'd prefer to point at, not a
+  bundled second one.
+- **Customer-provided S3-compatible bucket via env.** Considered — would
+  work in production but breaks the goal of a single-container demo and
+  air-gapped pharma footprint. Punt to a future ADR if a customer ever asks.
+- **Postgres `bytea` for all attachments without size cap.** Rejected —
+  large `bytea` rows bloat pg_dump, slow queries, hurt connection pooling.
+  10MB cap is a deliberate UX choice that nudges large content to the DMS
+  where it belongs.
+- **Git LFS via `gitWorkspace` for skill files.** Clever but mismatched
+  scope: skills are properties of an Agent Definition; `gitWorkspace` is a
+  per-workflow git working tree. Conflating them complicates ownership.
+- **External DMS only, no inline upload.** Rejected because it breaks the
+  demo experience — every evaluator would need to configure a DMS first.
+- **Drop task attachments as a feature.** Considered. Rejected — small
+  inline attachments are useful for screenshots, notes, sample data, and
+  cost nothing in the chosen design.
+
+## Consequences
+
+- Stack stays Postgres + Redis + Next.js + worker. Zero new SaaS or new
+  container.
+- Demo and local dev work out of the box; no Firebase project, no S3 bucket,
+  no MinIO container.
+- Pharma deploys do not need to configure storage to start. DMS integration
+  is a paste-a-URL feature, not an infrastructure setup.
+- `pg_dump` captures everything in one backup. PITR covers attachments too.
+- Postgres database size grows with attachment content. Estimate: 10MB cap,
+  ~thousands of attachments per workspace per year. Manageable. Future
+  retention policy in a separate ADR if a customer hits capacity limits.
+- The 10MB cap is a real product constraint. Users uploading clinical PDFs,
+  raw datasets, or long video must use the DMS link path. UI must surface
+  this clearly.
+- We give up the ability to serve files via a CDN-backed bucket URL.
+  Mediforce serves attachments via authenticated app routes. Slower for
+  very large or very frequent reads — fine at our scale.
+
+## Enterprise / pharma fit
+
+- DMS stays the source of truth for regulated files — exactly what 21 CFR
+  Part 11 expects: versioning, e-signature, retention, access audit all
+  live where the customer's QA team already runs them.
+- Mediforce orchestrates workflow around files; it does not try to be the
+  DMS. Clear separation of concerns in vendor-risk reviews.
+- Air-gapped pharma deploys (no internet egress, no SaaS) work end-to-end
+  with this design.
+- Inline 10MB covers ad-hoc / non-regulated work product (screenshots of
+  bugs, brief notes, mock data) without forcing every user through the
+  DMS for trivial attachments.
+
+## Out of scope
+
+- **External DMS integration adapters** (Veeva Vault API, SharePoint
+  Graph API, Documentum REST) — future feature, not infrastructure.
+  Stored URLs work as opaque strings today; preview / metadata fetch can
+  come later.
+- **Encryption at rest beyond Postgres defaults** (TDE, customer-managed
+  keys) — future ADR if a customer asks.
+- **File scanning / antivirus** for inline uploads — future ADR.
+- **CDN serving of attachments** — not needed at current scale.
+- **Customer-provided S3 adapter** — future ADR if a deployment ever needs
+  more than the 10MB inline + DMS-link combo.
+
+## Open questions for review
+
+- **10MB cap value** — confirm not 5 / 25 / 50. Trade-off: bigger inline
+  cap helps demos and small deployments; smaller cap protects Postgres
+  backups and connection pool. 10MB is the recommended starting point.
+- **Whether skill files realistically need to stay binary-capable** — today's
+  cap is 100KB and content is text/markdown/scripts in practice. Could
+  tighten to `text` column if confirmed never binary; `bytea` is safer.
+- **Whether attachments are stored on Tasks only, or also belong on
+  Process Instances / Cowork Sessions** — today only Tasks. Confirm we're
+  not pre-emptively adding the same on other entities.

--- a/docs/adr/PLAN-0003.md
+++ b/docs/adr/PLAN-0003.md
@@ -211,3 +211,115 @@ envs — only when the S3 `BlobStore` impl is actually built.
 - **Blob garbage-collection sweep** for soft-deleted attachments — later.
 - **Antivirus / content scanning**, **encryption at rest beyond volume
   defaults**, **CDN serving** — future ADRs if asked.
+
+---
+
+## 8. PR sequencing & test plan
+
+Ship as **4 PRs**, each non-breaking on staging and exercised by its own test
+at the right ceiling — no PR lands inert. The non-breaking guarantee for the UI
+flip rests on **migration (PR3) preceding the flip (PR4)**: staging holds real
+task attachments in Firebase Storage today, so the new `task_attachments` table
+must be populated before the read path leaves Firebase.
+
+Confirmed decisions (2026-06-17): `MEDIFORCE_ATTACHMENT_MAX_BYTES` default
+**100 MiB**; DELETE is **soft-delete metadata + keep blob**, blob GC is a later
+sweep (§7).
+
+### PR1 — Delete uploaded-skills feature
+
+Dead feature (empty everywhere), independent of attachments.
+
+| Action | File |
+|---|---|
+| del `skillFileNames` field | `platform-core/src/schemas/agent-definition.ts` |
+| drop `skill_file_names` col + migration | `platform-infra/src/postgres/schema/agent-definition.ts` + new `migrations/000X_*.sql` |
+| drop col mapping | `platform-infra/src/postgres/repositories/agent-definition-repository.ts` |
+| del `downloadSkillFiles` + `## Skills` | `platform-ui/src/lib/resolve-agent-identity.ts` |
+| del skill-upload UI | `app/(app)/[handle]/agents/new/page.tsx`, `.../agents/definitions/[id]/page.tsx` |
+| drop `skills` row | `cli/src/commands/agent-get.ts` |
+| drop field from fixtures | `e2e/helpers/seed-data.ts`, `e2e/helpers/postgres-seed.ts`, ~12 `__tests__` |
+
+| Level | Coverage |
+|---|---|
+| L1 | `agent-definition` schema (field gone); `resolve-agent-identity.test.ts` (no `## Skills`, no storage call) |
+| L2 | `agent-definition-parity.test.ts` pg↔in-memory parity w/o column; migration drops column |
+| L3 | existing agents route tests (create/get/update) green w/o field — API surface intact |
+| gate | `grep -r skillFileNames packages/` → 0 |
+
+Non-breaking: no real skill data exists.
+
+### PR2 — Attachments backend (vertical slice)
+
+`BlobStore` + `task_attachments` repo + headless routes + typed client, all in
+one PR so the L3 suite drives the whole path (UI not wired — the test is the
+caller).
+
+| Layer | File (new unless noted) |
+|---|---|
+| port | `platform-core/src/interfaces/blob-store.ts` |
+| port | `platform-core/src/interfaces/task-attachment-repository.ts` |
+| schema | `platform-core/src/schemas/task-attachment.ts` (Zod + `z.infer`) |
+| test doubles | `platform-core/src/testing/in-memory-blob-store.ts`, `.../in-memory-task-attachment-repository.ts` |
+| authz wrapper | `platform-core/src/.../authorized-task-attachment-repository.ts` |
+| fs impl | `platform-infra/src/storage/filesystem-blob-store.ts` |
+| pg schema + migration | `platform-infra/src/postgres/schema/task-attachment.ts` + `migrations/000X_*.sql` |
+| pg repo | `platform-infra/src/postgres/repositories/task-attachment-repository.ts` |
+| handlers | `platform-api/src/handlers/tasks/attachments/{upload,list,delete,get-blob}.ts` |
+| contracts | `platform-api/src/contracts/task-attachment.ts` |
+| typed client | `platform-api/src/client/…` → `mediforce.tasks.attachments.{list,upload,delete}` + `attachments.blobUrl` |
+| route adapters | `app/api/tasks/[id]/attachments/route.ts`, `app/api/attachments/[id]/blob/route.ts`, `app/api/attachments/[id]/route.ts` |
+| env | `MEDIFORCE_ATTACHMENT_MAX_BYTES` wiring + `.env.example` |
+
+| Level | Coverage |
+|---|---|
+| L1 | `task-attachment` Zod schema; `FilesystemBlobStore` (tmpdir) put/getStream/delete, missing-key→null, 60 MB streaming (no full-load); `InMemoryBlobStore` parity |
+| L2 | `TaskAttachmentRepository` pg-testcontainer + in-memory double: create/list/getById/delete, cascade-delete with task, workspace scope via `Authorized` wrapper, CHECK `size_bytes ≤ 100 MiB` rejects |
+| L3 | upload happy (row + bytes on disk); `GET blob` byte-identical round-trip; oversize → reject; foreign-workspace → 404; delete → soft (row flagged, blob remains) |
+
+Non-breaking: additive endpoints, no UI/staging behaviour change.
+
+### PR3 — Staging migration + run
+
+| Action | File |
+|---|---|
+| one-off migrator (TS — reuses `BlobStore` + repo; copy logic as pure fn) | `scripts/migrate-firebase-attachments.ts` |
+| fixture | fake Firebase-export sample |
+
+TS not Python: must reuse the `BlobStore` port + repo (Python can't).
+
+| Level | Coverage |
+|---|---|
+| L2 | copy-fn vs `InMemoryBlobStore` + in-memory repo + fake export: each `tasks/…` → blob + row; idempotent on `blob_key` (re-run safe); `agentSkills/…` abandoned (counted); download-failure reported |
+| manual | run once on staging; report = every legacy attachment has a row + readable blob |
+
+Non-breaking: writes rows only; UI still reads Firebase → zero visible change.
+
+### PR4 — UI flip + Firebase Storage removal
+
+| Action | File |
+|---|---|
+| swap to typed client | `platform-ui/src/components/tasks/file-upload-view.tsx` |
+| single-mode + size hint | `platform-ui/src/components/tasks/file-upload-zone.tsx` |
+| rewrite test | `components/tasks/__tests__/task-detail-upload.test.tsx` |
+| del `getStorage` / `storage` | `platform-ui/src/lib/firebase.ts` |
+| del env | `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` in `.env.example` + config |
+
+| Level | Coverage |
+|---|---|
+| L1 (jsdom) | `file-upload-view`: posts via typed client (mocked), renders list from `GET …/attachments`, over-limit hint |
+| L4 UI E2E | real upload via `FileUploadZone` single-mode → appears in list → download byte-works; over-limit error. GIF deliverable |
+| gate | `grep -rE "firebase/storage\|getStorage" packages/` → 0; `pnpm test` + `pnpm test:e2e` green with no Firebase project |
+
+Non-breaking: PR3 pre-migrated legacy attachments → new read path renders them.
+
+### Coverage rollup
+
+| PR | L1 | L2 | L3 | L4 | gate |
+|---|---|---|---|---|---|
+| 1 skill-del | ✓ | ✓ | ✓ | — | grep=0 |
+| 2 backend | ✓ | ✓ | ✓ | — | — |
+| 3 migration | ✓ (copy-fn) | ✓ | — | — | staging report |
+| 4 UI flip | ✓ | — | — | ✓ | grep=0, full suite |
+
+Full attachment path proven by PR2 L3; full user journey by PR4 L4.

--- a/docs/adr/PLAN-0003.md
+++ b/docs/adr/PLAN-0003.md
@@ -3,8 +3,9 @@
 Companion to [`0003-remove-firebase-storage.md`](./0003-remove-firebase-storage.md).
 Cross-reference for domain language: [`../../CONTEXT.md`](../../CONTEXT.md).
 
-Assumes ADR-0001 has landed (Postgres is live; Drizzle and the fail-proof
-repository base are in place).
+Assumes ADR-0001 has landed (Postgres is live; Drizzle is wired) and the
+caller-set repository base codified by
+[ADR-0004](./0004-scoped-data-access-authorization.md) is in place.
 
 ---
 
@@ -112,8 +113,10 @@ export interface AgentSkillRepository {
 }
 ```
 
-Both repos extend `WorkspaceScopedRepository` (ADR-0001 fail-proof base) so
-attachments and skills are workspace-isolated.
+Both repos extend the caller-set repository base from ADR-0001 (see
+[ADR-0004](./0004-scoped-data-access-authorization.md)) so attachments and
+skills are filtered by `workspace IN $callerWorkspaces` on every default
+read path.
 
 ### 2.4 New / changed API routes
 

--- a/docs/adr/PLAN-0003.md
+++ b/docs/adr/PLAN-0003.md
@@ -1,0 +1,255 @@
+# PLAN-0003 — Implementation plan for ADR-0003
+
+Companion to [`0003-remove-firebase-storage.md`](./0003-remove-firebase-storage.md).
+Cross-reference for domain language: [`../../CONTEXT.md`](../../CONTEXT.md).
+
+Assumes ADR-0001 has landed (Postgres is live; Drizzle and the fail-proof
+repository base are in place).
+
+---
+
+## 1. Schema additions
+
+### 1.1 Skill blobs
+
+```sql
+create table agent_definition_skills (
+  id uuid primary key default gen_random_uuid(),
+  agent_definition_id uuid not null references agent_definitions(id) on delete cascade,
+  name text not null,
+  content_type text not null default 'text/plain',
+  content bytea not null,
+  size_bytes int not null,
+  created_at timestamptz not null default now(),
+  unique (agent_definition_id, name)
+);
+create index on agent_definition_skills (agent_definition_id);
+
+alter table agent_definition_skills
+  add constraint skill_size_cap check (size_bytes <= 102400);  -- 100KB
+```
+
+### 1.2 Task attachments — metadata + blob split
+
+```sql
+create table task_attachments (
+  id uuid primary key default gen_random_uuid(),
+  task_id uuid not null references human_tasks(id) on delete cascade,
+  workspace text not null references workspaces(handle) on delete cascade,
+  kind text not null,                          -- 'inline' | 'link'
+  name text not null,                          -- filename (inline) or display label (link)
+  content_type text,                           -- inline only
+  size_bytes int,                              -- inline only
+  external_url text,                           -- link only — e.g. https://acme.veevavault.com/...
+  uploaded_by uuid not null references auth_users(id) on delete restrict,
+  uploaded_at timestamptz not null default now(),
+  check (
+    (kind = 'inline' and external_url is null and content_type is not null and size_bytes is not null)
+    or
+    (kind = 'link' and external_url is not null)
+  )
+);
+create index on task_attachments (task_id, uploaded_at);
+create index on task_attachments (workspace, uploaded_at);
+
+create table task_attachment_blobs (
+  attachment_id uuid primary key references task_attachments(id) on delete cascade,
+  content bytea not null
+);
+
+alter table task_attachments
+  add constraint inline_size_cap check (size_bytes is null or size_bytes <= 10485760);  -- 10MB
+```
+
+Reasons for splitting blob into a separate table:
+
+- `task_attachments` stays light — list queries (e.g. "attachments on task X")
+  don't load multi-MB blobs.
+- Postgres TOAST handles `bytea` well, but a dedicated blob table makes it
+  trivial to skip in `SELECT *` and to apply a partial backup policy later.
+
+### 1.3 No changes to `human_tasks`
+
+Today's `humanTasks` document has an `attachments` field referencing
+storage paths. After this ADR, attachments live in their own table — drop
+the inline field as part of the Firestore → Postgres mapping (it was
+informational and small).
+
+---
+
+## 2. Files touched
+
+### 2.1 Client-side Firebase Storage usage — replace
+
+- [`packages/platform-ui/src/app/(app)/[handle]/agents/new/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/agents/new/page.tsx) — `uploadBytes` to `agentSkills/...` → server action that `INSERT`s into `agent_definition_skills` with the file bytes.
+- [`packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx) — same refactor for edit-existing flow.
+- [`packages/platform-ui/src/components/tasks/task-detail.tsx`](../../packages/platform-ui/src/components/tasks/task-detail.tsx) — `uploadBytesResumable` + `getDownloadURL` → POST to a new server route `/api/tasks/{id}/attachments` that writes the `task_attachments` + `task_attachment_blobs` rows.
+- [`packages/platform-ui/src/components/tasks/file-upload-zone.tsx`](../../packages/platform-ui/src/components/tasks/file-upload-zone.tsx) — UI component. Add a dual mode: drop-zone for inline upload (with 10MB visible cap and "too large" error) **plus** a small "Attach a link" form that takes a URL. Both produce a `task_attachments` row of the appropriate `kind`.
+- [`packages/platform-ui/src/lib/firebase.ts`](../../packages/platform-ui/src/lib/firebase.ts) — delete the `getStorage` import + `storage` export. (Auth init is handled by ADR-0002; this ADR finishes the Storage portion.)
+
+### 2.2 Server-side Firebase Admin SDK Storage usage — replace
+
+- [`packages/platform-ui/src/lib/resolve-agent-identity.ts`](../../packages/platform-ui/src/lib/resolve-agent-identity.ts) — currently downloads skill files from Firebase Storage with `getStorage().bucket(...)`. Refactor to load from `agent_definition_skills` rows via the new repository.
+
+### 2.3 New repository (platform-core interface + Postgres impl)
+
+```ts
+// packages/platform-core/src/interfaces/task-attachment-repository.ts
+export interface TaskAttachmentRepository {
+  list(taskId: string): Promise<TaskAttachment[]>;
+  createInline(task: string, opts: { name: string; contentType: string; content: Buffer; uploadedBy: string }): Promise<TaskAttachment>;
+  createLink(task: string, opts: { name: string; url: string; uploadedBy: string }): Promise<TaskAttachment>;
+  readBlob(attachmentId: string): Promise<{ content: Buffer; contentType: string; name: string } | null>;
+  delete(attachmentId: string, actor: string): Promise<void>;
+}
+
+// packages/platform-core/src/interfaces/agent-skill-repository.ts
+export interface AgentSkillRepository {
+  list(agentDefinitionId: string): Promise<AgentSkill[]>;
+  upsert(agentDefinitionId: string, name: string, contentType: string, content: Buffer): Promise<AgentSkill>;
+  read(agentDefinitionId: string, name: string): Promise<{ content: Buffer; contentType: string } | null>;
+  deleteAll(agentDefinitionId: string): Promise<void>;
+}
+```
+
+Both repos extend `WorkspaceScopedRepository` (ADR-0001 fail-proof base) so
+attachments and skills are workspace-isolated.
+
+### 2.4 New / changed API routes
+
+- `POST /api/tasks/{id}/attachments` — accepts either:
+  - `multipart/form-data` with a file (inline mode), or
+  - `application/json` with `{ name, url }` (link mode).
+  - Validates 10MB cap for inline. Validates URL shape for link. Audits the action.
+- `GET /api/tasks/{id}/attachments` — list metadata only (no blobs).
+- `GET /api/attachments/{id}/blob` — stream blob bytes; returns 404 for link
+  kind. Authenticated and workspace-scoped.
+- `DELETE /api/attachments/{id}` — soft delete or hard delete (decide; soft
+  matches ADR-0001 default).
+
+Agent runtime continues to receive skills inline (via `WorkflowAgentContext`)
+— no new HTTP route needed; the repository call is server-side.
+
+### 2.5 Schema migration script (one-off, part of ADR-0001 cutover)
+
+Adds two tasks to the Python migration script already specified in
+[PLAN-0001](./PLAN-0001.md) §8:
+
+1. **Skill files migration.** For each Agent Definition in Firestore that
+   references a `skillFileNames` array of storage paths:
+   - Download the file from Firebase Storage.
+   - Validate `size <= 100KB`.
+   - Insert into `agent_definition_skills` with the same `name` and
+     `content_type` from the storage metadata.
+   - Drop the `skillFileNames` field from the Firestore Agent Definition
+     during the Postgres insert.
+
+2. **Task attachments migration.** For each Human Task in Firestore that
+   has an `attachments` array (today: storage paths + download URLs):
+   - Download each file.
+   - If size ≤10MB → insert `task_attachments (kind='inline')` + blob.
+   - If size >10MB → write a warning to the migration audit log, leave a
+     placeholder `task_attachments (kind='link', external_url=<best-known-url>)`
+     row pointing at the Firebase download URL. **Manual triage** required
+     after migration to move oversized files into the customer's DMS and
+     update the URL. The migration log lists all such rows.
+
+---
+
+## 3. UI changes
+
+### 3.1 `FileUploadZone` redesign
+
+Two tabs (or two side-by-side panels):
+
+```
+┌──────────────────────────┬───────────────────────────────┐
+│  Drag & drop a file       │  Attach a link                │
+│  (up to 10MB)             │  https://...                  │
+│                           │  Label (optional)             │
+│  [Browse...]              │  [Attach]                     │
+└──────────────────────────┴───────────────────────────────┘
+```
+
+Validation:
+- Inline mode rejects files >10MB with a friendly error suggesting the link
+  mode.
+- Link mode accepts only `http(s)://` URLs.
+
+### 3.2 Attachment list
+
+For each `task_attachments` row, render:
+
+- `kind='inline'` → filename + size + download icon (calls
+  `/api/attachments/{id}/blob`).
+- `kind='link'` → label + URL + external-link icon (opens URL in a new
+  tab). Mouseover shows the full URL.
+
+For both: uploaded-by, uploaded-at, delete button (if user has permission).
+
+### 3.3 Agent Definition skill upload
+
+Simplify: server action accepts files in the form submission, writes
+directly to `agent_definition_skills`. No client SDK upload. Progress
+indication via standard form submit pending state.
+
+---
+
+## 4. Test infrastructure
+
+- L2 repository tests for `AgentSkillRepository` and `TaskAttachmentRepository`
+  (Postgres testcontainer) — cover insert / read / cascade-delete / size-cap
+  enforcement.
+- L3 API E2E for the new routes — happy paths + error paths (oversize,
+  malformed URL, unauthorised).
+- L4 UI E2E for `FileUploadZone` covering both modes — including the
+  "too large → switch to link mode" hint.
+
+---
+
+## 5. Verification
+
+The migration is done when **all** of these hold:
+
+1. `grep -r "firebase/storage\|firebase-admin/storage" packages/` returns zero
+   matches.
+2. `pnpm test` + `pnpm test:e2e` pass with no Firebase project configured
+   and no S3 bucket.
+3. Cold-clone smoke test: `docker-compose up`, create an Agent Definition
+   with two skill files, create a Workflow that produces a Human Task,
+   attach a 5MB file inline, attach a Veeva-shaped URL, finalize the task,
+   re-read the task — both attachments are visible and downloadable / clickable.
+4. Migration script verification reports: every skill file migrated, every
+   task attachment ≤10MB migrated inline, oversize attachments flagged with
+   a placeholder link row and a row in the migration audit log.
+
+### Rollback
+
+Inline with ADR-0001's storage rollback: if Firestore writes leak after
+cutover, restore Firestore + GCS from snapshot, retry next window. Firebase
+Storage is read-only between cutover start and verify-success.
+
+---
+
+## 6. Env variables
+
+**Remove:**
+- `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET`
+
+**Add:**
+- `INLINE_ATTACHMENT_MAX_BYTES` (default `10485760`, i.e. 10MB) — runtime
+  override of the 10MB cap, audited.
+
+---
+
+## 7. Out-of-scope follow-ups
+
+- **Veeva Vault / SharePoint metadata previews** for `kind='link'` attachments
+  (preview thumbnail, file size, last modified) — future feature once a
+  customer asks.
+- **Antivirus / content scanning** of inline uploads — future ADR.
+- **Encryption at rest beyond Postgres defaults** — future ADR.
+- **Customer-provided S3 adapter** for deployments that want big inline
+  uploads without DMS — future ADR if asked. Architecture stays
+  pluggable through `TaskAttachmentRepository` so this is a non-breaking
+  addition.

--- a/docs/adr/PLAN-0003.md
+++ b/docs/adr/PLAN-0003.md
@@ -1,236 +1,190 @@
 # PLAN-0003 — Implementation plan for ADR-0003
 
 Companion to [`0003-remove-firebase-storage.md`](./0003-remove-firebase-storage.md).
-Cross-reference for domain language: [`../../CONTEXT.md`](../../CONTEXT.md).
+Reshaped 2026-06-16: uploaded-skills **deleted**, task attachments to a thin
+`BlobStore` (**filesystem impl only** — no S3 in the MVP), no DMS link,
+attachments scoped to Human Tasks. All write paths are **headless handlers**
+(ADR-0005 / AGENTS.md §8) — never Server Actions.
 
-Assumes ADR-0001 has landed (Postgres is live; Drizzle is wired) and the
-caller-set repository base codified by
-[ADR-0004](./0004-scoped-data-access-authorization.md) is in place.
+Assumes ADR-0001 has landed (Postgres live, Drizzle wired) and the caller-set
+repository base from [ADR-0004](./0004-scoped-data-access-authorization.md) is
+in place. Lands **before** ADR-0002 (auth), so user references are Firebase-uid
+`text`.
 
 ---
 
-## 1. Schema additions
+## 1. Skill upload removal (no migration)
 
-### 1.1 Skill blobs
+`AgentDefinition.skillFileNames` is empty everywhere — delete the feature:
 
-```sql
-create table agent_definition_skills (
-  id uuid primary key default gen_random_uuid(),
-  agent_definition_id uuid not null references agent_definitions(id) on delete cascade,
-  name text not null,
-  content_type text not null default 'text/plain',
-  content bytea not null,
-  size_bytes int not null,
-  created_at timestamptz not null default now(),
-  unique (agent_definition_id, name)
-);
-create index on agent_definition_skills (agent_definition_id);
+- `packages/platform-core/src/schemas/agent-definition.ts` — remove the
+  `skillFileNames` field.
+- `packages/platform-infra/src/postgres/schema/agent-definition.ts` — drop the
+  `skill_file_names` `jsonb` column (Drizzle migration).
+- `packages/platform-ui/src/lib/resolve-agent-identity.ts` — delete
+  `downloadSkillFiles` and the `## Skills` prompt section; keep the
+  `systemPrompt` assembly. The function loses its Firebase-admin/storage import.
+- `packages/platform-ui/src/app/(app)/[handle]/agents/new/page.tsx` and
+  `.../agents/definitions/[id]/page.tsx` — remove the `uploadBytes` →
+  `agentSkills/…` upload UI and any skill-file form controls.
+- Update fixtures/tests that set `skillFileNames: []` to drop the field.
 
-alter table agent_definition_skills
-  add constraint skill_size_cap check (size_bytes <= 102400);  -- 100KB
+The git-native `skillsDir` path is untouched — it remains the only skill
+mechanism.
+
+---
+
+## 2. Task attachments
+
+### 2.1 `BlobStore` port (bytes) — filesystem impl only
+
+```ts
+// packages/platform-core/src/interfaces/blob-store.ts
+import type { Readable } from 'node:stream';
+
+export interface BlobStore {
+  put(key: string, content: Buffer): Promise<void>;
+  getStream(key: string): Promise<Readable | null>;   // null = missing key
+  delete(key: string): Promise<void>;
+}
 ```
 
-### 1.2 Task attachments — metadata + blob split
+- `packages/platform-infra/src/storage/filesystem-blob-store.ts` —
+  `FilesystemBlobStore`. Root = the existing `~/.mediforce` data dir (same
+  volume ADR-0007 uses for bare repos); attachments under
+  `${root}/attachments/<key>`. `key` is the attachment uuid (optionally
+  sharded by first 2 chars to avoid one huge dir). Streams on read, so large
+  files never load fully into memory. Content-type is **not** stored on disk —
+  it lives in the `task_attachments` metadata row.
+- `packages/platform-core/src/testing/in-memory-blob-store.ts` —
+  `InMemoryBlobStore` (a `Map<string, Buffer>`) for the L2 repo/handler tests.
+- **No S3 implementation.** The port keeps it a non-breaking future add.
+
+### 2.2 Metadata schema
 
 ```sql
 create table task_attachments (
   id uuid primary key default gen_random_uuid(),
-  task_id uuid not null references human_tasks(id) on delete cascade,
+  task_id text not null references human_tasks(id) on delete cascade,  -- match human_tasks.id (text, ADR-0001 "stay text")
   workspace text not null references workspaces(handle) on delete cascade,
-  kind text not null,                          -- 'inline' | 'link'
-  name text not null,                          -- filename (inline) or display label (link)
-  content_type text,                           -- inline only
-  size_bytes int,                              -- inline only
-  external_url text,                           -- link only — e.g. https://acme.veevavault.com/...
-  uploaded_by uuid not null references auth_users(id) on delete restrict,
-  uploaded_at timestamptz not null default now(),
-  check (
-    (kind = 'inline' and external_url is null and content_type is not null and size_bytes is not null)
-    or
-    (kind = 'link' and external_url is not null)
-  )
+  name text not null,
+  content_type text not null,
+  size_bytes bigint not null,
+  blob_key text not null,                       -- key into BlobStore
+  uploaded_by text not null,                    -- Firebase uid; remapped by ADR-0002 staging script
+  uploaded_at timestamptz not null default now()
 );
 create index on task_attachments (task_id, uploaded_at);
 create index on task_attachments (workspace, uploaded_at);
 
-create table task_attachment_blobs (
-  attachment_id uuid primary key references task_attachments(id) on delete cascade,
-  content bytea not null
-);
-
 alter table task_attachments
-  add constraint inline_size_cap check (size_bytes is null or size_bytes <= 10485760);  -- 10MB
+  add constraint attachment_size_guard
+  check (size_bytes <= 104857600);  -- 100 MiB default; mirror MEDIFORCE_ATTACHMENT_MAX_BYTES
 ```
 
-Reasons for splitting blob into a separate table:
+No blob table — bytes live in the `BlobStore`, only metadata in Postgres.
+Drop the legacy `humanTasks.attachments` inline field during the read mapping
+(it pointed at Firebase storage paths).
 
-- `task_attachments` stays light — list queries (e.g. "attachments on task X")
-  don't load multi-MB blobs.
-- Postgres TOAST handles `bytea` well, but a dedicated blob table makes it
-  trivial to skip in `SELECT *` and to apply a partial backup policy later.
-
-### 1.3 No changes to `human_tasks`
-
-Today's `humanTasks` document has an `attachments` field referencing
-storage paths. After this ADR, attachments live in their own table — drop
-the inline field as part of the Firestore → Postgres mapping (it was
-informational and small).
-
----
-
-## 2. Files touched
-
-### 2.1 Client-side Firebase Storage usage — replace
-
-- [`packages/platform-ui/src/app/(app)/[handle]/agents/new/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/agents/new/page.tsx) — `uploadBytes` to `agentSkills/...` → server action that `INSERT`s into `agent_definition_skills` with the file bytes.
-- [`packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx`](../../packages/platform-ui/src/app/(app)/[handle]/agents/definitions/[id]/page.tsx) — same refactor for edit-existing flow.
-- [`packages/platform-ui/src/components/tasks/task-detail.tsx`](../../packages/platform-ui/src/components/tasks/task-detail.tsx) — `uploadBytesResumable` + `getDownloadURL` → POST to a new server route `/api/tasks/{id}/attachments` that writes the `task_attachments` + `task_attachment_blobs` rows.
-- [`packages/platform-ui/src/components/tasks/file-upload-zone.tsx`](../../packages/platform-ui/src/components/tasks/file-upload-zone.tsx) — UI component. Add a dual mode: drop-zone for inline upload (with 10MB visible cap and "too large" error) **plus** a small "Attach a link" form that takes a URL. Both produce a `task_attachments` row of the appropriate `kind`.
-- [`packages/platform-ui/src/lib/firebase.ts`](../../packages/platform-ui/src/lib/firebase.ts) — delete the `getStorage` import + `storage` export. (Auth init is handled by ADR-0002; this ADR finishes the Storage portion.)
-
-### 2.2 Server-side Firebase Admin SDK Storage usage — replace
-
-- [`packages/platform-ui/src/lib/resolve-agent-identity.ts`](../../packages/platform-ui/src/lib/resolve-agent-identity.ts) — currently downloads skill files from Firebase Storage with `getStorage().bucket(...)`. Refactor to load from `agent_definition_skills` rows via the new repository.
-
-### 2.3 New repository (platform-core interface + Postgres impl)
+### 2.3 `TaskAttachmentRepository` (metadata)
 
 ```ts
 // packages/platform-core/src/interfaces/task-attachment-repository.ts
 export interface TaskAttachmentRepository {
   list(taskId: string): Promise<TaskAttachment[]>;
-  createInline(task: string, opts: { name: string; contentType: string; content: Buffer; uploadedBy: string }): Promise<TaskAttachment>;
-  createLink(task: string, opts: { name: string; url: string; uploadedBy: string }): Promise<TaskAttachment>;
-  readBlob(attachmentId: string): Promise<{ content: Buffer; contentType: string; name: string } | null>;
-  delete(attachmentId: string, actor: string): Promise<void>;
-}
-
-// packages/platform-core/src/interfaces/agent-skill-repository.ts
-export interface AgentSkillRepository {
-  list(agentDefinitionId: string): Promise<AgentSkill[]>;
-  upsert(agentDefinitionId: string, name: string, contentType: string, content: Buffer): Promise<AgentSkill>;
-  read(agentDefinitionId: string, name: string): Promise<{ content: Buffer; contentType: string } | null>;
-  deleteAll(agentDefinitionId: string): Promise<void>;
+  create(input: { taskId: string; workspace: string; name: string; contentType: string; sizeBytes: number; blobKey: string; uploadedBy: string }): Promise<TaskAttachment>;
+  getById(attachmentId: string): Promise<TaskAttachment | null>;
+  delete(attachmentId: string): Promise<void>;
 }
 ```
 
-Both repos extend the caller-set repository base from ADR-0001 (see
-[ADR-0004](./0004-scoped-data-access-authorization.md)) so attachments and
-skills are filtered by `workspace IN $callerWorkspaces` on every default
-read path.
+Postgres impl + in-memory double (repository pattern). Wrapped by
+`AuthorizedTaskAttachmentRepository` so reads/writes are `workspace IN
+$callerWorkspaces` gated per [ADR-0004](./0004-scoped-data-access-authorization.md).
+The `BlobStore` itself is unscoped (bytes-by-key) — authorization happens at
+the metadata layer: you can only learn a `blob_key` by reading an attachment
+row, which is workspace-gated.
 
-### 2.4 New / changed API routes
+### 2.4 Headless routes (handlers + adapters + typed client)
 
-- `POST /api/tasks/{id}/attachments` — accepts either:
-  - `multipart/form-data` with a file (inline mode), or
-  - `application/json` with `{ name, url }` (link mode).
-  - Validates 10MB cap for inline. Validates URL shape for link. Audits the action.
-- `GET /api/tasks/{id}/attachments` — list metadata only (no blobs).
-- `GET /api/attachments/{id}/blob` — stream blob bytes; returns 404 for link
-  kind. Authenticated and workspace-scoped.
-- `DELETE /api/attachments/{id}` — soft delete or hard delete (decide; soft
-  matches ADR-0001 default).
+- `POST /api/tasks/{id}/attachments` — `multipart/form-data` with a file.
+  Handler validates size ≤ `MEDIFORCE_ATTACHMENT_MAX_BYTES`, generates a
+  `blob_key`, calls `blobStore.put`, writes the `task_attachments` row, emits
+  audit (`task.attachment_added`). Returns the metadata row (entity echo).
+- `GET /api/tasks/{id}/attachments` — list metadata (no bytes).
+- `GET /api/attachments/{id}/blob` — load the row (workspace-gated), stream
+  `blobStore.getStream(blob_key)`, set `Content-Type` / `Content-Length` /
+  `Content-Disposition` from the row. 404 for missing.
+- `DELETE /api/attachments/{id}` — soft-delete the row + `blobStore.delete`
+  (or keep blob; decide at impl — soft-delete metadata is enough, blob GC is a
+  later sweep). Audit `task.attachment_deleted`.
+- Typed client: `mediforce.tasks.attachments.{list,upload,delete}` +
+  `mediforce.attachments.blobUrl(id)` helper.
 
-Agent runtime continues to receive skills inline (via `WorkflowAgentContext`)
-— no new HTTP route needed; the repository call is server-side.
+### 2.5 Client UI — replace Firebase Storage
 
-### 2.5 Schema migration script (one-off, part of ADR-0001 cutover)
-
-Adds two tasks to the Python migration script already specified in
-[PLAN-0001](./PLAN-0001.md) §8:
-
-1. **Skill files migration.** For each Agent Definition in Firestore that
-   references a `skillFileNames` array of storage paths:
-   - Download the file from Firebase Storage.
-   - Validate `size <= 100KB`.
-   - Insert into `agent_definition_skills` with the same `name` and
-     `content_type` from the storage metadata.
-   - Drop the `skillFileNames` field from the Firestore Agent Definition
-     during the Postgres insert.
-
-2. **Task attachments migration.** For each Human Task in Firestore that
-   has an `attachments` array (today: storage paths + download URLs):
-   - Download each file.
-   - If size ≤10MB → insert `task_attachments (kind='inline')` + blob.
-   - If size >10MB → write a warning to the migration audit log, leave a
-     placeholder `task_attachments (kind='link', external_url=<best-known-url>)`
-     row pointing at the Firebase download URL. **Manual triage** required
-     after migration to move oversized files into the customer's DMS and
-     update the URL. The migration log lists all such rows.
+- `packages/platform-ui/src/components/tasks/file-upload-view.tsx` — drop
+  `firebase/storage` (`ref`/`uploadBytesResumable`/`getDownloadURL`) and the
+  `storage` import; POST the file to `POST /api/tasks/{id}/attachments` via the
+  typed client. Progress via the upload request (or simple pending state).
+- `packages/platform-ui/src/components/tasks/file-upload-zone.tsx` — single
+  inline-upload mode (no DMS-link tab). Show the configured size limit and a
+  friendly over-limit error.
+- Read-only attachment list renders rows from `GET …/attachments`; download
+  links point at `GET /api/attachments/{id}/blob`.
+- `packages/platform-ui/src/lib/firebase.ts` — delete the `getStorage` import
+  + `storage` export. (Auth init handled by ADR-0002 later.)
 
 ---
 
-## 3. UI changes
+## 3. Storage-only migration (standalone, one-off, staging)
 
-### 3.1 `FileUploadZone` redesign
+ADR-0001's data cutover already shipped (#534) — this is a **separate**
+script, run once against staging:
 
-Two tabs (or two side-by-side panels):
+1. For each Human Task with a legacy `attachments` array (Firestore →
+   already in Postgres as a field, or read from the Firebase export):
+   - Download each `tasks/…` object from Firebase Storage.
+   - `blobStore.put(newKey, bytes)`; insert a `task_attachments` row
+     (`uploaded_by` = best-known Firebase uid, else a system placeholder).
+2. `agentSkills/…` objects are **abandoned** (feature deleted) — log counts
+   only.
+3. Verify: every legacy task attachment has a row + a readable blob; report
+   any download failures.
 
-```
-┌──────────────────────────┬───────────────────────────────┐
-│  Drag & drop a file       │  Attach a link                │
-│  (up to 10MB)             │  https://...                  │
-│                           │  Label (optional)             │
-│  [Browse...]              │  [Attach]                     │
-└──────────────────────────┴───────────────────────────────┘
-```
-
-Validation:
-- Inline mode rejects files >10MB with a friendly error suggesting the link
-  mode.
-- Link mode accepts only `http(s)://` URLs.
-
-### 3.2 Attachment list
-
-For each `task_attachments` row, render:
-
-- `kind='inline'` → filename + size + download icon (calls
-  `/api/attachments/{id}/blob`).
-- `kind='link'` → label + URL + external-link icon (opens URL in a new
-  tab). Mouseover shows the full URL.
-
-For both: uploaded-by, uploaded-at, delete button (if user has permission).
-
-### 3.3 Agent Definition skill upload
-
-Simplify: server action accepts files in the form submission, writes
-directly to `agent_definition_skills`. No client SDK upload. Progress
-indication via standard form submit pending state.
+No production data exists; this is purely to preserve staging.
 
 ---
 
 ## 4. Test infrastructure
 
-- L2 repository tests for `AgentSkillRepository` and `TaskAttachmentRepository`
-  (Postgres testcontainer) — cover insert / read / cascade-delete / size-cap
-  enforcement.
-- L3 API E2E for the new routes — happy paths + error paths (oversize,
-  malformed URL, unauthorised).
-- L4 UI E2E for `FileUploadZone` covering both modes — including the
-  "too large → switch to link mode" hint.
+- L2: `FilesystemBlobStore` (tmpdir) + `InMemoryBlobStore` — put/getStream/
+  delete, missing-key null, large-file streaming.
+- L2: `TaskAttachmentRepository` (Postgres testcontainer) + in-memory double —
+  create/list/getById/delete, cascade-delete with task, workspace scoping via
+  the Authorized wrapper.
+- L3 API E2E: upload happy path, oversize rejection, unauthorised/foreign-
+  workspace 404, blob stream round-trip.
+- L4 UI E2E: `FileUploadZone` single-mode upload + over-limit hint.
 
 ---
 
 ## 5. Verification
 
-The migration is done when **all** of these hold:
+Done when **all** hold:
 
-1. `grep -r "firebase/storage\|firebase-admin/storage" packages/` returns zero
-   matches.
-2. `pnpm test` + `pnpm test:e2e` pass with no Firebase project configured
-   and no S3 bucket.
-3. Cold-clone smoke test: `docker-compose up`, create an Agent Definition
-   with two skill files, create a Workflow that produces a Human Task,
-   attach a 5MB file inline, attach a Veeva-shaped URL, finalize the task,
-   re-read the task — both attachments are visible and downloadable / clickable.
-4. Migration script verification reports: every skill file migrated, every
-   task attachment ≤10MB migrated inline, oversize attachments flagged with
-   a placeholder link row and a row in the migration audit log.
+1. `grep -rE "firebase/storage|firebase-admin/storage|skillFileNames" packages/`
+   returns zero matches.
+2. `pnpm test` + `pnpm test:e2e` pass with no Firebase project and no S3 bucket.
+3. Cold-clone smoke: `docker-compose up`, create a Human Task, upload a large
+   (e.g. 60 MB) file, re-read the task, download it back byte-identical.
+4. Staging migration report: every legacy task attachment migrated + readable;
+   abandoned skill-file count logged.
 
 ### Rollback
 
-Inline with ADR-0001's storage rollback: if Firestore writes leak after
-cutover, restore Firestore + GCS from snapshot, retry next window. Firebase
-Storage is read-only between cutover start and verify-success.
+Pre-cutover the Firebase Storage bucket stays read-only; if the migration
+mis-copies, re-run (idempotent on `blob_key`). No production at risk.
 
 ---
 
@@ -240,19 +194,20 @@ Storage is read-only between cutover start and verify-success.
 - `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET`
 
 **Add:**
-- `INLINE_ATTACHMENT_MAX_BYTES` (default `10485760`, i.e. 10MB) — runtime
-  override of the 10MB cap, audited.
+- `MEDIFORCE_ATTACHMENT_MAX_BYTES` — its own knob (not coupled to any other
+  size env). Default `104857600` (100 MiB), chosen on its own merit. Guards
+  disk, not a design cap.
+- (Attachment root reuses the existing `~/.mediforce` data dir — no new env.)
+
+**Not added (deferred, non-breaking):** S3 endpoint / bucket / credentials
+envs — only when the S3 `BlobStore` impl is actually built.
 
 ---
 
 ## 7. Out-of-scope follow-ups
 
-- **Veeva Vault / SharePoint metadata previews** for `kind='link'` attachments
-  (preview thumbnail, file size, last modified) — future feature once a
-  customer asks.
-- **Antivirus / content scanning** of inline uploads — future ADR.
-- **Encryption at rest beyond Postgres defaults** — future ADR.
-- **Customer-provided S3 adapter** for deployments that want big inline
-  uploads without DMS — future ADR if asked. Architecture stays
-  pluggable through `TaskAttachmentRepository` so this is a non-breaking
-  addition.
+- **S3-compatible `BlobStore` impl** — when a deployment asks.
+- **External DMS reference-link attachments** — future product feature.
+- **Blob garbage-collection sweep** for soft-deleted attachments — later.
+- **Antivirus / content scanning**, **encryption at rest beyond volume
+  defaults**, **CDN serving** — future ADRs if asked.


### PR DESCRIPTION
## ADR-0003 — Remove Firebase Storage

Eliminate Firebase Storage. **Refreshed 2026-06-16** after a grilling pass against the *current* codebase; the ADR + PLAN files are the source of truth and supersede the original 2026-05-20 proposal.

### Key decisions (current)

1. **Delete the uploaded-skills feature** (`AgentDefinition.skillFileNames`) — it is empty everywhere and every app uses the git-native `skillsDir` mechanism, which remains the single skill path. (No `agent_definition_skills` table; no skill migration.)
2. **Task attachments → a thin `BlobStore` port, filesystem impl only** — bytes under the existing `~/.mediforce` volume (ADR-0007 precedent); **metadata in Postgres, bytes on the volume (no PG `bytea`)**. **S3 impl deferred** (non-breaking future add).
3. **DMS external-link mode dropped** — it was net-new (never in code); a real `BlobStore` makes it unnecessary. May return later as an optional reference-file feature.
4. **No hard 10MB cap** — a configurable disk guard (`MEDIFORCE_ATTACHMENT_MAX_BYTES`, its own env, not coupled to any other cap). Large workflow files are supported.
5. **Headless handlers, no Server Actions** (ADR-0005 / AGENTS.md §8). Attachments scoped to Human Tasks. `uploaded_by` is a Firebase-uid `text` column.
6. **Lands before ADR-0002** (storage-first) so client-direct uploads don't break when Firebase Auth is removed. Standalone one-time staging migration (ADR-0001's data cutover already shipped, #534).

### Out of scope

S3 `BlobStore` impl (until a deployment asks), external DMS reference-link adapters, antivirus / content scanning, encryption beyond volume defaults, CDN serving.

### Review

- [ ] Read `docs/adr/0003-remove-firebase-storage.md` + `PLAN-0003.md`.
- [ ] Confirm the BlobStore-filesystem direction + the uploaded-skills deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pnjk1ySMuCwmoT873iqXTd