### PR TITLE
test(cli): add bin-shim spawn smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ### Removed
 - Duplicate Python migration script `scripts/migrations/migrate_workflow_doc_ids.py` — superseded by the TypeScript `packages/platform-infra/scripts/migrate-workflow-namespacing.ts` which is the canonical version ([#424](https://github.com/Appsilon/mediforce/pull/424)).
 
+### Added
+- `packages/cli/src/__tests__/bin-shim.test.ts` — spawn-based smoke test that runs the real `bin/mediforce.cjs` shim through `tsx` and asserts exit codes + stderr/stdout for `--help`, a missing positional, and an unknown command. Catches regressions (ESM resolution, `tsx` loader, bin shim entry resolution) that the in-process `runCli` suite cannot.
+
 ### Fixed
 - `check-gif-freshness.py` now evaluates the net PR diff vs base instead of summing per-commit diffs. Add-then-revert within the same PR no longer trips the GIF freshness check (regression surfaced on [#481](https://github.com/Appsilon/mediforce/pull/481)).
 - PR #172 rebase polish: presentation-only agent outputs now render in review surfaces, report iframes escape stringify fallback data and block network exfiltration with CSP, and local script execution no longer inherits the full server environment.

--- a/packages/cli/src/__tests__/bin-shim.test.ts
+++ b/packages/cli/src/__tests__/bin-shim.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(here, '..', '..');
+const binPath = path.join(packageRoot, 'bin', 'mediforce.cjs');
+
+const requireFromPackage = createRequire(path.join(packageRoot, 'package.json'));
+let tsxResolvable = true;
+try {
+  requireFromPackage.resolve('tsx/cli');
+} catch {
+  tsxResolvable = false;
+}
+
+function runBin(args: string[]) {
+  return spawnSync(process.execPath, [binPath, ...args], {
+    encoding: 'utf8',
+    timeout: 30_000,
+    env: { ...process.env, MEDIFORCE_API_KEY: 'test-key' },
+  });
+}
+
+describe.skipIf(!tsxResolvable)('bin shim — spawned process', () => {
+  it('--help exits 0 and prints usage on stdout', () => {
+    const result = runBin(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/Usage: mediforce/);
+  });
+
+  it('missing positional (`run get`) exits 2 with a stderr error', () => {
+    const result = runBin(['run', 'get']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/runId is required/);
+  });
+
+  it('unknown command exits 2 with a stderr error', () => {
+    const result = runBin(['unknown-cmd']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/Unknown command/);
+  });
+});


### PR DESCRIPTION
## Summary
- New `packages/cli/src/__tests__/bin-shim.test.ts` (47 LOC) spawns the real `packages/cli/bin/mediforce.cjs` shim via `child_process.spawnSync` and asserts exit codes + stdout/stderr for three cases: `--help`, `run get` (missing positional), and `unknown-cmd`.
- Existing 154+ in-process `runCli` tests exercise the dispatch path but never spawn the binary. The shim path was only validated by manual `pnpm exec mediforce …`. This test fills that gap and catches regressions in ESM resolution, the `tsx` loader, and bin-shim entry-point lookup.
- None of the three cases reach the network. Cross-platform safe (no shell pipes, `path.join`, `process.execPath`). 30s per-call timeout so a loader deadlock fails fast instead of hanging the suite. Skips cleanly if `tsx/cli` is not resolvable from the package.

## Test plan
- [x] `pnpm --filter @mediforce/cli test` — 19 files / 157 tests pass locally
- [x] `pnpm --filter @mediforce/cli exec vitest run src/__tests__/bin-shim.test.ts` — 3/3 pass in ~1.9s
- [ ] CI green on Linux runner