### PR TITLE
skill(code-review): merge with self-review + Matt Pocock parallel-axis review + pre-existing-excuse gate

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -20,31 +20,16 @@ Three-axis review of a diff. Each axis runs as a **parallel sub-agent** so they 
 ## Usage
 
 ```
-/code-review              # review current branch vs main (auto-detects "self mode" → pre-flight + SHIP/ITERATE)
+/code-review              # review current branch vs main (auto self mode → pre-flight + SHIP/ITERATE)
 /code-review 42           # review GitHub PR #42
 /code-review <ref>        # review HEAD vs arbitrary fixed point (SHA, branch, tag, main, HEAD~5)
 ```
 
-## Always-spawn rule — `--inline` is internal
+Runs inline — does the actual work, no auto-spawn. If you wrote the code in this conversation, use `/self-review` instead — it spawns a subagent first so the review gets a clean context.
 
-`/code-review` from the main thread **always spawns a subagent** that runs `/code-review --inline [args]`. The subagent does the actual work and returns the report.
+## Mode auto-detection
 
-```
-Main thread sees:   /code-review [args]
-Main thread does:   Spawn Agent(general-purpose) with prompt:
-                      "Run /code-review --inline [args]. Treat the diff as if a stranger wrote it.
-                       Verify every 'pre-existing' claim with git blame before accepting.
-                       Return the full report and verdict."
-Subagent runs:      /code-review --inline [args]   ← everything below this section
-```
-
-Why: clean per-axis context, no "I just wrote this, it must be good" bias when reviewing own work, no pollution of main-thread context with diff details.
-
-`--inline` is internal. **Users never type it.** If the skill is invoked without `--inline`, spawn a subagent and stop.
-
-## Mode auto-detection (inside `--inline`)
-
-- **No arg / `--inline` only** → **self mode**: own current branch vs main. Adds Step 0 (pre-flight: typecheck + test:affected) and Step 6 (SHIP/ITERATE verdict).
+- **No arg** → **self mode**: own current branch vs main. Adds Step 0 (pre-flight: typecheck + test:affected) and Step 6 (SHIP/ITERATE verdict).
 - **PR number / ref arg** → **external review mode**: someone's PR or arbitrary commit range. Skip Step 0, use APPROVE / REQUEST CHANGES / NEEDS DISCUSSION verdict.
 
 ### Step 0 — Pre-flight (self mode only)
