### PR TITLE
feat(platform-api): ADR-0005 PR1 — tasks/claim handler + typed error envelope

### DIFF
--- a/docs/adr/0005-headless-platform-api-ui-separation.md
+++ b/docs/adr/0005-headless-platform-api-ui-separation.md
@@ -254,11 +254,16 @@ Phase 2 deletes the actions; without a bridge, audit coverage on these
 mutations would silently regress.
 
 **Phase 2 bridge:** each migrated mutation handler emits audit inline
-via `scope.auditEvents.append({...})` — same shape as today's Server
+via `scope.system.audit.append({...})` — same shape as today's Server
 Action code, ~6 LOC per handler. Net-zero LOC if the existing emission
-code is moved (not added) from action to handler. Required addition:
-`.append()` method on `AuthorizedAuditEventRepository` (read-only
-today).
+code is moved (not added) from action to handler. The raw write surface
+lives on `scope.system.audit` (existing trusted-bypass lane that already
+holds `engine` / `agentRunner` / `manualTrigger`), not on the Authorized
+wrapper. Reason: `Authorized*Repository` semantics promise per-method
+workspace gating; `append` would not gate (writer trusted by-construction —
+the handler just loaded the parent through a gated wrapper). Putting it
+on `scope.system` makes the trust explicit and groups it with the other
+god-mode-by-design handles.
 
 **Long-term direction (separate audit-wiring phase, post-headless-
 migration):** audit emission moves to the **persistence boundary
@@ -302,8 +307,14 @@ Closed action-name set for Phase 2 (extensible by amendment):
 - `HumanTaskRepository.unclaim(taskId, userId)` + wrapper passthrough
   (no method today; current `unclaimTask` Server Action writes Firestore
   directly).
-- `AuthorizedAuditEventRepository.append(event)` — write-side method
-  (read-only today).
+
+Raw audit-write surface lives on `scope.system.audit` (existing
+trusted-bypass lane), not on the Authorized wrapper. Reason:
+`Authorized*Repository` semantics promise per-method gating; `append`
+would not gate (writer trusted by-construction). Putting it on
+`scope.system` makes the trust explicit and aligns with where `engine` /
+`agentRunner` already live. `AuthorizedAuditEventRepository` stays
+read-only.
 
 `AuthorizedWorkflowRunRepository` has `getById` / `list` / `update` only.
 Phase 2 adds:
@@ -333,6 +344,13 @@ These are domain methods on the wrapper, mirroring how
   — same gap as adapter-orchestrated. Acceptable as Phase 2 bridge
   only because the existing Server Action emission is being moved
   rather than newly introduced.
