### PR TITLE
fix(platform-ui): default workspace redirect race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Fixed
+- Default workspace auto-redirect race condition — `useAllUserNamespaces` hook had a stale `nsLoading=false` window during uid transition, causing the redirect effect to skip the preferred-workspace check. Users with a default workspace set got stuck on the picker every time ([#489](https://github.com/Appsilon/mediforce/pull/489), proper fix via server-side user preferences tracked in [#486](https://github.com/Appsilon/mediforce/issues/486)).
+- E2E workspace-selection test cleared wrong localStorage key (`workspace-default-key` → `alwaysNamespace`).
+
 ### Added
 - Backlog triage workflow (`apps/backlog-triage/`) — fetches open GitHub issues, an LLM suggests assignments (human or AI workflow) with priority and rationale, a triager reviews and edits in a table, then dispatch PATCHes GitHub and POSTs the Mediforce process-start API for agent delegations.
 - `assignment-table` human-task UI for many-to-one item assignment with per-row assignee/priority/note. Items flow via `task.options` from the previous step; the assignee allowlist and labels live in `task.ui.config`.

--- a/packages/platform-ui/e2e/ui/workspace-selection.journey.ts
+++ b/packages/platform-ui/e2e/ui/workspace-selection.journey.ts
@@ -30,7 +30,7 @@ test.describe('Workspace Selection Journey', () => {
 
     // Clear any stored default workspace so the picker is always shown
     await page.addInitScript(() => {
-      localStorage.removeItem('workspace-default-key');
+      localStorage.removeItem('alwaysNamespace');
     });
 
     await page.goto('/workspace-selection');

--- a/packages/platform-ui/src/app/workspace-selection/page.tsx
+++ b/packages/platform-ui/src/app/workspace-selection/page.tsx
@@ -77,6 +77,7 @@ export default function WorkspaceSelectionPage() {
   const { namespaces, loading: nsLoading } = useAllUserNamespaces(firebaseUser?.uid);
   const [alwaysHandle, setAlwaysHandle] = React.useState<string | null>(null);
   const [ready, setReady] = React.useState(false);
+  const [redirecting, setRedirecting] = React.useState(false);
 
   // Read localStorage once on mount (SSR-safe)
   React.useEffect(() => {
@@ -85,26 +86,31 @@ export default function WorkspaceSelectionPage() {
   }, []);
 
   React.useEffect(() => {
-    if (authLoading || nsLoading || !ready) return;
+    if (authLoading || !ready) return;
 
     if (!firebaseUser) {
       router.replace('/login');
       return;
     }
 
-    // Single namespace — no choice needed, go straight there
-    if (namespaces.length <= 1) {
-      const target = namespaces[0]?.handle;
-      if (target !== undefined) {
-        router.replace(`/${target}`);
-      }
+    // Wait for namespaces to actually load (guards against stale nsLoading=false
+    // during the uid transition in useAllUserNamespaces)
+    if (nsLoading || namespaces.length === 0) return;
+
+    // Preferred workspace — check first so it wins over single-namespace shortcut
+    const preferred = localStorage.getItem(ALWAYS_KEY);
+    const handles = namespaces.map((ns) => ns.handle);
+    if (preferred !== null && preferred !== '' && handles.includes(preferred)) {
+      setRedirecting(true);
+      router.replace(`/${preferred}`);
       return;
     }
 
-    // Preferred workspace set — skip the picker
-    const preferred = localStorage.getItem(ALWAYS_KEY);
-    if (preferred !== null && preferred !== '' && namespaces.some((ns) => ns.handle === preferred)) {
-      router.replace(`/${preferred}`);
+    // Single namespace — no choice needed
+    if (namespaces.length === 1) {
+      setRedirecting(true);
+      router.replace(`/${namespaces[0].handle}`);
+      return;
     }
   }, [authLoading, nsLoading, ready, firebaseUser, namespaces, router]);
 
@@ -123,8 +129,10 @@ export default function WorkspaceSelectionPage() {
   }
 
   const loading = authLoading || nsLoading || !ready;
+  const willRedirect = !loading && alwaysHandle !== null && alwaysHandle !== ''
+    && namespaces.some((ns) => ns.handle === alwaysHandle);
 
-  if (loading || !firebaseUser) {
+  if (loading || !firebaseUser || redirecting || willRedirect) {
     return (
       <div className="flex h-screen items-center justify-center">
         <div className="text-sm text-muted-foreground animate-pulse">Loading…</div>

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -16,11 +16,14 @@ metadata:
 
 If you are the agent who wrote the code in this conversation, **STOP**. Spawn a subagent and have it run this skill. Reviewing your own work in the same context where you wrote it is unreliable — you carry "I just wrote this, it must be good" assumptions that an outside reader doesn't.
 
-From the main thread:
+From the main thread, spawn with `run_in_background: true` so the user isn't blocked:
 
 ```
-Spawn subagent with prompt:
-  Run /self-review on branch <current>. Report findings with verdict.
+Agent({
+  description: "Self-review",
+  prompt: "Run /self-review on branch <current>. Report findings with verdict.",
+  run_in_background: true,
+})
 ```
 
 If you ARE the subagent invoked for this purpose, continue with the checks below. Treat the diff as if a stranger wrote it.


### PR DESCRIPTION
## Problem

Default workspace auto-redirect was broken — users with a default workspace set got stuck on the workspace picker and had to click manually every time.

### Root cause

`useAllUserNamespaces` hook has a transient state during the `uid` transition (from `undefined` to real uid) where `nsLoading=false` with `namespaces=[]`. The redirect effect fired during this window and hit the `namespaces.length <= 1` early return (0 ≤ 1), which **exited without ever reaching the preferred workspace check**.

When namespaces eventually loaded and the effect re-ran, it should have redirected — but the stale-state window was long enough for the full picker to render and become the stable view.

### Why E2E didn't catch it

E2E tests run against local Firebase emulators where Firestore calls resolve in ~1ms. The race window is too short to matter. Playwright's `waitForURL` (10s timeout) patiently waits for the eventual redirect. Real Firestore over network makes the race window much wider.

## Changes

### 1. Fix redirect race condition (`workspace-selection/page.tsx`)
- Guard against empty namespaces (`namespaces.length === 0`) — catches stale hook state and waits for real data
- Check preferred workspace FIRST — preferred wins over single-namespace shortcut (reordered logic)
- Add `redirecting` state — suppresses picker rendering after `router.replace()` is called
- Add `willRedirect` render guard — prevents picker flash by detecting redirect intent in the render path (not just the effect)

### 2. Fix wrong localStorage key in E2E test
- First workspace-selection test cleared `'workspace-default-key'` but actual key is `'alwaysNamespace'`
- Test passed by coincidence (key was never set in that test context)

### 3. Self-review skill: `run_in_background`
- Updated subagent example to use `run_in_background: true` so user isn't blocked during review

## What this doesn't fix

The remaining brief flash ("Loading…" → workspace content) is inherent to client-side redirect. Proper fix is server-side user preferences (read preference on server, `redirect()` before any HTML ships). Tracked in #486.

## Test plan

- [x] Set default workspace via settings toggle → visit `/` → auto-redirects without showing picker
- [ ] No default set → picker shows normally
- [ ] Single namespace, no default → auto-redirects to that namespace
- [ ] Existing E2E `workspace-selection.journey.ts` passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)