@@ -64,9 +49,9 @@ If a failure looks environmental (remote/emulator down, port collision, weird st
 
 ### 1. Pin the fixed point
 
-- `--inline` no further arg → self mode. Fixed point = `main` (or repo default). Diff: `git diff main...HEAD`.
-- `--inline <number>` → external review. Fixed point = PR base. Diff: `gh pr diff <number>`. Capture title/body via `gh pr view <number>`.
-- `--inline <ref>` → external review. Fixed point = ref. Diff: `git diff <ref>...HEAD` (three-dot, against merge-base).
+- No arg → self mode. Fixed point = `main` (or repo default). Diff: `git diff main...HEAD`.
+- `<number>` → external review. Fixed point = PR base. Diff: `gh pr diff <number>`. Capture title/body via `gh pr view <number>`.
+- `<ref>` → external review. Fixed point = ref. Diff: `git diff <ref>...HEAD` (three-dot, against merge-base).
 
 Also capture commit list: `git log <fixed-point>..HEAD --oneline`.
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -20,21 +20,34 @@ Three-axis review of a diff. Each axis runs as a **parallel sub-agent** so they 
 ## Usage
 
 ```
-/code-review              # review current branch vs main
+/code-review              # review current branch vs main (auto-detects "self mode" → pre-flight + SHIP/ITERATE)
 /code-review 42           # review GitHub PR #42
 /code-review <ref>        # review HEAD vs arbitrary fixed point (SHA, branch, tag, main, HEAD~5)
-/code-review --self       # pre-PR self-review of your own current diff (adds pre-flight + SHIP/ITERATE verdict)
 ```
 
-## Self-review mode (`--self`)
+## Always-spawn rule — `--inline` is internal
 
-Triggered explicitly with `--self`, or implicitly when invoked via `/self-review`.
+`/code-review` from the main thread **always spawns a subagent** that runs `/code-review --inline [args]`. The subagent does the actual work and returns the report.
 
-**Hard rule — invoke as subagent if you wrote the code.** Reviewing your own work in the same context where you wrote it is unreliable — "I just wrote this, it must be good" assumptions carry over. The main thread MUST spawn a subagent and tell it to run this skill in self mode. The subagent treats the diff as if a stranger wrote it.
+```
+Main thread sees:   /code-review [args]
+Main thread does:   Spawn Agent(general-purpose) with prompt:
+                      "Run /code-review --inline [args]. Treat the diff as if a stranger wrote it.
+                       Verify every 'pre-existing' claim with git blame before accepting.
+                       Return the full report and verdict."
+Subagent runs:      /code-review --inline [args]   ← everything below this section
+```
 
-Self-review adds **Step 0 (pre-flight)** and **Step 6 (SHIP/ITERATE verdict)** around the normal three-axis flow. Skip Step 0 + Step 6 in other modes.
+Why: clean per-axis context, no "I just wrote this, it must be good" bias when reviewing own work, no pollution of main-thread context with diff details.
 
-### Step 0 — Pre-flight (self-review only)
+`--inline` is internal. **Users never type it.** If the skill is invoked without `--inline`, spawn a subagent and stop.
+
+## Mode auto-detection (inside `--inline`)
+
+- **No arg / `--inline` only** → **self mode**: own current branch vs main. Adds Step 0 (pre-flight: typecheck + test:affected) and Step 6 (SHIP/ITERATE verdict).
+- **PR number / ref arg** → **external review mode**: someone's PR or arbitrary commit range. Skip Step 0, use APPROVE / REQUEST CHANGES / NEEDS DISCUSSION verdict.
+
+### Step 0 — Pre-flight (self mode only)
 
 Run in parallel:
 
@@ -51,10 +64,9 @@ If a failure looks environmental (remote/emulator down, port collision, weird st
 
 ### 1. Pin the fixed point
 
-- `/code-review` no arg → fixed point = `main` (or repo default). Diff: `git diff main...HEAD`.
-- `/code-review <number>` → fixed point = PR base. Diff: `gh pr diff <number>`. Capture title/body via `gh pr view <number>`.
-- `/code-review <ref>` → fixed point = ref. Diff: `git diff <ref>...HEAD` (three-dot, against merge-base).
-- `/code-review --self` → same as no arg (current branch vs main).
+- `--inline` no further arg → self mode. Fixed point = `main` (or repo default). Diff: `git diff main...HEAD`.
+- `--inline <number>` → external review. Fixed point = PR base. Diff: `gh pr diff <number>`. Capture title/body via `gh pr view <number>`.
+- `--inline <ref>` → external review. Fixed point = ref. Diff: `git diff <ref>...HEAD` (three-dot, against merge-base).
 
 Also capture commit list: `git log <fixed-point>..HEAD --oneline`.
 
@@ -144,7 +156,7 @@ APPROVE / REQUEST CHANGES / NEEDS DISCUSSION
 - Big Picture: N questions (worst: …)
 ```
 
-### Step 6 — SHIP / ITERATE verdict (self-review only)
+### Step 6 — SHIP / ITERATE verdict (self mode only)
 
 Replace the normal verdict with one of:
 
@@ -205,7 +217,7 @@ When a sub-agent (or the implementer) labels a finding "pre-existing, not introd
 
 Reject "pre-existing" claims phrased as: "this was already broken", "not my change", "unrelated", "out of scope" — without git evidence.
 
-In `--self` mode this is a hard gate: any finding waved away as pre-existing without `git blame` output forces ITERATE.
+In self mode this is a hard gate: any finding waved away as pre-existing without `git blame` output forces ITERATE.
 
 ## Why three axes
 
@@ -224,11 +236,11 @@ Reporting separately stops one axis from masking another.
 - MUST include `file:line` references for every Standards / Spec finding.
 - Big Picture findings phrased as **questions to the user**, not assertions.
 - MUST verify every "pre-existing" claim with `git blame` before accepting it.
-- In `--self` mode: SHIP only when actually fixed; ITERATE if anything was waved away as pre-existing without git evidence.
+- In self mode: SHIP only when actually fixed; ITERATE if anything was waved away as pre-existing without git evidence.
 - If no findings in a category, omit that subsection.
 
 ## What this skill does NOT do
 
 - Does NOT commit, push, or open a PR — main thread acts on findings.
 - Does NOT silently fix things — findings come back as text, main thread decides.
-- Does NOT run full `pnpm test:e2e` (browser, ~4min) — pre-merge gate, run once before opening PR. L3 `test:e2e:api` (~30s, no browser) IS in scope when the diff touches handlers/middleware in `--self` mode.
+- Does NOT run full `pnpm test:e2e` (browser, ~4min) — pre-merge gate, run once before opening PR. L3 `test:e2e:api` (~30s, no browser) IS in scope when the diff touches handlers/middleware in self mode.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: code-review
-description: Review pull requests and code changes for architecture, security, conventions, and quality. Use when asked to review a PR, diff, or specific files.
-allowed-tools: Bash, Read, Glob, Grep
+description: Review pull requests and code changes along three parallel axes — Standards (file-by-file conventions, dead code, DRY/KISS, comments), Spec (does it match the originating issue/PRD), and Big Picture (scope creep, removable features, duplicated mechanisms). Use when asked to review a PR, diff, branch, or specific files.
+allowed-tools: Bash, Read, Glob, Grep, Agent
 metadata:
-  version: "1.0"
+  version: "2.0"
   domain: development
   complexity: intermediate
   tags: review, quality, security, architecture
@@ -11,49 +11,105 @@ metadata:
 
 # Code Review
 
+Three-axis review of a diff. Each axis runs as a **parallel sub-agent** so they don't pollute each other's context, then this skill aggregates findings side-by-side.
+
+- **Standards** — file-by-file: conventions, dead code, DRY/KISS, reuse of existing repo mechanisms, comment quality.
+- **Spec** — does the diff faithfully implement the originating issue / PRD?
+- **Big Picture** — should any of this be removed? Does it duplicate something we already have? Scope creep?
+
 ## Usage
 
 ```
-/code-review          # review current branch changes vs main
-/code-review 42       # review PR #42
+/code-review              # review current branch vs main
+/code-review 42           # review GitHub PR #42
+/code-review <ref>        # review HEAD vs arbitrary fixed point (SHA, branch, tag, main, HEAD~5)
 ```
 
-## Workflow
+## Process
 
-1. **Get the diff** — `gh pr diff <number>` or `git diff main...HEAD`
-2. **Classify files** — group by layer: API routes, UI components, data/schemas, config, tests
-3. **Apply checklist** — go through `references/review-checklist.md` section by section
-4. **Check test coverage** — verify behavioral changes have tests
-5. **Output findings** — structured report with severity levels
+### 1. Pin the fixed point
 
-## Output Format
+- `/code-review` with no arg → fixed point = `main` (or repo default branch). Diff: `git diff main...HEAD`.
+- `/code-review <number>` → fixed point = PR base. Diff: `gh pr diff <number>`. Capture title/body via `gh pr view <number>`.
+- `/code-review <ref>` → fixed point = ref. Diff: `git diff <ref>...HEAD` (three-dot, against merge-base).
+
+Also capture commit list: `git log <fixed-point>..HEAD --oneline`.
+
+### 2. Identify the spec source
+
+Look in this order:
+1. Issue refs in commit messages / PR body (`#123`, `Closes #45`) — fetch via `gh issue view <n>`.
+2. PRD / spec file under `docs/`, `specs/`, `.scratch/` matching branch name or feature.
+3. PR description itself (when reviewing a PR).
+4. If nothing found, ask user. If they say there isn't one, **Spec** sub-agent skips and reports "no spec available".
+
+### 3. Identify standards sources
+
+Always include: `AGENTS.md`, `CLAUDE.md`, `docs/adr/` (architectural decisions are standards), `references/review-checklist.md` (this skill's checklist). Skip what tooling enforces (eslint, biome, tsconfig) — note their existence but don't re-check.
+
+### 4. Spawn three sub-agents in parallel
+
+Single message, three `Agent` tool calls, `general-purpose` subagent. Each prompt MUST include the diff command, commit list, and the relevant inputs from steps 2–3.
+
+**Standards sub-agent prompt** (file-by-file, low-level):
+
+> Read `AGENTS.md`, `CLAUDE.md`, and `.claude/skills/code-review/references/review-checklist.md`. Walk the diff **file by file, hunk by hunk**. For each changed file report:
+> - Convention violations (cite the rule: file + line of the standard).
+> - **Dead code** — functions/exports/files not referenced anywhere. Grep to verify.
+> - **DRY/KISS violations** — duplicated logic, unnecessary abstraction, layers that solve nothing.
+> - **Reuse misses** — places where the diff reinvents a helper/util/pattern that already exists in the repo. Search for it before flagging.
+> - **Comment quality** — flag flowery / restating-the-code comments. Keep only comments that explain *why* (non-obvious constraints, invariants, gotchas). Self-documenting code wins.
+> Distinguish hard violations from judgement calls. Skip anything tooling already checks. Under 600 words. Format each finding as `file:line — issue — suggestion`.
+
+**Spec sub-agent prompt**:
+
+> Read the spec (path/contents provided). Then read the diff. Report:
+> - (a) Requirements asked for, missing or partial.
+> - (b) Behaviour in the diff not asked for (scope creep — flag for the Big Picture axis too).
+> - (c) Requirements that look implemented but wrong.
+> Quote the spec line for each finding. Under 400 words.
+
+**Big Picture sub-agent prompt**:
+
+> You are reviewing for *should this exist at all*, not for code quality. Read the diff and the spec. Ask:
+> - Are any added features/endpoints/UI elements **candidates for removal** instead of addition? Is the user replacing something — and if so, should the old thing be deleted in the same PR?
+> - Does the diff **duplicate functionality** that already exists in the repo (search for similar handlers, helpers, components)? Could the new code be a thin wrapper instead?
+> - Is there **scope creep** — work outside the stated intent that should be a separate PR?
+> - Are we **reinventing platform mechanisms** (CLI vs raw fetch, our `apiFetch`, our Zod schemas, our workflow engine primitives) where the project already has the proper tool?
+> Flag each item with a question for the user to confirm — these are big-picture judgement calls, not auto-rejections. Under 400 words.
+
+If spec is missing: skip Spec, run Standards + Big Picture, note in final report.
+
+### 5. Aggregate
+
+Present three reports under `## Standards`, `## Spec`, `## Big Picture` headings, verbatim or lightly cleaned. Do **not** merge or rerank — axes are deliberately separate so one can't mask another.
+
+End with:
 
 ```markdown
-## Summary
-[1-2 sentences on overall quality and readiness]
-
-## Findings
-
-### Critical (blocks merge)
-- `file:line` — description
-
-### High (should fix before merge)
-- `file:line` — description
-
-### Medium (improve if possible)
-- `file:line` — description
-
-### Low (suggestions)
-- `file:line` — description
-
 ## Verdict
 APPROVE / REQUEST CHANGES / NEEDS DISCUSSION
+
+## Summary
+- Standards: N findings (worst: …)
+- Spec: N findings (worst: …)
+- Big Picture: N questions (worst: …)
 ```
+
+## Why three axes
+
+A change can pass one and fail another:
+- Follows every standard but implements wrong thing → Standards pass, Spec fail.
+- Does exactly what issue asked but breaks conventions → Spec pass, Standards fail.
+- Both correct and well-written but **shouldn't exist** (duplicates existing feature, scope creep) → Standards + Spec pass, Big Picture fail.
+
+Reporting separately stops one axis from masking another.
 
 ## Rules
 
-- MUST check every changed file against the checklist
-- MUST flag known project conventions from `AGENTS.md` (no `any`, explicit booleans, Python scripts, etc.)
-- MUST NOT rubber-stamp — flag real issues, not just style preferences
-- MUST include file:line references for all findings
-- If no issues found in a category, omit it from the report
+- MUST check every changed file against the checklist.
+- MUST flag known project conventions from `AGENTS.md` (no `any`, explicit booleans, Python scripts, CLI > REST, etc.).
+- MUST NOT rubber-stamp — flag real issues, not just style preferences.
+- MUST include `file:line` references for every Standards / Spec finding.
+- Big Picture findings phrased as **questions to the user**, not assertions.
+- If no findings in a category, omit that subsection.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: code-review
-description: Review pull requests and code changes along three parallel axes — Standards (file-by-file conventions, dead code, DRY/KISS, comments), Spec (does it match the originating issue/PRD), and Big Picture (scope creep, removable features, duplicated mechanisms). Use when asked to review a PR, diff, branch, or specific files.
+description: Review pull requests, branches, or your own pre-PR diff along three parallel axes — Standards (file-by-file conventions, dead code, DRY/KISS, comments), Spec (does it match the originating issue/PRD), and Big Picture (scope creep, removable features, duplicated mechanisms). Use when asked to review a PR, diff, branch, specific files, or your own changes before shipping.
 allowed-tools: Bash, Read, Glob, Grep, Agent
 metadata:
-  version: "2.0"
+  version: "3.0"
   domain: development
   complexity: intermediate
-  tags: review, quality, security, architecture
+  tags: review, quality, security, architecture, pre-pr
 ---
 
 # Code Review
@@ -23,15 +23,38 @@ Three-axis review of a diff. Each axis runs as a **parallel sub-agent** so they 
 /code-review              # review current branch vs main
 /code-review 42           # review GitHub PR #42
 /code-review <ref>        # review HEAD vs arbitrary fixed point (SHA, branch, tag, main, HEAD~5)
+/code-review --self       # pre-PR self-review of your own current diff (adds pre-flight + SHIP/ITERATE verdict)
 ```
+
+## Self-review mode (`--self`)
+
+Triggered explicitly with `--self`, or implicitly when invoked via `/self-review`.
+
+**Hard rule — invoke as subagent if you wrote the code.** Reviewing your own work in the same context where you wrote it is unreliable — "I just wrote this, it must be good" assumptions carry over. The main thread MUST spawn a subagent and tell it to run this skill in self mode. The subagent treats the diff as if a stranger wrote it.
+
+Self-review adds **Step 0 (pre-flight)** and **Step 6 (SHIP/ITERATE verdict)** around the normal three-axis flow. Skip Step 0 + Step 6 in other modes.
+
+### Step 0 — Pre-flight (self-review only)
+
+Run in parallel:
+
+```bash
+pnpm typecheck
+pnpm test:affected
+```
+
+If either fails for a code reason — STOP, report. No point reviewing code that doesn't compile or pass affected tests.
+
+If a failure looks environmental (remote/emulator down, port collision, weird state), check `docs/knowledge-base/wiki/gotchas/` or invoke `/knowledge-base` before debugging. Distinguish "I broke this" from "the env is broken" before iterating.
 
 ## Process
 
 ### 1. Pin the fixed point
 
-- `/code-review` with no arg → fixed point = `main` (or repo default branch). Diff: `git diff main...HEAD`.
+- `/code-review` no arg → fixed point = `main` (or repo default). Diff: `git diff main...HEAD`.
 - `/code-review <number>` → fixed point = PR base. Diff: `gh pr diff <number>`. Capture title/body via `gh pr view <number>`.
 - `/code-review <ref>` → fixed point = ref. Diff: `git diff <ref>...HEAD` (three-dot, against merge-base).
+- `/code-review --self` → same as no arg (current branch vs main).
 
 Also capture commit list: `git log <fixed-point>..HEAD --oneline`.
 
@@ -45,7 +68,7 @@ Look in this order:
 
 ### 3. Identify standards sources
 
-Always include: `AGENTS.md`, `CLAUDE.md`, `docs/adr/` (architectural decisions are standards), `references/review-checklist.md` (this skill's checklist). Skip what tooling enforces (eslint, biome, tsconfig) — note their existence but don't re-check.
+Always include: `AGENTS.md`, `CLAUDE.md`, `docs/adr/`, `references/review-checklist.md`. Skip what tooling enforces (eslint, biome, tsconfig) — note their existence but don't re-check.
 
 ### 4. Spawn three sub-agents in parallel
 
@@ -84,7 +107,7 @@ If spec is missing: skip Spec, run Standards + Big Picture, note in final report
 
 Present three reports under `## Standards`, `## Spec`, `## Big Picture` headings, verbatim or lightly cleaned. Do **not** merge or rerank — axes are deliberately separate so one can't mask another.
 
-End with:
+End normal mode with:
 
 ```markdown
 ## Verdict
@@ -95,6 +118,69 @@ APPROVE / REQUEST CHANGES / NEEDS DISCUSSION
 - Spec: N findings (worst: …)
 - Big Picture: N questions (worst: …)
 ```
+
+### Step 6 — SHIP / ITERATE verdict (self-review only)
+
+Replace the normal verdict with one of:
+
+**SHIP** — only when ALL of:
+- typecheck: pass
+- test:affected: pass
+- Standards: zero blockers, zero "should fix"
+- Spec: nothing missing / wrong
+- Big Picture: no open questions you couldn't answer with certainty
+- Coverage exists at the right level: new endpoint → L3, new pure logic → L1, new UI journey → L4 with GIF
+- No finding waved away as "pre-existing" without git-blame evidence (see next section)
+
+```markdown
+## Verdict: SHIP
+
+- typecheck: pass
+- test:affected: pass (N tests)
+- diff: clean
+- coverage: <level> in <path>
+- Standards / Spec / Big Picture: no blockers
+
+Ready to commit / open PR.
+```
+
+**ITERATE** — everything else:
+
+```markdown
+## Verdict: ITERATE
+
+### Blockers
+- `file:line` — what's wrong, what to do
+
+### Should fix
+- `file:line` — what's wrong, what to do
+
+### Nice to have (optional)
+- `file:line` — suggestion
+
+Address blockers and re-run before shipping.
+```
+
+## The "pre-existing" excuse — treat as smell
+
+When a sub-agent (or the implementer) labels a finding "pre-existing, not introduced by this PR" — **do not auto-accept**. This is one of the most common cop-outs and often disguises:
+
+- Code the diff *touched* (same function, same file) but didn't fix while it was there.
+- Bugs the diff *exposed* or *propagated* further.
+- Issues the implementer noticed and chose to skip.
+
+**Hard verification before accepting a "pre-existing" claim:**
+
+1. `git blame <file> -L <line>,<line>` — was this line authored before the branch diverged? If the line itself is from the diff, it's not pre-existing, full stop.
+2. Even if the line is older: does the diff touch the same function / module / call path? If yes, the diff inherits responsibility — "while you're here, fix it" applies.
+3. Is the "pre-existing" issue something that would have been caught by the new standards / new test the diff adds? Then the diff should fix it consistently.
+4. Did the implementer *know* about it (commit messages, comments, conversation)? Knowing-and-skipping is a different category from didn't-notice.
+
+**Legitimate pre-existing**: line authored months ago, in a file the diff doesn't touch, surfaced only by an unrelated grep, with a real reason it can't be in scope (separate domain, risky refactor, would balloon the PR). Document why and ship — but **only after the above verification**, never on the implementer's word alone.
+
+Reject "pre-existing" claims phrased as: "this was already broken", "not my change", "unrelated", "out of scope" — without git evidence.
+
+In `--self` mode this is a hard gate: any finding waved away as pre-existing without `git blame` output forces ITERATE.
 
 ## Why three axes
 
@@ -112,4 +198,12 @@ Reporting separately stops one axis from masking another.
 - MUST NOT rubber-stamp — flag real issues, not just style preferences.
 - MUST include `file:line` references for every Standards / Spec finding.
 - Big Picture findings phrased as **questions to the user**, not assertions.
+- MUST verify every "pre-existing" claim with `git blame` before accepting it.
+- In `--self` mode: SHIP only when actually fixed; ITERATE if anything was waved away as pre-existing without git evidence.
 - If no findings in a category, omit that subsection.
+
+## What this skill does NOT do
+
+- Does NOT commit, push, or open a PR — main thread acts on findings.
+- Does NOT silently fix things — findings come back as text, main thread decides.
+- Does NOT run full `pnpm test:e2e` (browser, ~4min) — pre-merge gate, run once before opening PR. L3 `test:e2e:api` (~30s, no browser) IS in scope when the diff touches handlers/middleware in `--self` mode.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -66,9 +66,34 @@ Look in this order:
 3. PR description itself (when reviewing a PR).
 4. If nothing found, ask user. If they say there isn't one, **Spec** sub-agent skips and reports "no spec available".
 
-### 3. Identify standards sources
+### 3. Standards sources — fixed list
 
-Always include: `AGENTS.md`, `CLAUDE.md`, `docs/adr/`, `references/review-checklist.md`. Skip what tooling enforces (eslint, biome, tsconfig) — note their existence but don't re-check.
+Don't rediscover these every run. Always pass this exact list to the Standards sub-agent:
+
+**Required:**
+- `AGENTS.md` — top-level rules: KISS-first, test-first (`/new-test`), CLI > REST (`/use-mediforce`), no `any`, English everywhere, no docstrings on un-changed code, explicit boolean comparisons, Python scripts, main-thread = manager.
+- `CLAUDE.md` — entrypoint (currently `@AGENTS.md`).
+- `.claude/skills/code-review/references/review-checklist.md` — 9-section checklist including DRY/KISS (5a), dead code (5b), reuse repo mechanisms (5c), comment quality (5d).
+- `docs/adr/` — every accepted ADR is a binding standard. Currently:
+  - `docs/adr/0001-firestore-to-postgres.md` — data layer direction.
+  - `docs/adr/0004-scoped-data-access-authorization.md` — authz model.
+  - `docs/adr/0005-headless-platform-api-ui-separation.md` — package boundaries.
+- `docs/architecture.md` — package graph + dependency direction.
+- `docs/api-architecture.md` — handler / contract / repo layering inside `platform-api`.
+- `docs/development.md` — local dev conventions.
+- `docs/E2E-STRATEGY.md` — L1–L5 test-level model (`/new-test` enforces).
+- `docs/knowledge-base/wiki/STYLE.md` — wiki/docs style.
+- `docs/knowledge-base/wiki/gotchas/` — known environmental pitfalls; consult before debugging weird failures.
+
+**Skip** (tooling already enforces): `eslint.config.*`, `biome.json`, `tsconfig.json`, `.editorconfig`, `prettier.config.*`. Note their existence in the sub-agent prompt but don't re-check what tooling checks.
+
+**Reuse-targets cheat sheet** (for checklist section 5c — sub-agent should grep before flagging):
+- HTTP from browser → `@/lib/use-mediforce` / `apiFetch`.
+- Server-to-server → `Mediforce` client (`packages/cli`) or `pnpm exec mediforce`.
+- Validation → existing Zod schemas in `packages/platform-core`.
+- Background work → BullMQ via `packages/container-worker`.
+- Workflow / agent orchestration → `packages/workflow-engine` + `packages/agent-runtime`.
+- UI primitives → existing components / shadcn / sonner.
 
 ### 4. Spawn three sub-agents in parallel
 
@@ -76,7 +101,7 @@ Single message, three `Agent` tool calls, `general-purpose` subagent. Each promp
 
 **Standards sub-agent prompt** (file-by-file, low-level):
 
-> Read `AGENTS.md`, `CLAUDE.md`, and `.claude/skills/code-review/references/review-checklist.md`. Walk the diff **file by file, hunk by hunk**. For each changed file report:
+> Read the fixed standards list from step 3 (paste it in — `AGENTS.md`, `CLAUDE.md`, `.claude/skills/code-review/references/review-checklist.md`, every file under `docs/adr/`, `docs/architecture.md`, `docs/api-architecture.md`, `docs/development.md`, `docs/E2E-STRATEGY.md`, `docs/knowledge-base/wiki/STYLE.md`). Use the reuse-targets cheat sheet from step 3 when checking 5c. Walk the diff **file by file, hunk by hunk**. For each changed file report:
 > - Convention violations (cite the rule: file + line of the standard).
 > - **Dead code** — functions/exports/files not referenced anywhere. Grep to verify.
 > - **DRY/KISS violations** — duplicated logic, unnecessary abstraction, layers that solve nothing.

--- a/skills/code-review/references/review-checklist.md
+++ b/skills/code-review/references/review-checklist.md
@@ -36,6 +36,42 @@
 - [ ] Explicit boolean comparisons (`=== true`, not just truthy)
 - [ ] Scripts are Python, not bash
 
+## 5a. DRY / KISS — file-by-file, hunk-by-hunk
+
+- [ ] No duplicated logic — same code shape repeated ≥3 times → extract.
+- [ ] No premature abstractions — single-caller wrappers, "future-proof" layers that solve nothing now.
+- [ ] No needless indirection — pass-through functions, re-exports of re-exports, config objects with one field.
+- [ ] Each hunk is a *sensible* change — not a copy-paste of the adjacent file with one symbol renamed.
+- [ ] No half-implemented branches, dangling TODOs, or scaffolding left from intermediate steps.
+
+## 5b. Dead code & removal candidates
+
+- [ ] Grep every new export — is it actually called? If not, delete.
+- [ ] Grep every *removed* function — are call sites also gone? Stale references = bug.
+- [ ] When the diff replaces feature A with feature B: is A actually deleted in this PR, or left rotting?
+- [ ] Flag features/endpoints/UI elements that look obsolete now that the new code lands — **ask the user** before deleting.
+- [ ] Old fixtures / mock data / dead config keys removed alongside the code that used them.
+
+## 5c. Reuse existing repo mechanisms
+
+- [ ] HTTP from browser → `@/lib/use-mediforce` / `apiFetch`, never raw `fetch`.
+- [ ] Server-to-server → `Mediforce` client / `mediforce` CLI, never curl REST.
+- [ ] Validation → existing Zod schemas in `platform-core`, not new ad-hoc shapes.
+- [ ] Auth / tenancy / repo access → existing helpers, not hand-rolled.
+- [ ] UI primitives → existing components / shadcn / sonner, not bespoke divs reimplementing what we have.
+- [ ] Background work → BullMQ via `container-worker`, not setTimeout / setInterval.
+- [ ] Workflow / agent orchestration → `workflow-engine` + `agent-runtime` primitives, not parallel implementations.
+- [ ] Before approving any new helper: did you grep for an existing one? Note the search you ran.
+
+## 5d. Comment quality
+
+- [ ] Comments explain **why** — non-obvious constraints, invariants, gotchas, links to incidents/ADRs.
+- [ ] No comments that restate the code (`// increment i`).
+- [ ] No flowery / multi-paragraph prose where one line suffices.
+- [ ] No docstrings added to code the diff didn't change.
+- [ ] Self-documenting code wins: prefer a better name over a comment.
+- [ ] No "Added for X flow" / "Used by Y" / issue-number comments — that belongs in the PR description.
+
 ## 6. Testing
 
 - [ ] New behavior has unit tests (colocated `__tests__/` or `*.test.ts`)

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: self-review
-description: Final check on your own changes before reporting a task done, opening a PR, or asking for review. Thin wrapper that spawns `/code-review --self` in a subagent. **MUST be invoked as a subagent** — a clean context yields an honest review; reviewing your own work inline produces blindspots. Triggers include "self review", "review my changes", "check my diff", "ready to commit", "ready for PR", "I'm done", "before I ship".
+description: Final check on your own changes before reporting a task done, opening a PR, or asking for review. Alias for `/code-review` with no args — which already spawns a subagent, auto-detects self mode, runs pre-flight + three-axis review, and returns SHIP / ITERATE. Triggers include "self review", "review my changes", "check my diff", "ready to commit", "ready for PR", "I'm done", "before I ship".
 allowed-tools: Bash, Read, Glob, Grep, Agent
 metadata:
-  version: "2.0"
+  version: "3.0"
   domain: development
   complexity: intermediate
   tags: review, quality, pre-pr
@@ -11,19 +11,13 @@ metadata:
 
 # Self-Review
 
-Thin wrapper around `/code-review --self`. All logic lives there: pre-flight (typecheck + affected tests), three-axis review (Standards / Spec / Big Picture), `git blame` gate on "pre-existing" excuses, SHIP / ITERATE verdict.
+Alias for `/code-review` (no args). Run that. It already:
 
-## Hard rule — invoke as subagent
+- Always spawns a subagent (clean context — no "I just wrote this, it must be good" bias).
+- Auto-detects self mode when called with no args (own current branch vs main).
+- Runs pre-flight (`pnpm typecheck` + `pnpm test:affected`).
+- Runs the three-axis review (Standards / Spec / Big Picture).
+- Applies the `git blame` gate on every "pre-existing" excuse.
+- Returns SHIP / ITERATE verdict.
 
-If you wrote the code in this conversation, **STOP**. Spawn a subagent and have it run this skill. Reviewing your own work in the same context where you wrote it is unreliable — "I just wrote this, it must be good" assumptions don't carry to an outside reader.
-
-From the main thread:
-
-```
-Spawn Agent (general-purpose) with prompt:
-  Run /code-review --self on the current branch. Treat the diff as if a stranger wrote it.
-  Verify every "pre-existing" claim with git blame before accepting it.
-  Return the SHIP / ITERATE verdict and the full three-axis report.
-```
-
-That's the whole skill. See `.claude/skills/code-review/SKILL.md` for what `--self` mode does, the SHIP gate, and the pre-existing-excuse policy.
+See `.claude/skills/code-review/SKILL.md` for the full spec.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: self-review
-description: Final check on your own changes before reporting a task done, opening a PR, or asking for review. Alias for `/code-review` with no args — which already spawns a subagent, auto-detects self mode, runs pre-flight + three-axis review, and returns SHIP / ITERATE. Triggers include "self review", "review my changes", "check my diff", "ready to commit", "ready for PR", "I'm done", "before I ship".
-allowed-tools: Bash, Read, Glob, Grep, Agent
+description: Final check on your own changes before reporting a task done, opening a PR, or asking for review. Spawns a subagent that runs `/code-review` on the current branch — clean context, no "I just wrote this, it must be good" bias. Returns SHIP / ITERATE verdict. Triggers include "self review", "review my changes", "check my diff", "ready to commit", "ready for PR", "I'm done", "before I ship".
+allowed-tools: Agent
 metadata:
   version: "3.0"
   domain: development
@@ -11,13 +11,16 @@ metadata:
 
 # Self-Review
 
-Alias for `/code-review` (no args). Run that. It already:
+Spawn a subagent. Have it run `/code-review` on the current branch. Return the verdict.
 
-- Always spawns a subagent (clean context — no "I just wrote this, it must be good" bias).
-- Auto-detects self mode when called with no args (own current branch vs main).
-- Runs pre-flight (`pnpm typecheck` + `pnpm test:affected`).
-- Runs the three-axis review (Standards / Spec / Big Picture).
-- Applies the `git blame` gate on every "pre-existing" excuse.
-- Returns SHIP / ITERATE verdict.
+```
+Agent (general-purpose) prompt:
+  Run /code-review on the current branch (no args → auto self mode).
+  Treat the diff as if a stranger wrote it.
+  Verify every "pre-existing" claim with git blame before accepting it.
+  Return the full three-axis report + SHIP / ITERATE verdict.
+```
 
-See `.claude/skills/code-review/SKILL.md` for the full spec.
+That's it. Why a subagent: reviewing your own work in the same context where you wrote it is unreliable — "I just wrote this, it must be good" assumptions don't carry to an outside reader. A fresh context reviews honestly.
+
+All review logic lives in `.claude/skills/code-review/SKILL.md`: pre-flight (`pnpm typecheck` + `pnpm test:affected`), three-axis review (Standards / Spec / Big Picture), `git blame` gate on "pre-existing" excuses, SHIP / ITERATE verdict.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: self-review
-description: Final check on your own changes before reporting a task done, opening a PR, or asking for review. Runs typecheck, affected tests, diff inspection, style audit, and `/code-review`, then returns a SHIP / ITERATE verdict. **MUST be invoked as a subagent** — a clean context yields an honest review; reviewing your own work inline produces blindspots. Triggers include "self review", "review my changes", "check my diff", "ready to commit", "ready for PR", "I'm done", "before I ship".
-allowed-tools: Bash, Read, Glob, Grep
+description: Final check on your own changes before reporting a task done, opening a PR, or asking for review. Thin wrapper that spawns `/code-review --self` in a subagent. **MUST be invoked as a subagent** — a clean context yields an honest review; reviewing your own work inline produces blindspots. Triggers include "self review", "review my changes", "check my diff", "ready to commit", "ready for PR", "I'm done", "before I ship".
+allowed-tools: Bash, Read, Glob, Grep, Agent
 metadata:
-  author: Mediforce
-  version: "1.0"
+  version: "2.0"
   domain: development
   complexity: intermediate
   tags: review, quality, pre-pr
@@ -12,105 +11,19 @@ metadata:
 
 # Self-Review
 
+Thin wrapper around `/code-review --self`. All logic lives there: pre-flight (typecheck + affected tests), three-axis review (Standards / Spec / Big Picture), `git blame` gate on "pre-existing" excuses, SHIP / ITERATE verdict.
+
 ## Hard rule — invoke as subagent
 
-If you are the agent who wrote the code in this conversation, **STOP**. Spawn a subagent and have it run this skill. Reviewing your own work in the same context where you wrote it is unreliable — you carry "I just wrote this, it must be good" assumptions that an outside reader doesn't.
+If you wrote the code in this conversation, **STOP**. Spawn a subagent and have it run this skill. Reviewing your own work in the same context where you wrote it is unreliable — "I just wrote this, it must be good" assumptions don't carry to an outside reader.
 
 From the main thread:
 
 ```
-Spawn subagent with prompt:
-  Run /self-review on branch <current>. Report findings with verdict.
+Spawn Agent (general-purpose) with prompt:
+  Run /code-review --self on the current branch. Treat the diff as if a stranger wrote it.
+  Verify every "pre-existing" claim with git blame before accepting it.
+  Return the SHIP / ITERATE verdict and the full three-axis report.
 ```
 
-If you ARE the subagent invoked for this purpose, continue with the checks below. Treat the diff as if a stranger wrote it.
-
-## Step 1 — Pre-flight
-
-Run in parallel:
-
-```bash
-pnpm typecheck
-pnpm test:affected
-```
-
-If either fails for a code reason — STOP, report the failure. No point reviewing code that doesn't compile or pass affected tests.
-
-If a failure looks environmental (remote / emulator down / proxy / port collision / weird state), check `docs/knowledge-base/wiki/gotchas/` or invoke `/knowledge-base` before debugging from scratch — most repeat env failures are documented there. Distinguish "I broke this" from "the env is broken" before iterating.
-
-## Step 2 — Read the diff
-
-```bash
-git diff origin/main...HEAD
-```
-
-Read every line. Not just the new files — also context lines around edits. Look for:
-
-- Unjustified `any` (use Zod + `z.infer`).
-- One-letter variable names.
-- Implicit boolean comparisons (`if (foo)` vs `if (foo === true)`).
-- Bash scripts (should be Python).
-- New comments / docstrings added to code that was not changed.
-- Hacks: `// TODO`, `// HACK`, `// FIXME`, commented-out blocks.
-- Dead code: unused exports, never-called helpers, leftover scaffolding.
-- Scope creep: unrelated refactors mixed in.
-- Raw `fetch('/api/...')` in `"use client"` files — must use `mediforce.<domain>` or `apiFetch`.
-- Missing CLI command for an operation that should be dogfooded — see `/use-mediforce`.
-
-## Step 3 — Test coverage
-
-Verify the diff has tests at the right level:
-
-- New endpoint or handler → **L3 API E2E exists** (`packages/platform-ui/e2e/api/`). L2 alone is not enough.
-- New pure logic → L1 unit exists co-located in `__tests__/`.
-- New UI journey → L4 with GIF + gallery entry via `/e2e-test`.
-- Trivial edit (typo, single-line config, comment-only) → no test needed; flag this explicitly.
-
-If coverage is missing, that's a finding — not a "nice to have".
-
-## Step 4 — Run `/code-review`
-
-Delegate the architecture / security / convention pass to `/code-review`. It has its own 8-section checklist; don't duplicate.
-
-## Step 5 — Verdict
-
-Aggregate findings into one of two outputs:
-
-### SHIP
-
-```markdown
-## Verdict: SHIP
-
-- typecheck: pass
-- test:affected: pass (N tests)
-- test:unit (full): pass (N tests)
-- test:e2e:api: pass (N tests)   ← if relevant to the diff
-- diff: clean
-- coverage: <level> in <path>
-- code-review: no blockers
-
-Ready to commit / open PR.
-```
-
-### ITERATE
-
-```markdown
-## Verdict: ITERATE
-
-### Blockers
-- `file:line` — what's wrong, what to do
-
-### Should fix
-- `file:line` — what's wrong, what to do
-
-### Nice to have (optional)
-- `file:line` — suggestion
-
-Address blockers and re-run /self-review before shipping.
-```
-
-## What this skill does NOT do
-
-- It does NOT commit, push, or open a PR. That's the main thread's job after acting on findings.
-- It does NOT silently fix things. Findings come back as text — the main thread decides what to apply.
-- It does NOT run the full `pnpm test:e2e` (browser, ~4min). That's a pre-merge gate — run it once before opening the PR. L3 `test:e2e:api` (~30s, no browser) IS part of Step 5 when the diff touches handlers / middleware.
+That's the whole skill. See `.claude/skills/code-review/SKILL.md` for what `--self` mode does, the SHIP gate, and the pre-existing-excuse policy.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -11,16 +11,4 @@ metadata:
 
 # Self-Review
 
-Spawn a subagent. Have it run `/code-review` on the current branch. Return the verdict.
-
-```
-Agent (general-purpose) prompt:
-  Run /code-review on the current branch (no args → auto self mode).
-  Treat the diff as if a stranger wrote it.
-  Verify every "pre-existing" claim with git blame before accepting it.
-  Return the full three-axis report + SHIP / ITERATE verdict.
-```
-
-That's it. Why a subagent: reviewing your own work in the same context where you wrote it is unreliable — "I just wrote this, it must be good" assumptions don't carry to an outside reader. A fresh context reviews honestly.
-
-All review logic lives in `.claude/skills/code-review/SKILL.md`: pre-flight (`pnpm typecheck` + `pnpm test:affected`), three-axis review (Standards / Spec / Big Picture), `git blame` gate on "pre-existing" excuses, SHIP / ITERATE verdict.
+Spawn a subagent (general-purpose) and tell it to run `/code-review` on the current branch — fresh context reviews honestly.


### PR DESCRIPTION
## Summary

Consolidates three things into one skill:

1. **Merges Matt Pocock's `/review`** into our `/code-review` — parallel sub-agents per axis, clean per-axis context.
2. **Adds a third axis: Big Picture** — should this even exist? Duplicates of existing functionality? Scope creep? Old features that should be deleted alongside the new ones?
3. **Folds `self-review` into `code-review --self`** — single source of truth. `self-review` shrinks to a 30-line wrapper that spawns `/code-review --self` in a subagent.

## `/code-review` — three parallel sub-agents

- **Standards** — file-by-file, hunk-by-hunk. Conventions, dead code, DRY/KISS, reuse of existing repo mechanisms, comment quality.
- **Spec** — does the diff match the originating issue / PRD?
- **Big Picture** — questions to user about removable features, duplication, scope creep, reinvention.

## `--self` mode (pre-PR self-review)

Adds Step 0 (pre-flight: `pnpm typecheck` + `pnpm test:affected`) and Step 6 (SHIP/ITERATE verdict) around the normal flow. Triggered explicitly with `--self`, or implicitly when invoked via `/self-review`.

## "Pre-existing" excuse — hard gate

New section + rule: every finding labelled "pre-existing / not my change / out of scope" must be verified with `git blame` before acceptance. Often a cop-out for issues the diff touched, exposed, or propagated. In `--self` mode, any pre-existing claim without git evidence forces ITERATE — SHIP only when actually fixed.

## Checklist additions

- **5a DRY / KISS** — duplicated logic, premature abstractions, single-caller wrappers, half-implemented branches.
- **5b Dead code & removal candidates** — grep new exports for callers, grep removed functions for stale references, flag features replaced but left rotting.
- **5c Reuse existing repo mechanisms** — `apiFetch` not raw `fetch`, `Mediforce` client / CLI not curl, existing Zod schemas, BullMQ not setTimeout, workflow-engine / agent-runtime primitives, shadcn / sonner. Reviewer must note the grep they ran.
- **5d Comment quality** — comments explain *why*, never restate code; no flowery prose; no docstrings on un-changed code; no "added for X flow" rot.

## Test plan

- [ ] `/code-review` on an in-flight PR → three sub-agents spawn in parallel, separate headings.
- [ ] `/code-review --self` on a branch with a passing typecheck → returns SHIP.
- [ ] `/code-review --self` on a branch where a sub-agent flags an issue waved away as "pre-existing" without git blame → forces ITERATE.
- [ ] `/self-review` → spawns `/code-review --self` subagent and returns same verdict.
- [ ] `/code-review` on PR with intentional duplicate of existing helper → Big Picture catches it.
- [ ] `/code-review` on PR with dead exports → Standards flags with grep evidence.