### PR TITLE
fix(container-worker): add --conditions flag to tsx in Dockerfile

### DIFF
--- a/packages/container-worker/Dockerfile.worker
+++ b/packages/container-worker/Dockerfile.worker
@@ -27,4 +27,4 @@ COPY packages/container-worker/ packages/container-worker/
 COPY packages/platform-core/ packages/platform-core/
 COPY tsconfig.json ./
 
-CMD ["pnpm", "tsx", "packages/container-worker/src/worker-entry.ts"]
+CMD ["pnpm", "tsx", "--conditions", "@mediforce/source", "packages/container-worker/src/worker-entry.ts"]


### PR DESCRIPTION
## Summary
- Container worker crash-loops on staging: `Cannot find module '@mediforce/platform-core/dist/index.js'`
- Root cause: `tsx` in Docker resolves to `default` export (`dist/index.js`) which doesn't exist — monorepo uses `@mediforce/source` condition → `src/index.ts`
- Fix: add `--conditions @mediforce/source` to `CMD` in `Dockerfile.worker`

## Test plan
- [ ] Deploy to staging, verify container-worker stays up
- [ ] Check Infrastructure page shows Docker info

🤖 Generated with [Claude Code](https://claude.com/claude-code)