### PR TITLE
chore(agent-runtime): add python3-requests to golden image

### DIFF
--- a/packages/agent-runtime/container/Dockerfile.base
+++ b/packages/agent-runtime/container/Dockerfile.base
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
     python3 \
     python3-pip \
+    python3-requests \
     curl \
     jq \
     ca-certificates \


### PR DESCRIPTION
## What

Adds `python3-requests` to `packages/agent-runtime/container/Dockerfile.base`, the golden image used by every workflow agent/script step that doesn't ship a custom Dockerfile.

## Why

Python inline scripts in workflow steps regularly need an HTTP client. Without `requests`, options are:
- `urllib.request` — stdlib, but verbose (~10 lines for what `requests.post(..., json=..., headers=...)` does in 1)
- `pip install requests` at script start — slow cold start (5-10s), and PEP 668 blocks it on recent Debian without `--break-system-packages`

`python3-requests` from apt is the Debian-blessed path. ~280 KB unpacked, negligible for the image.

Surfaced during backlog-triage UAT (#470 discussion) where the absence of `requests` in golden was one factor pushing the scripts to javascript runtime. Future workflows that prefer Python (R-adjacent pharma teams, agents that need pandas/numpy + HTTP) get a cleaner default.

## Impact

- Rebuild golden image after merge: `docker build -t mediforce-golden-image:latest -f packages/agent-runtime/container/Dockerfile.base packages/agent-runtime/container/`
- No code change in any existing workflow. JS-based scripts unaffected.
- Image size: +280 KB.

## Test plan

- [ ] CI green (Dockerfile.base isn't covered by vitest; this is a runtime-only change)
- [ ] Manual: `docker build` produces an image where `python3 -c 'import requests; print(requests.__version__)'` succeeds

https://claude.ai/code/session_01TbKjF8JS3MuURqeN1ySwDs

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4bDBvvfNYiEF6S6scmFn3)_