### PR TITLE
chore: repo config — .gitattributes diff hiding + .worktreeinclude

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,23 @@
 # Append-only logs: take both sides on merge instead of flagging a conflict.
 # Order may interleave, but nothing is lost.
 CHANGELOG.md merge=union
+
+# Drizzle migration snapshots are auto-generated cumulative dumps of the
+# schema state. They're committed (drizzle needs them for next generate)
+# but reviewers don't read them — the SQL migration alongside is the
+# source of truth.
+#
+# `linguist-generated=true` → GitHub collapses these in PR diffs.
+# `-diff` → `git diff` shows "Binary files differ" instead of the dump.
+packages/platform-infra/src/postgres/migrations/meta/** linguist-generated=true
+packages/platform-infra/src/postgres/migrations/meta/** -diff
+
+# Lockfiles — reviewers care about package.json, not the lock dump.
+# pnpm is what mediforce uses; other patterns are defense-in-depth in case
+# someone accidentally commits a foreign lockfile.
+pnpm-lock.yaml linguist-generated=true
+pnpm-lock.yaml -diff
+**/package-lock.json linguist-generated=true
+**/package-lock.json -diff
+**/yarn.lock linguist-generated=true
+**/yarn.lock -diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Working directory for apps developer want to keep along the project but don't share publicly
 private-apps
-.worktreeinclude
 
 .planning
 .claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,10 @@
+# Files copied into every new Claude Code worktree.
+# Same syntax as .gitignore. Only files that are ALSO gitignored get copied —
+# tracked files are never duplicated.
+#
+# Use for local secrets / env files that every worktree needs but that don't
+# belong in git (Firebase keys, OAuth client secrets, dev DB URLs, etc.).
+
+# Per-package env files (gitignored via .env.local / .env*.local rules)
+**/.env.local
+**/.env*.local


### PR DESCRIPTION
Two small repo-config changes, bundled.

## 1. `.gitattributes` — hide drizzle snapshots + pnpm-lock in PR diff

Extracted from [#534](https://github.com/Appsilon/mediforce/pull/534) so the hygiene change lands independently of the Firestore→Postgres migration.

Two auto-generated cumulative-dump file groups dominate large PR diffs:
- `packages/platform-infra/src/postgres/migrations/meta/**` (~18K lines)
- `pnpm-lock.yaml` (~3K lines)

Both are committed because tooling needs them, but reviewers shouldn't read them — the SQL migration / `package.json` is the source of truth.

- `linguist-generated=true` → GitHub collapses these in PR diff view + excludes from language stats.
- `-diff` → `git diff` shows "Binary files differ" instead of dumping the contents; also removes the file from the PR's +/- line count.

Defense-in-depth patterns for `package-lock.json` / `yarn.lock` in case someone accidentally commits a foreign lockfile.

Docs (`docs/**`) intentionally NOT covered — they're hand-written ADRs / plans / checklists, meant to be reviewed in-diff.

## 2. `.worktreeinclude` — auto-copy `.env.local` into every new worktree

Claude Code reads `.worktreeinclude` (gitignore-syntax) and copies matching gitignored files into every new worktree. Only files that ARE gitignored get copied — tracked files are never duplicated.

Today the same job is done by a user-global Claude hook (`~/.claude/hooks/mediforce-env-sync.py`) which:
- exists only on one contributor's machine — others get broken worktrees on first `pnpm dev`
- hardcodes an absolute path to `/Users/marek/CODE/mediforce`
- targets `apps/supply-intelligence/.env.local`, which doesn't exist (real path is `supply-intelligence/.env.local` in repo root)

Moving to in-repo `.worktreeinclude` fixes all three. Patterns:
```
**/.env.local
**/.env*.local
```

Also un-gitignores `.worktreeinclude` itself — it must be committed for the feature to apply across worktrees / contributors.

### Follow-up (not in this PR)

Once merged + verified working on a fresh worktree, delete `~/.claude/hooks/mediforce-env-sync.py` and its `SessionStart` hook entry from `~/.claude/settings.json`.