### PR TITLE
docs: ADR-0005 headless platform API/UI separation + Phase 2 plan

### DIFF
--- a/docs/adr/0004-scoped-data-access-authorization.md
+++ b/docs/adr/0004-scoped-data-access-authorization.md
@@ -1,6 +1,6 @@
 # 0004 — Authorization enforcement moves to a scoped data-access layer
 
-- **Status:** Accepted
+- **Status:** Finalized (frozen 2026-05-25 per the post-merge note below; this ADR predates the formal `Finalized` status — treat it as locked, changes via supersession only)
 - **Date:** 2026-05-22
 - **Authors:** Marek Rogala (@marekrogala)
 - **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)

--- a/docs/adr/0005-headless-platform-api-ui-separation.md
+++ b/docs/adr/0005-headless-platform-api-ui-separation.md
@@ -1,0 +1,398 @@
+# 0005 — Headless platform: API/UI separation
+
+- **Status:** Accepted (mutable while implementation in progress per the
+  status policy in [`docs/adr/README.md`](./README.md); flips to
+  `Finalized` when the headless migration completes and
+  `headless-migration.md` is deleted)
+- **Date:** 2026-05-25 (sections may be amended; date reflects initial
+  acceptance)
+- **Authors:** Marek Rogala (@marekrogala)
+- **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
+- **Relates to:**
+  - Builds on [ADR-0004](./0004-scoped-data-access-authorization.md)
+    (`CallerScope` + wrapper layer). Partially supersedes ADR-0004 §5
+    when the future audit-wiring phase lands — until then ADR-0004 §5
+    stands as written.
+  - Implementation plan: [`docs/headless-migration.md`](../headless-migration.md)
+    (living phased plan; deleted on migration completion).
+  - Code architecture reference: [`docs/api-architecture.md`](../api-architecture.md).
+
+## Context
+
+[ADR-0004](./0004-scoped-data-access-authorization.md) put workspace
+authorization into a `CallerScope` data-access bag and migrated the
+ten Phase 1 GET endpoints to the handler shape
+`(input, scope) => Promise<output>`. Phase 2 of the headless migration
+([`docs/headless-migration.md`](../headless-migration.md)) is the next
+step — migrating eight lifecycle mutation routes (tasks claim/unclaim/
+complete/resolve, process cancel/resume, cron heartbeat) plus deleting
+the parallel Server Actions that hand-roll the same operations through
+a different code path.
+
+ADR-0004 specified handler signatures and the wrapper layer; it did not
+specify what mutations look like in particular:
+
+- How does a handler signal a 409 to the client?
+- What does the response body look like for a state-transition mutation?
+- Do Server Actions stay alongside the migrated API surface, or get
+  deleted?
+- How does the adapter map typed handler errors to HTTP responses?
+- What happens to the audit emission the Server Actions hand-roll today,
+  given the migration deletes them?
+
+This ADR settles those questions for Phase 2 and locks the patterns
+every subsequent headless-migration phase inherits.
+
+Domain terms (Workflow Run, Human Task, Cowork Session, Audit Event,
+…) are defined in [`CONTEXT.md`](../../CONTEXT.md). Implementation
+terms (handler, adapter, scope, contract) are defined in
+[`api-architecture.md`](../api-architecture.md).
+
+## Decision
+
+### 1. Error envelope: `{ error: { code, message, details? } }`
+
+Every error response from `createRouteAdapter` returns this shape:
+
+```json
+{
+  "error": {
+    "code": "precondition_failed",
+    "message": "Task must be claimed before complete; current: pending",
+    "details": { "taskId": "abc123", "currentStatus": "pending" }
+  }
+}
+```
+
+- `code` is a closed string union (see §3).
+- `message` is human-readable, may be shown to end users.
+- `details` is optional, free-form, useful for Zod issues
+  (`details: ZodIssue[]`) or for entity context (`{ taskId, currentStatus }`).
+
+Chosen over RFC 7807 Problem Details because:
+
+- We don't cross org boundaries yet; URI-as-type identifiers add ceremony
+  without payoff at our current external-API surface.
+- Stripe / Google Cloud / GitHub / Linear all use a `{ error: {...} }`
+  shape. Industry default for typed REST.
+- Existing UI reads `error` as a string; migration is a trivial codemod
+  (`error` → `error.message`).
+- Forward-compatible: if external partners eventually demand RFC 7807,
+  `code` derives a `type` URI mechanically.
+
+Field name `error` (not `status`) because HTTP status code (header)
+already says "this is an error class"; `status` collides with domain
+concepts (`task.status`, `run.status`).
+
+### 2. Typed errors: single `ApiError` class, code as string union
+
+```ts
+export type ApiErrorCode =
+  | 'unauthorized' | 'forbidden' | 'not_found'
+  | 'validation'   | 'precondition_failed' | 'conflict'
+  | 'rate_limited' | 'internal';
+
+export class ApiError extends Error {
+  constructor(
+    readonly code: ApiErrorCode,
+    message: string,
+    readonly details?: unknown,
+  ) { super(message); }
+}
+```
+
+Throw site:
+
+```ts
+if (task.status !== 'claimed') {
+  throw new ApiError(
+    'precondition_failed',
+    `Task must be claimed before complete; current: ${task.status}`,
+    { taskId, currentStatus: task.status },
+  );
+}
+```
+
+Chosen over a subclass hierarchy
+(`PreconditionFailedError extends ApiError`, etc.) because:
+
+- Subclasses don't cross the JSON wire. Server emits the same envelope
+  regardless of class.
+- Subclasses force a code → constructor mapping table on the client
+  side. Single class needs zero mapping (`throw new ApiError(body.error.code, body.error.message, body.error.details)`).
+- IDE narrowing on `instanceof ApiError && err.code === 'X'` is
+  equivalent to the subclass version.
+- ~50 LOC infrastructure total vs ~75 LOC + a third place of drift.
+
+Rejected: Result types (`Result<T, ApiError>`). Throws + a single
+well-known base class is idiomatic in TS; result types add boilerplate
+at every call site.
+
+#### 2a. Throw site
+
+State-machine invariants throw from the **wrapper repository layer** when
+the rule belongs to the entity ("task must be claimed before complete").
+Authorization-membership invariants throw from wrapper too. Cross-entity
+checks (e.g. complete-with-gate-validation needs the parent run) throw
+from the **handler** after a second explicit load via `scope`.
+
+The adapter has one `try/catch` ladder; it never branches on entity type.
+
+### 3. HTTP status mapping
+
+Locked table (extensible by ADR amendment while status `Accepted`):
+
+| code | HTTP | meaning |
+|---|---|---|
+| `unauthorized` | 401 | no caller / token invalid |
+| `forbidden` | 403 | known caller, denied (mutations only; reads use 404 anti-enum per Phase 1) |
+| `not_found` | 404 | resource missing OR caller can't see it (reads — anti-enum) |
+| `validation` | 400 | Zod parse failure on input |
+| `precondition_failed` | 409 | state-machine violation (task not claimed, run not pausable) |
+| `conflict` | 409 | concurrent-write race (stale version, duplicate create) |
+| `rate_limited` | 429 | per-caller rate cap |
+| `internal` | 500 | unexpected; logged + reported |
+
+Both `precondition_failed` and `conflict` map to 409 (HTTP-class
+correct; client branches on `code`, not the status nuance between 409
+and 412). `forbidden` on mutations is 403 — anti-enum payoff lower
+because the caller already proved intent by issuing the write.
+
+### 4. Adapter extension: `ApiError` catch in `createRouteAdapter`
+
+No new `mutationAdapter` helper. Mutations use the same
+`createRouteAdapter` as reads, with an added `ApiError` catch:
+
+```ts
+catch (err) {
+  if (err instanceof ApiError) return jsonError(err);
+  if (err instanceof z.ZodError) {
+    return jsonError(new ApiError('validation', 'Invalid input', err.issues));
+  }
+  console.error(err);
+  return jsonError(new ApiError('internal', 'Internal error'));
+}
+```
+
+`jsonError(err)` reads `err.code` against §3's table and serializes the
+envelope from §1. ~30 LOC added to `route-adapter.ts`; benefits all
+existing Phase 1 GET endpoints retroactively (they get typed errors too
+without rewriting).
+
+### 5. Response shape: entity echo
+
+Every single-entity mutation returns the entity in its post-mutation
+state. Reuse the GET output schema verbatim.
+
+```ts
+// POST /api/tasks/:taskId/claim → { task: HumanTask }
+// POST /api/processes/:instanceId/cancel → { run: WorkflowRun }
+```
+
+Carve-outs by operation kind:
+
+| Op kind | Response shape |
+|---|---|
+| Create | `201 Created` + entity echo (`{ run }`, `{ definition, version }`) |
+| State transition | `200 OK` + entity echo (`{ task }`, `{ run }`) |
+| Bulk | `{ results: Array<{ id, status: 'ok' \| 'error', error? }> }` |
+| Async / queued | `202 Accepted` + `{ jobId, status: 'queued' }` |
+| Streaming (Phase 3 cowork) | SSE response; not entity echo |
+| Operational ping (cron heartbeat) | `{ ok: true, processedAt }` |
+| True DELETE with nothing to say | `204 No Content` |
+
+Industry standard (Stripe / GitHub / Linear / Shopify all do entity
+echo for single-entity mutations). Eliminates "did it work + what's
+the new state" round trips; client never synthesises post-mutation
+state from inputs.
+
+Today's inconsistency
+(`{ ok, taskId, verdict, processInstanceId }` for complete;
+`{ instanceId, status }` for cancel/resume) is hand-rolled drift, not
+a deliberate pattern. Migration normalises in the same PR as each
+endpoint moves; UI callers update inline (~3 components in Phase 2).
+
+### 6. Server Action policy
+
+Per-endpoint judgement. Default: when migrating a mutation, delete the
+parallel Server Action; UI moves to `apiClient.X.Y()`. Keep a Server
+Action only when an actually-used Server Action feature justifies it —
+`<form action={...}>` progressive enhancement, `revalidatePath()`
+post-mutation freshness, or `redirect()`.
+
+Today's actions in `packages/platform-ui/src/app/actions/` use **none**
+of these features (they take `idToken` as an explicit arg, validate
+via `verifyIdToken` — API-route-shaped code wearing a Server Action
+costume). Empirical default for Phase 2: delete all migrated actions.
+
+When kept (future), Server Action is a thin wrapper over the handler:
+
+```ts
+'use server';
+import { claimTaskHandler } from '@mediforce/platform-api';
+
+export async function claimTaskAction(taskId: string) {
+  const result = await claimTaskHandler({ taskId }, await getServerScope());
+  revalidatePath(`/tasks/${taskId}`);
+  return result;
+}
+```
+
+Action body may only call handlers — never raw repos, never Firestore
+SDK, never inline business logic. PR-reviewed; no boundary test until
+drift proves it's needed.
+
+`getServerScope()` constructor shape is deferred until a real
+form-action use case appears (Phase 2 deletes all actions; nothing
+left to build it for).
+
+### 7. Audit emission: handler-resident bridge, repo-resident later
+
+Today's Server Actions hand-roll audit emission inline
+(`auditRepo.append({...})` per action). API routes don't emit at all.
+Phase 2 deletes the actions; without a bridge, audit coverage on these
+mutations would silently regress.
+
+**Phase 2 bridge:** each migrated mutation handler emits audit inline
+via `scope.auditEvents.append({...})` — same shape as today's Server
+Action code, ~6 LOC per handler. Net-zero LOC if the existing emission
+code is moved (not added) from action to handler. Required addition:
+`.append()` method on `AuthorizedAuditEventRepository` (read-only
+today).
+
+**Long-term direction (separate audit-wiring phase, post-headless-
+migration):** audit emission moves to the **persistence boundary
+(repository)** via a `MutationContext` threaded into every raw
+mutation method. Industry-standard transactional outbox pattern
+(Hohpe EIP, Fowler PoEAA audit-log-via-repository-decorator).
+Reasons:
+
+1. Repo is the only layer that sees every write path (HTTP handlers,
+   `WorkflowEngine`, `AgentRunner`, `container-worker`, future MCP).
+   Handler-resident silently misses non-HTTP writers — known gap.
+2. Atomicity belongs to the persistence layer. Postgres
+   ([ADR-0001](./0001-firestore-to-postgres.md)) makes entity-write +
+   audit-row-write transactional for free. Firestore era is best-effort
+   dual-write with documented gap.
+3. Audit-row-write is part of "how persistence happens", not "what the
+   user requested." Mixing it into handlers leaks infrastructure into
+   orchestration.
+
+This is captured in
+[`headless-migration.md` §"Captured for later"](../headless-migration.md);
+when that phase ships, this ADR partially supersedes ADR-0004 §5
+(narrowing "wrappers never depend on other wrappers" to exclude
+audit infrastructure).
+
+**Phase 2 audit handler code** is throwaway bridge. Recognisable
+pattern, easy to find-and-delete during the audit-wiring phase.
+
+Closed action-name set for Phase 2 (extensible by amendment):
+
+- `task.claimed`, `task.unclaimed`, `task.completed`, `task.resolved`
+- `run.cancelled`, `run.resumed`
+- `cron.heartbeat` (operational; `@no-audit` exemption — no entity
+  mutation)
+
+### 8. Wrapper layer additions for Phase 2
+
+`AuthorizedHumanTaskRepository` already has `claim` / `complete` /
+`cancel`. Phase 2 adds:
+
+- `HumanTaskRepository.unclaim(taskId, userId)` + wrapper passthrough
+  (no method today; current `unclaimTask` Server Action writes Firestore
+  directly).
+- `AuthorizedAuditEventRepository.append(event)` — write-side method
+  (read-only today).
+
+`AuthorizedWorkflowRunRepository` has `getById` / `list` / `update` only.
+Phase 2 adds:
+
+- `ProcessInstanceRepository.cancel(id, reason)` + wrapper passthrough.
+- `ProcessInstanceRepository.resume(id)` + wrapper passthrough.
+
+These are domain methods on the wrapper, mirroring how
+`AuthorizedHumanTaskRepository.claim()` was already shaped.
+
+## Considered alternatives
+
+- **RFC 7807 Problem Details** for error envelope. Rejected for now —
+  no external API surface yet; standard pays back when partners
+  consume. Forward-compatible: `code` → `type` URI conversion is
+  mechanical when needed.
+- **Subclass hierarchy** for typed errors. Rejected — subclasses don't
+  cross the JSON wire; force a code → constructor mapping table on the
+  client side; no real ergonomic gain over a single class.
+- **Result types** instead of throws. Rejected — adds boilerplate at
+  every call site; idiomatic TS uses throws + well-known base classes.
+- **Adapter-orchestrated audit** (mutation adapter takes an `audit:`
+  config). Rejected — only covers the HTTP path; misses engine +
+  worker writers; the audit-wiring phase will move audit to the repo
+  layer anyway, where it covers everyone.
+- **Handler-resident audit as permanent home.** Rejected as long-term
+  — same gap as adapter-orchestrated. Acceptable as Phase 2 bridge
+  only because the existing Server Action emission is being moved
+  rather than newly introduced.
+- **Keep Server Actions alongside the API.** Rejected — empirical:
+  today's actions use zero Server Action features. They are API-route-
+  shaped code in a Server Action costume, paying the auth-bifurcation
+  cost (cookie session vs Bearer) and losing Zod contract + URL
+  surface, for no benefit.
+- **`mutationAdapter` helper** distinct from `createRouteAdapter`.
+  Rejected — one adapter with an `ApiError` catch covers reads and
+  mutations; second helper adds vocabulary without behaviour change.
+- **Minimal-ack response shape** (`{ ok: true }`). Rejected — forces a
+  refetch round trip and creates race windows where the client renders
+  stale state. Industry standard is entity echo.
+- **Single mutation `/complete` route per body variant** vs
+  **multiple sub-routes**. Chose discriminated-union body schema on a
+  single `/complete` route — same underlying operation (`resolveTask`),
+  different payload kind discriminated by `kind`.
+
+## Consequences
+
+- Phase 2 mutation handlers share one signature
+  (`(input, scope) => Promise<output>`) and one error idiom (throw
+  `ApiError`). Phase 2.5 and Phase 3 mutations inherit unchanged.
+- `createRouteAdapter` becomes the single chokepoint for input parsing,
+  scope construction, error mapping, and output serialization across
+  reads and mutations.
+- The API now has a documented, typed contract for failure modes that
+  external consumers (CLI today; MCP / partners later) can rely on
+  without string-matching.
+- Server Action deletion in Phase 2 removes 8 of 6 hand-rolled
+  mutations from `app/actions/`; remaining files cover Phase 2.5 /
+  Phase 3 scope and stay until their endpoints migrate. By end of
+  Phase 3 the `app/actions/` directory is empty or gone.
+- Audit emission has a temporary handler-resident location for Phase 2;
+  the audit-wiring phase relocates it to the repository boundary
+  uniformly across HTTP, engine, and worker writers.
+- The headless story strengthens: every mutation has one URL, one
+  contract, one typed client method, one error shape. CLI, MCP, future
+  partner integrations consume the same surface as the UI.
+
+## Out of scope
+
+- **Audit-wiring phase.** Repo-resident emission via `MutationContext`
+  is scoped to its own phase post-headless-migration. This ADR captures
+  the direction; the implementation ADR is separate.
+- **`getServerScope()` shape.** Deferred until a real Server Action
+  use case appears. Phase 2 deletes all actions.
+- **Phase 3 streaming contract.** Cowork chat/message/finalize needs
+  an SSE adapter and a streaming handler shape — design pass deferred
+  to Phase 3, may produce ADR-0006.
+- **Phase 7 deploy split** (separate API server). Adapter abstraction
+  is forward-compatible (`createHonoAdapter` etc.) but the decision to
+  split is its own ADR.
+- **NextAuth migration** (ADR-0002). `CallerIdentity` shape stays;
+  the auth carrier change (Bearer ID token → cookie session) is
+  orthogonal.
+- **Idempotency keys.** Phase 2 mutations are naturally idempotent
+  (state transitions return 409 on repeat). Phase 2.5 create endpoints
+  (`POST /processes`, `POST /workflow-definitions`) revisit; not
+  decided here.
+
+## Open questions
+
+(None blocking Phase 2. Section reserved for amendments while the ADR
+is still `Accepted`.)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,6 +3,20 @@
 Short documents capturing significant architectural decisions, the rejected
 alternatives, and the rationale.
 
