### PR TITLE
PR1.1 — merge HandlerError into ApiError; workflows.setVisibility typed client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Changed
+- ADR-0005 PR1.1 cleanup: merge legacy `HandlerError` / `NotFoundError` / `ForbiddenError` hierarchy into `ApiError`. The route-adapter loses its `instanceof HandlerError` arm + `apiErrorCodeForStatus` helper — `ApiError` is now the sole throwable in `@mediforce/platform-api`. `mediforce.workflows.setVisibility()` now requires `namespace` and the UI workflow page consumes the typed client (no more `apiFetch` + envelope-sniffing). CLI `workflow set-visibility` gains a `--namespace` flag.
+
 ### Fixed
 - `check-gif-freshness.py` now evaluates the net PR diff vs base instead of summing per-commit diffs. Add-then-revert within the same PR no longer trips the GIF freshness check (regression surfaced on [#481](https://github.com/Appsilon/mediforce/pull/481)).
 

--- a/docs/adr/0005-headless-platform-api-ui-separation.md
+++ b/docs/adr/0005-headless-platform-api-ui-separation.md
@@ -128,6 +128,12 @@ Rejected: Result types (`Result<T, ApiError>`). Throws + a single
 well-known base class is idiomatic in TS; result types add boilerplate
 at every call site.
 
+**Amendment (PR1.1):** the legacy `HandlerError` / `NotFoundError` /
+`ForbiddenError` hierarchy (originally kept as a Phase 1 coexistence
+bridge) is deleted. `ApiError` is now the sole throwable in `platform-
+api`. The adapter catch in §4 lost its `instanceof HandlerError` arm
+accordingly.
+
 #### 2a. Throw site
 
 State-machine invariants throw from the **wrapper repository layer** when

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -134,7 +134,7 @@ mutations set the next pattern in stone.
 | `GET /api/runs` | runs | `scope.runs.list({def, status, limit})` |
 | `GET /api/runs/:runId` | runs | `scope.runs.getById` + `scope.workflowDefinitions.getByNameVersion` (custom handler — finalOutput walk + definitionNamespace enrichment) |
 | `GET /api/workflow-secrets` | secrets | `scope.workflowSecrets` or `scope.workspaceSecrets` (workflow query param picks) |
-| `PUT /api/workflow-secrets` | secrets | same; write methods throw `ForbiddenError` for non-members |
+| `PUT /api/workflow-secrets` | secrets | same; write methods throw `ApiError('forbidden', …)` for non-members |
 | `DELETE /api/workflow-secrets` | secrets | same |
 | `GET /api/system/docker-info` | system | `@public-handler` — deployment-global. Dispatcher delegates to `_docker.ts` (local execFile vs container-worker fetch). |
 | `GET /api/system/openrouter-credits` | system | `scope.workspaceSecrets.getSecrets(workspace)` to pluck `OPENROUTER_API_KEY`, then external fetch to openrouter.ai. |
@@ -151,7 +151,7 @@ machine mutations only".
 - `GET /api/runs/:runId` switches from **403 → 404** for foreign-workspace
   ids, matching the Phase 1 anti-enumeration lesson. The `scope.runs.getById`
   wrapper returns `null` for out-of-scope; `getByIdAdapter` (well, the custom
-  handler here) maps to `NotFoundError`. Grep CLI/UI for 403-specific
+  handler here) maps to `ApiError('not_found', …)`. Grep CLI/UI for 403-specific
   branching before merge — none expected, but cheap to confirm.
 - `GET /api/workflow-secrets` for a foreign workspace now returns an empty
   `{ keys: [] }` (soft-fail per wrapper contract) instead of 403.
@@ -361,20 +361,16 @@ PR1 picks a true minimal mutation instead.
 
 **Files to touch:**
 - `packages/platform-api/src/errors.ts` — add the `ApiError` class +
-  `ApiErrorCode` union. Existing `HandlerError` / `NotFoundError` /
-  `ForbiddenError` from [#482](https://github.com/Appsilon/mediforce/pull/482)
-  **stay** as a coexistence bridge — new code throws `ApiError`,
-  existing throws keep working, both produce the same envelope shape.
-  Migration of legacy throws to `ApiError` is incremental, not PR1
-  blocking.
+  `ApiErrorCode` union. PR1 originally kept the legacy `HandlerError`
+  / `NotFoundError` / `ForbiddenError` hierarchy from [#482](https://github.com/Appsilon/mediforce/pull/482)
+  as a coexistence bridge; **PR1.1 deleted that hierarchy** — `ApiError`
+  is now the sole throwable.
 - `packages/platform-ui/src/lib/route-adapter.ts` — extend the catch
-  block with two arms per ADR-0005 §3/§4:
-  - `instanceof ApiError` → envelope with `err.code`.
-  - `instanceof HandlerError` → derive code from `statusCode`
-    (`404 → 'not_found'`, `403 → 'forbidden'`); same envelope shape.
+  block per ADR-0005 §3/§4: `instanceof ApiError` → envelope with
+  `err.code`. (PR1's transitional `instanceof HandlerError` arm was
+  removed in PR1.1.)
 - `packages/platform-ui/src/lib/__tests__/route-adapter.test.ts` —
-  extend with tests per `ApiErrorCode` for status + envelope, plus
-  the `HandlerError` legacy-throw arm.
+  extend with tests per `ApiErrorCode` for status + envelope.
 - `loadOr404` helper — extract per [#482](https://github.com/Appsilon/mediforce/pull/482)
   out-of-scope note ("third copy" rule reached for the
   `entity = await scope.X.getById(id); if (!entity) throw …` pattern).
@@ -432,8 +428,7 @@ through the loopback pattern.
 - Audit emission preserved bit-for-bit: AuditEvent rows produced by
   the migrated handler match what `claimTask` Server Action emitted
   (action `task.claimed`, same actor/description/snapshots/basis).
-- All `ApiError` codes + the `HandlerError` legacy arm mapped to
-  correct HTTP status in adapter tests.
+- All `ApiError` codes mapped to correct HTTP status in adapter tests.
 - `api-boundaries.test.ts` + `no-raw-repo-imports.test.ts` pass.
 - Existing Phase 1 / Phase 1.5 GET endpoints retroactively return the
   new error envelope (`{ error: string }` → `{ error: { code, message } }`).

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -54,7 +54,7 @@ Commands:
   workflow register --file <path> --namespace <ns>   Register a workflow definition
   workflow list                                      List registered workflow definitions
   workflow get <name> --namespace <ns>               Fetch a workflow definition
-  workflow set-visibility <name> --visibility <v>    Set workflow visibility (public|private)
+  workflow set-visibility <name> --namespace <ns> --visibility <v>    Set workflow visibility (public|private)
   workflow copy <name> --target-namespace <ns>       Copy workflow to another namespace
   workflow archive <name> --version <n>|--all       Archive/unarchive workflow versions
   agent list                                         List agent definitions
@@ -97,7 +97,7 @@ Subcommands:
   register --file <path> --namespace <ns>   Register a workflow definition
   list                                      List registered workflow definitions
   get <name>                                Fetch a workflow definition
-  set-visibility <name> --visibility <v>    Set workflow visibility (public|private)
+  set-visibility <name> --namespace <ns> --visibility <v>    Set workflow visibility (public|private)
   copy <name> --target-namespace <ns>        Copy workflow to another namespace
   archive <name> --version <n>|--all        Archive/unarchive workflow versions
 

--- a/packages/cli/src/commands/workflow-set-visibility.ts
+++ b/packages/cli/src/commands/workflow-set-visibility.ts
@@ -10,7 +10,7 @@ interface CommandInput {
   output: OutputSink;
 }
 
-const HELP = `Usage: mediforce workflow set-visibility <name> --visibility <public|private> [options]
+const HELP = `Usage: mediforce workflow set-visibility <name> --namespace <ns> --visibility <public|private> [options]
 
 Set the visibility of a workflow definition.
 
@@ -18,6 +18,7 @@ Positional:
   <name>               Workflow definition name
 
 Required flags:
+  --namespace <ns>     Namespace that owns the workflow
   --visibility <v>     Visibility level (public | private)
 
 Optional flags:
@@ -27,6 +28,7 @@ Optional flags:
 `;
 
 const SET_VISIBILITY_OPTIONS = {
+  namespace: { type: 'string' },
   visibility: { type: 'string' },
   'base-url': { type: 'string' },
   json: { type: 'boolean' },
@@ -36,6 +38,7 @@ const SET_VISIBILITY_OPTIONS = {
 export async function workflowSetVisibilityCommand(input: CommandInput): Promise<number> {
   let positionals: string[];
   let flags: {
+    namespace?: string;
     visibility?: string;
     'base-url'?: string;
     json?: boolean;
@@ -70,6 +73,12 @@ export async function workflowSetVisibilityCommand(input: CommandInput): Promise
     return 2;
   }
 
+  if (typeof flags.namespace !== 'string' || flags.namespace.length === 0) {
+    printError(input.output, { error: '--namespace is required' }, jsonMode);
+    return 2;
+  }
+  const namespace = flags.namespace;
+
   if (flags.visibility !== 'public' && flags.visibility !== 'private') {
     printError(input.output, { error: '--visibility must be "public" or "private"' }, jsonMode);
     return 2;
@@ -86,7 +95,7 @@ export async function workflowSetVisibilityCommand(input: CommandInput): Promise
 
   const mediforce = new Mediforce({ apiKey: config.apiKey, baseUrl: config.baseUrl });
   try {
-    const result = await mediforce.workflows.setVisibility({ name, visibility });
+    const result = await mediforce.workflows.setVisibility({ name, namespace, visibility });
     if (jsonMode) {
       printJson(input.output, result);
     } else {

--- a/packages/platform-api/src/__tests__/auth.test.ts
+++ b/packages/platform-api/src/__tests__/auth.test.ts
@@ -5,7 +5,7 @@ import {
   filterByCaller,
   type CallerIdentity,
 } from '../auth.js';
-import { ForbiddenError } from '../errors.js';
+import { ApiError } from '../errors.js';
 
 const apiKey: CallerIdentity = { kind: 'apiKey', isSystemActor: true };
 const userInNsA: CallerIdentity = {
@@ -24,12 +24,22 @@ describe('assertNamespaceAccess', () => {
     expect(() => assertNamespaceAccess(apiKey, 'ns-a')).not.toThrow();
   });
 
-  it('throws ForbiddenError when the user is not a member (sad)', () => {
-    expect(() => assertNamespaceAccess(userInNsA, 'ns-b')).toThrow(ForbiddenError);
+  it('throws ApiError forbidden when the user is not a member (sad)', () => {
+    expect(() => assertNamespaceAccess(userInNsA, 'ns-b')).toThrow(ApiError);
+    try {
+      assertNamespaceAccess(userInNsA, 'ns-b');
+    } catch (err) {
+      expect((err as ApiError).code).toBe('forbidden');
+    }
   });
 
-  it('throws ForbiddenError when the namespace is undefined for a user (edge)', () => {
-    expect(() => assertNamespaceAccess(userInNsA, undefined)).toThrow(ForbiddenError);
+  it('throws ApiError forbidden when the namespace is undefined for a user (edge)', () => {
+    expect(() => assertNamespaceAccess(userInNsA, undefined)).toThrow(ApiError);
+    try {
+      assertNamespaceAccess(userInNsA, undefined);
+    } catch (err) {
+      expect((err as ApiError).code).toBe('forbidden');
+    }
   });
 });
 

--- a/packages/platform-api/src/auth.ts
+++ b/packages/platform-api/src/auth.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from './errors.js';
+import { ApiError } from './errors.js';
 
 /**
  * Identity of the caller hitting an API handler.
@@ -23,10 +23,11 @@ export type CallerIdentity =
     };
 
 /**
- * Throw `ForbiddenError` unless the caller is allowed to touch resources in
- * `namespace`. System-actor callers are unrestricted; user callers must have
- * the namespace in their membership set. Missing namespaces are treated as
- * forbidden — every domain entity that's gated must carry its namespace.
+ * Throw `ApiError('forbidden', …)` unless the caller is allowed to touch
+ * resources in `namespace`. System-actor callers are unrestricted; user
+ * callers must have the namespace in their membership set. Missing namespaces
+ * are treated as forbidden — every domain entity that's gated must carry its
+ * namespace.
  *
  * Handlers call this AFTER fetching the resource (so 404 still beats 403 for
  * non-existent ids — surfacing "exists but denied" leaks information).
@@ -37,10 +38,10 @@ export function assertNamespaceAccess(
 ): void {
   if (caller.isSystemActor) return;
   if (typeof namespace !== 'string' || namespace.length === 0) {
-    throw new ForbiddenError('Resource has no namespace');
+    throw new ApiError('forbidden', 'Resource has no namespace');
   }
   if (!caller.namespaces.has(namespace)) {
-    throw new ForbiddenError();
+    throw new ApiError('forbidden', 'Forbidden');
   }
 }
 

--- a/packages/platform-api/src/client/__tests__/mediforce.test.ts
+++ b/packages/platform-api/src/client/__tests__/mediforce.test.ts
@@ -602,7 +602,7 @@ describe('Mediforce', () => {
 
   describe('error envelope back-compat (legacy `{ error: string }`)', () => {
     it('extracts the message from the legacy string envelope', async () => {
-      // Some Phase 1 routes still throw plain HandlerError with a custom
+      // Some Phase 1 routes still throw ApiError with a custom
       // shape, and the legacy 5xx surface (`{ error: <string> }`) hasn't
       // been migrated. The client must tolerate both shapes during the
       // transition.

--- a/packages/platform-api/src/client/__tests__/workflows.test.ts
+++ b/packages/platform-api/src/client/__tests__/workflows.test.ts
@@ -123,3 +123,37 @@ describe('mediforce.workflows.list', () => {
     await expect(mediforce.workflows.list()).rejects.toThrow();
   });
 });
+
+describe('mediforce.workflows.setVisibility', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PATCHes /api/workflow-definitions/<name>?namespace=<ns> with the visibility body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ success: true, name: 'wf', visibility: 'public' }),
+    );
+
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    const result = await mediforce.workflows.setVisibility({
+      name: 'wf',
+      namespace: 'Appsilon',
+      visibility: 'public',
+    });
+
+    expect(result).toEqual({ success: true, name: 'wf', visibility: 'public' });
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('http://localhost/api/workflow-definitions/wf?namespace=Appsilon');
+    expect(init?.method).toBe('PATCH');
+    expect(init?.body).toBe(JSON.stringify({ visibility: 'public' }));
+  });
+
+  it('rejects when namespace is empty', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+    await expect(
+      mediforce.workflows.setVisibility({ name: 'wf', namespace: '', visibility: 'public' }),
+    ).rejects.toThrow();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -455,8 +455,9 @@ export class Mediforce {
       },
       setVisibility: async (input) => {
         const validated = SetVisibilityInputSchema.parse(input);
+        const qs = toSearchParams({ namespace: validated.namespace });
         const res = await this.request(
-          `/api/workflow-definitions/${encodeURIComponent(validated.name)}`,
+          `/api/workflow-definitions/${encodeURIComponent(validated.name)}${qs}`,
           {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },

--- a/packages/platform-api/src/contract/cowork.ts
+++ b/packages/platform-api/src/contract/cowork.ts
@@ -6,8 +6,8 @@ import { CoworkSessionSchema } from '@mediforce/platform-core';
  *
  * Single-resource reads — the output is `CoworkSessionSchema` bare (no
  * wrapper), matching the pattern set by `GET /api/tasks/:taskId`. Missing
- * sessions surface as `NotFoundError` from the handler and are mapped to
- * HTTP 404 by the route adapter. Namespace gating happens inside the
+ * sessions surface as `ApiError('not_found', …)` from the handler and are
+ * mapped to HTTP 404 by the route adapter. Namespace gating happens inside the
  * handler via the parent process instance's namespace, surfacing as 403
  * for non-member user callers.
  */

--- a/packages/platform-api/src/contract/processes.ts
+++ b/packages/platform-api/src/contract/processes.ts
@@ -14,9 +14,10 @@ import {
  *   - GET /api/processes/:instanceId/steps     → per-step input/output/status
  *
  * 404 semantics: missing instances (or the workflow definition behind a steps
- * lookup) surface as `NotFoundError` from the handler and map to HTTP 404 in
- * the route adapter. Namespace gating is enforced inside each handler and
- * maps to 403 via `ForbiddenError` — 404 always beats 403 for missing ids.
+ * lookup) surface as `ApiError('not_found', …)` from the handler and map to
+ * HTTP 404 in the route adapter. Namespace gating is enforced inside each
+ * handler and maps to 403 via `ApiError('forbidden', …)` — 404 always beats
+ * 403 for missing ids.
  */
 
 // Mirrors `WorkflowStep.type` (`creation | review | decision | terminal`).

--- a/packages/platform-api/src/contract/tasks.ts
+++ b/packages/platform-api/src/contract/tasks.ts
@@ -55,8 +55,8 @@ export type ListTasksOutput = z.infer<typeof ListTasksOutputSchema>;
  * Contract for `GET /api/tasks/:taskId`.
  *
  * Output is the raw `HumanTaskSchema` — single resource, no wrapper. A
- * missing task surfaces as 404 (handler throws `NotFoundError`, adapter maps
- * it). Same shape as `tasks[i]` from the list endpoint, so clients reuse the
+ * missing task surfaces as 404 (handler throws `ApiError('not_found', …)`,
+ * adapter maps it). Same shape as `tasks[i]` from the list endpoint, so clients reuse the
  * type.
  */
 export const GetTaskInputSchema = z.object({

--- a/packages/platform-api/src/contract/workflows.ts
+++ b/packages/platform-api/src/contract/workflows.ts
@@ -100,6 +100,7 @@ export type ArchiveAllOutput = z.infer<typeof ArchiveAllOutputSchema>;
 
 export const SetVisibilityInputSchema = z.object({
   name: z.string().min(1),
+  namespace: z.string().min(1),
   visibility: WorkflowVisibilitySchema,
 });
 

--- a/packages/platform-api/src/errors.ts
+++ b/packages/platform-api/src/errors.ts
@@ -1,29 +1,6 @@
 import { z } from 'zod';
 
-// ADR-0005 typed errors. `ApiError` is preferred for new handlers; the
-// `HandlerError` family stays as a coexistence bridge for Phase 1 throw sites.
-export class HandlerError extends Error {
-  constructor(public readonly statusCode: number, message: string) {
-    super(message);
-    this.name = 'HandlerError';
-  }
-}
-
-export class NotFoundError extends HandlerError {
-  constructor(message = 'Not found') {
-    super(404, message);
-    this.name = 'NotFoundError';
-  }
-}
-
-export class ForbiddenError extends HandlerError {
-  constructor(message = 'Forbidden') {
-    super(403, message);
-    this.name = 'ForbiddenError';
-  }
-}
-
-// Closed union of error codes. Zod is the source of truth so both the
+// ADR-0005 typed errors. Closed union of error codes. Zod is the source of truth so both the
 // adapter (output) and the client (input) parse against the same enum.
 export const ApiErrorCodeSchema = z.enum([
   'unauthorized',
@@ -89,21 +66,3 @@ export function httpStatusForApiErrorCode(code: ApiErrorCode): number {
   }
 }
 
-export function apiErrorCodeForStatus(statusCode: number): ApiErrorCode {
-  switch (statusCode) {
-    case 400:
-      return 'validation';
-    case 401:
-      return 'unauthorized';
-    case 403:
-      return 'forbidden';
-    case 404:
-      return 'not_found';
-    case 409:
-      return 'precondition_failed';
-    case 429:
-      return 'rate_limited';
-    default:
-      return 'internal';
-  }
-}

--- a/packages/platform-api/src/handlers/__tests__/_generic.test.ts
+++ b/packages/platform-api/src/handlers/__tests__/_generic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { CallerScope } from '../../repositories/index.js';
-import { NotFoundError } from '../../errors.js';
+import { ApiError } from '../../errors.js';
 import { getByIdAdapter, listAdapter } from '../_generic.js';
 
 const fakeScope = {} as unknown as CallerScope;
@@ -46,16 +46,16 @@ describe('getByIdAdapter', () => {
     expect(result).toEqual({ agent: { id: 'x' } });
   });
 
-  it('throws NotFoundError with a string message when the fetch returns null', async () => {
+  it('throws ApiError(not_found) with a string message when the fetch returns null', async () => {
     const handler = getByIdAdapter<{ id: string }, unknown>(
       async () => null,
       'Task not found',
     );
-    await expect(handler({ id: 'missing' }, fakeScope)).rejects.toThrow(NotFoundError);
+    await expect(handler({ id: 'missing' }, fakeScope)).rejects.toThrow(ApiError);
     await expect(handler({ id: 'missing' }, fakeScope)).rejects.toThrow('Task not found');
   });
 
-  it('throws NotFoundError with a function-built message including input fields', async () => {
+  it('throws ApiError(not_found) with a function-built message including input fields', async () => {
     const handler = getByIdAdapter<{ id: string }, unknown>(
       async () => null,
       (input) => `Entity ${input.id} not found`,
@@ -63,13 +63,13 @@ describe('getByIdAdapter', () => {
     await expect(handler({ id: 'abc' }, fakeScope)).rejects.toThrow('Entity abc not found');
   });
 
-  it('throws NotFoundError even with the envelope-key overload', async () => {
+  it('throws ApiError(not_found) even with the envelope-key overload', async () => {
     const handler = getByIdAdapter<{ id: string }, unknown, 'agent'>(
       async () => null,
       (input) => `Agent ${input.id} not found`,
       'agent',
     );
-    await expect(handler({ id: 'zzz' }, fakeScope)).rejects.toThrow(NotFoundError);
+    await expect(handler({ id: 'zzz' }, fakeScope)).rejects.toThrow(ApiError);
     await expect(handler({ id: 'zzz' }, fakeScope)).rejects.toThrow('Agent zzz not found');
   });
 

--- a/packages/platform-api/src/handlers/__tests__/_helpers.test.ts
+++ b/packages/platform-api/src/handlers/__tests__/_helpers.test.ts
@@ -23,10 +23,7 @@ describe('loadOr404', () => {
     expect((err as ApiError).message).toBe('Task not found');
   });
 
-  it('uses ApiError so the new typed envelope is produced (not legacy NotFoundError)', async () => {
-    // Sanity check: new handlers throw the ADR-0005 typed error, so the
-    // adapter takes the `instanceof ApiError` arm — no `code` derivation
-    // from a legacy `statusCode`.
+  it('uses ApiError so the typed envelope is produced', async () => {
     const err = await loadOr404(Promise.resolve(null), 'missing').catch((e) => e);
     expect((err as ApiError).name).toBe('ApiError');
   });

--- a/packages/platform-api/src/handlers/_generic.ts
+++ b/packages/platform-api/src/handlers/_generic.ts
@@ -1,5 +1,5 @@
 import type { CallerScope } from '../repositories/index.js';
-import { NotFoundError } from '../errors.js';
+import { ApiError } from '../errors.js';
 
 type ScopeHandler<Input, Output> = (input: Input, scope: CallerScope) => Promise<Output>;
 
@@ -17,8 +17,8 @@ export function listAdapter<Input, Item, Key extends string>(
 }
 
 /**
- * Build a handler that calls a scope-bound lookup, throws NotFoundError on
- * null, and returns the entity directly.
+ * Build a handler that calls a scope-bound lookup, throws
+ * `ApiError('not_found', …)` on null, and returns the entity directly.
  */
 export function getByIdAdapter<Input, Item>(
   fetch: (input: Input, scope: CallerScope) => Promise<Item | null>,
@@ -43,7 +43,7 @@ export function getByIdAdapter<Input, Item, Key extends string>(
     const result = await fetch(input, scope);
     if (result === null) {
       const msg = typeof notFoundMessage === 'function' ? notFoundMessage(input) : notFoundMessage;
-      throw new NotFoundError(msg);
+      throw new ApiError('not_found', msg);
     }
     return envelopeKey !== undefined
       ? ({ [envelopeKey]: result } as Record<Key, Item>)

--- a/packages/platform-api/src/handlers/cowork/__tests__/get-cowork-session-by-instance.test.ts
+++ b/packages/platform-api/src/handlers/cowork/__tests__/get-cowork-session-by-instance.test.ts
@@ -7,7 +7,7 @@ import {
   resetFactorySequence,
 } from '@mediforce/platform-core/testing';
 import { getCoworkSessionByInstance } from '../get-cowork-session-by-instance.js';
-import { NotFoundError } from '../../../errors.js';
+import { ApiError } from '../../../errors.js';
 import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope.js';
 
 describe('getCoworkSessionByInstance handler', () => {
@@ -66,19 +66,19 @@ describe('getCoworkSessionByInstance handler', () => {
     expect(result.id).toBe('sess-1');
   });
 
-  it('throws NotFoundError when the instance is completely unknown', async () => {
+  it('throws ApiError(not_found) when the instance is completely unknown', async () => {
     const scope = createTestScope({ coworkSessionRepo, instanceRepo });
     const err = await getCoworkSessionByInstance(
       { instanceId: 'inst-missing' },
       scope,
     ).catch((e) => e);
 
-    expect(err).toBeInstanceOf(NotFoundError);
-    expect((err as NotFoundError).statusCode).toBe(404);
-    expect((err as NotFoundError).message).toContain('inst-missing');
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).code).toBe('not_found');
+    expect((err as ApiError).message).toContain('inst-missing');
   });
 
-  it('throws NotFoundError when the instance has no active session', async () => {
+  it('throws ApiError(not_found) when the instance has no active session', async () => {
     await coworkSessionRepo.create(
       buildCoworkSession({
         id: 'sess-abandoned',
@@ -93,10 +93,10 @@ describe('getCoworkSessionByInstance handler', () => {
         { instanceId: 'inst-a' },
         scope,
       ),
-    ).rejects.toBeInstanceOf(NotFoundError);
+    ).rejects.toBeInstanceOf(ApiError);
   });
 
-  it('throws NotFoundError (not ForbiddenError) when a user caller is outside the instance’s namespace (anti-enumeration)', async () => {
+  it('throws ApiError(not_found) (not forbidden) when a user caller is outside the instance’s namespace (anti-enumeration)', async () => {
     await coworkSessionRepo.create(
       buildCoworkSession({
         id: 'sess-1',
@@ -115,10 +115,10 @@ describe('getCoworkSessionByInstance handler', () => {
         { instanceId: 'inst-a' },
         scope,
       ),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
-  it('throws NotFoundError when the instance has no namespace', async () => {
+  it('throws ApiError(not_found) when the instance has no namespace', async () => {
     await instanceRepo.create(
       buildProcessInstance({ id: 'inst-orphan', namespace: undefined }),
     );
@@ -140,7 +140,7 @@ describe('getCoworkSessionByInstance handler', () => {
         { instanceId: 'inst-orphan' },
         scope,
       ),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
   it('returns the most recent active session when several exist', async () => {
@@ -174,7 +174,7 @@ describe('getCoworkSessionByInstance handler', () => {
     // Instance exists in 'team-alpha', no sessions at all. A user in
     // 'team-beta' must NOT be able to probe "does this instance have an
     // active session?" — both the cross-namespace and the no-session case
-    // return the same NotFoundError.
+    // return the same ApiError(not_found).
     const scope = createTestScope({
       coworkSessionRepo,
       instanceRepo,
@@ -186,6 +186,6 @@ describe('getCoworkSessionByInstance handler', () => {
         { instanceId: 'inst-a' },
         scope,
       ),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 });

--- a/packages/platform-api/src/handlers/cowork/get-cowork-session-by-instance.ts
+++ b/packages/platform-api/src/handlers/cowork/get-cowork-session-by-instance.ts
@@ -1,5 +1,5 @@
 import type { CallerScope } from '../../repositories/index.js';
-import { NotFoundError } from '../../errors.js';
+import { ApiError } from '../../errors.js';
 import type {
   GetCoworkSessionByInstanceInput,
   GetCoworkSessionByInstanceOutput,
@@ -8,7 +8,7 @@ import type {
 /**
  * Get the most recent *active* cowork session for a given process instance.
  * Missing instance / no active session / cross-namespace access → all surface
- * as the same `NotFoundError`. Wrapper gates by parent run; only
+ * as the same `ApiError('not_found', …)`. Wrapper gates by parent run; only
  * `status === 'active'` sessions are considered.
  */
 export async function getCoworkSessionByInstance(
@@ -17,7 +17,8 @@ export async function getCoworkSessionByInstance(
 ): Promise<GetCoworkSessionByInstanceOutput> {
   const session = await scope.coworkSessions.findMostRecentActiveForInstance(input.instanceId);
   if (session === null) {
-    throw new NotFoundError(
+    throw new ApiError(
+      'not_found',
       `No active cowork session found for instance '${input.instanceId}'`,
     );
   }

--- a/packages/platform-api/src/handlers/models/get-model.ts
+++ b/packages/platform-api/src/handlers/models/get-model.ts
@@ -1,5 +1,5 @@
 import type { ModelRegistryRepository } from '@mediforce/platform-core';
-import { NotFoundError } from '../../errors.js';
+import { ApiError } from '../../errors.js';
 import type { GetModelInput, GetModelOutput } from '../../contract/models.js';
 
 export interface GetModelDeps {
@@ -20,7 +20,7 @@ export async function getModel(
 ): Promise<GetModelOutput> {
   const model = await deps.modelRegistryRepo.getById(input.id);
   if (!model) {
-    throw new NotFoundError(`Model '${input.id}' not found in registry`);
+    throw new ApiError('not_found', `Model '${input.id}' not found in registry`);
   }
   return { model };
 }

--- a/packages/platform-api/src/handlers/processes/__tests__/get-process-steps.test.ts
+++ b/packages/platform-api/src/handlers/processes/__tests__/get-process-steps.test.ts
@@ -8,7 +8,7 @@ import {
   resetFactorySequence,
 } from '@mediforce/platform-core/testing';
 import { getProcessSteps } from '../get-process-steps.js';
-import { NotFoundError } from '../../../errors.js';
+import { ApiError } from '../../../errors.js';
 import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope.js';
 
 /**
@@ -39,14 +39,14 @@ describe('getProcessSteps handler', () => {
     );
   });
 
-  it('throws NotFoundError when the instance does not exist', async () => {
+  it('throws ApiError(not_found) when the instance does not exist', async () => {
     const scope = createTestScope({ instanceRepo, processRepo });
     await expect(
       getProcessSteps({ instanceId: 'missing' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
-  it('throws NotFoundError when the workflow definition is missing', async () => {
+  it('throws ApiError(not_found) when the workflow definition is missing', async () => {
     await instanceRepo.create(
       buildProcessInstance({
         id: 'inst-1',
@@ -59,10 +59,10 @@ describe('getProcessSteps handler', () => {
     const scope = createTestScope({ instanceRepo, processRepo });
     await expect(
       getProcessSteps({ instanceId: 'inst-1' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
-  it('throws NotFoundError when definitionVersion is not numeric', async () => {
+  it('throws ApiError(not_found) when definitionVersion is not numeric', async () => {
     await instanceRepo.create(
       buildProcessInstance({
         id: 'inst-1',
@@ -75,7 +75,7 @@ describe('getProcessSteps handler', () => {
     const scope = createTestScope({ instanceRepo, processRepo });
     await expect(
       getProcessSteps({ instanceId: 'inst-1' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
   it('skips terminal steps in the output', async () => {
@@ -242,7 +242,7 @@ describe('getProcessSteps handler', () => {
     expect(result.steps).toHaveLength(2);
   });
 
-  it('throws NotFoundError (not ForbiddenError) for cross-namespace user callers (anti-enumeration)', async () => {
+  it('throws ApiError(not_found) (not forbidden) for cross-namespace user callers (anti-enumeration)', async () => {
     await instanceRepo.create(
       buildProcessInstance({
         id: 'inst-1',
@@ -260,10 +260,10 @@ describe('getProcessSteps handler', () => {
 
     await expect(
       getProcessSteps({ instanceId: 'inst-1' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
-  it('throws NotFoundError when the instance has no namespace', async () => {
+  it('throws ApiError(not_found) when the instance has no namespace', async () => {
     await instanceRepo.create(
       buildProcessInstance({
         id: 'inst-orphan',
@@ -281,6 +281,6 @@ describe('getProcessSteps handler', () => {
 
     await expect(
       getProcessSteps({ instanceId: 'inst-orphan' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 });

--- a/packages/platform-api/src/handlers/processes/__tests__/list-audit-events.test.ts
+++ b/packages/platform-api/src/handlers/processes/__tests__/list-audit-events.test.ts
@@ -7,7 +7,7 @@ import {
   resetFactorySequence,
 } from '@mediforce/platform-core/testing';
 import { listAuditEvents } from '../list-audit-events.js';
-import { NotFoundError } from '../../../errors.js';
+import { ApiError } from '../../../errors.js';
 import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope.js';
 
 describe('listAuditEvents handler', () => {
@@ -58,14 +58,14 @@ describe('listAuditEvents handler', () => {
     expect(result.events).toHaveLength(2);
   });
 
-  it('throws NotFoundError when the instance does not exist', async () => {
+  it('throws ApiError(not_found) when the instance does not exist', async () => {
     const scope = createTestScope({ auditRepo, instanceRepo });
     await expect(
       listAuditEvents({ instanceId: 'inst-missing' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
-  it('throws NotFoundError (not ForbiddenError) for cross-namespace user callers (anti-enumeration)', async () => {
+  it('throws ApiError(not_found) (not forbidden) for cross-namespace user callers (anti-enumeration)', async () => {
     const scope = createTestScope({
       auditRepo,
       instanceRepo,
@@ -73,10 +73,10 @@ describe('listAuditEvents handler', () => {
     });
     await expect(
       listAuditEvents({ instanceId: 'inst-a' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 
-  it('throws NotFoundError when the instance has no namespace', async () => {
+  it('throws ApiError(not_found) when the instance has no namespace', async () => {
     await instanceRepo.create(
       buildProcessInstance({ id: 'inst-orphan', namespace: undefined }),
     );
@@ -87,6 +87,6 @@ describe('listAuditEvents handler', () => {
     });
     await expect(
       listAuditEvents({ instanceId: 'inst-orphan' }, scope),
-    ).rejects.toThrow(NotFoundError);
+    ).rejects.toThrow(ApiError);
   });
 });

--- a/packages/platform-api/src/handlers/processes/get-process-steps.ts
+++ b/packages/platform-api/src/handlers/processes/get-process-steps.ts
@@ -1,6 +1,6 @@
 import type { StepExecution } from '@mediforce/platform-core';
 import type { CallerScope } from '../../repositories/index.js';
-import { NotFoundError } from '../../errors.js';
+import { ApiError } from '../../errors.js';
 import type {
   GetProcessStepsInput,
   GetProcessStepsOutput,
@@ -21,7 +21,7 @@ export async function getProcessSteps(
 
   const instance = await scope.runs.getById(instanceId);
   if (instance === null) {
-    throw new NotFoundError(`Process instance ${instanceId} not found`);
+    throw new ApiError('not_found', `Process instance ${instanceId} not found`);
   }
 
   const versionNum = Number.parseInt(instance.definitionVersion, 10);
@@ -34,7 +34,8 @@ export async function getProcessSteps(
     : null;
 
   if (definition === null) {
-    throw new NotFoundError(
+    throw new ApiError(
+      'not_found',
       `Workflow definition ${instance.definitionName}@${instance.definitionVersion} not found`,
     );
   }

--- a/packages/platform-api/src/handlers/processes/list-audit-events.ts
+++ b/packages/platform-api/src/handlers/processes/list-audit-events.ts
@@ -1,5 +1,5 @@
 import type { CallerScope } from '../../repositories/index.js';
-import { NotFoundError } from '../../errors.js';
+import { ApiError } from '../../errors.js';
 import type {
   ListAuditEventsInput,
   ListAuditEventsOutput,
@@ -20,7 +20,7 @@ export async function listAuditEvents(
 ): Promise<ListAuditEventsOutput> {
   const instance = await scope.runs.getById(input.instanceId);
   if (instance === null) {
-    throw new NotFoundError(`Process instance ${input.instanceId} not found`);
+    throw new ApiError('not_found', `Process instance ${input.instanceId} not found`);
   }
   const events = await scope.auditEvents.getByProcess(input.instanceId);
   return { events };

--- a/packages/platform-api/src/handlers/runs/__tests__/get-run.test.ts
+++ b/packages/platform-api/src/handlers/runs/__tests__/get-run.test.ts
@@ -8,7 +8,7 @@ import {
   resetFactorySequence,
 } from '@mediforce/platform-core/testing';
 import { getRun } from '../get-run.js';
-import { NotFoundError } from '../../../errors.js';
+import { ApiError } from '../../../errors.js';
 import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope.js';
 
 describe('getRun handler', () => {
@@ -121,7 +121,7 @@ describe('getRun handler', () => {
     expect(result.runId).toBe('r1');
   });
 
-  it('throws NotFoundError for a foreign-workspace runId (anti-enumeration)', async () => {
+  it('throws ApiError(not_found) for a foreign-workspace runId (anti-enumeration)', async () => {
     await instanceRepo.create(buildProcessInstance({ id: 'r1', namespace: 'alpha' }));
 
     const scope = createTestScope({
@@ -130,11 +130,11 @@ describe('getRun handler', () => {
       caller: userCaller('u-2', ['beta']),
     });
 
-    await expect(getRun({ runId: 'r1' }, scope)).rejects.toBeInstanceOf(NotFoundError);
+    await expect(getRun({ runId: 'r1' }, scope)).rejects.toBeInstanceOf(ApiError);
   });
 
-  it('throws NotFoundError for a truly missing runId', async () => {
+  it('throws ApiError(not_found) for a truly missing runId', async () => {
     const scope = createTestScope({ instanceRepo, processRepo });
-    await expect(getRun({ runId: 'missing' }, scope)).rejects.toBeInstanceOf(NotFoundError);
+    await expect(getRun({ runId: 'missing' }, scope)).rejects.toBeInstanceOf(ApiError);
   });
 });

--- a/packages/platform-api/src/handlers/runs/get-run.ts
+++ b/packages/platform-api/src/handlers/runs/get-run.ts
@@ -1,5 +1,5 @@
 import type { CallerScope } from '../../repositories/index.js';
-import { NotFoundError } from '../../errors.js';
+import { ApiError } from '../../errors.js';
 import type { GetRunInput, GetRunOutput } from '../../contract/runs.js';
 import type { InstanceStatus } from '@mediforce/platform-core';
 
@@ -21,7 +21,7 @@ export async function getRun(
 ): Promise<GetRunOutput> {
   const run = await scope.runs.getById(input.runId);
   if (run === null) {
-    throw new NotFoundError(`Run ${input.runId} not found`);
+    throw new ApiError('not_found', `Run ${input.runId} not found`);
   }
 
   const finalOutput = await resolveFinalOutput(run.status, input.runId, scope);

--- a/packages/platform-api/src/handlers/secrets/__tests__/delete-secret.test.ts
+++ b/packages/platform-api/src/handlers/secrets/__tests__/delete-secret.test.ts
@@ -4,7 +4,7 @@ import type {
   WorkflowSecretsRepository,
 } from '@mediforce/platform-core';
 import { deleteSecret } from '../delete-secret.js';
-import { ForbiddenError } from '../../../errors.js';
+import { ApiError } from '../../../errors.js';
 import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope.js';
 import {
   buildNamespaceSecretsRepo,
@@ -59,7 +59,7 @@ describe('deleteSecret handler', () => {
     expect(await workflowSecretsRepo.getSecretKeys('alpha', 'wf-1')).toEqual(['KEEP']);
   });
 
-  it('throws ForbiddenError when a user caller deletes outside their namespaces', async () => {
+  it('throws ApiError(forbidden) when a user caller deletes outside their namespaces', async () => {
     const scope = createTestScope({
       namespaceSecretsRepo: workspaceSecretsRepo,
       secretsRepo: workflowSecretsRepo,
@@ -68,9 +68,9 @@ describe('deleteSecret handler', () => {
 
     await expect(
       deleteSecret({ namespace: 'alpha', key: 'KEEP_ME' }, scope),
-    ).rejects.toBeInstanceOf(ForbiddenError);
+    ).rejects.toBeInstanceOf(ApiError);
     await expect(
       deleteSecret({ namespace: 'alpha', workflow: 'wf-1', key: 'DB_URL' }, scope),
-    ).rejects.toBeInstanceOf(ForbiddenError);
+    ).rejects.toBeInstanceOf(ApiError);
   });
 });

--- a/packages/platform-api/src/handlers/secrets/__tests__/set-secret.test.ts
+++ b/packages/platform-api/src/handlers/secrets/__tests__/set-secret.test.ts
@@ -4,7 +4,7 @@ import type {
   WorkflowSecretsRepository,
 } from '@mediforce/platform-core';
 import { setSecret } from '../set-secret.js';
-import { ForbiddenError } from '../../../errors.js';
+import { ApiError } from '../../../errors.js';
 import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope.js';
 import {
   buildNamespaceSecretsRepo,
@@ -62,7 +62,7 @@ describe('setSecret handler', () => {
     expect(await workspaceSecretsRepo.getSecrets('alpha')).toEqual({});
   });
 
-  it('throws ForbiddenError when a user caller writes outside their namespaces', async () => {
+  it('throws ApiError(forbidden) when a user caller writes outside their namespaces', async () => {
     const scope = createTestScope({
       namespaceSecretsRepo: workspaceSecretsRepo,
       secretsRepo: workflowSecretsRepo,
@@ -71,9 +71,9 @@ describe('setSecret handler', () => {
 
     await expect(
       setSecret({ namespace: 'alpha', key: 'X', value: 'y' }, scope),
-    ).rejects.toBeInstanceOf(ForbiddenError);
+    ).rejects.toBeInstanceOf(ApiError);
     await expect(
       setSecret({ namespace: 'alpha', workflow: 'wf-1', key: 'X', value: 'y' }, scope),
-    ).rejects.toBeInstanceOf(ForbiddenError);
+    ).rejects.toBeInstanceOf(ApiError);
   });
 });

--- a/packages/platform-api/src/handlers/secrets/delete-secret.ts
+++ b/packages/platform-api/src/handlers/secrets/delete-secret.ts
@@ -6,7 +6,7 @@ import type {
 
 /**
  * Delete a secret. Workflow-scoped when `workflow` is set, workspace-scoped
- * otherwise. The wrapper throws `ForbiddenError` for non-members; this
+ * otherwise. The wrapper throws `ApiError('forbidden', …)` for non-members; this
  * handler delegates and trusts the adapter to translate the throw.
  */
 export async function deleteSecret(

--- a/packages/platform-api/src/handlers/secrets/set-secret.ts
+++ b/packages/platform-api/src/handlers/secrets/set-secret.ts
@@ -4,7 +4,7 @@ import type { SetSecretInput, SetSecretOutput } from '../../contract/secrets.js'
 /**
  * Upsert a secret value. When `workflow` is set, writes to the workflow-
  * scoped store; otherwise writes to the workspace-scoped store. The wrapper
- * (`assertNamespaceWrite`) throws `ForbiddenError` for non-members — the
+ * (`assertNamespaceWrite`) throws `ApiError('forbidden', …)` for non-members — the
  * adapter maps that to 403, so this handler never pre-checks.
  */
 export async function setSecret(

--- a/packages/platform-api/src/handlers/workflows/__tests__/get-workflow.test.ts
+++ b/packages/platform-api/src/handlers/workflows/__tests__/get-workflow.test.ts
@@ -4,7 +4,7 @@ import {
   buildWorkflowDefinition,
 } from '@mediforce/platform-core/testing';
 import { getWorkflow } from '../get-workflow.js';
-import { NotFoundError } from '../../../errors.js';
+import { ApiError } from '../../../errors.js';
 import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope.js';
 
 describe('getWorkflow handler', () => {
@@ -51,14 +51,14 @@ describe('getWorkflow handler', () => {
     expect(result.definition.version).toBe(1);
   });
 
-  it('throws NotFoundError when the name is unknown', async () => {
+  it('throws ApiError(not_found) when the name is unknown', async () => {
     const scope = createTestScope({ processRepo });
     await expect(
       getWorkflow({ name: 'missing' }, scope),
-    ).rejects.toBeInstanceOf(NotFoundError);
+    ).rejects.toBeInstanceOf(ApiError);
   });
 
-  it('throws NotFoundError when the explicit version does not exist', async () => {
+  it('throws ApiError(not_found) when the explicit version does not exist', async () => {
     await processRepo.saveWorkflowDefinition(
       buildWorkflowDefinition({ name: 'flow-a', version: 1, namespace: '' }),
     );
@@ -66,10 +66,10 @@ describe('getWorkflow handler', () => {
     const scope = createTestScope({ processRepo });
     await expect(
       getWorkflow({ name: 'flow-a', version: 99 }, scope),
-    ).rejects.toBeInstanceOf(NotFoundError);
+    ).rejects.toBeInstanceOf(ApiError);
   });
 
-  it('throws NotFoundError when the namespace filter does not match', async () => {
+  it('throws ApiError(not_found) when the namespace filter does not match', async () => {
     await processRepo.saveWorkflowDefinition(
       buildWorkflowDefinition({
         name: 'flow-a',
@@ -85,7 +85,7 @@ describe('getWorkflow handler', () => {
         { name: 'flow-a', namespace: 'team-beta' },
         scope,
       ),
-    ).rejects.toBeInstanceOf(NotFoundError);
+    ).rejects.toBeInstanceOf(ApiError);
   });
 
   it('apiKey callers bypass visibility on private workflows', async () => {
@@ -153,7 +153,7 @@ describe('getWorkflow handler', () => {
     expect(result.definition.name).toBe('flow-private');
   });
 
-  it('returns NotFoundError (not Forbidden) when a user reads a private workflow outside their namespace', async () => {
+  it('returns ApiError(not_found) (not forbidden) when a user reads a private workflow outside their namespace', async () => {
     // Anti-enumeration: a forbidden private workflow looks identical on the
     // wire to a missing one. Matches the pre-migration behaviour from
     // `app/api/workflow-definitions/[name]/route.ts`.
@@ -176,6 +176,6 @@ describe('getWorkflow handler', () => {
         { name: 'flow-private', namespace: 'team-alpha' },
         scope,
       ),
-    ).rejects.toBeInstanceOf(NotFoundError);
+    ).rejects.toBeInstanceOf(ApiError);
   });
 });

--- a/packages/platform-api/src/handlers/workflows/get-workflow.ts
+++ b/packages/platform-api/src/handlers/workflows/get-workflow.ts
@@ -1,5 +1,5 @@
 import type { CallerScope } from '../../repositories/index.js';
-import { NotFoundError } from '../../errors.js';
+import { ApiError } from '../../errors.js';
 import type {
   GetWorkflowInput,
   GetWorkflowOutput,
@@ -23,17 +23,17 @@ export async function getWorkflow(
   } else {
     version = await scope.workflowDefinitions.getLatestVersion(lookupNamespace, input.name);
     if (version === 0) {
-      throw new NotFoundError(`Workflow '${input.name}' not found`);
+      throw new ApiError('not_found', `Workflow '${input.name}' not found`);
     }
   }
 
   const definition = await scope.workflowDefinitions.get(lookupNamespace, input.name, version);
   if (definition === null) {
-    throw new NotFoundError(`Workflow '${input.name}' not found`);
+    throw new ApiError('not_found', `Workflow '${input.name}' not found`);
   }
 
   if (input.namespace !== undefined && definition.namespace !== input.namespace) {
-    throw new NotFoundError(`Workflow '${input.name}' not found`);
+    throw new ApiError('not_found', `Workflow '${input.name}' not found`);
   }
 
   return { definition };

--- a/packages/platform-api/src/repositories/authorized-agent-definition-repository.ts
+++ b/packages/platform-api/src/repositories/authorized-agent-definition-repository.ts
@@ -5,7 +5,7 @@ import type {
   UpdateAgentDefinitionInput,
 } from '@mediforce/platform-core';
 import type { CallerIdentity } from '../auth.js';
-import { NotFoundError } from '../errors.js';
+import { ApiError } from '../errors.js';
 import { AuthorizedScope } from './authorized-repository.js';
 
 /**
@@ -42,24 +42,24 @@ export class AuthorizedAgentDefinitionRepository extends AuthorizedScope {
     // Mutations require workspace-write on the existing agent's namespace.
     // System actors bypass.
     const existing = await this.raw.getById(id);
-    if (existing === null) throw new NotFoundError();
+    if (existing === null) throw new ApiError('not_found', 'Not found');
     this.assertWriteOrThrowNotFound(existing.namespace);
     return this.raw.update(id, input);
   };
 
   delete = async (id: string): Promise<void> => {
     const existing = await this.raw.getById(id);
-    if (existing === null) throw new NotFoundError();
+    if (existing === null) throw new ApiError('not_found', 'Not found');
     this.assertWriteOrThrowNotFound(existing.namespace);
     await this.raw.delete(id);
   };
 
-  /** Mutation-path anti-enumeration: convert ForbiddenError into NotFoundError
-   *  so non-members can't probe existence of out-of-scope agents. */
+  /** Mutation-path anti-enumeration: surface as `not_found` so non-members
+   *  can't probe existence of out-of-scope agents. */
   private assertWriteOrThrowNotFound(namespace: string | undefined): void {
     if (this.caller.isSystemActor) return;
     if (typeof namespace !== 'string' || !this.caller.namespaces.has(namespace)) {
-      throw new NotFoundError();
+      throw new ApiError('not_found', 'Not found');
     }
   }
 }

--- a/packages/platform-api/src/repositories/authorized-handoff-repository.ts
+++ b/packages/platform-api/src/repositories/authorized-handoff-repository.ts
@@ -3,7 +3,7 @@ import type {
   HandoffRepository,
 } from '@mediforce/platform-core';
 import type { CallerIdentity } from '../auth.js';
-import { ForbiddenError } from '../errors.js';
+import { ApiError } from '../errors.js';
 import { AuthorizedScope } from './authorized-repository.js';
 
 /**
@@ -60,6 +60,6 @@ export class AuthorizedHandoffRepository extends AuthorizedScope {
 
   private async assertCanMutate(entityId: string): Promise<void> {
     const entity = await this.getById(entityId);
-    if (entity === null) throw new ForbiddenError();
+    if (entity === null) throw new ApiError('forbidden', 'Forbidden');
   }
 }

--- a/packages/platform-api/src/repositories/authorized-human-task-repository.ts
+++ b/packages/platform-api/src/repositories/authorized-human-task-repository.ts
@@ -3,7 +3,7 @@ import type {
   HumanTaskRepository,
 } from '@mediforce/platform-core';
 import type { CallerIdentity } from '../auth.js';
-import { ForbiddenError } from '../errors.js';
+import { ApiError } from '../errors.js';
 import { AuthorizedScope } from './authorized-repository.js';
 
 /**
@@ -52,6 +52,6 @@ export class AuthorizedHumanTaskRepository extends AuthorizedScope {
 
   private async assertCanMutate(taskId: string): Promise<void> {
     const task = await this.getById(taskId);
-    if (task === null) throw new ForbiddenError();
+    if (task === null) throw new ApiError('forbidden', 'Forbidden');
   }
 }

--- a/packages/platform-api/src/repositories/authorized-repository.ts
+++ b/packages/platform-api/src/repositories/authorized-repository.ts
@@ -1,5 +1,5 @@
 import type { CallerIdentity } from '../auth.js';
-import { ForbiddenError } from '../errors.js';
+import { ApiError } from '../errors.js';
 
 /**
  * Workspace-scope base for `Authorized<Entity>Repository` wrappers in
@@ -37,7 +37,7 @@ export abstract class AuthorizedScope {
   protected assertNamespaceWrite(namespace: string | undefined): void {
     if (this.caller.isSystemActor) return;
     if (typeof namespace !== 'string' || !this.caller.namespaces.has(namespace)) {
-      throw new ForbiddenError();
+      throw new ApiError('forbidden', 'Forbidden');
     }
   }
 }

--- a/packages/platform-api/src/repositories/authorized-workflow-run-repository.ts
+++ b/packages/platform-api/src/repositories/authorized-workflow-run-repository.ts
@@ -6,7 +6,7 @@ import type {
 } from '@mediforce/platform-core';
 import type { ListInstancesOptions } from '@mediforce/platform-core';
 import type { CallerIdentity } from '../auth.js';
-import { ForbiddenError } from '../errors.js';
+import { ApiError } from '../errors.js';
 import { AuthorizedScope } from './authorized-repository.js';
 
 /**
@@ -78,13 +78,13 @@ export class AuthorizedWorkflowRunRepository extends AuthorizedScope {
   update = async (id: string, updates: Partial<ProcessInstance>): Promise<void> => {
     const existing = await this.getById(id);
     if (existing === null) {
-      throw new ForbiddenError();
+      throw new ApiError('forbidden', 'Forbidden');
     }
     if (updates.namespace !== undefined && updates.namespace !== existing.namespace) {
-      throw new ForbiddenError();
+      throw new ApiError('forbidden', 'Forbidden');
     }
     if (updates.deleted !== undefined && !this.caller.isSystemActor) {
-      throw new ForbiddenError();
+      throw new ApiError('forbidden', 'Forbidden');
     }
     await this.raw.update(id, updates);
   };

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -13,6 +13,7 @@ import { DefinitionsList } from '@/components/workflows/definitions-list';
 import { StartRunButton } from '@/components/processes/start-run-button';
 import { setProcessArchived, transferWorkflowNamespace } from '@/app/actions/definitions';
 import { apiFetch } from '@/lib/api-fetch';
+import { mediforce } from '@/lib/mediforce';
 import type { WorkflowDefinition } from '@mediforce/platform-core';
 import { VersionLabel } from '@/components/ui/version-label';
 import { DeleteWorkflowDialog } from '@/components/workflows/delete-workflow-dialog';
@@ -372,20 +373,14 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
                     setMenuOpen(false);
                     setTogglingVisibility(true);
                     try {
-                      const res = await apiFetch(`/api/workflow-definitions/${encodeURIComponent(decodedName)}?namespace=${encodeURIComponent(handle)}`, {
-                        method: 'PATCH',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ visibility: newVisibility }),
+                      await mediforce.workflows.setVisibility({
+                        name: decodedName,
+                        namespace: handle,
+                        visibility: newVisibility,
                       });
-                      if (res.ok) {
-                        setVisibilityOverride(newVisibility);
-                      } else {
-                        const body = await res.json().catch(() => null);
-                        const msg = typeof body?.error === 'object' && body?.error !== null
-                          ? (body.error.message ?? 'Failed to update visibility')
-                          : (body?.error ?? 'Failed to update visibility');
-                        alert(msg);
-                      }
+                      setVisibilityOverride(newVisibility);
+                    } catch (err) {
+                      alert(err instanceof Error ? err.message : 'Failed to update visibility');
                     } finally {
                       setTogglingVisibility(false);
                     }

--- a/packages/platform-ui/src/app/api/workflow-definitions/[name]/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-definitions/[name]/route.ts
@@ -17,7 +17,7 @@ interface RouteContext {
  * Returns one workflow definition. Accepts optional `?version=` (defaults to
  * latest) and `?namespace=` (filters by owning namespace). Missing
  * name/version, namespace mismatch, and visibility-denied private workflows
- * all surface as 404 via `NotFoundError` — visibility-denied is intentionally
+ * all surface as 404 via `ApiError('not_found', …)` — visibility-denied is intentionally
  * 404 (anti-enumeration), not 403.
  */
 export const GET = createRouteAdapter<

--- a/packages/platform-ui/src/app/api/workflow-secrets/route.ts
+++ b/packages/platform-ui/src/app/api/workflow-secrets/route.ts
@@ -32,7 +32,7 @@ export const GET = createRouteAdapter<typeof ListSecretKeysInputSchema, ListSecr
 /**
  * PUT /api/workflow-secrets?namespace=…&workflow=…  body: {key, value}
  *
- * Writes go through the wrapper, which throws `ForbiddenError` for non-
+ * Writes go through the wrapper, which throws `ApiError('forbidden', …)` for non-
  * members; the adapter maps that to 403.
  */
 export const PUT = createRouteAdapter<typeof SetSecretInputSchema, SetSecretInput>(

--- a/packages/platform-ui/src/lib/__tests__/route-adapter.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/route-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { ApiError, ForbiddenError, NotFoundError } from '@mediforce/platform-api/errors';
+import { ApiError } from '@mediforce/platform-api/errors';
 import type { CallerIdentity } from '@mediforce/platform-api/auth';
 import type { CallerScope } from '@mediforce/platform-api/repositories';
 import { createRouteAdapter } from '../route-adapter';
@@ -136,40 +136,6 @@ describe('createRouteAdapter', () => {
         consoleError.mockRestore();
       });
     }
-  });
-
-  it('maps legacy NotFoundError → { code: "not_found", message } at 404', async () => {
-    const handler = vi.fn().mockRejectedValue(new NotFoundError('Task not found'));
-    const GET = createRouteAdapter(
-      InputSchema,
-      (req) => ({ name: req.nextUrl.searchParams.get('name') }),
-      handler,
-      { resolveCaller: stubCaller(), buildScope },
-    );
-
-    const res = await GET(makeRequest({ name: 'alice' }), undefined);
-
-    expect(res.status).toBe(404);
-    expect(await res.json()).toEqual({
-      error: { code: 'not_found', message: 'Task not found' },
-    });
-  });
-
-  it('maps legacy ForbiddenError → { code: "forbidden", message } at 403', async () => {
-    const handler = vi.fn().mockRejectedValue(new ForbiddenError());
-    const GET = createRouteAdapter(
-      InputSchema,
-      (req) => ({ name: req.nextUrl.searchParams.get('name') }),
-      handler,
-      { resolveCaller: stubCaller(), buildScope },
-    );
-
-    const res = await GET(makeRequest({ name: 'alice' }), undefined);
-
-    expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({
-      error: { code: 'forbidden', message: 'Forbidden' },
-    });
   });
 
   it('maps a thrown ZodError to validation with the issues in details', async () => {

--- a/packages/platform-ui/src/lib/api-auth.ts
+++ b/packages/platform-ui/src/lib/api-auth.ts
@@ -56,7 +56,7 @@ export async function resolveCallerIdentity(
  * Inline-route convenience: returns a 403 `NextResponse` when the caller is
  * not allowed to access `namespace`, or `null` when access is permitted.
  *
- * NEW handlers should throw `ForbiddenError` from @mediforce/platform-api/auth
+ * NEW handlers should throw `ApiError` from @mediforce/platform-api/auth
  * via `assertNamespaceAccess` instead — the route adapter handles the HTTP
  * mapping. This helper is kept for routes that still have inline handlers.
  */

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -2,8 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
   ApiError,
-  HandlerError,
-  apiErrorCodeForStatus,
   httpStatusForApiErrorCode,
   type ApiErrorCode,
 } from '@mediforce/platform-api/errors';
@@ -30,8 +28,9 @@ import { getPlatformServices } from './platform-services.js';
  *      Note: `ctx` is Next.js's `RouteContext` shape (`{ params: Promise<…> }`)
  *      for dynamic-segment routes, or `unknown` for flat routes.
  *   3. Handler — invoked with the parsed input and a `CallerScope`. Throws of
- *      type `HandlerError` (e.g. `NotFoundError`, `ForbiddenError`) map to
- *      their declared HTTP status. Anything else is a 500 (full error logged).
+ *      type `ApiError` map their `code` to an HTTP status via
+ *      `httpStatusForApiErrorCode`. `ZodError` becomes a 400. Anything else is
+ *      a 500 (full error logged).
  *
  * Auth note: middleware in `src/middleware.ts` already gates `/api/*` for
  * presence of credentials — that's the first line of defense and exists so
@@ -104,9 +103,6 @@ export function createRouteAdapter<
     } catch (err) {
       if (err instanceof ApiError) {
         return jsonError(err.code, err.message, err.details);
-      }
-      if (err instanceof HandlerError) {
-        return jsonError(apiErrorCodeForStatus(err.statusCode), err.message);
       }
       if (err instanceof z.ZodError) {
         return jsonError('validation', 'Invalid input', err.issues);


### PR DESCRIPTION
PR1.1 follow-up to [#491](https://github.com/Appsilon/mediforce/pull/491). Closes the ADR-0005 coexistence bridge introduced in PR1 so the headless migration is no longer carrying two parallel error hierarchies through Phase 2.

**Base:** `headless-pr1-phase2` (review in isolation; fold back via `gh pr merge` or re-pointing the base once approved).

## Part A — merge `HandlerError` family into `ApiError`

`@mediforce/platform-api` now has one throwable. The legacy hierarchy is gone.

**Deleted:**
- `class HandlerError`, `class NotFoundError`, `class ForbiddenError` from `packages/platform-api/src/errors.ts`
- `apiErrorCodeForStatus` helper (no callers after the adapter arm is removed)
- `instanceof HandlerError` arm + import in `packages/platform-ui/src/lib/route-adapter.ts`
- The two `route-adapter.test.ts` cases that exercised the legacy arm

**Converted to `new ApiError(code, msg)` throws:**
- `packages/platform-api/src/auth.ts` — `assertNamespaceAccess` (2 sites)
- `packages/platform-api/src/repositories/authorized-repository.ts` — base `assertNamespaceWrite`
- `packages/platform-api/src/repositories/authorized-{handoff,human-task,workflow-run,agent-definition}-repository.ts` — ~7 sites
- `packages/platform-api/src/handlers/_generic.ts` — `getByIdAdapter` (covers most Phase 1 GETs in one line)
- `packages/platform-api/src/handlers/{cowork,models,processes,runs,workflows}/*` — every remaining inline throw

Handler / wrapper tests that checked `instanceof NotFoundError` etc. now check `instanceof ApiError && err.code === 'not_found'` (or `'forbidden'`).

## Part B — `workflows.setVisibility` via typed client

The UI page previously called raw `apiFetch` + sniffed both envelope shapes. PR1.1 routes it through `mediforce.workflows.setVisibility(...)`.

- `packages/platform-api/src/contract/workflows.ts` — `SetVisibilityInputSchema` gains required `namespace: z.string().min(1)`
- `packages/platform-api/src/client/index.ts` — `setVisibility` appends `?namespace=` to the PATCH URL (matches existing route behaviour)
- `packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx` — visibility toggle (~ line 375) replaced with `mediforce.workflows.setVisibility({ name, namespace: handle, visibility })` + try/catch alert; raw `apiFetch` for copy etc. left for Phase 2.5
- `packages/cli/src/commands/workflow-set-visibility.ts` — `--namespace` flag (required, matches `workflow-register`)
- Inline PATCH route at `packages/platform-ui/src/app/api/workflow-definitions/[name]/route.ts` stays inline (Phase 2.5 scope) — already reads namespace from query
- New client tests: namespace appears in the query; empty namespace rejected

## Docs

- ADR-0005 §2 carries a PR1.1 amendment noting the legacy hierarchy is gone
- `docs/headless-migration.md` PR1 plan updated to reflect the bridge was deleted in PR1.1 (no more "derive code from statusCode" wording)
- `CHANGELOG.md` — Changed bullet under `[Unreleased]`

## Verification

```
pnpm -F @mediforce/platform-api test          # 271 passed (34 files)
pnpm -F @mediforce/platform-ui exec vitest run # 701 passed (71 files)
pnpm -F @mediforce/cli test                    # 154 passed (18 files)
pnpm -F @mediforce/platform-api exec tsc --noEmit # clean
pnpm -F @mediforce/platform-ui exec tsc --noEmit  # clean
pnpm -F @mediforce/cli exec tsc --noEmit          # clean
```

Test count up by 3 (two legacy-arm cases deleted; two new `setVisibility` client tests added) and the existing label-renames preserved coverage.