### PR TITLE
chore: add Claude Code project permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir -p *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git checkout *)",
+      "Bash(git worktree *)",
+      "Bash(git stash *)",
+      "Bash(git pull *)",
+      "Bash(git push *)",
+      "Bash(gh pr create *)",
+      "Bash(gh issue create *)",
+      "Bash(pnpm typecheck *)",
+      "Bash(pnpm typecheck:*)",
+      "Bash(pnpm test *)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm exec *)",
+      "Bash(pnpm --filter *)",
+      "Bash(pnpm install *)",
+      "Bash(pnpm -F *)",
+      "WebSearch"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with permission allowlist for common project operations
- Reduces permission prompts for subagents (git, pnpm, gh, mkdir)
- `Write`/`Edit` intentionally omitted — personal trust decision goes in `settings.local.json`

## Test plan

- [ ] Verify subagents can run git/pnpm/gh commands without prompts
- [ ] Verify Write/Edit still prompts (not in this allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)