+**How to read these.** ADRs are inputs to your judgement, not scripture. We
+wrote them; we can be wrong; the codebase moves and so does the team's
+understanding. When a prior ADR's constraint would force a worse design, the
+right move is to question it — supersede in part, supersede in full, or
+amend in place if still `Accepted`. Defer to a past ADR only after you've
+checked it still makes sense given what you know today.
+
+**Default to standard solutions.** Most problems we hit at the API,
+persistence, and HTTP-error layers are well-trodden — outbox patterns,
+repository decorators, RFC-aligned error envelopes, transactional audit
+trails. Reach for the boring industry answer before inventing a Mediforce-
+specific one. Custom is justified only when the standard answer demonstrably
+doesn't fit the constraint.
+
 ## Process
 
 1. Propose an ADR as a PR (status: `Proposed`). Discussion happens in PR review.
@@ -30,12 +44,24 @@ Sequential, zero-padded to four digits (`0001`, `0002`, …). Never reuse a numb
 ## Status values
 
 - `Proposed` — under discussion in a PR
-- `Accepted` — merged, decision is binding
+- `Accepted` — merged; amendments allowed as implementation surfaces
+  things the original decision didn't anticipate. Each amendment is a
+  normal PR-reviewed change, no extra ceremony
+- `Finalized` — implementation done; locked. Changes from here happen
+  via supersession only
+- `Superseded by NNNN` — fully replaced by a later ADR
+- `Partially superseded by NNNN` — specific sections replaced; the rest
+  is still binding. Predecessor stays unedited; only its status field
+  changes. The successor names which sections it supersedes
 - `Deprecated` — no longer applies, kept for history
