### PR TITLE
fix(dev:mock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Duplicate Python migration script `scripts/migrations/migrate_workflow_doc_ids.py` — superseded by the TypeScript `packages/platform-infra/scripts/migrate-workflow-namespacing.ts` which is the canonical version ([#424](https://github.com/Appsilon/mediforce/pull/424)).
 
 ### Fixed
+- `pnpm dev:mock` now starts local Firebase emulators, seeds demo data, and then boots Next, so the browser no longer falls into offline Firestore/Auth mode on a fresh mock-dev run.
 - Workspace `Runs` page no longer leaks runs from other namespaces the viewer is a member of — list is now filtered to the current `handle`, and `useProcessInstances` requires `namespace` so TypeScript catches future regressions compile-time ([#424](https://github.com/Appsilon/mediforce/pull/424), follow-ups tracked in [#447](https://github.com/Appsilon/mediforce/issues/447) and [#448](https://github.com/Appsilon/mediforce/issues/448)).
 - Instance namespace backfill now resolves namespace per instance definition version instead of global latest-by-name, preventing cross-tenant run reassignment during migration ([#424](https://github.com/Appsilon/mediforce/pull/424)).
 - Workflow definition storage now scopes definition and metadata keys by namespace, so tenants can register the same workflow name independently ([#424](https://github.com/Appsilon/mediforce/pull/424)).

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -17,8 +17,9 @@ pnpm install
 pnpm dev:mock
 ```
 
-Open http://localhost:9007. No Firebase, no keys, no Docker. Agents are mocked,
-workflow data lives in `MEDIFORCE_DATA_DIR` (in-memory file-based fake).
+Open http://localhost:9007. No Firebase project, cloud keys, Docker, or real agents.
+The launcher starts local Firebase emulators, seeds demo data, and uses mocked
+agent execution.
 Use this to explore the UI before configuring anything real.
 
 ---
@@ -430,7 +431,7 @@ Make sure:
 | Command | Description |
 |---------|-------------|
 | `pnpm install` | Install dependencies |
-| `pnpm dev:mock` | Mocked agents + in-memory data, port 9007 — no setup |
+| `pnpm dev:mock` | Mocked agents + seeded local emulator data, port 9007 |
 | `pnpm emulators` | Start Firebase emulators (Auth + Firestore + Storage) |
 | `pnpm seed` | Seed demo data into running emulators |
 | `NEXT_PUBLIC_USE_EMULATORS=true pnpm dev` | Run with emulators (port 9003) |

--- a/README.md
+++ b/README.md
@@ -109,17 +109,17 @@ We're building the standard for human-agent collaboration in pharma — and we'r
 
 ```bash
 pnpm install
-pnpm dev:mock        # port 9007, mocked agents, in-memory data, no Firebase needed
+pnpm dev:mock        # port 9007, mocked agents, local emulators + demo data
 ```
 
-Open `http://localhost:9007`. Use this to click through the UI without configuring anything.
+Open `http://localhost:9007`. Use this to click through the UI without configuring a Firebase project, cloud keys, Docker, or real agents.
 
 ### Dev modes
 
 | Command | What it gives you |
 |---|---|
 | `pnpm dev` | Default. Real Firebase per `.env.local`, agents in Docker. The main dev loop. |
-| `pnpm dev:mock` | Mocked agents + in-memory data store, port 9007. No keys, no Docker, no Firebase. |
+| `pnpm dev:mock` | Mocked agents + seeded local emulator data, port 9007. No cloud keys, no Docker, no Firebase project. |
 | `pnpm dev:no-docker` | Like `dev`, but agents run via host `claude` CLI instead of Docker. |
 | `pnpm dev:queue` | Like `dev`, but agent execution goes through BullMQ queue (production architecture). Requires Redis + worker running — see below. |
 

--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack -p 9003",
-    "dev:mock": "NEXT_PUBLIC_USE_EMULATORS=true NEXT_PUBLIC_FIREBASE_PROJECT_ID=demo-mediforce MOCK_AGENT=true MEDIFORCE_DATA_DIR=/tmp/mediforce-e2e-data NEXT_PUBLIC_APP_URL=http://localhost:9007 NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 next dev --webpack -p 9007",
+    "dev:mock": "python3 scripts/dev-mock.py",
     "build": "rm -rf .next && next build --webpack",
     "build:e2e": "NEXT_PUBLIC_USE_EMULATORS=true NEXT_PUBLIC_FIREBASE_PROJECT_ID=demo-mediforce NEXT_PUBLIC_APP_URL=http://localhost:9007 next build --webpack",
     "start:e2e": "(test -f .next/BUILD_ID || pnpm build:e2e) && MOCK_AGENT=true MEDIFORCE_DATA_DIR=/tmp/mediforce-e2e-data NEXT_PUBLIC_APP_URL=http://localhost:9007 NO_PROXY=localhost,127.0.0.1 no_proxy=localhost,127.0.0.1 next start -p 9007",

--- a/packages/platform-ui/scripts/dev-mock.py
+++ b/packages/platform-ui/scripts/dev-mock.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Run the zero-cloud local mock development server."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PLATFORM_UI = Path(__file__).resolve().parent.parent
+ROOT = PLATFORM_UI.parent.parent
+FIREBASE_CONFIG = Path("/tmp/mediforce-dev-mock-firebase.json")
+
+AUTH_PORT = 9099
+FIRESTORE_PORT = 8080
+STORAGE_PORT = 9199
+NEXT_PORT = 9007
+
+DEMO_ENV: dict[str, str] = {
+    "NEXT_PUBLIC_USE_EMULATORS": "true",
+    "NEXT_PUBLIC_FIREBASE_API_KEY": "fake-api-key-for-emulators",
+    "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN": "demo-mediforce.firebaseapp.com",
+    "NEXT_PUBLIC_FIREBASE_PROJECT_ID": "demo-mediforce",
+    "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET": "demo-mediforce.appspot.com",
+    "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID": "000000000000",
+    "NEXT_PUBLIC_FIREBASE_APP_ID": "1:000000000000:web:0000000000000000",
+    "FIREBASE_AUTH_EMULATOR_HOST": f"127.0.0.1:{AUTH_PORT}",
+    "FIRESTORE_EMULATOR_HOST": f"127.0.0.1:{FIRESTORE_PORT}",
+    "FIREBASE_STORAGE_EMULATOR_HOST": f"127.0.0.1:{STORAGE_PORT}",
+    "MOCK_AGENT": "true",
+    "MEDIFORCE_DATA_DIR": "/tmp/mediforce-e2e-data",
+    "NEXT_PUBLIC_APP_URL": f"http://localhost:{NEXT_PORT}",
+    "NO_PROXY": "localhost,127.0.0.1",
+    "no_proxy": "localhost,127.0.0.1",
+    "OPENROUTER_API_KEY": "fake-openrouter-key",
+    "PLATFORM_API_KEY": "test-api-key",
+    "SECRETS_ENCRYPTION_KEY": "0" * 64,
+    "MEDIFORCE_DISABLE_EMAIL": "true",
+}
+
+
+def log(message: str) -> None:
+    print(f"[dev:mock] {message}", flush=True)
+
+
+def port_open(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def wait_for_ports(ports: list[int], timeout_seconds: int) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if all(port_open(port) for port in ports):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def write_firebase_config() -> None:
+    firestore_rules = ROOT / "firestore.e2e.rules"
+    storage_rules = PLATFORM_UI / "storage.rules"
+    if not firestore_rules.exists():
+        raise RuntimeError(f"Missing Firestore rules file: {firestore_rules}")
+    if not storage_rules.exists():
+        raise RuntimeError(f"Missing Storage rules file: {storage_rules}")
+
+    config = {
+        "firestore": {"rules": str(firestore_rules)},
+        "storage": {"rules": str(storage_rules)},
+        "emulators": {
+            "auth": {"port": AUTH_PORT},
+            "firestore": {"port": FIRESTORE_PORT},
+            "storage": {"port": STORAGE_PORT},
+            "ui": {"enabled": False},
+        },
+    }
+    FIREBASE_CONFIG.write_text(json.dumps(config, indent=2))
+
+
+def command_exists(command: str) -> bool:
+    return shutil.which(command) is not None
+
+
+def with_local_java(env: dict[str, str]) -> dict[str, str]:
+    if env.get("JAVA_HOME") or command_exists("java"):
+        return env
+
+    for java_home in [
+        Path("/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home"),
+        Path("/usr/local/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home"),
+    ]:
+        java_bin = java_home / "bin"
+        if java_bin.exists():
+            return {
+                **env,
+                "JAVA_HOME": str(java_home),
+                "PATH": f"{java_bin}{os.pathsep}{env.get('PATH', '')}",
+            }
+
+    return env
+
+
+def start_emulators(env: dict[str, str]) -> subprocess.Popen[bytes] | None:
+    emulator_ports = [AUTH_PORT, FIRESTORE_PORT, STORAGE_PORT]
+    open_ports = [port for port in emulator_ports if port_open(port)]
+    if len(open_ports) == len(emulator_ports):
+        log("Firebase emulators already running on 9099, 8080, and 9199.")
+        return None
+
+    if open_ports:
+        ports = ", ".join(str(port) for port in open_ports)
+        missing = ", ".join(str(port) for port in emulator_ports if port not in open_ports)
+        raise RuntimeError(
+            f"Some emulator ports are already in use ({ports}), but others are missing ({missing}). "
+            "Stop the stale emulator process and run pnpm dev:mock again."
+        )
+
+    if not command_exists("pnpm"):
+        raise RuntimeError("pnpm is required to run dev:mock.")
+
+    write_firebase_config()
+    log("Starting local Firebase emulators...")
+    proc = subprocess.Popen(
+        [
+            "pnpm",
+            "exec",
+            "firebase",
+            "emulators:start",
+            "--project",
+            "demo-mediforce",
+            "--only",
+            "auth,firestore,storage",
+            "--config",
+            str(FIREBASE_CONFIG),
+        ],
+        cwd=str(PLATFORM_UI),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if not wait_for_ports(emulator_ports, 45):
+        proc.terminate()
+        raise RuntimeError(
+            "Firebase emulators did not become ready within 45 seconds. "
+            "Run `pnpm --filter @mediforce/platform-ui emulators` for full logs."
+        )
+    log("Firebase emulators are ready.")
+    return proc
+
+
+def seed_demo_data(env: dict[str, str]) -> None:
+    if os.environ.get("MEDIFORCE_DEV_MOCK_SEED") == "false":
+        log("Skipping demo seed because MEDIFORCE_DEV_MOCK_SEED=false.")
+        return
+
+    log("Seeding demo user and workspace data...")
+    subprocess.run(
+        ["pnpm", "exec", "tsx", "scripts/seed-dev-data.ts"],
+        cwd=str(PLATFORM_UI),
+        env=env,
+        check=True,
+    )
+
+
+def run_next(env: dict[str, str]) -> int:
+    log(f"Starting Next.js on http://localhost:{NEXT_PORT}")
+    proc = subprocess.Popen(
+        ["pnpm", "exec", "next", "dev", "--webpack", "-p", str(NEXT_PORT)],
+        cwd=str(PLATFORM_UI),
+        env=env,
+    )
+    try:
+        return proc.wait()
+    except KeyboardInterrupt:
+        proc.send_signal(signal.SIGINT)
+        return proc.wait()
+
+
+def main() -> int:
+    env = with_local_java({**os.environ, **DEMO_ENV})
+    emulator_proc: subprocess.Popen[bytes] | None = None
+    try:
+        if port_open(NEXT_PORT):
+            raise RuntimeError(
+                f"Port {NEXT_PORT} is already in use. Stop that process and run pnpm dev:mock again."
+            )
+        emulator_proc = start_emulators(env)
+        seed_demo_data(env)
+        return run_next(env)
+    except subprocess.CalledProcessError as error:
+        log(f"Command failed with exit code {error.returncode}: {' '.join(error.cmd)}")
+        return error.returncode
+    except RuntimeError as error:
+        log(str(error))
+        return 1
+    finally:
+        if emulator_proc is not None and emulator_proc.poll() is None:
+            log("Stopping Firebase emulators...")
+            emulator_proc.terminate()
+            try:
+                emulator_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                emulator_proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/platform-ui/src/test/integration/dev-mock-script.test.ts
+++ b/packages/platform-ui/src/test/integration/dev-mock-script.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('dev:mock script', () => {
+  it('runs the mock dev launcher instead of starting Next directly', () => {
+    const packageJsonPath = resolve(__dirname, '../../../package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['dev:mock']).toBe('python3 scripts/dev-mock.py');
+  });
+});


### PR DESCRIPTION
## Problem

`pnpm dev:mock` set `NEXT_PUBLIC_USE_EMULATORS=true` and started only Next.js. On a fresh machine with no local Firebase emulators running, the browser Firebase client tried to reach Auth/Firestore on the emulator ports, failed to fetch an auth token, and then Firestore fell into offline mode. That broke startup paths such as `ensurePersonalNamespace` and the `mustChangePassword` user-doc read.

## Changed

- Replace the inline `dev:mock` command with a small Python launcher.
- Start local Firebase Auth, Firestore, and Storage emulators when they are not already running.
- Seed the demo user/workspace data before starting Next on port `9007`.
- Keep mock agent execution and demo env defaults in one place.
- Update README/Getting Started wording to describe zero-cloud local emulator mode.
- Add a regression test that keeps `dev:mock` pointed at the launcher.

## Verification

- `pnpm exec vitest run src/test/integration/dev-mock-script.test.ts`
- `python3 -m py_compile packages/platform-ui/scripts/dev-mock.py`
- `pnpm typecheck`
- `git diff --check`