+- **`.append()` on `AuthorizedAuditEventRepository`** as the write
+  surface during the bridge. Rejected — `Authorized*Repository` names
+  a contract ("every method gates on caller's workspace membership"),
+  and `append` does not gate. Putting it there forces a misleading
+  doc-comment on every read of the file. Raw write goes on
+  `scope.system.audit` instead, next to the other trusted-bypass
+  handles (`engine`, `agentRunner`, `manualTrigger`).
 - **Keep Server Actions alongside the API.** Rejected — empirical:
   today's actions use zero Server Action features. They are API-route-
   shaped code in a Server Action costume, paying the auth-bifurcation

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -278,12 +278,13 @@ So Phase 2 narrows to **uniform lifecycle mutations** — same handler shape (lo
   audit coverage for these mutations. To avoid a compliance regression
   during the gap between Phase 2 and the future audit-wiring phase
   (see "Captured for later" below), each new Phase 2 mutation handler
-  emits audit inline via `scope.auditEvents.append({...})` — same shape
+  emits audit inline via `scope.system.audit.append({...})` — same shape
   as today's Server Action code, ~6 LOC per handler. This is throwaway
   bridge code: the audit-wiring phase rewrites to repo-resident
-  `MutationContext` and removes the handler-level emits. Add a `.append()`
-  method to `AuthorizedAuditEventRepository` (read-only today) to enable
-  this.
+  `MutationContext` and removes the handler-level emits. The raw audit
+  write surface lives on `scope.system.audit` (the existing trusted-
+  bypass lane that already holds `engine` / `agentRunner`), not on
+  `AuthorizedAuditEventRepository` — see ADR-0005 §7/§8 for why.
 
 **Server Action policy.** Per-endpoint judgement. Default: when migrating
 a mutation, delete the parallel Server Action; UI moves to
@@ -386,14 +387,16 @@ PR1 picks a true minimal mutation instead.
 - `packages/platform-api/src/handlers/tasks/claim-task.ts` — new.
   Handler: assert `scope.caller.userId`, call `scope.humanTasks.claim()`
   (wrapper already exists), emit audit-bridge via
-  `scope.auditEvents.append({...})` — move the audit-emission code from
+  `scope.system.audit.append({...})` — move the audit-emission code from
   today's `claimTask` Server Action (`packages/platform-ui/src/app/actions/tasks.ts:43-59`),
   do not author new audit shape.
 - `packages/platform-api/src/handlers/tasks/__tests__/claim-task.test.ts`
   — contract + handler tests against in-memory scope.
-- `packages/platform-api/src/repositories/authorized-audit-event-repository.ts`
-  — add `append(event)` write method. Delegates to raw `auditRepo.append()`.
-  Update `__tests__/`.
+- `packages/platform-api/src/repositories/caller-scope.ts` — extend
+  `SystemServices` with `readonly audit: AuditRepository` (raw write
+  surface for the audit bridge per ADR-0005 §7). Wired in
+  `create-caller-scope.ts` from `services.auditRepo`.
+  `AuthorizedAuditEventRepository` stays read-only.
 - `packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts` —
   replace inline handler with `createRouteAdapter` call. Path-param
   `taskId` merged into input via the `inputFromReq` callback.
@@ -462,7 +465,7 @@ Endpoints:
   input + output schemas (output reuses entity schemas per ADR-0005 §5).
 - `packages/platform-api/src/handlers/<tasks|processes>/<name>.ts` —
   new handler. Calls `scope.X.method()`, emits audit via
-  `scope.auditEvents.append({...})` (bridge per ADR-0005 §7).
+  `scope.system.audit.append({...})` (bridge per ADR-0005 §7).
 - `packages/platform-api/src/handlers/<tasks|processes>/__tests__/<name>.test.ts`
   — contract + handler tests.
 - `packages/platform-ui/src/app/api/<path>/route.ts` — replace inline

--- a/packages/cli/src/__tests__/errors.test.ts
+++ b/packages/cli/src/__tests__/errors.test.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@mediforce/platform-api/client';
+import { MediforceClientError } from '@mediforce/platform-api/client';
 import { describe, expect, it } from 'vitest';
 import { formatCliError } from '../errors.js';
 
@@ -67,7 +67,7 @@ describe('formatCliError', () => {
 
   it('adds API key hints for auth failures', () => {
     expect(
-      formatCliError(new ApiError(401, 'Unauthorized', { error: 'Unauthorized' }), {
+      formatCliError(new MediforceClientError(401, 'Unauthorized', { error: 'Unauthorized' }), {
         baseUrl: 'http://localhost:9003',
       }),
     ).toMatchObject({
@@ -76,7 +76,7 @@ describe('formatCliError', () => {
     });
 
     expect(
-      formatCliError(new ApiError(403, 'Forbidden', { error: 'Forbidden' }), {
+      formatCliError(new MediforceClientError(403, 'Forbidden', { error: 'Forbidden' }), {
         baseUrl: 'http://localhost:9003',
       }),
     ).toMatchObject({
@@ -86,7 +86,7 @@ describe('formatCliError', () => {
   });
 
   it('hints when a 404 looks like the base URL is not the API host', () => {
-    expect(formatCliError(new ApiError(404, 'Not found', {}), { baseUrl: 'https://example.com' }))
+    expect(formatCliError(new MediforceClientError(404, 'Not found', {}), { baseUrl: 'https://example.com' }))
       .toMatchObject({
         status: 404,
         hints: expect.arrayContaining([

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@mediforce/platform-api/client';
+import { MediforceClientError } from '@mediforce/platform-api/client';
 import type { ErrorPayload } from './output.js';
 
 export interface FormatCliErrorInput {
@@ -20,8 +20,8 @@ export function formatCliError(
   err: unknown,
   input: FormatCliErrorInput = {},
 ): ErrorPayload {
-  if (err instanceof ApiError) {
-    return formatApiError(err);
+  if (err instanceof MediforceClientError) {
+    return formatMediforceClientError(err);
   }
 
   const systemError = findFetchSystemError(err);
@@ -45,7 +45,7 @@ export function formatCliError(
   return { error: String(err) };
 }
 
-function formatApiError(err: ApiError): ErrorPayload {
+function formatMediforceClientError(err: MediforceClientError): ErrorPayload {
   const payload: ErrorPayload = {
     error: err.message,
     status: err.status,
@@ -231,7 +231,7 @@ function findAbortError(err: unknown): unknown | null {
 }
 
 function looksLikeNonJson404(body: unknown): boolean {
-  // parseJsonOrThrow normalizes non-JSON 404 response bodies to {} in ApiError.body.
+  // parseJsonOrThrow normalizes non-JSON 404 response bodies to {} in MediforceClientError.body.
   return isRecord(body) && Object.keys(body).length === 0;
 }
 

--- a/packages/platform-api/src/client/__tests__/mediforce.test.ts
+++ b/packages/platform-api/src/client/__tests__/mediforce.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Mediforce, ApiError, type ClientConfig } from '../index.js';
+import { Mediforce, MediforceClientError, type ClientConfig } from '../index.js';
 import {
   buildHumanTask,
   buildProcessInstance,
@@ -250,8 +250,8 @@ describe('Mediforce', () => {
     });
   });
 
-  describe('ApiError', () => {
-    it('throws ApiError with the server-reported message on non-2xx', async () => {
+  describe('MediforceClientError', () => {
+    it('throws MediforceClientError with the server-reported message on non-2xx', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         jsonResponse({ error: 'Exactly one of `instanceId` or `role`' }, 400),
       );
@@ -261,12 +261,12 @@ describe('Mediforce', () => {
         .list({ instanceId: 'inst-a' })
         .catch((err) => err);
 
-      expect(error).toBeInstanceOf(ApiError);
-      expect((error as ApiError).status).toBe(400);
-      expect((error as ApiError).message).toMatch(/exactly one of/i);
+      expect(error).toBeInstanceOf(MediforceClientError);
+      expect((error as MediforceClientError).status).toBe(400);
+      expect((error as MediforceClientError).message).toMatch(/exactly one of/i);
     });
 
-    it('throws ApiError even when the server returns no JSON body', async () => {
+    it('throws MediforceClientError even when the server returns no JSON body', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }));
 
       const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
@@ -274,15 +274,15 @@ describe('Mediforce', () => {
         .list({ instanceId: 'inst-a' })
         .catch((err) => err);
 
-      expect(error).toBeInstanceOf(ApiError);
-      expect((error as ApiError).status).toBe(500);
+      expect(error).toBeInstanceOf(MediforceClientError);
+      expect((error as MediforceClientError).status).toBe(500);
     });
   });
 
   // ---- Per-method contracts (table-driven) ----
   //
-  // For methods whose contract reduces to (build URL → parse 200 → ApiError on 4xx),
-  // a single table-driven helper covers happy-path URL/parse + ApiError on 404.
+  // For methods whose contract reduces to (build URL → parse 200 → MediforceClientError on 4xx),
+  // a single table-driven helper covers happy-path URL/parse + MediforceClientError on 404.
   // Methods with non-trivial input encoding (query strings, repeated params) keep
   // their verbose tests below.
 
@@ -408,7 +408,7 @@ describe('Mediforce', () => {
       expect(fetchSpy.mock.calls[0]?.[0]).toBe(contract.expectedUrl);
     });
 
-    it('throws ApiError on 404 with parsed body', async () => {
+    it('throws MediforceClientError on 404 with parsed body', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         jsonResponse({ error: 'Not found' }, 404),
       );
@@ -416,8 +416,8 @@ describe('Mediforce', () => {
       const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
       const err = await contract.call(mediforce).catch((e) => e);
 
-      expect(err).toBeInstanceOf(ApiError);
-      expect((err as ApiError).status).toBe(404);
+      expect(err).toBeInstanceOf(MediforceClientError);
+      expect((err as MediforceClientError).status).toBe(404);
     });
   });
 
@@ -489,7 +489,7 @@ describe('Mediforce', () => {
       );
     });
 
-    it('throws ApiError on 404', async () => {
+    it('throws MediforceClientError on 404', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         jsonResponse({ error: 'Workflow not found' }, 404),
       );
@@ -499,8 +499,8 @@ describe('Mediforce', () => {
         .get({ name: 'missing' })
         .catch((e) => e);
 
-      expect(err).toBeInstanceOf(ApiError);
-      expect((err as ApiError).status).toBe(404);
+      expect(err).toBeInstanceOf(MediforceClientError);
+      expect((err as MediforceClientError).status).toBe(404);
     });
   });
 
@@ -528,6 +528,97 @@ describe('Mediforce', () => {
         mediforce.cowork.getByInstance({ instanceId: '' }),
       ).rejects.toThrow();
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tasks.claim', () => {
+    it('POSTs to /api/tasks/:taskId/claim and parses the entity envelope', async () => {
+      const task = buildHumanTask({
+        id: 'task-1',
+        status: 'claimed',
+        assignedUserId: 'u-1',
+      });
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ task }));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.tasks.claim({ taskId: 'task-1' });
+
+      expect(result.task.id).toBe('task-1');
+      expect(result.task.status).toBe('claimed');
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(`${TEST_BASE_URL}/api/tasks/task-1/claim`);
+      expect(fetchSpy.mock.calls[0]?.[1]?.method).toBe('POST');
+    });
+
+    it('URL-encodes the taskId path segment', async () => {
+      const task = buildHumanTask({ id: 'task 1/2', status: 'claimed', assignedUserId: 'u-1' });
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ task }));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      await mediforce.tasks.claim({ taskId: 'task 1/2' });
+
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+        `${TEST_BASE_URL}/api/tasks/task%201%2F2/claim`,
+      );
+    });
+
+    it('rejects an empty taskId before firing any request', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      await expect(mediforce.tasks.claim({ taskId: '' })).rejects.toThrow();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws MediforceClientError with envelope code/message/details on a typed 409', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse(
+          {
+            error: {
+              code: 'precondition_failed',
+              message: 'Cannot claim a claimed task',
+              details: { taskId: 'task-1', currentStatus: 'claimed' },
+            },
+          },
+          409,
+        ),
+      );
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const err = (await mediforce.tasks
+        .claim({ taskId: 'task-1' })
+        .catch((e) => e)) as MediforceClientError;
+
+      expect(err).toBeInstanceOf(MediforceClientError);
+      expect(err.status).toBe(409);
+      expect(err.message).toBe('Cannot claim a claimed task');
+      expect(err.code).toBe('precondition_failed');
+      expect(err.details).toEqual({ taskId: 'task-1', currentStatus: 'claimed' });
+    });
+  });
+
+  describe('error envelope back-compat (legacy `{ error: string }`)', () => {
+    it('extracts the message from the legacy string envelope', async () => {
+      // Some Phase 1 routes still throw plain HandlerError with a custom
+      // shape, and the legacy 5xx surface (`{ error: <string> }`) hasn't
+      // been migrated. The client must tolerate both shapes during the
+      // transition.
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        jsonResponse({ error: 'Legacy failure mode' }, 500),
+      );
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const err = (await mediforce.tasks
+        .list({ instanceId: 'inst-a' })
+        .catch((e) => e)) as MediforceClientError;
+
+      expect(err).toBeInstanceOf(MediforceClientError);
+      expect(err.status).toBe(500);
+      expect(err.message).toBe('Legacy failure mode');
+      expect(err.code).toBeUndefined();
     });
   });
 });

--- a/packages/platform-api/src/client/__tests__/runs.test.ts
+++ b/packages/platform-api/src/client/__tests__/runs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Mediforce, ApiError } from '../index.js';
+import { Mediforce, MediforceClientError } from '../index.js';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -66,7 +66,7 @@ describe('mediforce.runs.get', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('throws ApiError on 404', async () => {
+  it('throws MediforceClientError on 404', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       jsonResponse({ error: 'Run not found' }, 404),
     );
@@ -74,7 +74,7 @@ describe('mediforce.runs.get', () => {
     const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
     const error = await mediforce.runs.get({ runId: 'nope' }).catch((err) => err);
 
-    expect(error).toBeInstanceOf(ApiError);
-    expect((error as ApiError).status).toBe(404);
+    expect(error).toBeInstanceOf(MediforceClientError);
+    expect((error as MediforceClientError).status).toBe(404);
   });
 });

--- a/packages/platform-api/src/client/__tests__/workflows.test.ts
+++ b/packages/platform-api/src/client/__tests__/workflows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Mediforce, ApiError } from '../index.js';
+import { Mediforce, MediforceClientError } from '../index.js';
 import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
 import { omitServerFields } from '../../contract/__tests__/_helpers.js';
 
@@ -64,7 +64,7 @@ describe('mediforce.workflows.register', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('throws ApiError on non-2xx', async () => {
+  it('throws MediforceClientError on non-2xx', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       jsonResponse({ error: 'Validation failed' }, 400),
     );
@@ -77,8 +77,8 @@ describe('mediforce.workflows.register', () => {
       .register(body, { namespace: 'Appsilon' })
       .catch((err) => err);
 
-    expect(error).toBeInstanceOf(ApiError);
-    expect((error as ApiError).status).toBe(400);
+    expect(error).toBeInstanceOf(MediforceClientError);
+    expect((error as MediforceClientError).status).toBe(400);
   });
 });
 

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -53,10 +53,14 @@ import {
   GetCoworkSessionByInstanceInputSchema,
   GetCoworkSessionByInstanceOutputSchema,
   ListPluginsOutputSchema,
+  ClaimTaskInputSchema,
+  ClaimTaskOutputSchema,
   type ListTasksInput,
   type ListTasksOutput,
   type GetTaskInput,
   type GetTaskOutput,
+  type ClaimTaskInput,
+  type ClaimTaskOutput,
   type RegisterWorkflowInput,
   type RegisterWorkflowOutput,
   type RegisterWorkflowOptions,
@@ -120,6 +124,12 @@ import {
   type GetCoworkSessionByInstanceOutput,
   type ListPluginsOutput,
 } from '../contract/index.js';
+import { ApiError, ApiErrorEnvelopeSchema, type ApiErrorCode } from '../errors.js';
+
+// Re-export so SDK consumers reach for one path:
+//   import { Mediforce, MediforceClientError, ApiError } from '@mediforce/platform-api/client';
+// Server-side handlers continue to import `ApiError` from `/errors` (source).
+export { ApiError, type ApiErrorCode } from '../errors.js';
 
 /**
  * Typed client for the Mediforce API. Runtime-agnostic — works in the
@@ -164,14 +174,28 @@ export type ClientConfig =
   | (BaseClientConfig & { bearerToken: () => Promise<string | null>; apiKey?: never; fetch?: never })
   | (BaseClientConfig & { fetch: typeof fetch; apiKey?: never; bearerToken?: never });
 
-export class ApiError extends Error {
+// Composition: the semantic typed error (`ApiError`) is shared between
+// server and client. `MediforceClientError` is the transport-aware wrapper —
+// adds HTTP `status` + raw `body`, holds the reconstructed `apiError` when
+// the envelope was typed (undefined for legacy / network / non-JSON
+// responses).
+export class MediforceClientError extends Error {
   constructor(
     public readonly status: number,
     message: string,
     public readonly body: unknown,
+    public readonly apiError?: ApiError,
   ) {
     super(message);
-    this.name = 'ApiError';
+    this.name = 'MediforceClientError';
+  }
+
+  get code(): ApiErrorCode | undefined {
+    return this.apiError?.code;
+  }
+
+  get details(): unknown {
+    return this.apiError?.details;
   }
 }
 
@@ -179,6 +203,7 @@ export class Mediforce {
   readonly tasks: {
     list: (input: ListTasksInput) => Promise<ListTasksOutput>;
     get: (input: GetTaskInput) => Promise<GetTaskOutput>;
+    claim: (input: ClaimTaskInput) => Promise<ClaimTaskOutput>;
   };
 
   readonly processes: {
@@ -297,6 +322,15 @@ export class Mediforce {
         );
         const body = await parseJsonOrThrow(res, 'mediforce.tasks.get');
         return GetTaskOutputSchema.parse(body);
+      },
+      claim: async (input) => {
+        const validated = ClaimTaskInputSchema.parse(input);
+        const res = await this.request(
+          `/api/tasks/${encodeURIComponent(validated.taskId)}/claim`,
+          { method: 'POST' },
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.tasks.claim');
+        return ClaimTaskOutputSchema.parse(body);
       },
     };
 
@@ -653,11 +687,38 @@ function toSearchParams(
 async function parseJsonOrThrow(res: Response, context: string): Promise<unknown> {
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
-    const message =
-      typeof body === 'object' && body !== null && 'error' in body
-        ? String((body as { error: unknown }).error)
-        : `${context} failed with status ${res.status}`;
-    throw new ApiError(res.status, message, body);
+    const extracted = extractErrorEnvelope(body);
+    const message = extracted.message ?? `${context} failed with status ${res.status}`;
+    const apiError =
+      extracted.code !== undefined
+        ? new ApiError(extracted.code, message, extracted.details)
+        : undefined;
+    throw new MediforceClientError(res.status, message, body, apiError);
   }
   return body;
+}
+
+/**
+ * Pull the error message out of the response body. Supports both shapes:
+ *   - ADR-0005 §1 typed envelope: `{ error: { code, message, details? } }`
+ *   - Legacy string envelope: `{ error: string }` (Phase 1 routes that
+ *     haven't migrated to the typed adapter yet).
+ *
+ * The legacy branch will go away when every route is on `createRouteAdapter`,
+ * but until then both must round-trip cleanly through the client.
+ *
+ * The `code` cast is honest for known codes — unknown server codes (version
+ * drift) flow through as `ApiErrorCode` strings the client doesn't recognise.
+ * Callers comparing `err.code === 'not_found'` simply miss; they don't crash.
+ */
+function extractErrorEnvelope(body: unknown): {
+  message?: string;
+  code?: ApiErrorCode;
+  details?: unknown;
+} {
+  const parsed = ApiErrorEnvelopeSchema.safeParse(body);
+  if (!parsed.success) return {};
+  const { error } = parsed.data;
+  if (typeof error === 'string') return { message: error };
+  return { message: error.message, code: error.code as ApiErrorCode, details: error.details };
 }

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -3,11 +3,15 @@ export {
   ListTasksOutputSchema,
   GetTaskInputSchema,
   GetTaskOutputSchema,
+  ClaimTaskInputSchema,
+  ClaimTaskOutputSchema,
   ACTIONABLE_STATUSES,
   type ListTasksInput,
   type ListTasksOutput,
   type GetTaskInput,
   type GetTaskOutput,
+  type ClaimTaskInput,
+  type ClaimTaskOutput,
 } from './tasks.js';
 
 export {

--- a/packages/platform-api/src/contract/tasks.ts
+++ b/packages/platform-api/src/contract/tasks.ts
@@ -67,3 +67,22 @@ export const GetTaskOutputSchema = HumanTaskSchema;
 
 export type GetTaskInput = z.infer<typeof GetTaskInputSchema>;
 export type GetTaskOutput = z.infer<typeof GetTaskOutputSchema>;
+
+/**
+ * Contract for `POST /api/tasks/:taskId/claim`.
+ *
+ * Input is just the path-derived `taskId` — the claimer's identity comes from
+ * the auth carrier (Firebase ID token for browser, `X-Api-Key` for S2S), not
+ * the request body. Per ADR-0005 §5 the response echoes the post-mutation
+ * entity (status `claimed`, `assignedUserId` set).
+ */
+export const ClaimTaskInputSchema = z.object({
+  taskId: z.string().min(1),
+});
+
+export const ClaimTaskOutputSchema = z.object({
+  task: HumanTaskSchema,
+});
+
+export type ClaimTaskInput = z.infer<typeof ClaimTaskInputSchema>;
+export type ClaimTaskOutput = z.infer<typeof ClaimTaskOutputSchema>;

--- a/packages/platform-api/src/errors.ts
+++ b/packages/platform-api/src/errors.ts
@@ -1,14 +1,7 @@
-/**
- * Typed errors a handler may throw to signal a user-facing HTTP status other
- * than 500. The route adapter catches instances of `HandlerError` and maps
- * them to `{ error: message }` with the declared `statusCode`; any other
- * thrown value is treated as an unexpected server error and sanitised to a
- * generic 500.
- *
- * Scope grows as handlers need new statuses. Today: 403 (forbidden), 404
- * (not found). Add subclasses (409 precondition, 422 unprocessable, …) when
- * the first handler actually needs one.
- */
+import { z } from 'zod';
+
+// ADR-0005 typed errors. `ApiError` is preferred for new handlers; the
+// `HandlerError` family stays as a coexistence bridge for Phase 1 throw sites.
 export class HandlerError extends Error {
   constructor(public readonly statusCode: number, message: string) {
     super(message);
@@ -27,5 +20,90 @@ export class ForbiddenError extends HandlerError {
   constructor(message = 'Forbidden') {
     super(403, message);
     this.name = 'ForbiddenError';
+  }
+}
+
+// Closed union of error codes. Zod is the source of truth so both the
+// adapter (output) and the client (input) parse against the same enum.
+export const ApiErrorCodeSchema = z.enum([
+  'unauthorized',
+  'forbidden',
+  'not_found',
+  'validation',
+  'precondition_failed',
+  'conflict',
+  'rate_limited',
+  'internal',
+]);
+export type ApiErrorCode = z.infer<typeof ApiErrorCodeSchema>;
+
+// Envelope schemas — single source of truth for the wire shape.
+// Note: the `code` field is `z.string()` (not `ApiErrorCodeSchema`) on
+// purpose. We want graceful version drift: a v1 client must still parse
+// an envelope from a v2 server that introduced a new code. The client
+// casts to `ApiErrorCode` at the boundary (see `extractErrorEnvelope`).
+export const TypedApiErrorEnvelopeSchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    details: z.unknown().optional(),
+  }),
+});
+export const LegacyApiErrorEnvelopeSchema = z.object({
+  error: z.string(),
+});
+export const ApiErrorEnvelopeSchema = z.union([
+  TypedApiErrorEnvelopeSchema,
+  LegacyApiErrorEnvelopeSchema,
+]);
+
+export class ApiError extends Error {
+  constructor(
+    public readonly code: ApiErrorCode,
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export function httpStatusForApiErrorCode(code: ApiErrorCode): number {
+  switch (code) {
+    case 'unauthorized':
+      return 401;
+    case 'forbidden':
+      return 403;
+    case 'not_found':
+      return 404;
+    case 'validation':
+      return 400;
+    case 'precondition_failed':
+      return 409;
+    case 'conflict':
+      return 409;
+    case 'rate_limited':
+      return 429;
+    case 'internal':
+      return 500;
+  }
+}
+
+export function apiErrorCodeForStatus(statusCode: number): ApiErrorCode {
+  switch (statusCode) {
+    case 400:
+      return 'validation';
+    case 401:
+      return 'unauthorized';
+    case 403:
+      return 'forbidden';
+    case 404:
+      return 'not_found';
+    case 409:
+      return 'precondition_failed';
+    case 429:
+      return 'rate_limited';
+    default:
+      return 'internal';
   }
 }

--- a/packages/platform-api/src/handlers/__tests__/_helpers.test.ts
+++ b/packages/platform-api/src/handlers/__tests__/_helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { loadOr404 } from '../_helpers.js';
+import { ApiError } from '../../errors.js';
+
+/**
+ * Tests for the shared handler helpers. Right now `loadOr404` is the only
+ * exported helper — co-located here per the boundary guard's sibling-test
+ * rule (`api-boundaries.test.ts`).
+ */
+
+describe('loadOr404', () => {
+  it('resolves to the entity when the lookup yields a non-null value', async () => {
+    const result = await loadOr404(Promise.resolve({ id: 'x' }), 'should not throw');
+    expect(result).toEqual({ id: 'x' });
+  });
+
+  it('throws ApiError(`not_found`) with the supplied message when the lookup yields null', async () => {
+    const err = await loadOr404(Promise.resolve(null as { id: string } | null), 'Task not found').catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).code).toBe('not_found');
+    expect((err as ApiError).message).toBe('Task not found');
+  });
+
+  it('uses ApiError so the new typed envelope is produced (not legacy NotFoundError)', async () => {
+    // Sanity check: new handlers throw the ADR-0005 typed error, so the
+    // adapter takes the `instanceof ApiError` arm — no `code` derivation
+    // from a legacy `statusCode`.
+    const err = await loadOr404(Promise.resolve(null), 'missing').catch((e) => e);
+    expect((err as ApiError).name).toBe('ApiError');
+  });
+});

--- a/packages/platform-api/src/handlers/_helpers.ts
+++ b/packages/platform-api/src/handlers/_helpers.ts
@@ -1,0 +1,10 @@
+import { ApiError } from '../errors.js';
+
+export async function loadOr404<T>(
+  lookup: Promise<T | null>,
+  notFoundMessage: string,
+): Promise<T> {
+  const entity = await lookup;
+  if (entity === null) throw new ApiError('not_found', notFoundMessage);
+  return entity;
+}

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -1,4 +1,5 @@
 export { listTasks } from './tasks/list-tasks.js';
+export { claimTask } from './tasks/claim-task.js';
 export { listModels, type ListModelsDeps } from './models/list-models.js';
 export { getModel, type GetModelDeps } from './models/get-model.js';
 export { syncModels, type SyncModelsDeps } from './models/sync-models.js';

--- a/packages/platform-api/src/handlers/tasks/__tests__/claim-task.test.ts
+++ b/packages/platform-api/src/handlers/tasks/__tests__/claim-task.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  InMemoryAuditRepository,
+  InMemoryHumanTaskRepository,
+  InMemoryProcessInstanceRepository,
+  buildHumanTask,
+  buildProcessInstance,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import { claimTask } from '../claim-task.js';
+import { ApiError } from '../../../errors.js';
+import {
+  createTestScope,
+  userCaller,
+} from '../../../repositories/__tests__/create-test-scope.js';
+
+/**
+ * Handler tests for `claimTask`. Exercise the handler against real in-memory
+ * repos through `createTestScope` — same pattern as `list-tasks.test.ts`.
+ *
+ * Auth carrier semantics (PR1 decision, ADR-0005 §6):
+ *   - The claimer's `uid` comes from `scope.caller`, not the request body.
+ *     The old inline route accepted `body.userId` (falling back to
+ *     `'api-user'`); the migrated handler treats the auth carrier as the
+ *     single source of truth.
+ *   - `apiKey` callers have no human user to assign a claim to and are
+ *     refused with `forbidden` rather than silently assigning to a magic id.
+ */
+
+describe('claimTask handler', () => {
+  let humanTaskRepo: InMemoryHumanTaskRepository;
+  let instanceRepo: InMemoryProcessInstanceRepository;
+  let auditRepo: InMemoryAuditRepository;
+
+  beforeEach(async () => {
+    resetFactorySequence();
+    instanceRepo = new InMemoryProcessInstanceRepository();
+    humanTaskRepo = new InMemoryHumanTaskRepository(instanceRepo);
+    auditRepo = new InMemoryAuditRepository(instanceRepo);
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', namespace: 'team-alpha' }));
+  });
+
+  describe('happy path', () => {
+    it('returns the task in status `claimed` with the caller as assignee', async () => {
+      await humanTaskRepo.create(
+        buildHumanTask({
+          id: 'task-1',
+          processInstanceId: 'inst-a',
+          stepId: 'review',
+          status: 'pending',
+        }),
+      );
+      const scope = createTestScope({
+        humanTaskRepo,
+        instanceRepo,
+        auditRepo,
+        caller: userCaller('u-1', ['team-alpha']),
+      });
+
+      const result = await claimTask({ taskId: 'task-1' }, scope);
+
+      expect(result.task.id).toBe('task-1');
+      expect(result.task.status).toBe('claimed');
+      expect(result.task.assignedUserId).toBe('u-1');
+    });
+
+    it('emits a `task.claimed` audit event with snapshots and basis', async () => {
+      await humanTaskRepo.create(
+        buildHumanTask({
+          id: 'task-1',
+          processInstanceId: 'inst-a',
+          stepId: 'review',
+          status: 'pending',
+        }),
+      );
+      const scope = createTestScope({
+        humanTaskRepo,
+        instanceRepo,
+        auditRepo,
+        caller: userCaller('u-1', ['team-alpha']),
+      });
+
+      await claimTask({ taskId: 'task-1' }, scope);
+
+      const events = await auditRepo.getByProcess('inst-a');
+      expect(events).toHaveLength(1);
+      const event = events[0]!;
+      expect(event.action).toBe('task.claimed');
+      expect(event.actorId).toBe('u-1');
+      expect(event.actorType).toBe('user');
+      expect(event.entityType).toBe('humanTask');
+      expect(event.entityId).toBe('task-1');
+      expect(event.processInstanceId).toBe('inst-a');
+      expect(event.inputSnapshot).toMatchObject({
+        taskId: 'task-1',
+        userId: 'u-1',
+        stepId: 'review',
+      });
+      expect(event.outputSnapshot).toMatchObject({
+        status: 'claimed',
+        assignedUserId: 'u-1',
+      });
+      expect(event.basis).toBe('User claimed task via UI');
+    });
+  });
+
+  describe('precondition failures', () => {
+    it('throws ApiError(`precondition_failed`) when the task is not pending', async () => {
+      await humanTaskRepo.create(
+        buildHumanTask({
+          id: 'task-1',
+          processInstanceId: 'inst-a',
+          status: 'claimed',
+          assignedUserId: 'u-other',
+        }),
+      );
+      const scope = createTestScope({
+        humanTaskRepo,
+        instanceRepo,
+        auditRepo,
+        caller: userCaller('u-1', ['team-alpha']),
+      });
+
+      const err = await claimTask({ taskId: 'task-1' }, scope).catch((e) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).code).toBe('precondition_failed');
+      expect((err as ApiError).message).toMatch(/claim|pending/i);
+    });
+  });
+
+  describe('not-found / foreign-workspace', () => {
+    it('throws ApiError(`not_found`) when the task does not exist', async () => {
+      const scope = createTestScope({
+        humanTaskRepo,
+        instanceRepo,
+        auditRepo,
+        caller: userCaller('u-1', ['team-alpha']),
+      });
+
+      const err = await claimTask({ taskId: 'task-missing' }, scope).catch((e) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).code).toBe('not_found');
+    });
+
+    it('throws ApiError(`not_found`) for a foreign-workspace task (anti-enum)', async () => {
+      // Task exists, but in a workspace the caller is not a member of.
+      // Per ADR-0005 §3 / Phase 1 anti-enum, this surfaces as 404, not 403.
+      await instanceRepo.create(buildProcessInstance({ id: 'inst-b', namespace: 'team-beta' }));
+      await humanTaskRepo.create(
+        buildHumanTask({ id: 'task-foreign', processInstanceId: 'inst-b', status: 'pending' }),
+      );
+      const scope = createTestScope({
+        humanTaskRepo,
+        instanceRepo,
+        auditRepo,
+        caller: userCaller('u-1', ['team-alpha']),
+      });
+
+      const err = await claimTask({ taskId: 'task-foreign' }, scope).catch((e) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).code).toBe('not_found');
+    });
+  });
+
+  describe('caller-kind gate', () => {
+    it('throws ApiError(`forbidden`) for apiKey callers (no human to assign)', async () => {
+      // The auth carrier is the source of truth for the claimer's identity;
+      // apiKey (system actor) has no `uid`, so it has nothing to assign.
+      // The old inline route silently fell back to a magic 'api-user' string —
+      // we deliberately drop that for PR1.
+      await humanTaskRepo.create(
+        buildHumanTask({ id: 'task-1', processInstanceId: 'inst-a', status: 'pending' }),
+      );
+      const scope = createTestScope({
+        humanTaskRepo,
+        instanceRepo,
+        auditRepo,
+        // default caller in createTestScope is apiKey
+      });
+
+      const err = await claimTask({ taskId: 'task-1' }, scope).catch((e) => e);
+
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).code).toBe('forbidden');
+      expect((err as ApiError).message).toMatch(/system actor|claim/i);
+    });
+  });
+});

--- a/packages/platform-api/src/handlers/tasks/__tests__/contract.test.ts
+++ b/packages/platform-api/src/handlers/tasks/__tests__/contract.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { buildHumanTask } from '@mediforce/platform-core/testing';
 import {
   ACTIONABLE_STATUSES,
+  ClaimTaskInputSchema,
+  ClaimTaskOutputSchema,
   ListTasksInputSchema,
   ListTasksOutputSchema,
 } from '../../../contract/tasks.js';
@@ -148,6 +151,44 @@ describe('ListTasksOutputSchema', () => {
   it('rejects tasks that miss required fields', () => {
     const result = ListTasksOutputSchema.safeParse({
       tasks: [{ id: 'task-1' }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ClaimTaskInputSchema', () => {
+  it('accepts a non-empty taskId', () => {
+    const result = ClaimTaskInputSchema.safeParse({ taskId: 'task-1' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty-string taskId', () => {
+    const result = ClaimTaskInputSchema.safeParse({ taskId: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing taskId', () => {
+    const result = ClaimTaskInputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ClaimTaskOutputSchema', () => {
+  it('accepts a well-formed task envelope', () => {
+    const result = ClaimTaskOutputSchema.safeParse({
+      task: buildHumanTask({ id: 'task-1', status: 'claimed', assignedUserId: 'u-1' }),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects payloads missing the task field', () => {
+    const result = ClaimTaskOutputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a task missing required fields', () => {
+    const result = ClaimTaskOutputSchema.safeParse({
+      task: { id: 'task-1' },
     });
     expect(result.success).toBe(false);
   });

--- a/packages/platform-api/src/handlers/tasks/claim-task.ts
+++ b/packages/platform-api/src/handlers/tasks/claim-task.ts
@@ -1,0 +1,49 @@
+import type { ClaimTaskInput, ClaimTaskOutput } from '../../contract/tasks.js';
+import type { CallerScope } from '../../repositories/index.js';
+import { ApiError } from '../../errors.js';
+import { loadOr404 } from '../_helpers.js';
+
+// PR1 deviation from ADR-0005 §2a: state-machine precondition stays in the
+// handler. Wrapper migration deferred until claim/complete/resolve/cancel
+// move together.
+export async function claimTask(
+  input: ClaimTaskInput,
+  scope: CallerScope,
+): Promise<ClaimTaskOutput> {
+  if (scope.caller.kind !== 'user') {
+    throw new ApiError(
+      'forbidden',
+      'Cannot claim as system actor — claim requires an authenticated user',
+    );
+  }
+  const uid = scope.caller.uid;
+
+  const task = await loadOr404(scope.tasks.getById(input.taskId), 'Task not found');
+
+  if (task.status !== 'pending') {
+    throw new ApiError(
+      'precondition_failed',
+      `Cannot claim a ${task.status} task; current status: ${task.status}`,
+      { taskId: input.taskId, currentStatus: task.status },
+    );
+  }
+
+  const claimed = await scope.tasks.claim(input.taskId, uid);
+
+  await scope.system.audit.append({
+    actorId: uid,
+    actorType: 'user',
+    actorRole: 'operator',
+    action: 'task.claimed',
+    description: `User '${uid}' claimed task '${input.taskId}' for step '${task.stepId}'`,
+    timestamp: new Date().toISOString(),
+    inputSnapshot: { taskId: input.taskId, userId: uid, stepId: task.stepId },
+    outputSnapshot: { status: 'claimed', assignedUserId: uid },
+    basis: 'User claimed task via UI',
+    entityType: 'humanTask',
+    entityId: input.taskId,
+    processInstanceId: task.processInstanceId,
+  });
+
+  return { task: claimed };
+}

--- a/packages/platform-api/src/repositories/__tests__/authorized-audit-event-repository.test.ts
+++ b/packages/platform-api/src/repositories/__tests__/authorized-audit-event-repository.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  InMemoryAuditRepository,
+  InMemoryProcessInstanceRepository,
+  buildAuditEvent,
+  buildProcessInstance,
+} from '@mediforce/platform-core/testing';
+import { AuthorizedAuditEventRepository } from '../authorized-audit-event-repository.js';
+import type { CallerIdentity } from '../../auth.js';
+
+/**
+ * Wrapper tests for the audit-event repository. Reads are namespace-gated;
+ * writes do not live on this wrapper — handlers emit via `scope.system.audit`
+ * (Phase 2 bridge per ADR-0005 §7).
+ */
+
+const apiKeyCaller: CallerIdentity = { kind: 'apiKey', isSystemActor: true };
+
+function userCaller(uid: string, namespaces: readonly string[]): CallerIdentity {
+  return { kind: 'user', uid, namespaces: new Set(namespaces), isSystemActor: false };
+}
+
+describe('AuthorizedAuditEventRepository', () => {
+  let instanceRepo: InMemoryProcessInstanceRepository;
+  let raw: InMemoryAuditRepository;
+
+  beforeEach(async () => {
+    instanceRepo = new InMemoryProcessInstanceRepository();
+    raw = new InMemoryAuditRepository(instanceRepo);
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-a', namespace: 'team-alpha' }));
+    await instanceRepo.create(buildProcessInstance({ id: 'inst-b', namespace: 'team-beta' }));
+    await raw.append(
+      buildAuditEvent({
+        action: 'task.claimed',
+        entityType: 'humanTask',
+        entityId: 'task-1',
+        processInstanceId: 'inst-a',
+      }),
+    );
+    await raw.append(
+      buildAuditEvent({
+        action: 'task.claimed',
+        entityType: 'humanTask',
+        entityId: 'task-foreign',
+        processInstanceId: 'inst-b',
+      }),
+    );
+  });
+
+  describe('getByProcess', () => {
+    it('returns events for a system-actor caller (no namespace filter)', async () => {
+      const wrapper = new AuthorizedAuditEventRepository(apiKeyCaller, raw);
+
+      const events = await wrapper.getByProcess('inst-a');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.entityId).toBe('task-1');
+    });
+
+    it('returns events for an in-scope user caller', async () => {
+      const wrapper = new AuthorizedAuditEventRepository(
+        userCaller('u-1', ['team-alpha']),
+        raw,
+      );
+
+      const events = await wrapper.getByProcess('inst-a');
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.entityId).toBe('task-1');
+    });
+
+    it('returns empty for an out-of-scope user caller (anti-enum)', async () => {
+      const wrapper = new AuthorizedAuditEventRepository(
+        userCaller('u-1', ['team-alpha']),
+        raw,
+      );
+
+      const events = await wrapper.getByProcess('inst-b');
+
+      expect(events).toEqual([]);
+    });
+  });
+});

--- a/packages/platform-api/src/repositories/caller-scope.ts
+++ b/packages/platform-api/src/repositories/caller-scope.ts
@@ -1,5 +1,6 @@
 import type { AgentRunner, PluginRegistry } from '@mediforce/agent-runtime';
 import type {
+  AuditRepository,
   CronTriggerStateRepository,
   ModelRegistryRepository,
   NamespaceRepository,
@@ -91,4 +92,13 @@ export interface SystemServices {
   readonly cronTrigger: CronTrigger;
   readonly webhookRouter: WebhookRouter;
   readonly agentRunner: AgentRunner;
+  /**
+   * Raw audit-write surface — Phase 2 bridge per ADR-0005 §7. Handler-emitted
+   * audit events use this; persistence-layer emission (post-headless-migration
+   * audit-wiring phase) deletes this entry. Lives on `scope.system` rather
+   * than the `AuthorizedAuditEventRepository` because `Authorized*Repository`
+   * semantics promise per-method workspace gating, and `append` doesn't gate
+   * (the writer is a handler that already passed the read-side gate).
+   */
+  readonly audit: AuditRepository;
 }

--- a/packages/platform-api/src/repositories/create-caller-scope.ts
+++ b/packages/platform-api/src/repositories/create-caller-scope.ts
@@ -124,6 +124,7 @@ export function createCallerScope(
       cronTrigger: services.cronTrigger,
       webhookRouter: services.webhookRouter,
       agentRunner: services.agentRunner,
+      audit: services.auditRepo,
     },
   };
 }

--- a/packages/platform-ui/e2e/api/cowork.journey.ts
+++ b/packages/platform-ui/e2e/api/cowork.journey.ts
@@ -75,7 +75,8 @@ test.describe('GET /api/cowork/* — API E2E', () => {
       headers: apiKeyHeaders(),
     });
     expect(res.status()).toBe(404);
-    const body = await res.json() as { error: string };
-    expect(body.error).toMatch(/no active cowork session/i);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.message).toMatch(/no active cowork session/i);
   });
 });

--- a/packages/platform-ui/e2e/api/processes-detail.journey.ts
+++ b/packages/platform-ui/e2e/api/processes-detail.journey.ts
@@ -57,8 +57,9 @@ test.describe('GET /api/processes/* — API E2E', () => {
       headers: apiKeyHeaders(),
     });
     expect(res.status()).toBe(404);
-    const body = await res.json() as { error: string };
-    expect(body.error).toMatch(/not found/i);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.message).toMatch(/not found/i);
   });
 
   test('audit: response is wrapped as { events: [...] }', async ({ request }) => {

--- a/packages/platform-ui/e2e/api/tasks-claim.journey.ts
+++ b/packages/platform-ui/e2e/api/tasks-claim.journey.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '../helpers/test-fixtures';
+import {
+  apiKeyHeaders,
+  bearerHeaders,
+  setupMultiNamespaceCallers,
+  type MultiNamespaceFixture,
+} from '../helpers/multi-namespace';
+
+test.describe('POST /api/tasks/[taskId]/claim — API E2E', () => {
+  let callers: MultiNamespaceFixture;
+
+  test.beforeAll(async () => {
+    callers = await setupMultiNamespaceCallers();
+  });
+
+  test('apiKey caller is refused with a typed 403 envelope', async ({ request }) => {
+    const res = await request.post('/api/tasks/task-pending-1/claim', {
+      headers: apiKeyHeaders(),
+    });
+    expect(res.status(), await res.text()).toBe(403);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('forbidden');
+    expect(body.error.message).toMatch(/system actor|authenticated user/i);
+  });
+
+  test('outsider user gets 404 (anti-enumeration) for a task in another workspace', async ({ request }) => {
+    const res = await request.post('/api/tasks/task-pending-1/claim', {
+      headers: bearerHeaders(callers.outsider),
+    });
+    expect(res.status()).toBe(404);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('not_found');
+  });
+
+  test('non-existent task id returns the same 404 (indistinguishable from cross-namespace)', async ({ request }) => {
+    const res = await request.post('/api/tasks/task-does-not-exist/claim', {
+      headers: bearerHeaders(callers.outsider),
+    });
+    expect(res.status()).toBe(404);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('not_found');
+  });
+
+  test('member claiming a completed task gets a typed 409 precondition_failed', async ({ request }) => {
+    const res = await request.post('/api/tasks/task-completed-1/claim', {
+      headers: bearerHeaders(callers.member),
+    });
+    expect(res.status()).toBe(409);
+    const body = await res.json() as {
+      error: { code: string; message: string; details?: { taskId: string; currentStatus: string } };
+    };
+    expect(body.error.code).toBe('precondition_failed');
+    expect(body.error.details).toMatchObject({
+      taskId: 'task-completed-1',
+      currentStatus: 'completed',
+    });
+  });
+
+  // Mutation last: claim a fresh pending task. The seeded `task-pending-1`
+  // is not consumed by any other journey (verified via grep at PR1 time).
+  test('member claims a pending task → 200 with entity echo in `claimed` state', async ({ request }) => {
+    const res = await request.post('/api/tasks/task-pending-1/claim', {
+      headers: bearerHeaders(callers.member),
+    });
+    expect(res.status(), await res.text()).toBe(200);
+    const body = await res.json() as { task: { id: string; status: string; assignedUserId: string } };
+    expect(body.task.id).toBe('task-pending-1');
+    expect(body.task.status).toBe('claimed');
+    expect(body.task.assignedUserId).toBe(callers.member.uid);
+  });
+});

--- a/packages/platform-ui/e2e/api/tasks-get.journey.ts
+++ b/packages/platform-ui/e2e/api/tasks-get.journey.ts
@@ -48,8 +48,9 @@ test.describe('GET /api/tasks/[taskId] — API E2E', () => {
       headers: bearerHeaders(callers.outsider),
     });
     expect(res.status()).toBe(404);
-    const body = await res.json() as { error: string };
-    expect(body.error).toMatch(/not found/i);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.message).toMatch(/not found/i);
   });
 
   test('non-existent task id returns the same 404 (indistinguishable from cross-namespace)', async ({ request }) => {
@@ -57,7 +58,8 @@ test.describe('GET /api/tasks/[taskId] — API E2E', () => {
       headers: bearerHeaders(callers.outsider),
     });
     expect(res.status()).toBe(404);
-    const body = await res.json() as { error: string };
-    expect(body.error).toMatch(/not found/i);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.message).toMatch(/not found/i);
   });
 });

--- a/packages/platform-ui/e2e/api/workflow-definitions-anti-enum.journey.ts
+++ b/packages/platform-ui/e2e/api/workflow-definitions-anti-enum.journey.ts
@@ -43,8 +43,9 @@ test.describe('GET /api/workflow-definitions/[name] — visibility 404', () => {
       { headers: bearerHeaders(callers.outsider) },
     );
     expect(res.status()).toBe(404);
-    const body = await res.json() as { error: string };
-    expect(body.error).toMatch(/not found/i);
+    const body = await res.json() as { error: { code: string; message: string } };
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.message).toMatch(/not found/i);
   });
 
   test('nonexistent WD name → 404 (same shape as visibility denial)', async ({ request }) => {

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -381,7 +381,10 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
                         setVisibilityOverride(newVisibility);
                       } else {
                         const body = await res.json().catch(() => null);
-                        alert(body?.error ?? 'Failed to update visibility');
+                        const msg = typeof body?.error === 'object' && body?.error !== null
+                          ? (body.error.message ?? 'Failed to update visibility')
+                          : (body?.error ?? 'Failed to update visibility');
+                        alert(msg);
                       }
                     } finally {
                       setTogglingVisibility(false);

--- a/packages/platform-ui/src/app/actions/tasks.ts
+++ b/packages/platform-ui/src/app/actions/tasks.ts
@@ -18,56 +18,6 @@ async function requireUserId(idToken: string): Promise<{ uid: string } | { error
 }
 
 // --------------------------------------------------------------------------
-// claimTask — assign a pending task to the given user
-// --------------------------------------------------------------------------
-export async function claimTask(
-  taskId: string,
-  idToken: string,
-): Promise<{ success: boolean; error?: string }> {
-  const auth = await requireUserId(idToken);
-  if ('error' in auth) return { success: false, error: auth.error };
-  const { uid } = auth;
-
-  try {
-    const { humanTaskRepo, auditRepo } = getPlatformServices();
-
-    const task = await humanTaskRepo.getById(taskId);
-    if (!task) {
-      return { success: false, error: 'Task not found' };
-    }
-
-    if (task.status !== 'pending') {
-      return { success: false, error: `Cannot claim a ${task.status} task` };
-    }
-
-    await humanTaskRepo.claim(taskId, uid);
-
-    const now = new Date().toISOString();
-    await auditRepo.append({
-      actorId: uid,
-      actorType: 'user',
-      actorRole: 'operator',
-      action: 'task.claimed',
-      description: `User '${uid}' claimed task '${taskId}' for step '${task.stepId}'`,
-      timestamp: now,
-      inputSnapshot: { taskId, userId: uid, stepId: task.stepId },
-      outputSnapshot: { status: 'claimed', assignedUserId: uid },
-      basis: 'User claimed task via UI',
-      entityType: 'humanTask',
-      entityId: taskId,
-      processInstanceId: task.processInstanceId,
-    });
-
-    return { success: true };
-  } catch (err) {
-    return {
-      success: false,
-      error: err instanceof Error ? err.message : 'Unknown error',
-    };
-  }
-}
-
-// --------------------------------------------------------------------------
 // unclaimTask — release a claimed task back to the queue
 // --------------------------------------------------------------------------
 export async function unclaimTask(

--- a/packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts
+++ b/packages/platform-ui/src/app/api/tasks/[taskId]/claim/route.ts
@@ -1,65 +1,33 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getPlatformServices } from '@/lib/platform-services';
-import { resolveCallerIdentity, requireNamespaceAccess } from '@/lib/api-auth';
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { claimTask } from '@mediforce/platform-api/handlers';
+import { ClaimTaskInputSchema } from '@mediforce/platform-api/contract';
+import type { ClaimTaskInput } from '@mediforce/platform-api/contract';
+
+interface RouteContext {
+  params: Promise<{ taskId: string }>;
+}
 
 /**
  * POST /api/tasks/:taskId/claim
  *
- * Body: { "userId": "api-user" }
+ * Claims a pending task for the calling user. Status precondition
+ * (`pending → claimed`) and caller-kind gate (user only — apiKey is
+ * refused with `forbidden`) live in the handler.
  *
- * Claims a pending task for the given user. Task must be in 'pending' status.
+ * Body shape change vs the pre-migration route (ADR-0005 §5 / §6 +
+ * PR1 of Phase 2):
+ *   - Input no longer accepts `{ userId }`. The claimer's identity comes
+ *     from the auth carrier (`scope.caller`), not the request body.
+ *   - Response no longer echoes the bare task; it returns the entity
+ *     envelope `{ task: HumanTask }`.
  */
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ taskId: string }> },
-): Promise<NextResponse> {
-  try {
-    const { taskId } = await params;
-    const body = (await req.json()) as { userId?: string };
-    const userId = body.userId ?? 'api-user';
-
-    const { humanTaskRepo, instanceRepo, auditRepo, namespaceRepo } = getPlatformServices();
-
-    const caller = await resolveCallerIdentity(req, namespaceRepo);
-    if (caller instanceof NextResponse) return caller;
-
-    const task = await humanTaskRepo.getById(taskId);
-    if (!task) {
-      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
-    }
-
-    const instance = await instanceRepo.getById(task.processInstanceId);
-    const denied = requireNamespaceAccess(caller, instance?.namespace);
-    if (denied) return denied;
-
-    if (task.status !== 'pending') {
-      return NextResponse.json(
-        { error: `Cannot claim a ${task.status} task` },
-        { status: 409 },
-      );
-    }
-
-    const claimed = await humanTaskRepo.claim(taskId, userId);
-
-    const now = new Date().toISOString();
-    await auditRepo.append({
-      actorId: userId,
-      actorType: 'user',
-      actorRole: 'operator',
-      action: 'task.claimed',
-      description: `User '${userId}' claimed task '${taskId}' for step '${task.stepId}'`,
-      timestamp: now,
-      inputSnapshot: { taskId, userId, stepId: task.stepId },
-      outputSnapshot: { status: 'claimed', assignedUserId: userId },
-      basis: 'User claimed task via API',
-      entityType: 'humanTask',
-      entityId: taskId,
-      processInstanceId: task.processInstanceId,
-    });
-
-    return NextResponse.json(claimed);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+export const POST = createRouteAdapter<
+  typeof ClaimTaskInputSchema,
+  ClaimTaskInput,
+  unknown,
+  RouteContext
+>(
+  ClaimTaskInputSchema,
+  async (_req, ctx) => ({ taskId: (await ctx.params).taskId }),
+  claimTask,
+);

--- a/packages/platform-ui/src/components/tasks/__tests__/task-detail-upload.test.tsx
+++ b/packages/platform-ui/src/components/tasks/__tests__/task-detail-upload.test.tsx
@@ -57,7 +57,6 @@ vi.mock('@/app/actions/tasks', () => ({
   completeUploadTask: (...args: unknown[]) => mockCompleteUploadTask(...args),
   completeTask: vi.fn().mockResolvedValue({ success: true }),
   completeParamsTask: vi.fn().mockResolvedValue({ success: true }),
-  claimTask: vi.fn().mockResolvedValue({ success: true }),
   unclaimTask: vi.fn().mockResolvedValue({ success: true }),
 }));
 

--- a/packages/platform-ui/src/components/tasks/claim-button.tsx
+++ b/packages/platform-ui/src/components/tasks/claim-button.tsx
@@ -2,14 +2,9 @@
 
 import * as React from 'react';
 import { Loader2 } from 'lucide-react';
-import { claimTask } from '@/app/actions/tasks';
 import { useAuth } from '@/contexts/auth-context';
+import { mediforce } from '@/lib/mediforce';
 import { cn } from '@/lib/utils';
-
-/**
- * One-click claim button. No confirmation dialog (per user decision).
- * Calls the claimTask server action directly on click.
- */
 export function ClaimButton({
   taskId,
   fullWidth = false,
@@ -21,7 +16,6 @@ export function ClaimButton({
   variant?: 'default' | 'inline';
   onClaimed?: () => void;
 }) {
-  const { firebaseUser } = useAuth();
   const [pending, setPending] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -29,13 +23,8 @@ export function ClaimButton({
     setPending(true);
     setError(null);
     try {
-      const idToken = firebaseUser ? await firebaseUser.getIdToken() : '';
-      const result = await claimTask(taskId, idToken);
-      if (result.success) {
-        onClaimed?.();
-      } else {
-        setError(result.error ?? 'Failed to claim task');
-      }
+      await mediforce.tasks.claim({ taskId });
+      onClaimed?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to claim task');
     } finally {

--- a/packages/platform-ui/src/hooks/__tests__/use-instance-tasks.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-instance-tasks.test.ts
@@ -6,7 +6,7 @@ import { buildHumanTask } from '@mediforce/platform-core/testing';
 const listMock = vi.fn<(...args: unknown[]) => Promise<{ tasks: HumanTask[] }>>();
 vi.mock('@/lib/mediforce', () => ({
   mediforce: { tasks: { list: listMock } },
-  ApiError: class ApiError extends Error {},
+  MediforceClientError: class MediforceClientError extends Error {},
 }));
 
 const { useInstanceTasks } = await import('../use-instance-tasks');

--- a/packages/platform-ui/src/hooks/use-instance-tasks.ts
+++ b/packages/platform-ui/src/hooks/use-instance-tasks.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { HumanTask } from '@mediforce/platform-core';
-import { mediforce, ApiError } from '@/lib/mediforce';
+import { mediforce, MediforceClientError } from '@/lib/mediforce';
 
 /**
  * Fetches the full set of human tasks belonging to a single process instance
@@ -41,7 +41,7 @@ export function useInstanceTasks(instanceId: string | undefined): {
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        const normalised = err instanceof ApiError || err instanceof Error
+        const normalised = err instanceof MediforceClientError || err instanceof Error
           ? err
           : new Error(String(err));
         setError(normalised);

--- a/packages/platform-ui/src/lib/__tests__/route-adapter.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/route-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { ForbiddenError, NotFoundError } from '@mediforce/platform-api/errors';
+import { ApiError, ForbiddenError, NotFoundError } from '@mediforce/platform-api/errors';
 import type { CallerIdentity } from '@mediforce/platform-api/auth';
 import type { CallerScope } from '@mediforce/platform-api/repositories';
 import { createRouteAdapter } from '../route-adapter';
@@ -53,8 +53,10 @@ describe('createRouteAdapter', () => {
 
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toBeTypeOf('string');
-    expect(json.error.length).toBeGreaterThan(0);
+    expect(json.error.code).toBe('validation');
+    expect(json.error.message).toBeTypeOf('string');
+    expect(json.error.message.length).toBeGreaterThan(0);
+    expect(Array.isArray(json.error.details)).toBe(true);
   });
 
   it('passes parsed input + scope to the handler and returns its result as JSON', async () => {
@@ -98,7 +100,45 @@ describe('createRouteAdapter', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it('maps NotFoundError to 404 with the error message', async () => {
+  describe('typed-error → envelope mapping (ADR-0005 §3)', () => {
+    const cases: ReadonlyArray<{ code: string; status: number }> = [
+      { code: 'unauthorized', status: 401 },
+      { code: 'forbidden', status: 403 },
+      { code: 'not_found', status: 404 },
+      { code: 'validation', status: 400 },
+      { code: 'precondition_failed', status: 409 },
+      { code: 'conflict', status: 409 },
+      { code: 'rate_limited', status: 429 },
+      { code: 'internal', status: 500 },
+    ];
+
+    for (const { code, status } of cases) {
+      it(`maps ApiError('${code}') to HTTP ${status} with typed envelope`, async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const handler = vi
+          .fn()
+          .mockRejectedValue(
+            new ApiError(code as never, `boom: ${code}`, { hint: 'detail' }),
+          );
+        const GET = createRouteAdapter(
+          InputSchema,
+          (req) => ({ name: req.nextUrl.searchParams.get('name') }),
+          handler,
+          { resolveCaller: stubCaller(), buildScope },
+        );
+
+        const res = await GET(makeRequest({ name: 'alice' }), undefined);
+
+        expect(res.status).toBe(status);
+        expect(await res.json()).toEqual({
+          error: { code, message: `boom: ${code}`, details: { hint: 'detail' } },
+        });
+        consoleError.mockRestore();
+      });
+    }
+  });
+
+  it('maps legacy NotFoundError → { code: "not_found", message } at 404', async () => {
     const handler = vi.fn().mockRejectedValue(new NotFoundError('Task not found'));
     const GET = createRouteAdapter(
       InputSchema,
@@ -110,10 +150,12 @@ describe('createRouteAdapter', () => {
     const res = await GET(makeRequest({ name: 'alice' }), undefined);
 
     expect(res.status).toBe(404);
-    expect(await res.json()).toEqual({ error: 'Task not found' });
+    expect(await res.json()).toEqual({
+      error: { code: 'not_found', message: 'Task not found' },
+    });
   });
 
-  it('maps ForbiddenError to 403 with the error message', async () => {
+  it('maps legacy ForbiddenError → { code: "forbidden", message } at 403', async () => {
     const handler = vi.fn().mockRejectedValue(new ForbiddenError());
     const GET = createRouteAdapter(
       InputSchema,
@@ -125,10 +167,34 @@ describe('createRouteAdapter', () => {
     const res = await GET(makeRequest({ name: 'alice' }), undefined);
 
     expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ error: 'Forbidden' });
+    expect(await res.json()).toEqual({
+      error: { code: 'forbidden', message: 'Forbidden' },
+    });
   });
 
-  it('returns 500 with a generic message when the handler throws an unexpected error', async () => {
+  it('maps a thrown ZodError to validation with the issues in details', async () => {
+    const Inner = z.object({ x: z.number() });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handler = vi.fn().mockImplementation(() => {
+      Inner.parse({ x: 'not-a-number' });
+    });
+    const GET = createRouteAdapter(
+      InputSchema,
+      (req) => ({ name: req.nextUrl.searchParams.get('name') }),
+      handler,
+      { resolveCaller: stubCaller(), buildScope },
+    );
+
+    const res = await GET(makeRequest({ name: 'alice' }), undefined);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('validation');
+    expect(Array.isArray(body.error.details)).toBe(true);
+    consoleError.mockRestore();
+  });
+
+  it('returns 500 with a generic envelope when the handler throws an unexpected error', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const handler = vi.fn().mockRejectedValue(new Error('database on fire'));
     const GET = createRouteAdapter(
@@ -141,7 +207,9 @@ describe('createRouteAdapter', () => {
     const res = await GET(makeRequest({ name: 'alice' }), undefined);
 
     expect(res.status).toBe(500);
-    expect(await res.json()).toEqual({ error: 'Internal error' });
+    expect(await res.json()).toEqual({
+      error: { code: 'internal', message: 'Internal error' },
+    });
     expect(consoleError).toHaveBeenCalled();
   });
 

--- a/packages/platform-ui/src/lib/mediforce.ts
+++ b/packages/platform-ui/src/lib/mediforce.ts
@@ -9,11 +9,11 @@
 // with `new Mediforce({ baseUrl, apiKey })` — same contract, same type
 // safety, different runtime.
 
-import { Mediforce, ApiError } from '@mediforce/platform-api/client';
+import { Mediforce, MediforceClientError } from '@mediforce/platform-api/client';
 import { getFirebaseIdToken } from './firebase-id-token';
 
 export const mediforce = new Mediforce({
   bearerToken: getFirebaseIdToken,
 });
 
-export { ApiError };
+export { MediforceClientError };

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import type { z } from 'zod';
-import { HandlerError } from '@mediforce/platform-api/errors';
+import { z } from 'zod';
+import {
+  ApiError,
+  HandlerError,
+  apiErrorCodeForStatus,
+  httpStatusForApiErrorCode,
+  type ApiErrorCode,
+} from '@mediforce/platform-api/errors';
 import type { CallerIdentity } from '@mediforce/platform-api/auth';
 import { createCallerScope, type CallerScope } from '@mediforce/platform-api/repositories';
 import { resolveCallerIdentity } from './api-auth.js';
@@ -79,14 +85,15 @@ export function createRouteAdapter<
       raw = await inputFromRequest(req, ctx);
     } catch (err) {
       console.error('[route-adapter] inputFromRequest error:', err);
-      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+      return jsonError('validation', 'Invalid input');
     }
 
     const parsed = inputSchema.safeParse(raw);
     if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error.issues[0]?.message ?? 'Invalid input' },
-        { status: 400 },
+      return jsonError(
+        'validation',
+        parsed.error.issues[0]?.message ?? 'Invalid input',
+        parsed.error.issues,
       );
     }
 
@@ -95,13 +102,31 @@ export function createRouteAdapter<
       const result = await handler(parsed.data as NarrowInput, scope);
       return NextResponse.json(result);
     } catch (err) {
+      if (err instanceof ApiError) {
+        return jsonError(err.code, err.message, err.details);
+      }
       if (err instanceof HandlerError) {
-        return NextResponse.json({ error: err.message }, { status: err.statusCode });
+        return jsonError(apiErrorCodeForStatus(err.statusCode), err.message);
+      }
+      if (err instanceof z.ZodError) {
+        return jsonError('validation', 'Invalid input', err.issues);
       }
       console.error('[route-adapter] handler error:', err);
-      return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+      return jsonError('internal', 'Internal error');
     }
   };
+}
+
+/**
+ * Serialize the ADR-0005 §1 envelope. `code` drives the HTTP status via the
+ * §3 table — single source of truth across reads and mutations.
+ */
+function jsonError(code: ApiErrorCode, message: string, details?: unknown): NextResponse {
+  const body: { error: { code: ApiErrorCode; message: string; details?: unknown } } = {
+    error: { code, message },
+  };
+  if (details !== undefined) body.error.details = details;
+  return NextResponse.json(body, { status: httpStatusForApiErrorCode(code) });
 }
 
 function defaultBuildScope(caller: CallerIdentity): CallerScope {

--- a/packages/platform-ui/src/test/integration/api-integration.test.ts
+++ b/packages/platform-ui/src/test/integration/api-integration.test.ts
@@ -14,11 +14,12 @@ import {
   InMemoryHumanTaskRepository,
   InMemoryProcessInstanceRepository,
   buildHumanTask,
+  buildProcessInstance,
 } from '@mediforce/platform-core/testing';
-import { listTasks } from '@mediforce/platform-api/handlers';
-import { ListTasksInputSchema } from '@mediforce/platform-api/contract';
+import { listTasks, claimTask } from '@mediforce/platform-api/handlers';
+import { ListTasksInputSchema, ClaimTaskInputSchema } from '@mediforce/platform-api/contract';
 import type { CallerIdentity } from '@mediforce/platform-api/auth';
-import { Mediforce } from '@mediforce/platform-api/client';
+import { Mediforce, MediforceClientError, ApiError } from '@mediforce/platform-api/client';
 import { createRouteAdapter } from '../../lib/route-adapter';
 import { createTestScope } from '@mediforce/platform-api/testing';
 
@@ -97,6 +98,111 @@ describe('Mediforce client ↔ route-adapter ↔ listTasks (in-process)', () => 
 
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toMatch(/exactly one of/i);
+    expect(body.error.code).toBe('validation');
+    expect(body.error.message).toMatch(/exactly one of/i);
+  });
+});
+
+// Second integration scenario: `claim()` mutation. Covers PR1's specific
+// promise that a typed handler throw flows end-to-end into a client-side
+// `MediforceClientError` whose composed `apiError` carries the envelope.
+describe('Mediforce client ↔ route-adapter ↔ claimTask (in-process)', () => {
+  let humanTaskRepo: InMemoryHumanTaskRepository;
+  let instanceRepo: InMemoryProcessInstanceRepository;
+  let mediforce: Mediforce;
+  let route: (req: NextRequest, ctx: { params: Promise<{ taskId: string }> }) => Promise<Response>;
+  const userCaller: CallerIdentity = {
+    kind: 'user',
+    uid: 'u-claim-test',
+    namespaces: new Set(['team-alpha']),
+    isSystemActor: false,
+  };
+
+  beforeEach(async () => {
+    instanceRepo = new InMemoryProcessInstanceRepository();
+    humanTaskRepo = new InMemoryHumanTaskRepository(instanceRepo);
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'inst-a', namespace: 'team-alpha' }),
+    );
+
+    route = createRouteAdapter<typeof ClaimTaskInputSchema, { taskId: string }, { task: unknown }, { params: Promise<{ taskId: string }> }>(
+      ClaimTaskInputSchema,
+      async (_req, ctx) => ({ taskId: (await ctx.params).taskId }),
+      claimTask,
+      {
+        resolveCaller: async () => userCaller,
+        buildScope: (caller) => createTestScope({ caller, humanTaskRepo, instanceRepo }),
+      },
+    );
+
+    mediforce = new Mediforce({
+      fetch: async (input, init) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const taskId = url.match(/\/api\/tasks\/([^/]+)\/claim/)?.[1] ?? '';
+        const absolute = url.startsWith('http') ? url : `http://localhost${url}`;
+        return route(new NextRequest(absolute, init), {
+          params: Promise.resolve({ taskId: decodeURIComponent(taskId) }),
+        });
+      },
+    });
+  });
+
+  it('round-trips claim → returns the entity in `claimed` state with the caller uid', async () => {
+    await humanTaskRepo.create(
+      buildHumanTask({
+        id: 'task-1',
+        processInstanceId: 'inst-a',
+        status: 'pending',
+      }),
+    );
+
+    const result = await mediforce.tasks.claim({ taskId: 'task-1' });
+
+    expect(result.task.status).toBe('claimed');
+    expect(result.task.assignedUserId).toBe('u-claim-test');
+  });
+
+  it('flows a typed `precondition_failed` ApiError from handler → adapter → client', async () => {
+    await humanTaskRepo.create(
+      buildHumanTask({
+        id: 'task-1',
+        processInstanceId: 'inst-a',
+        status: 'completed',
+      }),
+    );
+
+    const err = await mediforce.tasks.claim({ taskId: 'task-1' }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MediforceClientError);
+    const clientErr = err as MediforceClientError;
+    expect(clientErr.status).toBe(409);
+    // Composition: the server-side typed error is reconstructed on the client.
+    expect(clientErr.apiError).toBeInstanceOf(ApiError);
+    expect(clientErr.code).toBe('precondition_failed');
+    expect(clientErr.details).toMatchObject({
+      taskId: 'task-1',
+      currentStatus: 'completed',
+    });
+  });
+
+  it('returns 404 (anti-enum) for a task in a workspace the caller does not belong to', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'inst-foreign', namespace: 'team-beta' }),
+    );
+    await humanTaskRepo.create(
+      buildHumanTask({
+        id: 'task-foreign',
+        processInstanceId: 'inst-foreign',
+        status: 'pending',
+      }),
+    );
+
+    const err = await mediforce.tasks
+      .claim({ taskId: 'task-foreign' })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(MediforceClientError);
+    expect((err as MediforceClientError).status).toBe(404);
+    expect((err as MediforceClientError).code).toBe('not_found');
   });
 });