-- `Superseded by NNNN` — replaced by a later ADR
+
+When promoting `Accepted → Finalized`, do it in whatever PR wraps the
+implementation. An optional `## Implementation notes (frozen YYYY-MM-DD)`
+appendix can capture what actually shipped vs the original decision body.
 
 ## Index
 
 - [0001 — Move primary datastore from Firestore to self-hosted Postgres](./0001-firestore-to-postgres.md) (+ [PLAN](./PLAN-0001.md))
 - [0002 — Move authentication from Firebase Auth to NextAuth (Auth.js v5)](./0002-firebase-auth-to-nextauth.md) (+ [PLAN](./PLAN-0002.md))
 - [0004 — Authorization enforcement moves to a scoped data-access layer](./0004-scoped-data-access-authorization.md)
+- [0005 — Headless platform: API/UI separation](./0005-headless-platform-api-ui-separation.md)

--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -1,0 +1,196 @@
+# Mediforce API code architecture
+
+How API code is organised across packages, what the layers do, and why
+the headless platform separates them this way. Companion to product-level
+[`architecture.md`](./architecture.md) (which documents Steps, Processes,
+Autonomy levels — the *what*), this doc covers the *how*: the runtime
+shape of code that serves an API request.
+
+> Living doc. Architecture decisions land in
+> [`docs/adr/`](./adr/); this file describes the current implementation so
+> contributors can navigate it without re-deriving the pattern. Update
+> alongside ADR changes.
+
+## The split
+
+Two layers with different concerns:
+
+- **Handler** — pure, framework-free function. `(input, scope) => Promise<output>`.
+  Knows nothing about HTTP, Next.js, or JSON. Pure business logic over a
+  typed input and scoped data-access. Lives in
+  `packages/platform-api/src/handlers/`.
+
+- **Adapter** — boundary translator between HTTP-land and handler-land.
+  Takes a `NextRequest`, parses JSON body + path params into the input
+  shape, builds `scope` from the authenticated caller, calls the handler,
+  serializes output back to a `NextResponse`. Errors become HTTP status
+  codes. Lives in `packages/platform-ui/src/lib/route-adapter.ts`
+  (`createRouteAdapter`).
+
+```
+HTTP world                     Adapter                    Handler world
+─────────────                  ───────                    ─────────────
+NextRequest                    parse JSON                 input: ParsedInput
+URL path params       ─────►   extract path     ─────►    scope: CallerScope
+Authorization header           build scope                ↓
+                                                          (pure logic)
+                                                          ↓
+NextResponse (JSON)   ◄─────   serialize         ◄─────   output: TypedOutput
+HTTP status code               map ApiError → status      throw ApiError
+```
+
+This is the textbook ports-and-adapters / hexagonal split. The handler is
+the application core; the adapter is one of N possible presentation
+layers. Same handler, different adapter per consumer.
+
+## Why headless
+
+Today's adapters:
+
+- `createRouteAdapter` → Next.js route file mount. (Only one in use.)
+
+Forward-looking adapters the same handler can support without rewriting:
+
+- `createHonoAdapter` → standalone HTTP server (Hono, Fastify, etc.) for
+  a Phase 7 split deploy.
+- `createCliCommand` → direct in-process invocation from
+  `packages/cli/`, skipping the HTTP round-trip when the caller is the
+  same machine as the server. *(Today the CLI uses the `Mediforce` HTTP
+  client class instead — over HTTP to localhost. Direct invocation is
+  available later if the cost of the round-trip matters.)*
+- `createMcpTool` → MCP server tool definition wrapping the handler.
+
+Handler stays one file. New consumers wrap it from outside.
+
+## The pieces in code
+
+| Concept | Package | File / dir | Purpose |
+|---|---|---|---|
+| **Contract** | `@mediforce/platform-api` | `contract/<domain>.ts` | Zod input + output schemas. The API surface. |
+| **Handler** | `@mediforce/platform-api` | `handlers/<domain>/<name>.ts` | Pure function `(input, scope) => output`. Throws typed `ApiError`. |
+| **Scope** | `@mediforce/platform-api` | `repositories/caller-scope.ts` + `authorized-*-repository.ts` | Per-request data-access bag with workspace authorization baked in. See [ADR-0004](./adr/0004-scoped-data-access-authorization.md). |
+| **Adapter** | `@mediforce/platform-ui` | `lib/route-adapter.ts` | `createRouteAdapter(schema, fromReq, handler)` → Next.js route fn. Also `listAdapter` / `getByIdAdapter` for trivial reads. |
+| **Route file** | `@mediforce/platform-ui` | `app/api/<path>/route.ts` | ~15 LOC. Imports contract + handler, wires the adapter. |
+| **Client (typed)** | `@mediforce/platform-api/client` | `Mediforce` class | Browser + Node + CLI consume the same contract. Parses responses through output schemas. |
+
+## Where decisions live
+
+- [`docs/adr/0004-scoped-data-access-authorization.md`](./adr/0004-scoped-data-access-authorization.md)
+  — `CallerScope` + `Authorized<Entity>Repository` wrappers; why
+  authorization moved out of handlers and into the data-access boundary.
+- [`docs/adr/0005-headless-platform-api-ui-separation.md`](./adr/0005-headless-platform-api-ui-separation.md)
+  — Mutation handler contract: error envelope, typed `ApiError`, HTTP
+  status mapping, response shape, Server Action policy, audit-bridge.
+- [`docs/headless-migration.md`](./headless-migration.md)
+  — Living phased plan executing the separation. Gets deleted when the
+  migration completes; ADRs persist.
+
+## Adapter responsibilities, in detail
+
+`createRouteAdapter`:
+
+1. Parse the `NextRequest` body / query / path params via the contract's
+   input schema. Zod failure → `400` with the validation issues in
+   `error.details`.
+2. Resolve `CallerIdentity` (currently from Firebase ID token middleware
+   set by [Filip's PR #220]; post-NextAuth ADR-0002 from cookie session).
+3. Build `CallerScope` via `createCallerScope(rawServices, caller)`.
+4. Invoke the handler `(input, scope) => Promise<output>`.
+5. Catch `ApiError` → status from the mapping table (see ADR-0005
+   §status mapping). Catch unexpected → `500` + `console.error`.
+6. Serialize the handler's output to `NextResponse.json(output)`.
+
+The route file is mechanical:
+
+```ts
+import { ClaimTaskInputSchema, claimTaskHandler } from '@mediforce/platform-api';
+import { createRouteAdapter } from '@/lib/route-adapter';
+
+export const POST = createRouteAdapter(
+  ClaimTaskInputSchema,
+  (req) => ({ taskId: req.params.taskId, ...await req.json() }),
+  claimTaskHandler,
+);
+```
+
+Trivial reads skip the handler file entirely via `listAdapter` /
+`getByIdAdapter` — see ADR-0004 §10.
+
+## What never goes in a handler
+
+- `NextRequest`, `NextResponse`, `cookies()`, any Next.js import.
+- Firestore / Firebase Admin SDK imports.
+- Raw repositories from `@mediforce/platform-core/interfaces`.
+  Handler receives `CallerScope` only; the static guard
+  `no-raw-repo-imports.test.ts` (ADR-0004 §9) enforces this in CI.
+
+## What never goes in an adapter
+
+- Business logic. Adapter is pure plumbing.
+- State-machine validation. Lives in the handler or the entity-aware
+  wrapper repo.
+- Audit emission. Today handler-resident; future repo-resident (see
+  "Captured for later" in `headless-migration.md`).
+
+## The handler signature, illustrated
+
+```ts
+// contract/tasks.ts
+export const ClaimTaskInputSchema = z.object({ taskId: z.string().min(1) });
+export const ClaimTaskOutputSchema = z.object({ task: HumanTaskSchema });
+
+// handlers/tasks/claim-task.ts
+export const claimTaskHandler = async (
+  input: ClaimTaskInput,
+  scope: CallerScope,
+): Promise<ClaimTaskOutput> => {
+  if (!scope.caller.userId) {
+    throw new ApiError('forbidden', 'User identity required');
+  }
+  const task = await scope.humanTasks.claim(input.taskId, scope.caller.userId);
+  await scope.auditEvents.append({
+    action: 'task.claimed',
+    actorId: scope.caller.userId,
+    /* … see ADR-0005 audit-bridge … */
+  });
+  return { task };
+};
+```
+
+The handler reads as plain code: type-checked input, type-checked output,
+typed errors, scoped data-access. Nothing else.
+
+## Testing layers
+
+See [`headless-migration.md`](./headless-migration.md) §Testing strategy
+for the full pyramid. Short version:
+
+- **Contract** — Zod schema invariants. <50ms.
+- **Handler** — pure function against `InMemory*Repository` from
+  `@mediforce/platform-core/testing`. No mocks.
+- **Adapter** — `createRouteAdapter` wiring + error mapping. Sampled per
+  route.
+- **Cross-layer integration** — apiClient ↔ adapter ↔ handler ↔ repo,
+  in-process via loopback `apiFetch`. One per major feature.
+- **Structural guards** — `api-boundaries.test.ts`,
+  `no-raw-repo-imports.test.ts` (ADR-0004), forthcoming
+  mutation-pattern tests (ADR-0005).
+
+## Glossary
+
+Domain terms (Workflow Run, Human Task, Cowork Session, …) are defined
+in [`CONTEXT.md`](../CONTEXT.md). This doc uses them as given; it
+documents implementation concepts only.
+
+Implementation concepts introduced here that aren't in `CONTEXT.md`:
+
+- **Adapter** — boundary translator between transport (HTTP) and
+  framework-free handler.
+- **Handler** — pure framework-free function serving one API operation.
+- **Scope** (a.k.a. `CallerScope`) — per-request data-access bag with
+  workspace authorization wrappers around raw repositories. ADR-0004.
+- **Contract** — Zod input + output schema for one API operation; the
+  source of truth for the API.
+
+These are code-architecture vocabulary, not domain vocabulary — they
+deliberately live outside `CONTEXT.md`.

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -211,39 +211,316 @@ Phase 1 ended with namespace authorization threaded **explicitly** through every
 
 **Status:** in design review via the `/grill-with-docs` skill, stress-testing the working hypothesis against the existing domain model, ADRs, and Mediforce-specific concerns (pharma tenant isolation, NextAuth migration, per-user API keys). See the spawned design session.
 
-### Phase 2 — Migrate mutations (grouped by domain)
+### Phase 2 — Lifecycle mutations (narrow)
 
-**Prerequisite:** Phase 1.7 closed — authorization architecture decision merged. Mutation handlers are written against the decided shape, not retrofitted.
+**Prerequisite:** Phase 1.7 closed — [ADR-0004](./adr/0004-scoped-data-access-authorization.md) merged in #463 (2026-05-25). Mutation handlers ship with the `(input, scope: CallerScope)` signature from day one; no raw repo access.
 
-Harder than GETs because each mutation has a state machine and side effects. Break into small PRs.
+**Scope note (rewritten 2026-05-25):** the original Phase 2 list (PR #445 / branch `claude/cool-jennings-035e0c`) bundled tasks + process + definitions + configs + cron into one phase. Three things changed since:
+1. Mutation surface is wider in practice (~30 routes, not 14). Agents+MCP+OAuth subroutes, admin oauth-providers/tool-catalog/docker-images, users invite, workflow-definitions archive/copy/version-archive landed after the plan was written.
+2. ADR-0004 wrapper layer is new — mutation pattern is unproven. Validate on uniform state-machine cases before tackling cross-entity work (archive cascades, copy across versions).
+3. `configs` was deleted on main in #292; the original bullet is dead.
 
-**Status note**: PR #445 (the first Phase 2 batch) was closed because it
-was stacked on #256 (the original Phase 1 PR without caller threading) —
-copy-pasting the same auth gap into every mutation handler. Redo from
-branch `claude/cool-jennings-035e0c` (preserved) on top of #450 once it
-lands: every mutation handler picks up the `caller: CallerIdentity` third
-argument and the `auth-coverage.test.ts` guard runs against the new files
-automatically.
+So Phase 2 narrows to **uniform lifecycle mutations** — same handler shape (load → gate → state transition → write → audit), no cross-entity cascades, no special namespace semantics. The wider surface moves to **Phase 2.5**, planned against the lessons Phase 2 produces.
 
-- **Tasks lifecycle**: `POST /api/tasks/:id/claim`, `POST /api/tasks/:id/complete`, `POST /api/tasks/:id/resolve`
-- **Process lifecycle**: `POST /api/processes`, `POST /api/processes/:id/advance`, `POST /api/processes/:id/cancel`, `POST /api/processes/:id/resume`, `POST /api/processes/:id/steps/:stepId/retry`
-- **Definitions & configs**: `PUT /api/definitions`, `POST /api/workflow-definitions`, `POST /api/agents`, `POST /api/configs`, `PUT /api/configs`
-- **Cron heartbeat**: `POST /api/cron/heartbeat`
+**In scope:**
+
+| Endpoint | Domain | Shape |
+|---|---|---|
+| `POST /api/tasks/:taskId/claim` | tasks | scope.tasks.claim(taskId, caller) |
+| `POST /api/tasks/:taskId/complete` | tasks | scope.tasks.complete(taskId, data) — validates against parent run's step gate |
+| `POST /api/tasks/:taskId/resolve` | tasks | scope.tasks.resolve(taskId, verdict) |
+| `POST /api/processes/:instanceId/cancel` | processes | scope.runs.cancel(id, reason) |
+| `POST /api/processes/:instanceId/resume` | processes | scope.runs.resume(id) |
+| `POST /api/cron/heartbeat` | cron | `caller.isSystemActor` bypass; no scope gate |
+
+**Out of Phase 2 (moved to Phase 2.5 or Phase 3):**
+
+- `POST /api/processes` (create new run) → Phase 2.5 — workspace-write gate, trigger payload validation, idempotency design needed.
+- `POST /api/processes/:id/advance`, `POST /api/processes/:id/run`, `POST /api/processes/:id/steps/:stepId/retry` → **Phase 3** — orchestrates `WorkflowEngine` + `AgentRunner`, spawns Docker, fire-and-forget side effects. Needs its own design pass (sync vs queued execution).
+- All cowork (`chat`/`message`/`finalize`) → **Phase 3** — SSE adapter unsolved.
+
+**Already shipped (post-original-plan):** `POST /api/model-registry/sync`, `POST /api/model-registry/rankings`, `GET /api/model-registry`, `GET /api/model-registry/:id` — five model-registry endpoints landed under `packages/platform-api/src/handlers/models/` ahead of the formal Phase 2 plan because that domain was being touched anyway. Treat them as Phase 2 reference shape for future mutations.
 
 **Additional concerns per mutation:**
 
-- Response shape often echoes the corresponding GET — reuse the schema.
-- Fire-and-forget internal fetches (`getAppBaseUrl()` callers) keep working because we stay on same-origin deploy.
-- State-machine invariants surface as additional contract refines (e.g. "cannot complete a task that is not claimed").
+- **Response shape: entity echo.** Every single-entity mutation returns
+  the entity in its post-mutation state — `POST /api/tasks/:id/claim` →
+  `{ task: HumanTask }`, `POST /api/processes/:id/cancel` →
+  `{ run: WorkflowRun }`. Reuse the GET output schema verbatim. This is
+  the REST textbook answer (Stripe, GitHub, Linear, Shopify all do it).
+  Eliminates "did it work + what's the new state" round trips, kills
+  drift between client-synthesised state and server truth.
 
-**PR sizing**: one lifecycle domain per PR (all Tasks mutations, all Process mutations, all Definitions). Typically 3-5 endpoints.
+  Carve-outs (use when they apply, not by default):
+  | Op kind | Response shape |
+  |---|---|
+  | Create | `201 Created` + entity echo (`{ run }`, `{ definition, version }`) |
+  | State transition | `200 OK` + entity echo (`{ task }`, `{ run }`) |
+  | Bulk | `{ results: Array<{ id, status: 'ok' \| 'error', error? }> }` |
+  | Async / queued | `202 Accepted` + `{ jobId, status: 'queued' }` |
+  | Streaming (Phase 3 cowork) | SSE response, not entity echo |
+  | Operational ping (cron heartbeat) | `{ ok: true, processedAt }` |
+  | True DELETE with nothing to say | `204 No Content` |
 
-**Pause-safe**: yes — same as Phase 1, unmigrated mutations stay on their inline Next.js handlers.
+  Today's inconsistency (`{ ok, taskId, verdict, processInstanceId }` for
+  complete; `{ instanceId, status }` for cancel/resume) is hand-rolled
+  drift, not a deliberate pattern. Migration normalises in the same PR
+  as each endpoint moves; UI callers update inline (~3 components in
+  Phase 2).
 
-**Open questions to settle before starting**:
-- How do we encode state-machine preconditions in the contract? Candidate: extra Zod `.refine()` on the output of a prior GET shape, combined with repo-level assertions throwing a typed `PreconditionFailedError` that the adapter maps to 409.
-- Do we still have separate Server Actions and API routes for the same mutation, or does migrating the handler let us delete the server action? (Next.js-specific concerns like `revalidatePath` stay behind.)
-- Idempotency keys for operations like `POST /api/processes` — worth adding now or later?
+- State-machine invariants surface as typed errors (`ApiError` with `code: 'precondition_failed'` → 409). See the **error contract** open question below.
+- **Audit emission — bridge.** Today's Server Actions hand-roll audit
+  (`auditRepo.append({...})` inline in each action). API routes don't
+  emit. Deleting the actions during Phase 2 would erase the only existing
+  audit coverage for these mutations. To avoid a compliance regression
+  during the gap between Phase 2 and the future audit-wiring phase
+  (see "Captured for later" below), each new Phase 2 mutation handler
+  emits audit inline via `scope.auditEvents.append({...})` — same shape
+  as today's Server Action code, ~6 LOC per handler. This is throwaway
+  bridge code: the audit-wiring phase rewrites to repo-resident
+  `MutationContext` and removes the handler-level emits. Add a `.append()`
+  method to `AuthorizedAuditEventRepository` (read-only today) to enable
+  this.
+
+**Server Action policy.** Per-endpoint judgement. Default: when migrating
+a mutation, delete the parallel Server Action; UI moves to
+`apiClient.X.Y()`. Keep a Server Action only when an actually-used Server
+Action feature justifies it — `<form action={...}>` progressive
+enhancement, `revalidatePath()` post-mutation freshness, or
+`redirect()`. Today's actions in `src/app/actions/` use **none** of
+these features (they take `idToken` as an explicit arg and call
+`verifyIdToken`, i.e. API-route-shaped code wearing a Server Action
+costume); the empirical default is therefore "delete". When a future
+mutation genuinely needs a Server Action feature, the policy doesn't
+forbid adding a thin wrapper:
+
+```ts
+'use server';
+export async function claimTaskAction(taskId: string) {
+  const result = await claimTaskHandler({ taskId }, await getServerScope());
+  revalidatePath(`/tasks/${taskId}`);
+  return result;
+}
+```
+
+Action file may only call handlers — never raw repos, never Firestore
+SDK, never inline business logic. Enforced by PR review; no boundary
+test until drift proves it's needed.
+
+**Phase 2 Server Action deletions** (concrete list, all in
+`packages/platform-ui/src/app/actions/`):
+
+| File | Functions to delete in Phase 2 |
+|---|---|
+| `tasks.ts` | `claimTask`, `unclaimTask`, `completeTask`, `completeParamsTask`, `completeUploadTask`, `completeAssignmentTask` (all 6) |
+| `processes.ts` | `cancelProcessRun`, `resumeProcessRun` (Phase 2 lifecycle scope) |
+
+Phase 2.5 / Phase 3 picks up the rest (`processes.ts`:
+`startWorkflowRun` / `retryFailedStep` / `archiveProcessRun` /
+`bulkCancelProcessRuns` / `bulkArchiveProcessRuns`; whole files for
+`cowork.ts` / `definitions.ts` / `namespace-secrets.ts` /
+`workflow-secrets.ts`). Surfaced gap: `unclaimTask` currently writes
+Firestore directly (`db.collection('humanTasks').doc(taskId).update(...)`),
+bypassing the repo — Phase 2 must add an `unclaim` method to
+`HumanTaskRepository` + wrapper to give the migrated handler a
+non-bypass path.
+
+**PR sizing**: one lifecycle domain per PR. Five PRs total — tasks (3 endpoints), process-state (2), cron (1, trivial). 1-2 week phase.
+
+**Pause-safe**: yes — same as Phase 1.
+
+### Phase 2 — Implementation tracker
+
+Locked design decisions live in
+[ADR-0005](./adr/0005-headless-platform-api-ui-separation.md);
+code-architecture concepts in [`api-architecture.md`](./api-architecture.md).
+This tracker is the entry point for a fresh session picking up Phase 2.
+
+**Two PRs, sequential.** Pattern is unproven (wrapper layer has only
+served GETs); smallest endpoint first to validate it, then the rest.
+
+#### PR1 — Cron heartbeat + adapter `ApiError` extension
+
+**Scope.** One endpoint (`POST /api/cron/heartbeat`) plus the
+`createRouteAdapter` extension that every subsequent mutation depends
+on.
+
+**Files to touch:**
+- `packages/platform-api/src/contract/cron.ts` — new. `HeartbeatInputSchema`
+  (empty / trivial), `HeartbeatOutputSchema` (`{ ok, processedAt }`).
+- `packages/platform-api/src/handlers/cron/heartbeat.ts` — new. System-
+  actor bypass: `if (!scope.caller.isSystemActor) throw new ApiError('forbidden', ...)`.
+  No audit emission (`@no-audit` operational exemption per ADR-0005 §7).
+- `packages/platform-api/src/handlers/cron/__tests__/heartbeat.test.ts`
+  — new. Contract + handler tests against in-memory scope.
+- `packages/platform-api/src/errors.ts` — extend with the `ApiError`
+  class + `ApiErrorCode` union (replaces today's narrower error
+  helpers if any).
+- `packages/platform-ui/src/lib/route-adapter.ts` — extend with
+  `ApiError` catch + status-mapping table per ADR-0005 §3/§4.
+- `packages/platform-ui/src/lib/__tests__/route-adapter.test.ts` —
+  extend with tests for each code → status mapping.
+- `packages/platform-ui/src/app/api/cron/heartbeat/route.ts` —
+  replace inline handler with `createRouteAdapter` call.
+- `packages/platform-api/src/client/mediforce.ts` — add
+  `mediforce.cron.heartbeat()` method.
+
+**Server Actions deleted:** none in this PR.
+
+**New routes added:** none (heartbeat route already exists).
+
+**Test layers:** contract + handler + adapter + 1 cross-layer integration.
+
+**Exit criteria:**
+- `POST /api/cron/heartbeat` returns `{ ok: true, processedAt }` on
+  system-actor caller; `403` + ApiError envelope otherwise.
+- All `ApiError` codes mapped to correct HTTP status in adapter tests.
+- `api-boundaries.test.ts` + `no-raw-repo-imports.test.ts` pass.
+- Existing GET endpoints retroactively return the new error envelope
+  (no regression — they previously returned `{ error: string }`; now
+  return `{ error: { code, message } }`; UI codemod `err.error` →
+  `err.error.message` lands same PR).
+
+#### PR2 — Tasks + Process state lifecycle mutations
+
+**Scope.** Six endpoints + audit-bridge wiring + Server Action
+deletions.
+
+Endpoints:
+- `POST /api/tasks/:taskId/claim` — migrate existing route.
+- `POST /api/tasks/:taskId/unclaim` — **new route** (no existing
+  route today; current functionality is Server Action only).
+- `POST /api/tasks/:taskId/complete` — migrate. Body uses discriminated
+  union over four kinds (`verdict | params | upload | assignment`)
+  covering today's `completeTask`, `completeParamsTask`,
+  `completeUploadTask`, `completeAssignmentTask` Server Actions.
+- `POST /api/tasks/:taskId/resolve` — migrate.
+- `POST /api/processes/:instanceId/cancel` — migrate.
+- `POST /api/processes/:instanceId/resume` — migrate.
+
+**Files to touch (per endpoint):**
+- `packages/platform-api/src/contract/<tasks|processes>.ts` — add
+  input + output schemas (output reuses entity schemas per ADR-0005 §5).
+- `packages/platform-api/src/handlers/<tasks|processes>/<name>.ts` —
+  new handler. Calls `scope.X.method()`, emits audit via
+  `scope.auditEvents.append({...})` (bridge per ADR-0005 §7).
+- `packages/platform-api/src/handlers/<tasks|processes>/__tests__/<name>.test.ts`
+  — contract + handler tests.
+- `packages/platform-ui/src/app/api/<path>/route.ts` — replace inline
+  with `createRouteAdapter`.
+- `packages/platform-api/src/client/mediforce.ts` — add typed methods.
+
+**Server Actions deleted (move, don't add):**
+- `packages/platform-ui/src/app/actions/tasks.ts` — delete all six
+  (`claimTask`, `unclaimTask`, `completeTask`, `completeParamsTask`,
+  `completeUploadTask`, `completeAssignmentTask`). Move audit-emission
+  code into the corresponding handlers.
+- `packages/platform-ui/src/app/actions/processes.ts` — delete
+  `cancelProcessRun` and `resumeProcessRun`. Move audit code. Leave
+  `startWorkflowRun`, `retryFailedStep`, `archiveProcessRun`,
+  `bulkCancelProcessRuns`, `bulkArchiveProcessRuns` in place
+  (Phase 2.5 / Phase 3 scope).
+
+**UI callers to update:**
+- `packages/platform-ui/src/components/tasks/claim-button.tsx` —
+  replace `claimTask` / `unclaimTask` action imports with
+  `mediforce.tasks.claim()` / `mediforce.tasks.unclaim()`.
+- Components calling the other `complete*` actions — same pattern;
+  body shape becomes discriminated union (`{ kind: 'verdict', ... }`,
+  etc.).
+- Process detail components calling `cancelProcessRun` /
+  `resumeProcessRun` — same.
+
+**Repository layer additions:**
+- `HumanTaskRepository.unclaim(taskId, userId)` — new method on both
+  the interface and `InMemoryHumanTaskRepository` and the Firestore
+  impl. `AuthorizedHumanTaskRepository.unclaim()` wrapper passthrough
+  (calls `assertCanMutate` first like the existing `claim`).
+- `ProcessInstanceRepository.cancel(id, reason)` — new method on
+  interface + in-memory + Firestore. `AuthorizedWorkflowRunRepository.cancel()`
+  wrapper.
+- `ProcessInstanceRepository.resume(id)` — same.
+- `AuthorizedAuditEventRepository.append(event)` — new write method
+  on the wrapper (read-only today). Delegates to raw `auditRepo.append()`.
+
+**Test layers:** contract + handler + adapter + hook update + journey
+test for at least one tasks flow (claim → complete) and one process
+flow (cancel).
+
+**Exit criteria:**
+- All eight Server Actions deleted; `app/actions/tasks.ts` empty
+  (delete file); `app/actions/processes.ts` retains only the five
+  out-of-Phase-2 functions.
+- UI callers updated to use `mediforce` client; `apiFetch` direct
+  calls for these mutations removed.
+- Audit emission preserved (move-not-add): the AuditEvent rows
+  produced before and after Phase 2 are identical in actor/action/
+  description/snapshots for the eight migrated mutations.
+- `api-boundaries.test.ts` + `no-raw-repo-imports.test.ts` +
+  Phase 2 audit-coverage structural guard pass.
+- Discriminated-union `/complete` body validates all four variants
+  end-to-end (contract test).
+- E2E journey for claim→complete still green.
+
+**Open questions to settle before starting** (carried forward + new):
+
+- **Error contract schema** (from Phase 1 gap list — now blocking). Mutations introduce 409 (precondition_failed), 412 (state-machine), 422 (validation-with-context). Today's `{ error: string }` shape can't carry a discriminant for the client. Proposal: `{ error: { code: 'precondition_failed' | 'not_found' | ..., message: string, details?: unknown } }`. Decide before any mutation handler ships.
+- **State-machine precondition encoding.** Two layers: contract refines (input shape — "verdict must be `approve`/`reject`") + repo-level typed errors (`TaskNotClaimedError`, `TaskAlreadyCompletedError`) that the adapter maps to 409 with the agreed error code. Stay out of Zod refines for cross-entity invariants.
+- **Server Actions vs API routes.** Many tasks/process mutations have parallel Server Actions in `src/app/actions/*.ts` for form posts (`revalidatePath`). Decide per endpoint: delete the action (UI moves to `apiClient.tasks.claim()` + manual revalidation), or keep the action as a thin wrapper around the handler. Default: delete unless `revalidatePath` is load-bearing.
+- **Idempotency keys.** Not needed for tasks/process-state mutations (each has a natural idempotency via target state — claiming an already-claimed task by you is a no-op, by someone else is 409). Revisit for `POST /api/processes` in Phase 2.5.
+- **`apiKey` god-mode rename (#448).** Cron heartbeat uses `caller.isSystemActor`. If #448 lands first, terminology stays clean; if not, document the alias and rename in follow-up.
+
+### Phase 2.5 — Definitions, agents, admin, users
+
+Wider mutation surface that doesn't fit Phase 2's uniform shape. Each group has a quirk that justifies its own design pass once Phase 2 has validated the wrapper-layer mutation pattern.
+
+**Definitions & versioning:**
+- `POST /api/workflow-definitions` — creates new version of a workflow. Mints next `version` integer; concurrency on version assignment needs thought (DB sequence vs check-then-insert).
+- `PUT /api/workflow-definitions/:name` — update default-version pointer / visibility.
+- `POST /api/workflow-definitions/:name/archive` — archives the whole workflow (cascades to all versions — soft-delete pattern).
+- `POST /api/workflow-definitions/:name/copy` — copies into another workspace (cross-namespace write, needs both source-read and target-write gates).
+- `POST /api/workflow-definitions/:name/versions/:version/archive` — archives one version only.
+
+**Process create (split from Phase 2):**
+- `POST /api/processes` — instantiate run from definition. Trigger payload validation against definition's input schema. Idempotency design (client-supplied key vs server-derived dedupe window).
+
+**Agents:**
+- `POST /api/agents` — create new agent (workspace-scoped write).
+- `PUT /api/agents/:id` — update agent.
+- `PUT/DELETE /api/agents/:id/mcp-servers/:name` — MCP binding lifecycle.
+- `POST /api/agents/:id/oauth/:provider/start` — initiate OAuth flow.
+- `POST /api/agents/:id/oauth/:provider` + `oauth-discover` — callback-side persistence.
+
+**Workflow secrets:**
+- `POST /api/workflow-secrets` — workspace + workflow-scoped secret write.
+
+**Admin (deployment-admin-only):**
+- `POST/PUT/DELETE /api/admin/oauth-providers[/:id]`
+- `POST/PUT/DELETE /api/admin/tool-catalog[/:id]`
+- `POST /api/admin/docker-images` — image management.
+
+These bypass workspace scope (deployment-admin gate). The wrapper layer's `caller.isDeploymentAdmin` predicate needs to exist (or inline the check until a second admin endpoint exists).
+
+**Users:**
+- `POST /api/users/invite` — sends invite email.
+- `POST /api/users/resend-invite` — re-sends.
+
+Touches NextAuth migration boundary (ADR-0002 unwritten). May want to wait for that ADR to land before designing the contract.
+
+**Out of Phase 2.5 (intentionally inline forever, not API surface):**
+
+- `POST /api/oauth/:provider/callback` — external OAuth callback, redirect-based protocol, not part of our typed contract.
+- `POST /api/triggers/webhook/[...path]` — external webhook ingestion, body shape is whoever-is-calling-us, validated per-trigger.
+- `POST /api/tickets` — external GitHub Issues bridge with its own rate limit; no Mediforce-domain meaning.
+
+**Open questions for Phase 2.5 design pass** (defer until Phase 2 ships):
+
+- Cross-namespace write (`copy`): does the wrapper support "two scopes at once" or do we drop to raw repo with explicit double-gate?
+- Cascade archive: soft-delete vs hard-delete + reference invalidation; per-version vs parent.
+- Deployment-admin predicate: lives on `CallerIdentity` directly, or as a separate `AdminScope` analog of `CallerScope`?
+- NextAuth boundary: do user-invite endpoints wait for ADR-0002?
+
+**Pause-safe**: yes — Phase 2 leaves Phase 2.5 routes inline; they keep working.
 
 ### Phase 3 — Complex flows
 
@@ -472,3 +749,62 @@ The migration is complete when:
 - [ ] A CLI / agent / MCP server can consume `@mediforce/platform-api/contract` + call the deployed API with the same type safety the UI enjoys
 
 Phases are independent; we can pause between any two and still have a working, tested product.
+
+## Captured for later — out of headless-migration scope
+
+Items surfaced during phase grilling that are real and worth doing, but
+explicitly outside the UI/API separation goal. Review this section when the
+migration is done — most of these become dedicated phases of their own.
+
+### Mutation audit emission (deferred during Phase 2 grilling, 2026-05-25)
+
+**Current state.** Inline routes for tasks/process-state mutations
+(`claim`, `complete`, `resolve`, `cancel`, `resume`) emit **zero** audit
+events today. Engine + container-worker emit audit through their own paths.
+HTTP-handler subset of mutations is the silent gap.
+
+**Why deferred.** Headless-migration goal is UI/API separation (typed
+contract, framework-free handlers). Audit emission is orthogonal:
+- It doesn't gate the migration's value.
+- Fixing it only on the HTTP-handler subset would be a half-fix — engine +
+  worker write the same entities and need the same pipeline. Half-fix would
+  ship inconsistency.
+- Phase 2 mutations at parity with status-quo (no emission) is honest, not
+  regressive.
+
+**Likely future shape (sketched, not committed).** Industry-standard for
+this problem is **repo-resident emission via a `MutationContext`** threaded
+into every raw mutation method on entity repositories. Wrappers
+(`Authorized<Entity>Repository`) build `MutationContext` from
+`CallerIdentity` and pass through; raw repos write entity + audit row
+together. Postgres-era (ADR-0001) gets free atomicity via transaction;
+Firestore-era is best-effort dual-write with documented gap. Pattern
+names: transactional outbox (Hohpe), audit log via repository decorator
+(Fowler PoEAA). Handler ergonomics: zero audit boilerplate, no chance of
+forgetting.
+
+**Why repo-resident and not handler-resident:**
+1. Repo is the only layer that sees **every** write path (HTTP, engine,
+   worker, future MCP). Handler-resident silently misses non-HTTP writers.
+2. Atomicity belongs to the persistence layer — only the repo can wrap
+   entity-write + audit-row-write in a single transaction.
+3. Audit-row-write is part of "how persistence happens", not "what the
+   user requested." Mixing it into handlers leaks infrastructure into
+   orchestration.
+
+**Rejected alternatives sketched during grilling:**
+- DB triggers (Postgres `AFTER UPDATE`). Free atomicity but action names
+  (`task.claimed` vs `task.cancelled`) depend on which method was called,
+  not detectable from row diff alone. Trigger sees "row changed" not "this
+  was a claim." Reject.
+- Event sourcing / domain events. Heavier infra than needed.
+- Adapter-orchestrated. Only covers HTTP path; misses engine + worker.
+
+**Interaction with ADR-0004.** §5 ("Wrappers never depend on other
+wrappers") was written for cross-domain entity composition (e.g. tasks
+wrapper not loading runs). Audit infrastructure is orthogonal and a
+reasonable reading of §5 doesn't reach it; the future audit ADR will
+either narrow §5 explicitly or supersede the relevant clause.
+
+**Action.** Dedicated audit-wiring phase post-migration, with its own ADR
+covering HTTP handlers + engine + worker uniformly. Don't pre-design here.

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -233,7 +233,8 @@ So Phase 2 narrows to **uniform lifecycle mutations** — same handler shape (lo
 | `POST /api/tasks/:taskId/resolve` | tasks | scope.tasks.resolve(taskId, verdict) |
 | `POST /api/processes/:instanceId/cancel` | processes | scope.runs.cancel(id, reason) |
 | `POST /api/processes/:instanceId/resume` | processes | scope.runs.resume(id) |
-| `POST /api/cron/heartbeat` | cron | `caller.isSystemActor` bypass; no scope gate |
+
+(`POST /api/cron/heartbeat` was originally in this list — repicked to Phase 3 because the route self-fetches `/api/processes/:id/run` to kick the run loop, making it an orchestration endpoint rather than an operational ping. See PR1 tracker's "Repick history" note + Phase 3 below.)
 
 **Out of Phase 2 (moved to Phase 2.5 or Phase 3):**
 
@@ -341,20 +342,23 @@ This tracker is the entry point for a fresh session picking up Phase 2.
 **Two PRs, sequential.** Pattern is unproven (wrapper layer has only
 served GETs); smallest endpoint first to validate it, then the rest.
 
-#### PR1 — Cron heartbeat + adapter `ApiError` extension
+#### PR1 — `tasks/claim` migration + adapter `ApiError` extension + `loadOr404`
 
-**Scope.** One endpoint (`POST /api/cron/heartbeat`) plus the
-`createRouteAdapter` extension that every subsequent mutation depends
-on.
+**Scope.** Smallest pure state-transition mutation
+(`POST /api/tasks/:taskId/claim`) plus the `createRouteAdapter`
+extension every subsequent mutation depends on. No orchestration, no
+self-fetch, no new abstractions — proves the wrapper-layer + ApiError
++ audit-bridge pattern end-to-end on one endpoint.
+
+**Repick history (2026-05-25).** Originally scoped to `cron/heartbeat`.
+Repicked because cron-heartbeat is not operational — it scans cron
+triggers, fires them, then **self-fetches** `/api/processes/:id/run` to
+kick the run loop. That's fire-and-forget orchestration, same category
+as `processes/run` and `processes/advance` which Phase 3 explicitly
+defers. Cron-heartbeat moves to Phase 3 with its orchestration siblings;
+PR1 picks a true minimal mutation instead.
 
 **Files to touch:**
-- `packages/platform-api/src/contract/cron.ts` — new. `HeartbeatInputSchema`
-  (empty / trivial), `HeartbeatOutputSchema` (`{ ok, processedAt }`).
-- `packages/platform-api/src/handlers/cron/heartbeat.ts` — new. System-
-  actor bypass: `if (!scope.caller.isSystemActor) throw new ApiError('forbidden', ...)`.
-  No audit emission (`@no-audit` operational exemption per ADR-0005 §7).
-- `packages/platform-api/src/handlers/cron/__tests__/heartbeat.test.ts`
-  — new. Contract + handler tests against in-memory scope.
 - `packages/platform-api/src/errors.ts` — add the `ApiError` class +
   `ApiErrorCode` union. Existing `HandlerError` / `NotFoundError` /
   `ForbiddenError` from [#482](https://github.com/Appsilon/mediforce/pull/482)
@@ -367,44 +371,84 @@ on.
   - `instanceof ApiError` → envelope with `err.code`.
   - `instanceof HandlerError` → derive code from `statusCode`
     (`404 → 'not_found'`, `403 → 'forbidden'`); same envelope shape.
+- `packages/platform-ui/src/lib/__tests__/route-adapter.test.ts` —
+  extend with tests per `ApiErrorCode` for status + envelope, plus
+  the `HandlerError` legacy-throw arm.
 - `loadOr404` helper — extract per [#482](https://github.com/Appsilon/mediforce/pull/482)
   out-of-scope note ("third copy" rule reached for the
   `entity = await scope.X.getById(id); if (!entity) throw …` pattern).
   Lives in `packages/platform-api/src/handlers/_helpers.ts` (or
-  similar); used by `get-run` plus any new lookup-with-404 handler in
-  PR2.
-- `packages/platform-ui/src/lib/__tests__/route-adapter.test.ts` —
-  extend with tests for each code → status mapping.
-- `packages/platform-ui/src/app/api/cron/heartbeat/route.ts` —
-  replace inline handler with `createRouteAdapter` call.
+  similar); used by PR1's claim handler + future lookup-with-404 sites.
+- `packages/platform-api/src/contract/tasks.ts` — add
+  `ClaimTaskInputSchema` (`{ taskId: z.string().min(1) }`) and
+  `ClaimTaskOutputSchema` (`{ task: HumanTaskSchema }`). Export from
+  `contract/index.ts`.
+- `packages/platform-api/src/handlers/tasks/claim-task.ts` — new.
+  Handler: assert `scope.caller.userId`, call `scope.humanTasks.claim()`
+  (wrapper already exists), emit audit-bridge via
+  `scope.auditEvents.append({...})` — move the audit-emission code from
+  today's `claimTask` Server Action (`packages/platform-ui/src/app/actions/tasks.ts:43-59`),
+  do not author new audit shape.
+- `packages/platform-api/src/handlers/tasks/__tests__/claim-task.test.ts`
+  — contract + handler tests against in-memory scope.
+- `packages/platform-api/src/repositories/authorized-audit-event-repository.ts`
+  — add `append(event)` write method. Delegates to raw `auditRepo.append()`.
+  Update `__tests__/`.
+- `packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts` —
+  replace inline handler with `createRouteAdapter` call. Path-param
+  `taskId` merged into input via the `inputFromReq` callback.
 - `packages/platform-api/src/client/mediforce.ts` — add
-  `mediforce.cron.heartbeat()` method.
+  `mediforce.tasks.claim(input)` method. Test it.
+- `packages/platform-ui/src/app/actions/tasks.ts` — **delete** the
+  `claimTask` function (only; leave `unclaimTask` and the four
+  `complete*` actions — they migrate in PR2).
+- `packages/platform-ui/src/components/tasks/claim-button.tsx` —
+  replace the dynamic `import('@/app/actions/tasks').then(({claimTask})...)`
+  with `mediforce.tasks.claim({taskId})`. **Leaves the unclaim path on
+  the Server Action** as an intentional temp state — PR2 deletes it
+  when adding the new `/unclaim` route.
 
-**Server Actions deleted:** none in this PR.
+**Server Actions deleted:** `claimTask` only.
 
-**New routes added:** none (heartbeat route already exists).
+**New routes added:** none (claim route already exists).
 
-**Test layers:** contract + handler + adapter + 1 cross-layer integration.
+**Mixed-state callout for PR description:** `claim-button.tsx` is
+temporarily split — claim goes through `apiClient`, unclaim goes
+through the existing Server Action. PR2 closes the loop by adding the
+`/unclaim` route, migrating unclaim, and deleting `unclaimTask`.
+
+**Test layers:** contract + handler + adapter + client method test +
+hook/component test for claim-button update + 1 cross-layer integration
+through the loopback pattern.
 
 **Exit criteria:**
-- `POST /api/cron/heartbeat` returns `{ ok: true, processedAt }` on
-  system-actor caller; `403` + ApiError envelope otherwise.
-- All `ApiError` codes mapped to correct HTTP status in adapter tests.
+- `POST /api/tasks/:taskId/claim` returns `{ task: HumanTask }` on
+  success; `403` + ApiError envelope for non-member; `404` + envelope
+  for foreign-workspace task (anti-enum); `409` + envelope for task
+  not in `pending` status.
+- Audit emission preserved bit-for-bit: AuditEvent rows produced by
+  the migrated handler match what `claimTask` Server Action emitted
+  (action `task.claimed`, same actor/description/snapshots/basis).
+- All `ApiError` codes + the `HandlerError` legacy arm mapped to
+  correct HTTP status in adapter tests.
 - `api-boundaries.test.ts` + `no-raw-repo-imports.test.ts` pass.
-- Existing GET endpoints retroactively return the new error envelope
-  (no regression — they previously returned `{ error: string }`; now
-  return `{ error: { code, message } }`; UI codemod `err.error` →
-  `err.error.message` lands same PR).
+- Existing Phase 1 / Phase 1.5 GET endpoints retroactively return the
+  new error envelope (`{ error: string }` → `{ error: { code, message } }`).
+  UI code reading `err.error` updated to `err.error.message`. Tests
+  asserting on string envelope updated mechanically.
+- `mediforce.tasks.claim()` round-trip green via cross-layer integration
+  test.
+- E2E journey involving claim still green.
 
-#### PR2 — Tasks + Process state lifecycle mutations
+#### PR2 — Remaining tasks + Process state lifecycle mutations
 
-**Scope.** Six endpoints + audit-bridge wiring + Server Action
-deletions.
+**Scope.** Five endpoints + audit-bridge wiring + Server Action
+deletions. `claim` already shipped in PR1, so PR2 closes the loop on
+tasks and migrates process state.
 
 Endpoints:
-- `POST /api/tasks/:taskId/claim` — migrate existing route.
-- `POST /api/tasks/:taskId/unclaim` — **new route** (no existing
-  route today; current functionality is Server Action only).
+- `POST /api/tasks/:taskId/unclaim` — **new route** (no existing route
+  today; current functionality is Server Action only).
 - `POST /api/tasks/:taskId/complete` — migrate. Body uses discriminated
   union over four kinds (`verdict | params | upload | assignment`)
   covering today's `completeTask`, `completeParamsTask`,
@@ -426,10 +470,11 @@ Endpoints:
 - `packages/platform-api/src/client/mediforce.ts` — add typed methods.
 
 **Server Actions deleted (move, don't add):**
-- `packages/platform-ui/src/app/actions/tasks.ts` — delete all six
-  (`claimTask`, `unclaimTask`, `completeTask`, `completeParamsTask`,
-  `completeUploadTask`, `completeAssignmentTask`). Move audit-emission
-  code into the corresponding handlers.
+- `packages/platform-ui/src/app/actions/tasks.ts` — delete the
+  remaining five (`unclaimTask`, `completeTask`, `completeParamsTask`,
+  `completeUploadTask`, `completeAssignmentTask`). `claimTask` already
+  deleted in PR1. Move audit-emission code into the corresponding
+  handlers. File ends up empty — delete it.
 - `packages/platform-ui/src/app/actions/processes.ts` — delete
   `cancelProcessRun` and `resumeProcessRun`. Move audit code. Leave
   `startWorkflowRun`, `retryFailedStep`, `archiveProcessRun`,
@@ -438,13 +483,12 @@ Endpoints:
 
 **UI callers to update:**
 - `packages/platform-ui/src/components/tasks/claim-button.tsx` —
-  replace `claimTask` / `unclaimTask` action imports with
-  `mediforce.tasks.claim()` / `mediforce.tasks.unclaim()`.
-- Components calling the other `complete*` actions — same pattern;
-  body shape becomes discriminated union (`{ kind: 'verdict', ... }`,
-  etc.).
+  replace `unclaimTask` action import with `mediforce.tasks.unclaim()`.
+  (Claim path already on `mediforce.tasks.claim()` from PR1.)
+- Components calling the `complete*` actions — replace with
+  `mediforce.tasks.complete({ kind: 'verdict' | ..., ... })`.
 - Process detail components calling `cancelProcessRun` /
-  `resumeProcessRun` — same.
+  `resumeProcessRun` — same pattern.
 
 **Repository layer additions:**
 - `HumanTaskRepository.unclaim(taskId, userId)` — new method on both
@@ -455,8 +499,6 @@ Endpoints:
   interface + in-memory + Firestore. `AuthorizedWorkflowRunRepository.cancel()`
   wrapper.
 - `ProcessInstanceRepository.resume(id)` — same.
-- `AuthorizedAuditEventRepository.append(event)` — new write method
-  on the wrapper (read-only today). Delegates to raw `auditRepo.append()`.
 
 **Test layers:** contract + handler + adapter + hook update + journey
 test for at least one tasks flow (claim → complete) and one process
@@ -542,6 +584,7 @@ Each of these needs its own design pass:
 
 - **Cowork streaming** (`POST /api/cowork/:id/chat`, `POST /api/cowork/:id/message`, `POST /api/cowork/:id/finalize`) — requires an SSE adapter between the pure handler and Next.js `ReadableStream`. Design question: does the handler yield events, or return an async iterator?
 - **Process execution** (`POST /api/processes/:id/run`, `POST /api/processes/:id/advance` with agent side-effects) — orchestrates `AgentRunner` + `WorkflowEngine`; handler becomes an orchestrator instead of a thin read. Decide on sync vs. queued execution.
+- **Cron heartbeat** (`POST /api/cron/heartbeat`) — added to Phase 3 (2026-05-25). Steps 1-3 (scan triggers / check due / fire) are clean handler work. Step 4 (self-fetch `/api/processes/:id/run` to kick the run loop) is the same orchestration kick `processes/run` and `processes/advance` need. Design the orchestration kick once, apply to all three.
 - **Server actions** in `src/app/actions/*.ts` — fold into handlers where sensible, keep Next.js-specific concerns (`revalidatePath`, `redirect`) in a thin action wrapper.
 
 **Pause-safe**: yes, but granularity is coarser — streaming and orchestration are each a PR of meaningful size.
@@ -554,6 +597,7 @@ Each of these needs its own design pass:
   The first is the cleanest functional style; the second is the most flexible for pre-existing code.
 - Orchestrator side-effects — `executeAgentStep` spawns Docker containers and writes audit events. Do we keep it as a handler (pure-ish, deps include `AgentRunner`) or promote it to a queue worker entrypoint?
 - Cowork finalize writes to multiple repos atomically today — do we need a transaction abstraction in the repo interfaces, or accept non-atomic writes with compensating actions?
+- **Orchestration kick mechanism** — today three call sites self-fetch via HTTP (`/api/processes/:id/run`): inline `cron/heartbeat` route, inline `tasks/complete` route post-completion, Server Actions in `processes.ts`. The pattern bypasses framework boundaries (`platform-api` handlers don't know own URL or API key). Three options: (a) `scope.system.runKicker(instanceId)` abstraction wired in `caller-scope.ts`; (b) push the kick inside `engine.startInstance()` so callers don't kick at all; (c) queue worker entrypoint replacing self-fetch with a real job dispatch. Decide once, apply to cron-heartbeat + processes/run + processes/advance + tasks/complete-then-advance.
 
 ### Phase 4 — Typed `apiClient` + first hook migration
 

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -120,9 +120,11 @@ The rule of thumb: **design the contract against real UI consumers, and change t
 
 ### Phase 1.5 — Hybrid endpoint cleanup
 
-Five endpoints already declare contracts in `platform-api` but still run
-inline route code that bypasses the `createRouteAdapter` pipeline AND the
-ADR-0004 scoped data-access layer. Drain the backlog before Phase 2
+**✅ Status: done in [#482](https://github.com/Appsilon/mediforce/pull/482)** (merged 2026-05-25). Shipped scope below for historical record; planning notes preserved for the institutional memory of why we did this before Phase 2.
+
+Five endpoints already declared contracts in `platform-api` but still ran
+inline route code that bypassed the `createRouteAdapter` pipeline AND the
+ADR-0004 scoped data-access layer. Drained the backlog in #482 before Phase 2
 mutations set the next pattern in stone.
 
 **Scope — one PR, three domains:**
@@ -353,11 +355,24 @@ on.
   No audit emission (`@no-audit` operational exemption per ADR-0005 §7).
 - `packages/platform-api/src/handlers/cron/__tests__/heartbeat.test.ts`
   — new. Contract + handler tests against in-memory scope.
-- `packages/platform-api/src/errors.ts` — extend with the `ApiError`
-  class + `ApiErrorCode` union (replaces today's narrower error
-  helpers if any).
-- `packages/platform-ui/src/lib/route-adapter.ts` — extend with
-  `ApiError` catch + status-mapping table per ADR-0005 §3/§4.
+- `packages/platform-api/src/errors.ts` — add the `ApiError` class +
+  `ApiErrorCode` union. Existing `HandlerError` / `NotFoundError` /
+  `ForbiddenError` from [#482](https://github.com/Appsilon/mediforce/pull/482)
+  **stay** as a coexistence bridge — new code throws `ApiError`,
+  existing throws keep working, both produce the same envelope shape.
+  Migration of legacy throws to `ApiError` is incremental, not PR1
+  blocking.
+- `packages/platform-ui/src/lib/route-adapter.ts` — extend the catch
+  block with two arms per ADR-0005 §3/§4:
+  - `instanceof ApiError` → envelope with `err.code`.
+  - `instanceof HandlerError` → derive code from `statusCode`
+    (`404 → 'not_found'`, `403 → 'forbidden'`); same envelope shape.
+- `loadOr404` helper — extract per [#482](https://github.com/Appsilon/mediforce/pull/482)
+  out-of-scope note ("third copy" rule reached for the
+  `entity = await scope.X.getById(id); if (!entity) throw …` pattern).
+  Lives in `packages/platform-api/src/handlers/_helpers.ts` (or
+  similar); used by `get-run` plus any new lookup-with-404 handler in
+  PR2.
 - `packages/platform-ui/src/lib/__tests__/route-adapter.test.ts` —
   extend with tests for each code → status mapping.
 - `packages/platform-ui/src/app/api/cron/heartbeat/route.ts` —
@@ -491,8 +506,7 @@ Wider mutation surface that doesn't fit Phase 2's uniform shape. Each group has 
 - `POST /api/agents/:id/oauth/:provider/start` — initiate OAuth flow.
 - `POST /api/agents/:id/oauth/:provider` + `oauth-discover` — callback-side persistence.
 
-**Workflow secrets:**
-- `POST /api/workflow-secrets` — workspace + workflow-scoped secret write.
+**Workflow secrets:** ✅ done in [#482](https://github.com/Appsilon/mediforce/pull/482). `set-secret` handler is an upsert (PUT semantics) covering create + update — no separate `POST` needed.
 
 **Admin (deployment-admin-only):**
 - `POST/PUT/DELETE /api/admin/oauth-providers[/:id]`
@@ -755,6 +769,24 @@ Phases are independent; we can pause between any two and still have a working, t
 Items surfaced during phase grilling that are real and worth doing, but
 explicitly outside the UI/API separation goal. Review this section when the
 migration is done — most of these become dedicated phases of their own.
+
+### Phase 1.8 — File-serving + ticket endpoints (deferred from #482)
+
+Endpoints with no contract started yet, so finishing-the-loop logic from
+Phase 1.5 didn't apply. File-serving shape (streaming, range requests,
+content-type negotiation) deserves its own design pass before the
+contract gets written.
+
+- `GET /api/agent-logs` — agent run log retrieval.
+- `GET /api/agent-output-file` — agent output file retrieval.
+- `GET /api/step-logs` — step execution log retrieval.
+- `POST /api/tickets` — GitHub Issues bridge. Already inline-forever per
+  Phase 2.5 out-of-scope list (external integration, has its own rate
+  limit). Mentioned here only because #482 grouped it with the file-
+  serving deferral; the headless-migration position is unchanged
+  (stays inline).
+- `DELETE /api/admin/docker-images` — mutation + deployment-admin
+  auth; folds into Phase 2.5 admin bullet rather than Phase 1.8.
 
 ### Mutation audit emission (deferred during Phase 2 grilling, 2026-05-25)
 


### PR DESCRIPTION
## Summary

- **ADR-0005 — Headless platform: API/UI separation** (umbrella, status `Accepted` mutable until headless migration completes). Locks Phase 2+ mutation handler contract: error envelope `{ error: { code, message, details? } }`, single `ApiError` class with closed code union, HTTP status mapping, entity-echo response shape with carve-outs, Server Action default-delete policy, `createRouteAdapter` extension with `ApiError` catch, handler-resident audit-bridge.
- **`docs/api-architecture.md`** — new permanent concept doc explaining handler / adapter / scope / contract. Survives `headless-migration.md` deletion at end of migration.
- **`docs/adr/README.md`** — status policy relaxed: `Accepted` is mutable while implementation in progress, `Finalized` is frozen, partial supersession allowed (predecessor stays unedited, only status field changes). Adds "How to read these" and "default to standard solutions" reading-guidance paragraphs.
- **ADR-0004** — grandfathered to `Finalized` per its own post-merge self-immutability note (predates the formal `Finalized` status).
- **`docs/headless-migration.md`** — Phase 2 narrowed to lifecycle mutations (tasks claim/unclaim/complete/resolve, process cancel/resume, cron heartbeat); new Phase 2.5 fleshed out (definitions/agents/admin/users). Adds per-PR implementation tracker so a fresh session can grab PR1/PR2 cold. Server Action deletion list explicit. Audit-bridge rationale captured. "Captured for later" section preserves deferred audit-wiring design.

Follow-up PRs implement against this plan:
- **PR1** — cron heartbeat migration + `createRouteAdapter` `ApiError` extension (spawned via chip).
- **PR2** — tasks + process state lifecycle endpoints, Server Action deletions, audit-bridge wiring.

## Test plan

- [ ] Docs render correctly on GitHub (links between ADRs, headless-migration.md, api-architecture.md, CONTEXT.md).
- [ ] ADR README index includes 0005.
- [ ] Cross-references in ADR-0005 resolve to existing docs.
- [ ] `headless-migration.md` "Phase 2 — Implementation tracker" subsection is self-contained enough for a fresh session to start PR1 cold.