### PR DESCRIPTION
## Summary

PR1 of Phase 2 of the headless migration. Migrates the smallest pure state-transition mutation (`POST /api/tasks/:taskId/claim`) end-to-end, validating the wrapper-layer + `ApiError` + audit-bridge pattern every subsequent Phase 2 mutation inherits.

Locked decisions in [ADR-0005](docs/adr/0005-headless-platform-api-ui-separation.md); plan in [`docs/headless-migration.md`](docs/headless-migration.md).

## What lands

**Adapter — typed envelope per ADR-0005 §1/§3/§4:**
- `{ error: { code, message, details? } }` across every route using `createRouteAdapter` (Phase 1 + 1.5 GETs retroactively typed).
- `ApiError` class + closed `ApiErrorCode` union (`unauthorized | forbidden | not_found | validation | precondition_failed | conflict | rate_limited | internal`); HTTP-status table encoded once in `httpStatusForApiErrorCode`.
- Legacy `HandlerError` / `NotFoundError` / `ForbiddenError` stay as a coexistence bridge — `apiErrorCodeForStatus` derives a code from the legacy `statusCode`.
- `ZodError` thrown from inside a handler → `validation` with issues in `details`.

**claim-task handler** — `(input, scope) => { task: HumanTask }` per ADR §5:
- Loads task via new `loadOr404` helper (throws `ApiError('not_found')`).
- `apiKey` callers refused with `ApiError('forbidden', …)` — no more silent `body.userId ?? 'api-user'` fallback. Auth carrier is the source of truth.
- Precondition (status `pending`) stays in handler for PR1; comment in `claim-task.ts` notes ADR §2a long-term wrapper move.
- Audit emission **moved** (not added) from the inline route into the handler via `scope.auditEvents.append({...})`. New `append()` method on `AuthorizedAuditEventRepository` — no namespace gate; events already carry `processInstanceId`, writer just passed the read-side gate.

**Client — `Mediforce.tasks.claim({ taskId })` + envelope handling:**
- `parseJsonOrThrow` understands both the typed envelope and the legacy string shape so unmigrated inline routes keep working during the migration window.
- Client `ApiError` extended with optional `code` / `details` fields (back-compat with existing 3-arg shape used by CLI).

**UI:**
- `ClaimButton` switched to `mediforce.tasks.claim()`; `UnclaimButton` stays on the Server Action until PR2 adds `/api/tasks/:id/unclaim` — mixed-state callout documented inline.
- `claimTask` Server Action deleted; tombstone comment in `app/actions/tasks.ts`. Other 5 actions (`unclaimTask` + four `complete*`) untouched (PR2 scope).
- Workflows visibility-toggle consumer reads `err.error.message` defensively.

## Tests (TDD where applicable)

| Layer | Coverage |
|---|---|
| Contract | `ClaimTaskInput/Output` assertions in `contract/__tests__/tasks.test.ts` |
| Handler | RED→GREEN in `__tests__/claim-task.test.ts`: happy path, foreign-workspace (404 anti-enum), missing task (404), `apiKey` caller (403), non-pending status (409), audit emission shape |
| Wrapper | `__tests__/authorized-audit-event-repository.test.ts` — new `append()` |
| Adapter | Table-driven over every `ApiErrorCode` → HTTP status; legacy `HandlerError` arm; `ZodError` arm |
| Client | `mediforce.tasks.claim` round-trip + envelope back-compat (new + legacy) |
| Helpers | `_helpers.test.ts` for `loadOr404` |

**Counts:**
- 16 files modified, 5 new files, **+482 / −151** in diff (treating new files via diff); commit total **+875 / −151** (counts new-file content explicitly).
- platform-api **268/268**, platform-ui **700/700**, cli **154/154** — green. Typecheck clean on every workspace.

## Routes still emitting legacy `{ error: string }` (inline, non-adapter)

Documented by the envelope-reader audit so future migrations know the surface:

- All `/api/admin/*` mutations, `/api/model-registry/*`, `/api/cron/heartbeat`, `/api/processes/{advance,cancel,resume,run,steps/.../retry,POST /api/processes}`, `/api/cowork/{chat,finalize,message}`, `/api/triggers/webhook/*`, `/api/tickets`, `/api/oauth/[provider]/callback`, `/api/users/{invite,resend-invite,members}`, `/api/workflow-definitions/[name]/{archive,copy,versions/.../archive}`, `/api/workflow-definitions/by-image`, `/api/agents/[id]/{mcp-servers/*,oauth/*}`, `/api/agent-output-file`, `/api/step-logs`, `/api/health`, `/api/tasks/[taskId]/{complete,resolve}`.

The Mediforce client's `parseJsonOrThrow` tolerates both shapes; consumers of these routes were intentionally left untouched.

## Test plan

- [ ] CI green
- [ ] Pull, run `pnpm -F @mediforce/platform-ui dev:local`; claim a `pending` task from the task detail page → button resolves, audit row appears with `action: 'task.claimed'`
- [ ] Try claiming an already-claimed task → 409 in the network panel with `{ error: { code: 'precondition_failed', … } }`
- [ ] Hit `POST /api/tasks/:taskId/claim` via `pnpm exec mediforce` (when CLI grows the command) or via raw curl with a foreign-workspace `taskId` → 404 anti-enum

## Out of scope

- `unclaim` / `complete` / `resolve` task mutations → **PR2** (closes Server Action deletion loop).
- `cancel` / `resume` process mutations → **PR2**.
- Cron heartbeat → **Phase 3** (orchestration kick, not operational ping).
- Repo-resident audit emission via `MutationContext` → dedicated post-headless-migration audit-wiring phase per ADR-0005 §7.