### PR TITLE
docs(phase-4): PRD + ADR-0006 + ADR-0001 §5 amendment

### DIFF
--- a/docs/adr/0001-firestore-to-postgres.md
+++ b/docs/adr/0001-firestore-to-postgres.md
@@ -53,9 +53,19 @@ Move the primary datastore to **self-hosted Postgres 16**, accessed via
    `archived: boolean` flags with `deleted_at timestamptz` and
    `archived_at timestamptz` columns. NULL = active. Soft-delete is **forever**
    for now; a later ADR may introduce a retention purge.
-5. **Realtime swap.** All `onSnapshot` listeners are removed. Lists move to
-   **SWR polling** (2–10 s interval). Live agent run logs and cowork text chat
-   move to **Server-Sent Events**. No WebSockets are introduced.
+5. **Realtime swap.** All `onSnapshot` listeners are removed. Everything moves
+   to **react-query polling** (1–10 s interval, terminal-state gating per
+   resource — see [`ADR-0006`](./0006-client-side-server-state.md)). No SSE
+   and no WebSockets at cutover. SSE remains a forward option for surfaces
+   where polling lag proves visible in practice (live token-stream during
+   agent runs, multi-second cowork tool loops); tracked by
+   [#516](https://github.com/Appsilon/mediforce/issues/516) and a future ADR.
+   `createRouteAdapter` stays forward-compatible — the handler shape
+   `(input, scope) => Promise<output>` does not preclude a sibling
+   `createStreamingRouteAdapter` later. _Amended 2026-05-28 to drop the
+   original SSE-at-cutover commitment per Phase 4 plan grilling; see
+   [`docs/headless-migration-phase-4-plan.md`](../headless-migration-phase-4-plan.md)
+   § 2 "ADR amendments bundled" for full reasoning._
 6. **Cross-workspace public discovery.** `WorkflowDefinition.visibility =
    'public'` remains a live, cross-Workspace feature — teams may publish,
    platform examples ship as public. Access goes through an explicit repo
@@ -147,8 +157,10 @@ Move the primary datastore to **self-hosted Postgres 16**, accessed via
   removing a class of race-condition workarounds (notably the personal-
   namespace bootstrap dance in `auth-context.tsx`).
 - One-time migration effort, estimated 2 focused engineering weeks.
-- ~14 UI hook sites + 3 page-component sites are rewired from `onSnapshot` to
-  SWR / SSE. Mostly mechanical.
+- ~20 UI consumer sites are rewired from `onSnapshot` to react-query polling
+  (1–10 s, terminal-state gating). Mostly mechanical; see
+  [`docs/headless-migration-phase-4-plan.md`](../headless-migration-phase-4-plan.md)
+  per-consumer migration table.
 - New operational responsibility for self-hosted customers: Postgres backup.
   Standard tooling; documented as part of this migration.
 - Cross-workspace public-workflow discovery is the **single permitted scope

--- a/docs/adr/0006-client-side-server-state.md
+++ b/docs/adr/0006-client-side-server-state.md
@@ -1,0 +1,366 @@
+# 0006 — Client-side server-state management
+
+- **Status:** Accepted (mutable while implementation in progress per the
+  status policy in [`README.md`](./README.md); flips to `Finalized` when
+  Phase 4 of the headless migration completes)
+- **Date:** 2026-05-28
+- **Authors:** Marek Rogala (@marekrogala)
+- **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
+- **Relates to:**
+  - Lands together with [`docs/headless-migration-phase-4-plan.md`](../headless-migration-phase-4-plan.md)
+    (Phase 4 of the headless migration).
+  - Complements [`ADR-0001`](./0001-firestore-to-postgres.md) — this ADR
+    is the browser-side counterpart of ADR-0001's "realtime swap"
+    (§5, amended 2026-05-28).
+  - Builds on [`ADR-0005`](./0005-headless-platform-api-ui-separation.md) — consumes the entity-echo
+    response shape (§5) directly via `setQueryData`.
+  - Forward-compat with deferred SSE work
+    ([#516](https://github.com/Appsilon/mediforce/issues/516)) and a
+    future per-resource event-stream consolidation ADR.
+
+## Context
+
+[ADR-0004](./0004-scoped-data-access-authorization.md) put workspace
+authorization in a `CallerScope` data-access bag. [ADR-0005](./0005-headless-platform-api-ui-separation.md) locked
+the HTTP boundary contract (handler shape, error envelope, entity
+echo). Together they shape the **server side** of the headless
+platform.
+
+The headless migration's Phase 4
+([`docs/headless-migration-phase-4-plan.md`](../headless-migration-phase-4-plan.md)) is the **browser
+side** of the same architecture: every UI consumer stops importing
+`firebase/firestore` and reads / writes through the typed
+`mediforce.X.Y()` client. To do that without losing the live-update
+behaviour Firestore `onSnapshot` provided, the browser needs a
+**client-side cache** with polling, dedup, cancellation, mutation
+lifecycle, and (eventually) SSE hooks.
+
+`platform-ui` today has **no cache library**. The single data-fetching
+hook (`useInstanceTasks`) is `useState + useEffect + AbortController`
+hand-rolled. Phase 4 migrates ~20 hooks; rolling each on the same
+pattern duplicates the seams across the codebase and re-invents the
+parts a cache library already solves (dedup across components,
+focus-refetch, mutation invalidation, optimistic-update lifecycle).
+
+Domain terms used below — Workspace (Namespace), Workflow Run, Human
+Task, Cowork Session, Agent Run — are defined in [`CONTEXT.md`](../../CONTEXT.md).
+
+## Decision
+
+Adopt **`@tanstack/react-query`** as the project-wide client-side
+server-state manager. One library, one `QueryClient` per app instance,
+one cache-key convention, one mutation lifecycle pattern. The
+following commitments form the contract; implementation lands in
+Phase 4's six-PR rollout (see Phase 4 PRD).
+
+### 1. Library: `@tanstack/react-query` (v5)
+
+Single dependency added to `packages/platform-ui`. Dev-only
+`@tanstack/react-query-devtools` ships behind a `NODE_ENV !== 'production'`
+gate.
+
+Rejected: SWR, custom helper. See "Considered alternatives" below.
+
+### 2. Cache key convention
+
+All cache keys are arrays with a string-prefix-first shape:
+
+```
+[domain, scopeKey?, ...filters]
+```
+
+- **`domain`** — kebab-case noun matching the resource family.
+  Examples: `'tasks'`, `'runs'`, `'workflows'`, `'agent-runs'`,
+  `'cowork'`, `'audit'`, `'namespace'`, `'users'`, `'monitoring'`.
+- **`scopeKey`** — the workspace `handle`, the user identifier
+  (`'me'`), or an entity id (`runId`, `sessionId`). Determines what
+  the rest of the key narrows. Omitted only for truly app-global
+  data.
+- **`...filters`** — additional structure for sub-resources or query
+  filters. Plain values for prefix-matching ergonomics; object
+  literal at the tail when the filter set has multiple fields.
+
+Examples:
+
+```ts
+['tasks', handle, role, status]
+['tasks', handle, { instanceId, stepId }]
+['run', runId]
+['runs', handle, { status, definitionName }]
+['workflows', handle]
+['workflow', handle, name]
+['agent-runs', handle, { runId, stepId }]
+['agent-run', agentRunId]
+['cowork', sessionId]
+['cowork', sessionId, 'turns']
+['audit', runId]
+['namespace', handle]
+['users', 'me']
+['monitoring', handle]
+```
+
+Tag-prefix invalidation in react-query catches every variant under a
+prefix: `qc.invalidateQueries({ queryKey: ['tasks', handle] })`
+refetches all roles, all statuses, all `(instanceId, stepId)` slices.
+
+A central `lib/query-keys.ts` module documents the convention with
+typed factory functions per domain. Not strictly enforced — react-query
+takes raw arrays — but the factory pattern keeps drift low.
+
+### 3. Default `QueryClient` configuration
+
+```
+{
+  queries: {
+    refetchInterval: 0,           // polling OFF by default; explicit per-hook opt-in
+    refetchOnWindowFocus: false,  // most data isn't time-critical
+    refetchOnReconnect: true,     // refresh on network recovery
+    staleTime: 0,                 // cache served immediately, revalidated in background
+    gcTime: 5 * 60 * 1000,        // 5 min cache eviction after no observer
+    retry: 2,                     // brief network blip resilience
+    retryDelay: (n) => Math.min(1000 * 2 ** n, 8000),
+  },
+  mutations: {
+    retry: 0,                     // mutations are caller-intentional; never auto-retry
+  },
+}
+```
+
+Per-hook overrides are explicit at the call site. Terminal-state
+gating (e.g. `enabled: run.status !== 'completed' && ...`) keeps
+polling from hitting the backend for resources nobody is advancing.
+
+Mediforce single-VPS Postgres math at default-off-polling: a list-view
+tab with 3 live hooks × 1 s polling = 3 RPS. 10 concurrent operators ×
+3 tabs each = 90 RPS — well under Postgres capacity for
+workspace-indexed lookups. The default-off rule prevents drift toward
+"every hook polls."
+
+### 4. Polling cadence — four-tier classification
+
+Inherited from Phase 4 PRD; documented here so future hooks have a
+default placement:
+
+- **CRITICAL LIVE — 1–2 s** while resource non-terminal; `null` key
+  when terminal. Use for: operator-watching-execution surfaces (run
+  detail, step detail, agent run detail, task detail page, audit feed
+  during a running run, cowork turns during active POST).
+- **STANDARD LIVE — 5 s.** Use for: operator worklists (tasks page,
+  workspace home, runs list, workflow list).
+- **NICE LIVE — 30 s** (and `refetchOnWindowFocus: true` as
+  safety net). Use for: dashboards (monitoring summary).
+- **ONE-SHOT — `refetchInterval: 0`.** Two sub-cases:
+  - `refetchOnWindowFocus: true` for data that **may change** under
+    deliberate user action (workspace metadata, workflow definitions).
+  - `refetchOnWindowFocus: false` for data that **should not silently
+    change mid-session** (user role, membership). For these, a
+    membership / role change is intentionally a backend-403 canary,
+    not a silent UI mutation.
+
+### 5. Mutation lifecycle: `useMutation` + entity-echo via `setQueryData`
+
+Every mutation in the app goes through `useMutation`. The lifecycle:
+
+```ts
+const claim = useMutation({
+  mutationFn: (input) => mediforce.tasks.claim(input),
+  onMutate: async (input) => {
+    // 1. Cancel in-flight queries for affected keys
+    await qc.cancelQueries({ queryKey: ['tasks', handle] });
+    await qc.cancelQueries({ queryKey: ['task', input.taskId] });
+
+    // 2. Snapshot for rollback
+    const snapshot = {
+      list: qc.getQueryData(['tasks', handle, role, 'pending']),
+      detail: qc.getQueryData(['task', input.taskId]),
+    };
+
+    // 3. Optimistic patch
+    qc.setQueryData(['task', input.taskId], (old) =>
+      old ? { ...old, status: 'claimed', assignedUserId: caller.uid } : old);
+    qc.setQueryData(['tasks', handle, role, 'pending'], (old) =>
+      old?.filter((t) => t.id !== input.taskId));
+
+    return { snapshot };
+  },
+  onSuccess: (data) => {
+    // 4. Replace with server-echoed entity (ADR-0005 §5)
+    qc.setQueryData(['task', data.task.id], data.task);
+  },
+  onError: (_err, _input, ctx) => {
+    // 5. Restore snapshot on failure
+    if (ctx?.snapshot.list) qc.setQueryData(['tasks', handle, role, 'pending'], ctx.snapshot.list);
+    if (ctx?.snapshot.detail) qc.setQueryData(['task', input.taskId], ctx.snapshot.detail);
+  },
+});
+```
+
+The entity-echo response shape locked in [ADR-0005 §5](./0005-headless-platform-api-ui-separation.md)
+(`{ task: HumanTask }`, `{ run: WorkflowRun }`, etc.) is the natural
+input to `setQueryData` in `onSuccess`. No refetch round trip; UI
+updates instantly with server-truth post-mutation state.
+
+### 6. Optimistic update playbook — three templates
+
+Documented here for one-place reference; PRs adopting react-query
+copy-paste from these:
+
+- **State transition** (`claim`, `cancel`, `complete`, `resume`,
+  …): one entity flips status. Optimistic patch on detail key + filter
+  on relevant list keys. `onSuccess` replaces detail key with
+  entity-echo; `onError` restores snapshot.
+- **List-affecting create / delete** (`namespaces.create`, future
+  `workflows.delete`): optimistic prepend / filter on the relevant
+  list key. `onSuccess` for create: replace optimistic placeholder
+  with entity-echoed full entity; for delete: keep filter, no
+  replacement. Side-effect (redirect, focus) in `onSuccess` callback.
+- **Multi-cache-key cross-cutting** (`runs.bulkCancel` affecting many
+  runs + monitoring summary + audit feed): tag-prefix
+  `invalidateQueries({ queryKey: ['runs', handle] })` after success.
+  Optimistic update optional per call — bulk operations typically
+  skip optimistic and refetch.
+
+### 7. SSE forward-compat slot
+
+This ADR does **not** add SSE in Phase 4 (per [`ADR-0001`](./0001-firestore-to-postgres.md) §5
+amendment, 2026-05-28). When SSE arrives (per resource — see future
+per-resource event-stream consolidation ADR, captured-for-later in
+[`docs/headless-migration.md`](../headless-migration.md)), each SSE
+hook plugs into the existing cache via `setQueryData`:
+
+```ts
+function useRunStream(runId: string) {
+  const qc = useQueryClient();
+  useEffect(() => {
+    const abort = new AbortController();
+    // fetch + ReadableStream (EventSource lacks custom headers)
+    pipeSseFrames(`/api/runs/${runId}/stream`, abort.signal, (event, data) => {
+      if (event === 'step_changed')   qc.setQueryData(['run', runId, 'steps'], merge(data));
+      if (event === 'task_created')   qc.setQueryData(['tasks', handle, role], prepend(data.task));
+      if (event === 'instance_finished') qc.setQueryData(['run', runId], (old) => ({ ...old, status: data.status }));
+    });
+    return () => abort.abort();
+  }, [runId, qc]);
+}
+```
+
+Components keep reading via `useQuery(['run', runId])`. The transport
+(polling vs SSE) becomes a detail of which hook is mounted on the
+page. Zero rework on consumer code when SSE lands.
+
+### 8. Error handling
+
+Every mutation / query that fails throws a typed
+`ApiError` (from `@mediforce/platform-api/client`) carrying HTTP
+`status` + parsed `code` (per [ADR-0005 §1](./0005-headless-platform-api-ui-separation.md) error envelope) +
+optional `details`. UI handles in two layers:
+
+- **Catch in `onError` callback** at the call site for inline UX
+  (toast, inline error panel).
+- **Global error boundary** at the layout level for unhandled errors
+  (network down, 500 from backend, browser offline).
+
+Per-code narrowing (`if (err.code === 'precondition_failed')`) is
+allowed inline today; if it becomes a frequent pattern, revisit the
+"future-idea" note in [ADR-0005 §2](./0005-headless-platform-api-ui-separation.md) about reconstructing
+the matching `HandlerError` subclass on the client.
+
+`useSuspenseQuery` (react-query's Suspense-integrated variant)
+remains an opt-in per hook; nothing in this ADR commits the app to
+Suspense as the default loading-state mechanism. The two co-exist
+fine.
+
+## Considered alternatives
+
+- **SWR (vercel/swr).** Rejected. SWR covers polling + dedup + focus-refetch
+  out of the box and is smaller (~5 KB gz vs ~13 KB gz). Loses
+  precisely where Phase 4 cares most: (a) no tag-prefix invalidation
+  primitive — every invalidation needs an exact key or a match
+  function, and the mutator must know the consuming hook's key shape;
+  (b) `useSWRMutation` is auxiliary and less ergonomic than
+  react-query's `useMutation`, so optimistic-update lifecycle becomes
+  hand-rolled per call site; (c) no first-class devtools at our scale
+  (~30 hooks at end of Phase 4 + projected growth). The 8 KB delta is
+  noise against the existing browser bundle. Honest trade-off: SWR is
+  fine for 5–10 hooks; Phase 4 ships ~20 at once and Mediforce grows
+  past that.
+- **Custom helper extended from `useInstanceTasks`.** Rejected.
+  Re-implementing dedup, focus-refetch, cancellation, mutation
+  lifecycle, optimistic snapshot/rollback, devtools — the project would
+  spend the next year shipping a worse-tested replica of react-query.
+  Reasonable only if hook count stays under ~5; Phase 4 contradicts
+  that.
+- **Apollo Client.** Rejected. Apollo is GraphQL-shaped; Mediforce ships
+  a Zod-typed REST contract. The GraphQL machinery (link chain, schema
+  registry, query AST) is dead weight against an RPC-shaped API.
+- **RTK Query (Redux Toolkit).** Rejected. Mediforce has no Redux store
+  and no reason to add one; RTK Query couples cache lifecycle to a
+  Redux reducer tree without a payoff over react-query's standalone
+  cache.
+- **Vercel AI SDK for the cache layer.** Considered as a way to reuse
+  the AI SDK's streaming patterns if SSE comes later. Rejected — the
+  AI SDK is a wrapper around react-query for AI-specific streaming
+  primitives; we get the same forward-compat by using react-query
+  directly today and adopting the AI SDK pattern only if and when a
+  streaming-AI surface appears.
+
+## Consequences
+
+- One library, one mental model. New UI hooks follow the documented
+  key convention + cadence tier + mutation lifecycle without
+  architectural debate.
+- Phase 4 PR1 establishes the foundation (QueryClient provider,
+  defaults, devtools, key factory module). PRs 2–6 reuse it
+  mechanically; cross-PR architectural drift is minimised.
+- Entity-echo from [ADR-0005 §5](./0005-headless-platform-api-ui-separation.md) is naturally consumed —
+  every mutation handler's return shape lands in the cache without a
+  refetch.
+- Tag-prefix invalidation covers Mediforce's existing cross-cutting
+  mutation surface (bulk cancel / archive on runs, workflow
+  archive cascading to runs + human tasks, cross-namespace workflow
+  transfer) without ad-hoc key matchers per call site.
+- Optimistic updates become a documented, three-template pattern.
+  Operator-perceived latency on every mutation drops to "local state
+  change instant" without per-component custom code.
+- Devtools available in dev — debugging "why is this list stale" is a
+  visible tree of active queries + cache contents, not a console.log
+  archaeology session.
+- Bundle size delta vs no cache library: ~13 KB gz for react-query +
+  some dev-only weight for devtools. Acceptable against current
+  browser bundle (~800 KB gz Next.js + Tailwind + Radix + Monaco).
+- Future SSE migration is a `useResourceStream(id)` hook per resource
+  that pipes events into `setQueryData(...)`. Consumer code (`useQuery`,
+  `useMutation`) is untouched. The per-resource event-stream
+  consolidation ADR (captured-for-later) builds on this shape.
+
+## Out of scope
+
+- **SSE design.** Not part of Phase 4 (per ADR-0001 §5, amended
+  2026-05-28). Future per-resource consolidation ADR + [#516](https://github.com/Appsilon/mediforce/issues/516)
+  cover it.
+- **`useSuspenseQuery` as default.** Suspense + react-query is
+  ergonomic but requires Suspense / ErrorBoundary placement
+  decisions that are an orthogonal UI concern. Opt-in per hook;
+  default stays branchy `{ data, isLoading, error }`.
+- **Server-side cache** (Next.js `cache()`, `unstable_cache`, route-
+  level revalidation). Server-rendered pages today fetch through the
+  Next.js mechanisms; react-query is for client-rendered hooks. The
+  two coexist without coupling.
+- **Persistent cache across reloads** (`@tanstack/query-async-storage-persister`).
+  Premature — Mediforce sessions are short-lived, browser cache +
+  fresh fetch on load is fine. Add when a real use case (offline
+  reads, fast restore on slow connection) appears.
+- **Query-key codegen from API contract.** Would be elegant —
+  `mediforce.tasks.list` could produce its own cache key — but
+  premature. The hand-written key factory in `lib/query-keys.ts` is
+  ~50 LOC and explicit; codegen-ing it adds machinery for low payoff.
+- **Optimistic updates on every mutation.** PR1 (tasks) wires it for
+  the state-transition templates. PRs 2–6 wire it where the UX
+  payoff is clear; mutations with no visible immediate result (e.g.
+  `runs.archive` for an already-completed run) skip the optimistic
+  step and just invalidate.
+
+## Open questions
+
+(None blocking Phase 4. Section reserved for amendments while the
+ADR is `Accepted`.)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,3 +65,4 @@ appendix can capture what actually shipped vs the original decision body.
 - [0002 — Move authentication from Firebase Auth to NextAuth (Auth.js v5)](./0002-firebase-auth-to-nextauth.md) (+ [PLAN](./PLAN-0002.md))
 - [0004 — Authorization enforcement moves to a scoped data-access layer](./0004-scoped-data-access-authorization.md)
 - [0005 — Headless platform: API/UI separation](./0005-headless-platform-api-ui-separation.md)
+- [0006 — Client-side server-state management](./0006-client-side-server-state.md)

--- a/docs/headless-migration-phase-4-plan.md
+++ b/docs/headless-migration-phase-4-plan.md
@@ -1,0 +1,684 @@
+# Headless migration — Phase 4 plan
+
+- **Status:** Active (mutable through implementation; finalize on PR-final
+  merge)
+- **Date opened:** 2026-05-28
+- **Authors:** Marek Rogala (@marekrogala)
+- **Reviewers:** Filip Stachura (@filipstachura), Paweł Przytuła (@przytu1)
+- **Tracks:** Phase 4 of [`docs/headless-migration.md`](./headless-migration.md)
+- **Relates to:**
+  - Gate for [`ADR-0001`](./adr/0001-firestore-to-postgres.md) cutover
+    (PG PR2 [#534](https://github.com/Appsilon/mediforce/pull/534)).
+  - Builds on [`ADR-0004`](./adr/0004-scoped-data-access-authorization.md)
+    `CallerScope` + [`ADR-0005`](./adr/0005-headless-platform-api-ui-separation.md)
+    handler shape + entity-echo.
+  - Bundles ADR-0001 §5 amendment in the same PR as this plan.
+  - References new [`ADR-0006`](./adr/0006-client-side-server-state.md)
+    client-side cache architecture (created in same PR).
+  - Forward-compat with deferred SSE work
+    ([#516](https://github.com/Appsilon/mediforce/issues/516)) and
+    URL canonicalization ([#544](https://github.com/Appsilon/mediforce/issues/544)).
+
+## Problem statement
+
+Operator on Mediforce today sees workflow runs, tasks, agent runs, audit
+events and cowork chat **update live** in the UI because every list and
+detail view subscribes to Firestore via `onSnapshot`. [ADR-0001](./adr/0001-firestore-to-postgres.md)
+moves the server data layer to Postgres. Postgres has no `onSnapshot`
+equivalent. After the server-side cutover (PG PR2 / [#534](https://github.com/Appsilon/mediforce/pull/534))
+ships, every operator UI view stops updating — empty lists, stale
+detail pages, no progress indication during agent runs. Production is
+unusable.
+
+PG PR2 description names this PRD as its explicit gate: it cannot merge
+until UI stops importing `firebase/firestore`.
+
+## Solution
+
+Remove every `firebase/firestore` import from `packages/platform-ui/src`.
+Replace each consumer with:
+
+- A typed `mediforce.X.Y()` call from the platform-api client (Phase 1/2/3 endpoints already exist for most reads/writes).
+- A new **react-query** cache layer (`@tanstack/react-query`) providing polling, dedup, mutation lifecycle, optimistic updates, and forward-compat for future SSE — see [ADR-0006](./adr/0006-client-side-server-state.md).
+- Six new headless endpoints filling the remaining gaps (see §"Endpoint inventory").
+
+Phase 4 is a **behavioural no-op** as a standalone change: the server still
+runs on Firestore, the UI just reaches it through the headless contract
+rather than the Firestore SDK. Once Phase 4 ships, PG PR2 unblocks; UI
+keeps working when the server flips to Postgres because the contract is
+stable.
+
+Phase 4 is a **swap, not a redesign**. UX may lose smoothness where today's
+flow relied on incidental Firestore push (tool-call bubble animation in
+cowork chat, sub-second task appearance). That regression is accepted;
+UX overhauls live in dedicated tickets ([#516](https://github.com/Appsilon/mediforce/issues/516)
+for streaming cowork; per-resource SSE consolidation as a future ADR).
+
+## User stories
+
+1. As an operator, I want the task list to refresh within a few seconds of an agent producing a new task, so that I do not need to manually reload the page.
+2. As an operator, I want the run detail page to show step transitions within 1–2 seconds, so that I can monitor live execution.
+3. As an operator, I want my cowork chat to show my message immediately after I press Send, so that the UI feels responsive even when the backend is computing for several seconds.
+4. As an operator, I want tool-call bubbles to appear progressively during a cowork chat turn, so that I can see what the agent is doing.
+5. As an operator, I want the workspace switcher in the sidebar to populate without an extra round trip per page navigation, so that the app feels fast.
+6. As an operator, I want role-gated buttons (admin actions) to render reliably on the first paint, so that I do not accidentally see UI before the backend says I can use it.
+7. As an operator, I want a workspace I just created to appear in my switcher immediately and redirect me to it, so that the create flow feels finished.
+8. As an operator, I want claiming a task to update the list view instantly, so that I do not click Claim twice or doubt whether the click worked.
+9. As an operator, I want the monitoring dashboard to load with summary numbers, not 10 MB of raw data, so that the page renders in milliseconds even on a slow connection.
+10. As an operator with permission to invite members, I want the members list on the settings page to reflect a new invite within a few seconds, so that I can verify the invite landed.
+11. As a developer, I want every UI read and write to flow through a typed client method (`mediforce.X.Y()`), so that contract drift between UI and API is impossible.
+12. As a developer, I want a single cache library convention for the whole app, so that I do not have to learn three different data-fetching styles across files.
+13. As a developer, I want mutation responses to update the cache without a refetch round trip, so that the UI feels instant after a click.
+14. As a developer, I want a clear set of cache keys per domain, so that I know exactly which `invalidateQueries(...)` to call after a mutation.
+15. As a developer, I want optimistic updates wired through a documented pattern, so that I do not invent a new state-machine on every mutation site.
+16. As a developer, I want each PR in Phase 4 to land independently green, so that review can be parallel where possible and pause-safe where not.
+17. As an AFK Claude session implementing one PR, I want the plan to tell me exactly which hooks to migrate, which endpoint they map to, what polling interval to use, and which test layers to write, so that I do not need to re-grill the design from scratch.
+18. As a future implementer, I want the eventual SSE migration to be a small change to react-query consumers, not a rewrite, so that today's cache structure carries forward.
+19. As a compliance reviewer, I want audit emission to remain bit-for-bit identical to today's behavior, so that audit logs do not regress during the swap.
+20. As an SRE, I want the new endpoints to use server-side aggregation where possible, so that Postgres queries scale rather than copying the Firestore "load everything and aggregate in browser" anti-pattern.
+21. As the implementer of PG PR2, I want this plan to be the explicit gate — once it ships, the server cutover script can run, then PG PR2 merges with no UI fallout.
+22. As an authenticated user signing in for the first time on a Deployment, I want my personal workspace to be created automatically so that I land on a usable workspace home page.
+23. As a UI engineer adding a future hook, I want a documented key convention (`['domain', handle, ...filters]`), default config table, and optimistic playbook so that the hook fits in without architectural debate.
+24. As a developer reading the codebase six months from now, I want the headless-migration plan to refer me to ADR-0006 for the "why react-query, not SWR" rationale, so that I do not waste time re-deciding.
+
+## Implementation decisions
+
+### 1. Cache library: `@tanstack/react-query`
+
+Picked over SWR and a custom helper. Full rationale in [`ADR-0006`](./adr/0006-client-side-server-state.md).
+Phase 4 PRD references the ADR; do not duplicate the alternatives discussion here.
+
+Key implications for Phase 4 work:
+
+- Hook tests use the existing `useInstanceTasks` test pattern, wrapped in
+  a fresh `QueryClient` per test.
+- A single `QueryClient` is constructed at app boot with project-wide
+  defaults; per-hook overrides are explicit at call sites (polling
+  interval, terminal-state gating).
+- Cache key convention: `[domain, handle?, ...filters]` (string-prefix
+  array). Examples: `['tasks', handle, role]`, `['run', runId]`,
+  `['agent-runs', handle, { runId, stepId }]`, `['users', 'me']`.
+- Devtools (`@tanstack/react-query-devtools`) ship behind a dev-only
+  bundle gate.
+
+### 2. ADR amendments bundled in the same PR
+
+This PR also lands:
+
+- **[`ADR-0001`](./adr/0001-firestore-to-postgres.md) §5 amendment.** Drop "Live agent run logs and cowork
+  text chat move to Server-Sent Events." Replace with "All `onSnapshot`
+  listeners are removed. Everything moves to SWR / react-query polling
+  (1–10 s, terminal-state gating). No SSE, no WebSockets at cutover.
+  SSE remains a forward option for surfaces where polling lag proves
+  visible (live token-stream during agent runs, multi-second cowork
+  tool loops); tracked by [#516](https://github.com/Appsilon/mediforce/issues/516)
+  and a future ADR."
+- **ADR-0001 Consequences line** "~14 UI hook sites + 3 page-component
+  sites are rewired from `onSnapshot` to SWR / SSE" → drop "/ SSE".
+- **[`docs/headless-migration.md`](./headless-migration.md) Phase 4 section** rewritten to reflect this PRD
+  as the authoritative plan; the old "working hypothesis" tone goes
+  away.
+
+ADR-0001 is `Proposed`; amendment lands in the bundled PR per the
+status policy. ADR-0004 (`Finalized`) is unchanged. ADR-0005
+(`Accepted`) is unchanged.
+
+### 3. Endpoint inventory — six additions + two contract extensions
+
+After auditing each of the 22 firestore-importing files, six new
+headless endpoints cover the gaps. Two existing contracts get small
+backwards-compatible additive extensions. Three previously
+hypothesized endpoints (`/api/audit-events`, `/api/namespaces/:handle/role`,
+explicit `POST /api/users/me/ensure-personal-namespace`) are NOT
+needed — see notes below.
+
+#### `GET /api/users/me` — bundle with lazy bootstrap side-effect
+
+```ts
+export const GetMeOutputSchema = z.object({
+  user: z.object({
+    uid: z.string(),
+    email: z.string().email().nullable(),
+    displayName: z.string().nullable(),
+    // Mediforce-side user_profiles fields only; NextAuth columns out of scope here.
+  }),
+  namespaces: z.array(z.object({
+    handle: HandleSchema,
+    type: z.enum(['personal', 'organization']),
+    displayName: z.string(),
+    role: z.enum(['owner', 'admin', 'member']),
+  })),
+});
+```
+
+- Light projection (~1 KB). Powers sidebar switcher, page-gate role
+  checks (`useNamespaceRole(handle)` becomes a pure selector over this
+  cache), workspace header.
+- **Lazy bootstrap side-effect:** if the caller has no personal
+  namespace, the handler creates one inline (idempotent) before
+  returning, emitting `user.personal_namespace_created` audit event
+  exactly once.
+- Replaces direct Firestore reads in: `auth-context.tsx`,
+  `use-all-user-namespaces.ts`, `use-namespace-role.ts`, plus
+  `use-user-namespace.ts` (folded as a selector).
+- **TODO at ADR-0002 (NextAuth) landing:** move the bootstrap to
+  `events.createUser`; GET /me becomes a pure read (or a defensive
+  safety net — decision deferred to ADR-0002).
+
+The lazy-upsert pattern is reusable: future user-profile field
+defaults, settings migrations, or role-cache rebuilds can hang off the
+same "first call resolves missing state" hook.
+
+#### `GET /api/namespaces/:handle` — workspace detail
+
+```ts
+export const GetNamespaceOutputSchema = z.object({
+  namespace: NamespaceSchema, // existing full schema
+  members: z.array(NamespaceMemberSchema),
+  // Settings-specific projections (e.g. secrets count, workflow count)
+  // may be added additively when the settings page consumes them.
+});
+```
+
+- Loaded only on settings / workspace-detail pages. Cache key
+  `['namespace', handle]`.
+- Replaces direct Firestore reads in `use-namespace.ts`,
+  `[handle]/settings/page.tsx` (the remaining `onSnapshot` on
+  `namespaces/{handle}/members` after Phase 2.6 already migrated the
+  invite/member endpoints).
+
+#### `POST /api/namespaces` — workspace create (organization)
+
+```ts
+export const CreateNamespaceInputSchema = z.object({
+  handle: HandleSchema,
+  displayName: z.string().min(1).max(128),
+  bio: z.string().max(2048).optional(),
+  // type omitted; this endpoint always creates 'organization'.
+  // Personal namespaces are auto-bootstrapped via GET /api/users/me.
+});
+
+export const CreateNamespaceOutputSchema = z.object({
+  namespace: NamespaceSchema,
+});
+```
+
+- **Gate:** any authenticated user, preserving status quo. Gate
+  policy out of scope for Phase 4; revisit when spam / multi-tenancy
+  concerns arise.
+- **Atomicity:** repo gets a new consolidated method
+  `createNamespaceWithOwner({ namespace, ownerMember })`. Firestore
+  impl uses a `WriteBatch` (atomic across docs in same Firestore).
+  Postgres impl (ADR-0001 era) uses a transaction. Handler stays
+  clean — one wrapper call.
+- **Errors:** 409 conflict on duplicate handle (Firestore: existence
+  check + race window; Postgres: unique constraint).
+- **`users/{uid}.organizations` field:** PRD action item — verify
+  this field is dead (Phase 2.6's `getMembershipsForUser` reads the
+  member subcollection; if the array is truly unused, drop the third
+  write entirely. Reduces atomicity surface and eliminates one
+  Firestore consumer in `auth-context.tsx`.).
+- **Audit:** `namespace.created` emitted via handler-bridge per
+  [ADR-0005 §7](./adr/0005-headless-platform-api-ui-separation.md).
+- Replaces direct Firestore writes in
+  `app/(app)/workspaces/new/page.tsx`.
+
+#### `GET /api/agent-runs` — paginated list with filters
+
+```ts
+export const ListAgentRunsInputSchema = z.object({
+  namespace: z.string().optional(),
+  runId: z.string().optional(),
+  stepId: z.string().optional(),
+  limit: z.number().int().min(1).max(200).default(50),
+  cursor: z.string().optional(),
+}).refine(
+  (v) => !v.stepId || v.runId,
+  'stepId requires runId',
+);
+
+export const ListAgentRunsOutputSchema = z.object({
+  runs: z.array(AgentRunSchema),
+  nextCursor: z.string().optional(),
+});
+```
+
+- Single endpoint with filter params (not nested URL) — consistent
+  with `/api/runs?status=...` / `/api/tasks?role=...`.
+- Pagination: opaque cursor, default 50 / cap 200. Backend encodes
+  `{startedAt, id}` tie-breaker; client treats as token. Forward-compat
+  across Firestore→Postgres cursor mechanics.
+- **Repo addition:** `AgentRunRepository.listInNamespaces(allowed, { limit, cursor, runId?, stepId? })`.
+  Firestore impl: composite query with cursor `startAfter`. Postgres:
+  `WHERE (started_at, id) < ($cursor) AND ($namespace = ANY(allowed)) ORDER BY ... DESC LIMIT N`.
+- Wrapper passthrough via `AuthorizedAgentRunRepository`.
+- Replaces direct Firestore reads in `use-agent-runs.ts`.
+
+#### `GET /api/agent-runs/:agentRunId` — single detail
+
+- Trivial read per [ADR-0004 §10](./adr/0004-scoped-data-access-authorization.md) — no
+  bespoke handler; the route wires `getByIdAdapter` against
+  `AuthorizedAgentRunRepository.getById`.
+- Output: `{ run: AgentRun }`.
+- Replaces single-agent-run reads on `agents/[runId]/page.tsx`.
+
+#### `GET /api/namespaces/:handle/monitoring/summary` — dashboard aggregates
+
+```ts
+export const MonitoringSummarySchema = z.object({
+  runs: z.object({
+    running: z.number().int().nonnegative(),
+    completed_24h: z.number().int().nonnegative(),
+    failed_24h: z.number().int().nonnegative(),
+    archived_total: z.number().int().nonnegative(),
+  }),
+  tasks: z.object({
+    pending: z.number().int().nonnegative(),
+    claimed: z.number().int().nonnegative(),
+    stuck_count: z.number().int().nonnegative(), // claimed > 24h ago
+  }),
+  roleTaskCounts: z.record(z.string(), z.number().int().nonnegative()),
+});
+```
+
+- Compact (~200 B) response. Server-side aggregation, not a list
+  payload. Polling at 30 s costs nothing.
+- Backend handler: 2–3 `SELECT … COUNT(*) GROUP BY …` queries with
+  workspace-scoped partial indexes (Postgres era) or in-memory tally
+  per scope (Firestore era).
+- Closed shape, extensible additively (add `agent_runs_active`,
+  `cron_triggers_due` in follow-ups without breaking change).
+- Replaces direct Firestore reads + in-browser aggregation in
+  `use-monitoring.ts`.
+
+#### Extension: `ListTasksInputSchema` gains optional `instanceId` + `stepId`
+
+```ts
+// Add to existing schema (additive, backwards-compatible).
+instanceId: z.string().optional(),
+stepId: z.string().optional(),
+// Refine: stepId requires instanceId.
+```
+
+Folds the two `use-collection.ts` consumers (`next-step-card.tsx`,
+`task-detail.tsx`) into the existing `mediforce.tasks.list({...})`
+call. Handler gains a new filter branch; repo method extended.
+
+Phase 1 lessons (issue #231) flagged this trivial change.
+
+#### Extension: chat handler return shape gains `session` + `turns`
+
+Today the cowork chat endpoint (`POST /api/cowork/:sessionId/chat`,
+shipped in Phase 3.1) returns `{ agentText, artifact, toolCalls }`.
+Phase 4 extends additively to include the post-mutation session +
+full turns array:
+
+```ts
+export const ChatCoworkSessionOutputSchema = z.object({
+  // existing fields stay
+  agentText: z.string(),
+  artifact: ArtifactSchema.nullable(),
+  toolCalls: z.array(ToolCallSummarySchema),
+  // new — additive, backwards-compatible
+  session: CoworkSessionSchema,
+  turns: z.array(ConversationTurnSchema),
+});
+```
+
+Backwards-compatible — existing callers ignoring the new fields keep
+working. Enables UI optimistic-then-final-replace pattern without an
+extra round trip.
+
+#### Endpoints explicitly NOT added
+
+- **`GET /api/audit-events`** — `use-audit-events.ts`'s only consumer is
+  a per-run audit view, already covered by `GET /api/processes/:instanceId/audit`
+  (Phase 1 paginated). No cross-run admin audit view exists today;
+  add only when one does.
+- **`GET /api/namespaces/:handle/role`** — folded into `users/me.namespaces[].role`.
+  Single source of truth for the role cache; `useNamespaceRole(handle)`
+  is a selector over the bundle, not a dedicated endpoint.
+- **`POST /api/users/me/ensure-personal-namespace`** — folded into the
+  lazy bootstrap side-effect of `GET /api/users/me`. One less endpoint
+  in the inventory; one less round trip on login.
+
+### 4. Per-consumer migration table
+
+Twenty-two `firebase/firestore`-importing files (audited 2026-05-28).
+Each row records the migration target, polling cadence, cache key
+shape, and invalidation triggers. Four-tier classification from
+[`docs/headless-migration.md` § Phase 4](./headless-migration.md)
+(CRITICAL LIVE / STANDARD LIVE / NICE LIVE / ONE-SHOT) — verified
+per call site, not per hook name (the "live-by-default fallacy" rule
+in [`docs/headless-migration.md`](./headless-migration.md)).
+
+#### Hooks (12)
+
+| File | Tier | Endpoint | Polling | Cache key | Invalidation on |
+|---|---|---|---|---|---|
+| `hooks/use-tasks.ts` | STANDARD LIVE | `mediforce.tasks.list({role, status})` | 5 s | `['tasks', handle, role, status]` | `tasks.claim`, `tasks.complete`, `tasks.unclaim` (if returns), cowork finalize |
+| `hooks/use-process-instances.ts` | STANDARD LIVE (list) / CRITICAL LIVE (single, gated on terminal) | `mediforce.runs.list` / `mediforce.runs.get` | 5 s list / 1–2 s single while non-terminal, `null` when terminal | `['runs', handle, filters]` / `['run', runId]` | `runs.cancel`, `runs.archive`, `runs.start`, `runs.bulkCancel`, `runs.bulkArchive` |
+| `hooks/use-agent-runs.ts` | STANDARD LIVE | `mediforce.agentRuns.list` (new) | 5 s, paginated | `['agent-runs', handle, filters]` | None today (agent runs are append-only from system actor) |
+| `hooks/use-audit-events.ts` | CRITICAL LIVE | `mediforce.processes.audit(instanceId)` (existing) | 1–2 s while run non-terminal, `null` when terminal | `['audit', runId]` | None — append-only |
+| `hooks/use-process-definitions.ts` | ONE-SHOT | `mediforce.workflows.list({namespace})` | 0 (focus-refetch on definition mutations) | `['workflows', handle]` | `workflows.register`, `workflows.delete`, `workflows.archive`, `workflows.transfer`, `workflows.copy` |
+| `hooks/use-workflow-definitions.ts` | ONE-SHOT | `mediforce.workflows.get(name)` | 0 (focus-refetch on definition edits) | `['workflow', handle, name]` | Same as above |
+| `hooks/use-monitoring.ts` | NICE LIVE | `mediforce.monitoring.summary(handle)` (new) | 30 s, focus-refetch on | `['monitoring', handle]` | Any list-mutation (refresh on next tick is fine; no explicit invalidate) |
+| `hooks/use-collection.ts` | **DELETE** | n/a (consumers absorb specific endpoints) | n/a | n/a | n/a |
+| `hooks/use-namespace.ts` | ONE-SHOT | `mediforce.namespaces.get(handle)` (new) | 0, focus-refetch on | `['namespace', handle]` | Settings save (`mediforce.namespaces.update(handle, ...)` — not in Phase 4 scope; preserve today's update path if separate) |
+| `hooks/use-namespace-role.ts` | ONE-SHOT | **Selector** over `useUserMe()`'s `namespaces[].role` for `handle` | n/a (no own fetch) | derived from `['users', 'me']` | When `['users', 'me']` invalidates (membership change) |
+| `hooks/use-all-user-namespaces.ts` | ONE-SHOT | **Selector** over `useUserMe()`'s `namespaces[]` | n/a (no own fetch) | derived from `['users', 'me']` | Same |
+| `hooks/use-user-namespace.ts` | **DELETE** | **Selector** `useUserMe().namespaces.find(n => n.type === 'personal')` | n/a | derived | n/a |
+
+#### Pages (5)
+
+| File | Tier | Endpoint(s) | Polling | Notes |
+|---|---|---|---|---|
+| `app/(app)/[handle]/page.tsx` (workspace home) | STANDARD LIVE | `useProcessInstances`, `useAllUserNamespaces` (selector), `mediforce.users.listMembers` (Phase 2.6 already exists) | 5 s for runs list | Multi-hook page — coordinate PR sequencing (PR3 + PR4 overlap; see PR sizing) |
+| `app/(app)/[handle]/settings/page.tsx` | ONE-SHOT | `useNamespace`, `mediforce.users.listMembers` (Phase 2.6), `mediforce.users.invite/resend` (Phase 2.6) | 0 (focus-refetch on) | Drops remaining `onSnapshot` on `namespaces/{handle}/members` subcollection |
+| `app/(app)/[handle]/tasks/[taskId]/page.tsx` (task detail) | CRITICAL LIVE | `mediforce.tasks.get(taskId)` | 1–2 s while task non-terminal | Today does `onSnapshot(humanTasks/{taskId})` — replace with `useQuery` gated on task status |
+| `app/(app)/[handle]/cowork/[sessionId]/page.tsx` (cowork chat) | CRITICAL LIVE during active POST | `mediforce.cowork.getSession(sessionId)` | 1 s while `useSendMessage.isPending`, 5 s idle | See §"Cowork live-turn strategy" |
+| `app/(app)/workspaces/new/page.tsx` | n/a (mutation) | `mediforce.namespaces.create(input)` | n/a | Optimistic prepend to `['users', 'me']`; redirect on success |
+
+#### Components (2)
+
+| File | Tier | Endpoint(s) | Notes |
+|---|---|---|---|
+| `components/tasks/next-step-card.tsx` | CRITICAL LIVE | `mediforce.tasks.list({instanceId, stepId})` (extended ListTasks filter) + `mediforce.runs.get(instanceId)` + `mediforce.workflows.get(name)` | Replaces `use-collection.ts` + `useSubcollection` patterns; multiple cache keys, single page |
+| `components/tasks/task-detail.tsx` | STANDARD LIVE | `mediforce.tasks.list({role, status})` | Replaces `use-collection.ts` consumer; gives "remaining task count" sidebar |
+
+**Note on `chat-cowork-view.tsx`:** the Phase 4 doc previously listed
+this as importing `firebase/firestore`. The audit confirms it **does
+not**. Data flows via parent page props. No migration needed for this
+file; mention only for completeness.
+
+#### Context (1)
+
+| File | Migration |
+|---|---|
+| `contexts/auth-context.tsx` | Drop all Firestore reads/writes. Replace user-doc fetch + namespaces query + personal-namespace bootstrap (3-write inline) with a single `useUserMe()` (`useQuery(['users', 'me'])`). The lazy bootstrap moves to the GET /me handler's side-effect. Firebase Auth import stays — only `firebase/firestore` goes. |
+
+#### Library (1)
+
+| File | Migration |
+|---|---|
+| `lib/firebase.ts` | **PR-final.** Delete `getFirestore()` + `connectFirestoreEmulator()`. Leave Firebase Auth init. Uninstall `firebase/firestore` from `platform-ui`'s `package.json` peer deps. |
+
+### 5. Cowork live-turn strategy
+
+The cowork chat flow today: parent page subscribes to `coworkSessions/{sessionId}`
+via Firestore `onSnapshot`; user sends message → backend's blocking
+POST iterates a tool loop (≤10 iterations), persisting intermediate
+turns to the session doc as it goes; Firestore push delivers each
+intermediate turn to the parent page, which re-renders the chat view
+with progressive tool-call bubbles. Phase 3.1 migrated the POST itself
+but left this incidental "Firestore as notification channel" in place.
+
+After Phase 4, no Firestore SDK in the UI. Strategy:
+
+1. **Send mutation** wraps `mediforce.cowork.chat({...})` in
+   `useMutation`. `onMutate` cancels in-flight polling on the turns
+   cache key, snapshots current cache for rollback, optimistically
+   prepends the user's turn + an "agent thinking" placeholder. `onError`
+   restores snapshot + toasts. `onSuccess` replaces the cache with
+   `data.turns` (the server's final shape, via the additive return shape
+   extension above).
+2. **Turns query** runs an idle polling loop on
+   `['cowork', sessionId, 'turns']` at 5 s. Polling interval flips to
+   1 s while `sendMessage.isPending` (using `useMutation`'s `isPending`
+   as the gate). After `onSuccess` the polling drops back to 5 s.
+3. **Cancellation race protection.** `qc.cancelQueries({ queryKey: ['cowork', sessionId, 'turns'] })`
+   in `onMutate` stops the in-flight polling response from overwriting
+   the optimistic prepend with stale pre-message data (without this,
+   the user's turn would flicker in and out).
+
+UX outcomes vs today:
+
+| Today (Firestore push) | Phase 4 (polling + optimistic) |
+|---|---|
+| User turn appears instantly (Firestore round trip ~100 ms) | User turn appears instantly (local optimistic prepend) |
+| Tool-call bubbles arrive within ~100 ms of server persist | Tool-call bubbles arrive within 1 s of server persist (polling tick) |
+| Final agent text on POST resolve | Final agent text instant via `onSuccess` cache replacement |
+
+1-second lag on tool-call bubbles is the explicit regression. Acceptable
+per "preserve don't upgrade." If operator feedback shows it's painful, a
+focused follow-up adds an SSE stream for cowork turns
+([#516](https://github.com/Appsilon/mediforce/issues/516)).
+
+### 6. Optimistic update playbook
+
+Three reusable templates, applied across all mutations Phase 4 touches:
+
+- **State transition** (e.g. `tasks.claim`, `runs.cancel`): single
+  entity flips status. Pattern: `onMutate` snapshots cache for the
+  specific entity key + any list keys containing it, optimistically
+  flips status. `onSuccess` replaces both with the entity-echo from the
+  server (`{ task }`, `{ run }` — per [ADR-0005 §5](./adr/0005-headless-platform-api-ui-separation.md)).
+  `onError` restores snapshots.
+- **List-affecting** (e.g. `namespaces.create`, future `workflows.delete`):
+  mutation adds or removes from a list. Pattern: optimistic prepend /
+  filter on the relevant list key. `onSuccess` for create: replace
+  optimistic with server-echoed entity; for delete: keep filter, no
+  replacement needed. Redirect / focus shift in `onSuccess` if the flow
+  requires it (e.g. workspace create → navigate to `/${handle}`).
+- **Multi-cache-key** (e.g. `runs.bulkCancel` affecting many runs +
+  monitoring summary + audit logs): use `qc.invalidateQueries` with a
+  prefix key (`['runs', handle]`) — tag-prefix invalidation in
+  react-query catches every variant at once. Optimistic update optional
+  per call (bulk operations often skip optimistic and refetch instead).
+
+Each template is ~10 LOC; documented in [ADR-0006](./adr/0006-client-side-server-state.md)
+with code examples that PR1 will codify into copy-paste references for
+PRs 2–6.
+
+### 7. `use-collection.ts` + `use-user-namespace.ts` cleanup
+
+`use-collection.ts` is a generic Firestore subscription wrapper. Two
+consumers, both folded into specific endpoints:
+
+- `next-step-card.tsx`: needs tasks for one instance + step. Folds into
+  `mediforce.tasks.list({instanceId, stepId})` (contract extension above).
+- `task-detail.tsx`: needs remaining tasks for caller's role. Folds
+  into existing `mediforce.tasks.list({role, status})`.
+
+After both migrate, delete `use-collection.ts`.
+
+`use-user-namespace.ts` looks dead at first audit but is in fact called
+standalone for personal-namespace lookup. After Phase 4 it becomes a
+selector over `useUserMe()`:
+
+```ts
+function usePersonalNamespace() {
+  const { data } = useUserMe();
+  return data?.namespaces.find(n => n.type === 'personal');
+}
+```
+
+Then delete the original `use-user-namespace.ts` file.
+
+### 8. PR sizing — six-PR per-resource tracer
+
+PR1 establishes the pattern end-to-end with the smallest domain (tasks).
+PRs 2–5 adopt the pattern per domain (mechanical). PR-final removes
+Firestore entirely. Some sequencing required (multi-hook pages create
+conflicts):
+
+| PR | Scope | Sequencing |
+|---|---|---|
+| PR1 — tasks + react-query foundation | All react-query infra (QueryClient provider, defaults, devtools, key convention), tasks-domain hook migrations (`use-tasks` + `use-collection` consumers fold), `claim-button` + `task-detail` + task detail page rewires, `mediforce.tasks.list` extended contract. PRD's first end-to-end proof point. | Standalone — must merge first. |
+| PR2 — agent-runs + monitoring | `use-agent-runs` + `use-monitoring` migrations. Adds `/api/agent-runs` (list + single), `/api/namespaces/:handle/monitoring/summary`. Repo additions `AgentRunRepository.listInNamespaces`, monitoring aggregator. | Independent of PR3+; can run parallel. |
+| PR3 — processes/runs | `use-process-instances`, `use-audit-events`, `next-step-card` migrations. `process-detail.tsx` + cancel/archive/bulk mutations via `useMutation` + optimistic. | Must sequence with PR4 (shared `[handle]/page.tsx`). |
+| PR4 — namespaces + auth + workspaces/new | `GET /api/users/me` (with lazy bootstrap), `GET /api/namespaces/:handle`, `POST /api/namespaces`. `use-namespace`, `use-namespace-role`, `use-all-user-namespaces`, `use-user-namespace` → selectors. `auth-context.tsx` drops Firestore. `workspaces/new/page.tsx` uses `useMutation`. Settings page drops remaining `onSnapshot`. Repo addition `NamespaceRepository.createNamespaceWithOwner`. Schema constants `HandleSchema`. | Must sequence with PR3 (shared `[handle]/page.tsx`). |
+| PR5 — cowork | `cowork/[sessionId]/page.tsx` rewire, chat send via `useMutation` + optimistic + isPending-gated polling. Chat handler return shape extended (additive). | Can run parallel with PR3/PR4 once PR1 lands. |
+| PR-final — flip | Delete `lib/firebase.ts` `getFirestore` + emulator. Uninstall `firebase/firestore` from `platform-ui` peer deps. Verify `api-boundaries.test.ts` still passes. Update `docs/headless-migration.md` Phase 4 → "done". | Must merge last. |
+
+Pause-safe across PRs: each merged PR leaves a consistent app state.
+Multi-hook page conflicts (above) require sequencing, not full
+serialization — at most 2–3 PRs in parallel review.
+
+Once PR-final merges, PG PR2 ([#534](https://github.com/Appsilon/mediforce/pull/534))
+is unblocked.
+
+## Testing decisions
+
+Mediforce's test taxonomy from [`docs/headless-migration.md`](./headless-migration.md) §"Testing
+strategy" applies directly. New test work per PR:
+
+### What makes a good test (this project's invariants)
+
+- Tests assert on **external behavior** of the unit. Handler tests:
+  what the handler returns / throws given input + scope state. Hook
+  tests: what the consumer sees (data, loading, error, key-change
+  cancel). Never assert on `useEffect` invocation counts, React
+  internals, or implementation details.
+- **No mocks below the HTTP boundary.** Handlers use
+  `InMemoryXRepository` from `@mediforce/platform-core/testing`.
+- Above the HTTP boundary, mock at the **outermost seam**: `apiFetch`
+  for client tests, `mediforce.X.Y` for hook tests, or use the
+  loopback pattern for cross-layer integration.
+- **One assertion per concept.** Five `expect(...)` for five behaviors
+  = five tests.
+- **Hook test template:** the existing `useInstanceTasks` test
+  (`packages/platform-ui/src/hooks/__tests__/use-instance-tasks.test.ts`,
+  5 cases incl. cancel-on-deps-change) is the canonical shape. Every
+  migrated hook gets a sibling test with the same five-case structure,
+  wrapped in a fresh `QueryClient` per test (the only react-query
+  ceremony required).
+
+### Test scope per PR (foundation + per-domain)
+
+| Module | Test layer(s) |
+|---|---|
+| Schema constants (`HandleSchema`, `HANDLE_REGEX`) | Contract — boundary cases (min/max length, invalid chars, edge handles) |
+| Each new endpoint contract (Zod) | Contract test per schema (input + output) |
+| Each new handler | Handler test vs `InMemoryX` repos. Cover: success, not-found / anti-enum 404 path, forbidden (where applicable), and any state-machine invariant the handler enforces |
+| `GET /api/users/me` lazy bootstrap | Handler test — "creates personal namespace if missing", "no-op + same shape if exists", "idempotent under repeat call" |
+| `NamespaceRepository.createNamespaceWithOwner` | Repo unit test (in-memory) covering namespace + member written together + nothing written if either step fails. Postgres parity test added when PG impl lands. |
+| `AgentRunRepository.listInNamespaces` | Repo unit test — cursor stability across page boundary, namespace filter correctness, ordering invariant |
+| React-query infra (`QueryClient` defaults) | Smoke test — provider wraps, a hook reads through the provider |
+| Per-migrated hook | One hook test each (5-case `useInstanceTasks` template): initial load, success, error, deps change cancels in-flight, terminal-state gates polling |
+| Cross-layer integration | One per PR — loopback `apiClient → adapter → handler → in-memory repo` for the PR's primary domain. Existing `packages/platform-ui/src/test/api-integration.test.ts` is the pattern. |
+| Optimistic update patterns | One test per template (state transition / list-affecting / multi-cache-key) covering snapshot + rollback path |
+| Route adapter | No new work — already parametric from Phase 2 (covers HandlerError + ZodError + unknown) |
+
+### Skip
+
+- Component tests for trivial render wrappers (Phase 1 doctrine — render-doesn't-throw is coverage theater).
+- E2E new journeys — existing process / task / cowork journey tests cover the user-visible flows. Add a new journey only if a hook + integration test cannot catch the regression.
+- Tests for selector hooks (`useNamespaceRole`, `useAllUserNamespaces`, `usePersonalNamespace`) — they are pure derivations over `useUserMe()`'s cache. Test the underlying `useUserMe` hook; the selectors carry no risk surface.
+
+## Out of scope
+
+Items deliberately not in Phase 4 — they earn their own ticket / phase /
+ADR. The migration goal is **swap the data transport**, nothing more.
+
+- **Per-resource SSE event stream consolidation.** Future ADR; tracked
+  in [`docs/headless-migration.md`](./headless-migration.md) "Captured for after Phase 4."
+- **SSE for cowork tool-loop progress.** [#516](https://github.com/Appsilon/mediforce/issues/516).
+- **Phase 5 `@/lib/platform-services` shim cleanup.** Off-critical-path
+  cosmetic codemod. Schedule when convenient.
+- **Phase 7 — split API into separate deployable.** Forward-compatible
+  but unnecessary today.
+- **URL canonicalization across the API surface** ([#544](https://github.com/Appsilon/mediforce/issues/544)).
+  Phase 4 ships under today's URL shape (`/api/namespaces/:handle`,
+  `/api/admin/oauth-providers`, `?namespace=X` query params where
+  already present). The rename to `/api/workspaces/:handle` or any
+  other canonicalization lands as a coordinated independent PR.
+- **File-serving endpoints** (`agent-logs`, `agent-output-file`,
+  `step-logs`) — deferred under Phase 1.8 because file-serving shape
+  needs its own design pass.
+- **Audit-wiring phase.** Repo-resident `MutationContext` per
+  [ADR-0005 §7](./adr/0005-headless-platform-api-ui-separation.md) "long-term direction." Handler-bridge audit emission
+  from Phase 2/2.5/3 stays in place; new Phase 4 mutations emit via
+  the same bridge.
+- **Run-executor durability (BullMQ migration).** Captured for later
+  in [`docs/headless-migration.md`](./headless-migration.md); independent of UI/API separation.
+- **ADR-0002 NextAuth migration.** Lazy-bootstrap side-effect in
+  `GET /api/users/me` is a known intermediate; the bootstrap moves to
+  `events.createUser` when ADR-0002 ships.
+- **Adding role / ownership enforcement to wrappers.** `CallerScope`
+  already carries `namespaceRoles` (Phase 2.6); handler-resident
+  `assertCallerIsNamespaceAdmin` is the gate. Wrapper-level role
+  enforcement deferred per [ADR-0004 §4](./adr/0004-scoped-data-access-authorization.md) "Out of scope."
+- **Idempotency keys on creates.** `POST /api/namespaces` accepts
+  duplicate handles → 409. Add idempotency when a real client demands
+  it.
+- **Workspace member-management URL rename.** Phase 2.6 endpoints stay
+  under `/api/users/invite`, `/api/users/members`, etc. URL
+  canonicalization PR will rename together with the rest.
+
+## Further notes
+
+### Coordination with [#534](https://github.com/Appsilon/mediforce/pull/534) (PG PR2)
+
+PG PR2's description names this PRD as its explicit gate. The merge
+sequence is:
+
+1. PR #515 already merged (Postgres provision + tool-catalog tracer).
+2. **This phase ships** — all six PRs land sequentially per the
+   schedule above. UI stops importing `firebase/firestore`. Server data
+   layer still Firestore; behavioural no-op.
+3. Staging cutover via `scripts/migrate-firestore-to-postgres/`.
+   Iterate per `CUTOVER-CHECKLIST.md`.
+4. PG PR2 merges; server flips to Postgres; UI already reads through
+   headless endpoints; no fallout.
+5. Production cutover during maintenance window.
+
+### Why react-query is forward-compatible with eventual SSE
+
+`@tanstack/react-query` provides the cache. SSE provides updates.
+Future `useResourceStream(resourceId)` hooks dispatch each event into
+the same cache via `qc.setQueryData(key, updater)`. Polling becomes
+the fallback for the initial load + reconnect catchup; SSE pushes
+incremental deltas. Components read through the same `useQuery(key)`
+they read today; they do not know which transport delivered the
+update.
+
+This is the exact pattern "per-resource event stream consolidation"
+(captured-for-later in [`docs/headless-migration.md`](./headless-migration.md)) will use. Phase 4
+picking react-query now equals zero rework when SSE arrives.
+
+### Audit emission
+
+No new audit shape. Handler-bridge emission per [ADR-0005 §7](./adr/0005-headless-platform-api-ui-separation.md):
+
+- `namespace.created` — emitted by `POST /api/namespaces` handler.
+- `user.personal_namespace_created` — emitted exactly once by the
+  lazy bootstrap side-effect of `GET /api/users/me` (only when
+  creation happens, not on every call).
+
+No other Phase 4 endpoint emits audit (reads do not emit; existing
+mutations migrated in Phase 2/2.5/3 keep their existing emit shape).
+
+### Verification action items (block on these before implementation)
+
+Worth confirming before PR1:
+
+1. **`users/{uid}.organizations` field** — verify it is truly dead.
+   Grep for readers across `packages/`. If dead, drop from the
+   `POST /api/namespaces` handler's write set + remove from
+   `auth-context.tsx` bootstrap moved to GET /me. Reduces atomicity
+   surface and one Firestore consumer.
+2. **`agents/[runId]/page.tsx`** — confirm `runId` in this URL is an
+   agentRunId (not a workflowRunId). If workflowRunId, single endpoint
+   `GET /api/agent-runs/:agentRunId` does not apply; rethink.
+3. **`HandleSchema` location** — search existing schema package for a
+   handle constant. If one exists, point at it; if not, create per
+   the inventory.
+4. **`useSubcollection` / `useProcessInstance` / `useActiveTaskForInstance` /
+   `useActiveCoworkSession`** — phrases used in [`docs/headless-migration.md`](./headless-migration.md)
+   Phase 4 doc. Verify each maps to an existing file or is aspirational
+   shorthand; the audit found only the named 22 files. The per-consumer
+   table above is authoritative; the doc's prose lists need a sweep
+   pass during PR3 / PR5.
+5. **Cowork chat handler** — confirm extending return shape to include
+   `session` + `turns` is in fact additive (no schema rejection on
+   existing call sites). Should be — Zod object schemas with strict
+   defaults pass through extras — but verify by running existing chat
+   tests with the extended shape.
+
+### Living document
+
+This PRD is `Active` while implementation runs. Each PR may amend it
+to reflect what survived contact with the codebase. Finalize on PR-final
+merge, at which point `docs/headless-migration.md` § Phase 4 marks
+"done" and this PRD becomes the historical record.

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -1029,15 +1029,41 @@ Init (1):
 - `POST /api/namespaces` — create workspace (replaces direct writes in `workspaces/new/page.tsx`).
 - Audit + agent-runs per-instance endpoints already exist from Phase 1; verify shape covers UI needs before adding new ones.
 
-**SSE endpoints for live (~4 today, per `onSnapshot` consumers):**
+**Live-update strategy — default to polling.**
 
-- `GET /api/tasks/stream?role=…` — live task list per role.
-- `GET /api/processes/:id/stream` — live single-instance updates (status, current step, variables).
-- `GET /api/agent-runs/stream?processInstanceId=…` — live agent runs for a process.
-- `GET /api/cowork/:sessionId/stream` — live cowork turns (replaces `chat-cowork-view` snapshot).
+ADR-0001 §5 calls for "lists move to SWR polling 2-10s, live → SSE." Phase 4
+narrows that further: **polling for everything as the default**; SSE only
+when a concrete UX gap surfaces in a follow-up. Justification:
 
-`apiClient` wraps `fetch` + `ReadableStream` + incremental SSE parse (not
-`EventSource` — no custom-header support without a proxy hop).
+- Polling is one library + one interval config per hook. SSE per resource
+  requires: streaming `createRouteAdapter` variant, server-side change
+  detection (Postgres `LISTEN/NOTIFY` or in-process pub-sub from mutation
+  handlers — Postgres has no `onSnapshot` equivalent), connection lifecycle
+  (Firebase ID token refresh, reconnect), client-side `fetch +
+  ReadableStream` wrapper (`EventSource` lacks custom-header support).
+- Mediforce scale today (single-tenant, few concurrent users per workspace,
+  one VPS) makes a 1-2s polling lag invisible for everything except
+  streaming text deltas. Streaming text deltas are not in Phase 4 scope.
+- Polling is also the simpler rollback story during the PG cutover window:
+  one knob (`refreshInterval`) per consumer; SSE has more moving parts to
+  unwind if Postgres `LISTEN/NOTIFY` design proves wrong.
+
+**SSE endpoints if a concrete need surfaces (none mandatory in Phase 4):**
+
+- `GET /api/tasks/stream?role=…` — only if 1-2s task-list refresh feels
+  laggy to operators.
+- `GET /api/processes/:id/stream` — only if running-process detail page
+  visibly stutters under polling.
+- `GET /api/cowork/:sessionId/stream` — already deferred to
+  [#516](https://github.com/Appsilon/mediforce/issues/516)
+  alongside the streaming SSE chat overhaul.
+
+If/when added, `apiClient` wraps `fetch` + `ReadableStream` + incremental
+SSE parse (not `EventSource` — no custom-header support without a proxy
+hop). Server-side change detection in the Postgres era: Postgres
+`LISTEN/NOTIFY` from mutation triggers, OR in-process `EventEmitter`
+published from headless mutation handlers (simpler, single-worker only —
+falls apart under horizontal scaling). Pick when first SSE endpoint lands.
 
 **Client-side cache library — open question, not pre-decided.**
 
@@ -1064,10 +1090,38 @@ Firebase is never imported by `platform-api/client`. Browser wrapper
 Firebase Auth and reads `auth.currentUser.getIdToken()`. Same helper backs
 `apiFetch` — every browser call produces byte-identical auth headers.
 
-**Decision tree per file:**
-- Live updates needed? → SSE endpoint + `apiClient.X.subscribeY()` wrapper.
-- Static-ish list? → Polling via cache library, 2-10s per ADR-0001 §5.
-- One-shot read? → Direct `mediforce.X.Y()` call.
+**Migration principle — preserve, don't upgrade.**
+
+Phase 4 is a **swap**, not a redesign. Two cases per consumer:
+
+1. **Endpoint already exists, reads from API today** — UI just calls
+   `mediforce.X.Y()` instead of touching Firestore directly. No design pass,
+   no UX change. Mechanical.
+
+2. **Consumer reads Firestore directly today (no API endpoint exists)** —
+   needs design pass: add headless endpoint, decide live-update strategy
+   (polling vs SSE), wire UI hook. Each entry on the "Missing headless
+   endpoints" list above falls here.
+
+**Anti-upgrade rule.** Mutations migrated in Phase 2 / 2.5 / 2.6 / 3 / 3.1
+stay as they shipped — request/response shape unchanged. If today's flow
+relies on Firestore `onSnapshot` from a parent page to observe progress
+(e.g. cowork chat tool-loop turns), Phase 4 keeps that flow:
+**blocking handler stays blocking; UI polls session/turns at a sensible
+interval instead of subscribing.** UX may lose some smoothness (1-2s lag on
+tool-call animation vs instant snapshot push). That's acceptable. SSE
+streaming overhauls, message queue UIs, transactional finalize and similar
+UX improvements live in dedicated follow-up tickets ([#516](https://github.com/Appsilon/mediforce/issues/516)
+for cowork) — explicitly **not Phase 4**.
+
+**Decision tree per consumer:**
+
+| Today's source | Migration |
+|---|---|
+| One-shot Firestore `getDoc` / `getDocs` | Direct `mediforce.X.Y()` call (likely already exists from earlier phases; if not, add a GET endpoint). |
+| Live `onSnapshot` on a list / doc, no high-frequency changes (settings, namespace metadata, role) | Polling via cache library, 5-10s. |
+| Live `onSnapshot` driving progressive UX (active tasks, running process status, cowork turns during chat) | Polling 1-2s during active state, 5-10s when idle. Stretch goal: SSE in a follow-up if 1s lag proves bad in practice. |
+| Direct Firestore write (`addDoc` / `updateDoc` / `arrayUnion`) | Add headless mutation endpoint, call `mediforce.X.Y()`. |
 
 **Pause-safe**: yes — per-file migration, each backed by a journey test.
 Unmigrated consumers keep working on the Firestore bypass.

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -1110,24 +1110,70 @@ Firebase is never imported by `platform-api/client`. Browser wrapper
 Firebase Auth and reads `auth.currentUser.getIdToken()`. Same helper backs
 `apiFetch` — every browser call produces byte-identical auth headers.
 
-**Live-by-default fallacy — most hooks don't actually need live updates.**
+**Live-by-default fallacy — audit each consumer by its UI flow.**
 
 Today's hooks use `onSnapshot` not because UX requires live — because
-Firestore gave it for free. Audit each consumer before defaulting to
-polling: a lot of them are fine as one-shot fetch on mount, with manual
-refresh / focus-refetch / mutation-invalidate as the freshness mechanism.
+Firestore gave it for free. Walk each consumer at its **call site** (which
+page, what flow), not at its hook name; the same hook can be live on a run
+detail page and one-shot on a definition viewer.
 
-| Truly live (operator notices delay) | Live-by-accident (Firestore default; one-shot fetch is fine) |
+**CRITICAL LIVE (polling 1-2s; off when run is terminal)** — operator
+watching execution:
+
+| Call site | What the user watches |
 |---|---|
-| Active task list — new tasks appear from agents | Settings page |
-| Running process status — current step indicator | Namespace metadata / role |
-| Agent run page — log lines mid-execution | Workflow / agent definitions list |
-| Cowork chat turns — tool-call bubbles during blocking POST | Audit history |
-| Monitoring dashboard counts | User membership lists |
-| | Archived items |
+| `runs/[runId]/page.tsx` + `report/page.tsx` | run status, current step, **audit feed appearing as engine emits** |
+| `runs/[runId]/steps/[stepId]/page.tsx` | step detail, agent attempts, output growing |
+| `agents/[runId]/page.tsx` | agent run detail, log lines |
+| `process-detail.tsx` / `next-step-card.tsx` | "current task on this run" — task pops in when step completes |
+| Cowork chat (turns subscription) | tool-call bubbles during blocking POST |
 
-Default policy: **one-shot on mount, no polling**. Add polling only to the
-left-column hooks. Saves Postgres load + simplifies error surface.
+Pollers consumed here: `useProcessInstance`, `useSubcollection`,
+`useAuditEvents`, `useAgentRun`, `useAgentRunsForStep`,
+`useActiveTaskForInstance`, `useActiveCoworkSession`. Gate the polling
+key on `status !== 'completed' && status !== 'failed' && status !==
+'archived'` to stop hitting Postgres for runs nobody is advancing.
+
+**STANDARD LIVE (polling 3-5s)** — operator worklist:
+
+| Call site | Why live |
+|---|---|
+| `[handle]/tasks/page.tsx`, `[handle]/page.tsx` (home), `runs/page.tsx`, `workflows/[name]/page.tsx`, `agents/page.tsx` | new tasks / runs appear from agents; operator wants to see them without refresh |
+
+Pollers: `useMyTasks`, `useProcessInstances`, `useAgentRuns`.
+
+**NICE LIVE (polling 30s or focus-refetch only)** — dashboards:
+
+| Call site | Hook |
+|---|---|
+| `[handle]/monitoring/page.tsx` | `useMonitoringData` |
+
+**ONE-SHOT — no polling, focus-refetch policy varies:**
+
+| Call site | Hook | Refresh trigger | Reason |
+|---|---|---|---|
+| `settings/page.tsx`, workspace header, workspace home | `useNamespace` | invalidate after settings save; `revalidateOnFocus: true` as safety net | workspace metadata changes via deliberate edit |
+| App shell, admin pages, page gates | `useNamespaceRole` | **none — strictly one-shot**, `revalidateOnFocus: false` | role-change-mid-session → silent UI mutation = bad. Better: backend 403 on next mutation → user sees explicit "permission denied" and signs out+in |
+| App shell switcher, workflows/new, transfer dialogs | `useAllUserNamespaces` | `revalidateOnFocus: false` | same reasoning — membership change should not silently mutate UI |
+| Definition viewers (`definitions/[version]/page.tsx`), run-detail definition slice (`useWorkflowDefinitions`) | `useWorkflowDefinitions` | invalidate after edit/create mutation | engine snapshots definition at run start; mid-run edits don't apply |
+| `definitions-list.tsx`, `start-run-button.tsx`, `task-grouped-view.tsx` | `useProcessDefinitions`, `useProcessNameMap` | invalidate after edit/create | static lookups |
+
+**On `revalidateOnFocus` as a safety net:** for one-shot hooks where the
+data CAN change (workspace metadata, definitions list), turning on
+focus-refetch costs one refetch per tab-return — much cheaper than a
+polling loop, and catches "user came back from lunch, cache is stale."
+For one-shot hooks where the data SHOULD NOT silently change mid-session
+(role, membership), keep focus-refetch OFF and let the backend's 403 be
+the canary.
+
+**TO INVESTIGATE / DELETE:**
+
+- `use-collection.ts` — generic Firestore wrapper. Consumed by
+  `next-step-card.tsx`, `task-detail.tsx`. Replace consumers with specific
+  `mediforce.X.Y()` calls per the table above (live vs one-shot per
+  consumer); delete the helper.
+- `use-user-namespace.ts` — zero source-tree imports per grep. Likely dead,
+  drop with confirmation.
 
 **Migration principle — preserve, don't upgrade.**
 
@@ -1164,6 +1210,38 @@ for cowork) — explicitly **not Phase 4**.
 
 **Pause-safe**: yes — per-file migration, each backed by a journey test.
 Unmigrated consumers keep working on the Firestore bypass.
+
+**Captured for after Phase 4 — per-resource event stream consolidation.**
+
+The "CRITICAL LIVE" call sites above all poll *separately* for facets of
+the same logical resource: a run-detail page fires 4-5 polling hooks
+(`useProcessInstance`, `useSubcollection` for steps + agent-runs +
+turns, `useAuditEvents`, `useActiveTaskForInstance`) against the same
+run. Natural design is **one stream per resource the user is watching**:
+
+```
+GET /api/runs/:id/stream  (SSE)
+   event: step_changed     {stepId, status}
+   event: task_created     {task}
+   event: task_completed   {taskId}
+   event: audit_event      {action, ...}
+   event: agent_run_progress {runId, ...}
+   event: instance_finished {status}
+```
+
+Multiplexed at server (mutation handlers emit events; SSE handler
+listens via Postgres `LISTEN/NOTIFY`); client subscribes once per page,
+context-provider rebroadcasts to facet components. Pattern in
+production at Linear, Vercel deploy logs, GitHub Actions UI.
+
+Phase 4 explicitly does NOT do this. The migration is a swap, not a
+redesign — polling N hooks first, then consolidate per-resource streams
+as a focused follow-up after the polling baseline ships and PG cutover
+stabilises. Tracked as: future ADR / ticket.
+
+Trade-off captured here so the polling proliferation doesn't calcify:
+the moment two hooks on the same page are gated on the same "run not
+terminal" predicate, that's the signal to merge them into the stream.
 
 **Open questions to settle at the top of the phase:**
 - Cache library — SWR vs react-query vs custom (above).

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -964,29 +964,62 @@ Multi-tab live sync intentionally excluded — no demand. ChatGPT and Claude.ai 
 
 ### Phase 4 — UI off Firestore (gating for ADR-0001 cutover)
 
+**Status:** plan finalized 2026-05-28 — see
+[`headless-migration-phase-4-plan.md`](./headless-migration-phase-4-plan.md)
+for the authoritative implementation plan + per-consumer migration
+table + PR sizing. Cache architecture in
+[`ADR-0006`](./adr/0006-client-side-server-state.md). ADR-0001 §5
+amendment bundled with the plan (SSE deferred; polling at cutover).
+
 **Folded from previous Phase 4 + Phase 6 (2026-05-27).** Original split —
 "typed apiClient + first hook" vs "remaining UI data fetching" — was
 artificial. The typed `Mediforce` client already exists (started in #232,
-expanded alongside every Phase 1-3 endpoint), used punctually by
-`StepHistoryTabs` and `TaskDetail.siblingTasks`. Practical effort = one
+expanded alongside every Phase 1-3 endpoint). Practical effort = one
 stream: rewrite every UI consumer that imports `firebase/firestore` to go
-through `mediforce.X.Y()` + SSE. Treating it as one phase reflects reality.
+through `mediforce.X.Y()` + react-query. Treating it as one phase reflects
+reality.
 
 **Gating for ADR-0001.** Postgres has no `onSnapshot` equivalent. PG PR2
 ([#534](https://github.com/Appsilon/mediforce/pull/534)) — server-side
 Firestore deletion + cutover script — is explicitly blocked on this phase.
-Sequencing per ADR-0001 §8 + PR2 description:
+The PRD ([`headless-migration-phase-4-plan.md`](./headless-migration-phase-4-plan.md))
+holds the per-PR sequencing; high-level cutover order per ADR-0001 §8 + PR2 description:
 
 1. Merge PG PR1 ([#515](https://github.com/Appsilon/mediforce/pull/515)) —
    tracer-bullet `STORAGE_BACKEND=postgres` flag + `PostgresToolCatalogRepository`.
 2. **This phase** — UI off Firestore. Behavioural no-op alone (Firestore
    stays the server data layer); UI just routes reads through
-   `mediforce.X.Y()` + SSE instead of `onSnapshot`.
+   `mediforce.X.Y()` + react-query instead of `onSnapshot`.
 3. Staging cutover via `scripts/migrate-firestore-to-postgres/`.
 4. Merge PG PR2 ([#534](https://github.com/Appsilon/mediforce/pull/534)) —
    server flips to Postgres, `STORAGE_BACKEND` flag removed,
    `platform-infra/src/firestore/` deleted.
 5. Production cutover.
+
+**Locked decisions** (full reasoning in PRD + [`ADR-0006`](./adr/0006-client-side-server-state.md)):
+
+- Cache library: **`@tanstack/react-query`**.
+- Polling at cutover for every surface (CRITICAL LIVE 1–2 s, STANDARD LIVE 5 s,
+  NICE LIVE 30 s, ONE-SHOT). SSE deferred to a focused follow-up; ADR-0001 §5
+  amended to match.
+- **Six new endpoints** (`GET /api/users/me` with lazy bootstrap,
+  `GET /api/namespaces/:handle`, `POST /api/namespaces`,
+  `GET /api/agent-runs` + single, `GET /api/namespaces/:handle/monitoring/summary`).
+  Two contract extensions (`ListTasks +instanceId+stepId`, chat handler
+  `+session+turns`). No `/api/audit-events` (existing per-run audit covers).
+- **Six PRs** (per-resource tracer): tasks + react-query foundation →
+  agent-runs + monitoring → processes → namespaces + auth → cowork → final
+  flip (delete `lib/firebase.ts`).
+- `use-collection.ts` deleted (consumers fold into specific endpoints);
+  `use-user-namespace.ts` becomes a selector over `useUserMe()`.
+- Cowork live-turn observation: optimistic prepend + polling 1 s gated on
+  `useMutation.isPending`, 5 s idle.
+
+Everything below this point about scope / live-update / cache library /
+endpoint inventory / decision tree was the pre-grilling working hypothesis.
+The PRD supersedes it. Kept here only as historical context until PR-final
+merges, at which point this section reduces to a one-line "done" pointer at
+the PRD.
 
 **Scope — 22 files importing `firebase/firestore`, 11 with live `onSnapshot`:**
 

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -94,7 +94,7 @@ The underlying lesson is that the pilot contract was designed to match what `Hum
 
 Concrete Phase 1 tickets (tracked in #231):
 
-- **Drop the actionable-only filter from `HumanTaskRepository.getByRole`** — ~~planned~~ **done in #232**. Both the Firestore and in-memory implementations now return every task for a role regardless of status; callers narrow via the `status` field in the contract. The only pre-pilot production caller of `getByRole` was our new handler, so the change had zero user-visible effect on main and unblocked migration of `useCompletedTasks` in future Phase 6 work.
+- **Drop the actionable-only filter from `HumanTaskRepository.getByRole`** — ~~planned~~ **done in #232**. Both the Firestore and in-memory implementations now return every task for a role regardless of status; callers narrow via the `status` field in the contract. The only pre-pilot production caller of `getByRole` was our new handler, so the change had zero user-visible effect on main and unblocked migration of `useCompletedTasks` in future Phase 4 work.
 - **Unfiltered list** (`useAllTasks`) — add a `GET /api/tasks` variant with mandatory pagination (`limit` + opaque `cursor`) and probably admin scope. Don't add "filter is optional" — the unbounded read is the footgun.
 - **Aggregate stats** (`useMonitoringData`) — different shape (counts, not list). Add `GET /api/tasks/stats` as a separate endpoint rather than contorting the list contract.
 - **Multi-field filter** (`instanceId + stepId` in `NextStepCard`) — extend `ListTasksInputSchema` with optional `stepId`. Trivial.
@@ -962,73 +962,152 @@ Audit emission per handler via `scope.system.audit.append` (ADR-0005 §7 handler
 
 Multi-tab live sync intentionally excluded — no demand. ChatGPT and Claude.ai don't live-mirror multi-tab same-user; refresh-on-focus is the dominant pattern.
 
-### Phase 4 — Typed `apiClient` + first hook migration
+### Phase 4 — UI off Firestore (gating for ADR-0001 cutover)
 
-Close the loop: UI consumes the same contract it serves.
+**Folded from previous Phase 4 + Phase 6 (2026-05-27).** Original split —
+"typed apiClient + first hook" vs "remaining UI data fetching" — was
+artificial. The typed `Mediforce` client already exists (started in #232,
+expanded alongside every Phase 1-3 endpoint), used punctually by
+`StepHistoryTabs` and `TaskDetail.siblingTasks`. Practical effort = one
+stream: rewrite every UI consumer that imports `firebase/firestore` to go
+through `mediforce.X.Y()` + SSE. Treating it as one phase reflects reality.
 
-- Build `packages/platform-ui/src/lib/api-client.ts`:
-  - Methods like `apiClient.tasks.list(input)` → `Promise<ListTasksOutput>`.
-  - Shares the browser Bearer path with `apiFetch` (Filip's helper) via the
-    `getFirebaseIdToken()` helper in `lib/firebase-id-token.ts` — one source
-    of truth for `auth.currentUser.getIdToken()`. The typed client itself is
-    Firebase-free; the browser wrapper `lib/mediforce.ts` injects the helper
-    as its `bearerToken` callback.
-  - Parses the response through `<Endpoint>OutputSchema` — runtime guarantee.
-  - Input type + schema come from `@mediforce/platform-api/contract`.
-- Migrate one non-realtime hook (settings list, archived items, detail view) from `useCollection` / direct Firestore SDK to `apiClient`.
-- Journey test for that page stays green — establishes the pattern.
+**Gating for ADR-0001.** Postgres has no `onSnapshot` equivalent. PG PR2
+([#534](https://github.com/Appsilon/mediforce/pull/534)) — server-side
+Firestore deletion + cutover script — is explicitly blocked on this phase.
+Sequencing per ADR-0001 §8 + PR2 description:
 
-**Accepted trade-off:** the first migrated hook loses real-time updates. That's fine for a non-critical read. Live reads come back later via SSE (Phase 6).
+1. Merge PG PR1 ([#515](https://github.com/Appsilon/mediforce/pull/515)) —
+   tracer-bullet `STORAGE_BACKEND=postgres` flag + `PostgresToolCatalogRepository`.
+2. **This phase** — UI off Firestore. Behavioural no-op alone (Firestore
+   stays the server data layer); UI just routes reads through
+   `mediforce.X.Y()` + SSE instead of `onSnapshot`.
+3. Staging cutover via `scripts/migrate-firestore-to-postgres/`.
+4. Merge PG PR2 ([#534](https://github.com/Appsilon/mediforce/pull/534)) —
+   server flips to Postgres, `STORAGE_BACKEND` flag removed,
+   `platform-infra/src/firestore/` deleted.
+5. Production cutover.
 
-**Status**: started in #232 — `Mediforce` class in `@mediforce/platform-api/client` + `mediforce.tasks.list` + `useInstanceTasks` hook consuming it in `StepHistoryTabs` and `TaskDetail.siblingTasks`. Expand the class alongside each Phase 1 / 2 endpoint migration rather than in one sweep.
+**Scope — 22 files importing `firebase/firestore`, 11 with live `onSnapshot`:**
 
-**Client shape** — runtime-agnostic, Stripe-style. Exactly one of three config fields must be provided at construction:
+Hooks (12):
+- Data reads: `use-tasks.ts`, `use-process-instances.ts`, `use-agent-runs.ts`,
+  `use-audit-events.ts`, `use-process-definitions.ts`,
+  `use-workflow-definitions.ts`, `use-monitoring.ts`, `use-collection.ts`.
+- Workspace metadata: `use-namespace.ts`, `use-namespace-role.ts`,
+  `use-all-user-namespaces.ts`, `use-user-namespace.ts`.
+
+Pages (5):
+- `app/(app)/[handle]/page.tsx` (workspace home)
+- `app/(app)/[handle]/settings/page.tsx`
+- `app/(app)/[handle]/tasks/[taskId]/page.tsx` (live task detail)
+- `app/(app)/[handle]/cowork/[sessionId]/page.tsx` (live cowork chat)
+- `app/(app)/workspaces/new/page.tsx` (create namespace — direct writes)
+
+Components (3):
+- `components/tasks/task-detail.tsx`, `components/tasks/next-step-card.tsx`
+- `components/cowork/chat-cowork-view.tsx` (live chat turns)
+
+Context (1):
+- `contexts/auth-context.tsx` — reads `users/{uid}` doc on sign-in.
+  Confusingly mixes Firebase Auth (stays) with Firestore reads (out).
+  Migrates via headless `GET /api/users/me` (or similar).
+
+Init (1):
+- `lib/firebase.ts` — `getFirestore()` + `connectFirestoreEmulator()`.
+  Removed entirely once last consumer goes; `firebase/firestore` peer-dep
+  uninstall from `platform-ui`.
+
+**Missing headless endpoints (~8-9 per PG PR2 description; confirm by walking each file):**
+
+- `GET /api/users/me` — current-user doc (replaces `auth-context.tsx` direct read).
+- `GET /api/users/me/namespaces` — workspaces caller belongs to (replaces `use-all-user-namespaces`).
+- `GET /api/namespaces/:handle` — workspace details (replaces `use-namespace`).
+- `GET /api/namespaces/:handle/role` — caller role (replaces `use-namespace-role`).
+- `GET /api/audit-events` — paginated audit listing with namespace filter (replaces direct collection-group query in `use-audit-events`).
+- `GET /api/agent-runs` — paginated agent-run listing (replaces `use-agent-runs` direct query).
+- `POST /api/namespaces` — create workspace (replaces direct writes in `workspaces/new/page.tsx`).
+- Audit + agent-runs per-instance endpoints already exist from Phase 1; verify shape covers UI needs before adding new ones.
+
+**SSE endpoints for live (~4 today, per `onSnapshot` consumers):**
+
+- `GET /api/tasks/stream?role=…` — live task list per role.
+- `GET /api/processes/:id/stream` — live single-instance updates (status, current step, variables).
+- `GET /api/agent-runs/stream?processInstanceId=…` — live agent runs for a process.
+- `GET /api/cowork/:sessionId/stream` — live cowork turns (replaces `chat-cowork-view` snapshot).
+
+`apiClient` wraps `fetch` + `ReadableStream` + incremental SSE parse (not
+`EventSource` — no custom-header support without a proxy hop).
+
+**Client-side cache library — open question, not pre-decided.**
+
+Neither `platform-ui` nor PG PR2 ([#534](https://github.com/Appsilon/mediforce/pull/534))
+adds a cache library today. Decide at the top of this phase; document
+choice + reasoning.
+
+| Option | Trade-off |
+|---|---|
+| **SWR** | Small. Stale-while-revalidate + focus-refetch + dedup out of box. Fits ADR-0001 §5's "lists move to polling 2-10s". No mutation-invalidation primitive. |
+| **@tanstack/react-query** | Heavier. Covers mutation invalidation, which post-Phase 4 the UI starts to need (`mediforce.X.create` → invalidate relevant lists). |
+| **Custom helper** | Extend today's `useInstanceTasks` (`useState` + `useEffect` + cancelled flag). Smallest dep footprint; loses dedup + cache. |
+
+**Client shape** — runtime-agnostic, Stripe-style. `Mediforce` class with
+exactly one of three config fields at construction:
 
 - `apiKey: string` → server-to-server (CLI, agent, MCP server). Uses `globalThis.fetch`, attaches `X-Api-Key`.
 - `bearerToken: () => Promise<string | null>` → user session (browser). Called per request for rotation; attaches `Authorization: Bearer`.
-- `fetch: typeof fetch` → escape hatch. Test loopback, retry/tracing wrappers with auth baked in via closure. No auth headers added by the client — caller's fetch handles it.
+- `fetch: typeof fetch` → escape hatch. Test loopback; auth baked in via closure.
 
-Firebase is never imported by `platform-api/client` — the browser wrapper in `platform-ui/src/lib/mediforce.ts` supplies `bearerToken` by reference to `getFirebaseIdToken()` (in `lib/firebase-id-token.ts`), which lazily imports the Firebase SDK and reads `auth.currentUser.getIdToken()`. That same helper backs `apiFetch`, so every browser-initiated call — typed or raw — produces byte-identical auth headers. For Node consumers, just `new Mediforce({ baseUrl, apiKey })`.
+Firebase is never imported by `platform-api/client`. Browser wrapper
+`platform-ui/src/lib/mediforce.ts` supplies `bearerToken` via
+`getFirebaseIdToken()` (in `lib/firebase-id-token.ts`), which lazily imports
+Firebase Auth and reads `auth.currentUser.getIdToken()`. Same helper backs
+`apiFetch` — every browser call produces byte-identical auth headers.
 
-**Open questions to settle**:
-- Do we keep our own tiny async-hook helper (`useInstanceTasks` pattern — `useState` + `useEffect` + cancelled flag), or adopt an existing library (`@tanstack/react-query` / `swr`) that gives caching, dedup, stale-while-revalidate for free?
-- Error surface — today `ApiError` (with `code`/`details`) is thrown from the client; hooks map it to `{ error }` state. Do we standardise an error boundary + toast pattern for failed API calls?
-- UI per-code narrowing — once the first real `if (err.code === 'X')` switch appears in UI, revisit ADR-0005 §2 "future-idea" note: reconstruct the matching server-side `HandlerError` subclass on the client from envelope `code` via a small map and surface it as a field on `ApiError`, so UI can do `if (clientErr.handlerError instanceof PreconditionFailedError)` with full TS narrowing. Out of scope until a concrete use-case lands.
+**Decision tree per file:**
+- Live updates needed? → SSE endpoint + `apiClient.X.subscribeY()` wrapper.
+- Static-ish list? → Polling via cache library, 2-10s per ADR-0001 §5.
+- One-shot read? → Direct `mediforce.X.Y()` call.
 
-### Phase 5 — Delete `@/lib/platform-services` shim
+**Pause-safe**: yes — per-file migration, each backed by a journey test.
+Unmigrated consumers keep working on the Firestore bypass.
 
-Mechanical cleanup. After Phase 4 the adapter surface is mostly migrated and we can codemod the remaining imports:
+**Open questions to settle at the top of the phase:**
+- Cache library — SWR vs react-query vs custom (above).
+- Auth on long-lived SSE streams — Firebase ID tokens expire ~1 h. Reconnect on expiry / server-side refresh / shorter stream lifetime + client reopen?
+- SSE granularity — one endpoint per resource (`/api/tasks/stream`, `/api/processes/:id/stream`), or one generic `subscribe` with contract-defined query? Former simpler; latter mirrors Firestore.
+- Error surface — today `ApiError` (with `code`/`details`) thrown from client. Standard error boundary + toast pattern for failed API calls?
+- UI per-code error narrowing — once first real `if (err.code === 'X')` lands, revisit ADR-0005 §2 "future-idea" to reconstruct server `HandlerError` subclass on the client from envelope `code`. Out of scope until concrete use-case.
 
-- Every `import { getPlatformServices } from '@/lib/platform-services'` → `from '@mediforce/platform-api/services'`
-- Every `import { getAppBaseUrl } from '@/lib/platform-services'` → `from '@/lib/app-base-url'`
+### Phase 5 — Delete `@/lib/platform-services` shim (off critical path)
+
+Mechanical cleanup. Codemod the remaining imports:
+
+- `import { getPlatformServices } from '@/lib/platform-services'` → `from '@mediforce/platform-api/services'`
+- `import { getAppBaseUrl } from '@/lib/platform-services'` → `from '@/lib/app-base-url'`
 - Delete `packages/platform-ui/src/lib/platform-services.ts`
 
 **Scope:** ~100+ imports, trivial per file. Single PR.
 
-**Pause-safe**: yes, but the shim is intentionally minimal and trivial — pausing mid-codemod looks ugly. Best to do it in one go.
+**Critical-path status**: no longer gating. Does NOT block ADR-0001 cutover.
+Schedule whenever — before, during, or after PG cutover. Pure cosmetics.
 
-**Open questions**: none expected — this is mechanical.
+**Pause-safe**: yes, but the shim is minimal and trivial — pausing
+mid-codemod looks ugly. Do it in one go.
 
-### Phase 6 — Migrate remaining UI data fetching
+**Open questions**: none expected — mechanical.
 
-The biggest remaining bypass: client hooks that read Firestore directly via SDK, skipping the API entirely (`useCollection`, `useProcessInstance`, `useAuditEvents`, etc.).
+### ~~Phase 6~~ — Folded into Phase 4 (2026-05-27)
 
-- Each hook gets rewritten to consume `apiClient`.
-- Live-critical hooks (active tasks, running processes) need a live-update story — most likely **SSE endpoints** exposed from `platform-api` handlers, one per subscribable resource. `apiClient` wraps `EventSource`.
-- Firestore SDK can be removed from browser once all live hooks have moved; at that point the browser no longer needs Firestore project config.
+Original split (Phase 4 = "typed client + first hook"; Phase 6 = "remaining
+hooks") was artificial. Typed `Mediforce` client already exists; the
+practical effort is one stream of work — rewritten under Phase 4 above.
+This header retained for back-references; the work itself lives in Phase 4.
 
-Ship this progressively — one hook at a time, backed by journey tests.
+### Phase 7 — Optional: split API into separate deployable (off critical path)
 
-**Pause-safe**: yes — per-hook migration, each backed by a journey test that must stay green. Any pause leaves untouched hooks on the Firestore bypass, working as today.
-
-**Open questions to settle**:
-- How does the browser subscribe to an SSE endpoint through `apiFetch`? `fetch` with `Accept: text/event-stream` works; `EventSource` doesn't support custom headers without a proxy hop. The simplest path is `fetch` + `res.body.getReader()` + incremental parse — do we hide that inside `apiClient.tasks.subscribeByRole(role, onEvent)`?
-- Auth for long-lived streams — Firebase ID tokens expire (~1 h). Do we reconnect on expiry, refresh on the server, or scope streams to a shorter lifetime and let the client reopen?
-- Granularity — one endpoint per subscribable collection (`/api/tasks/stream`, `/api/processes/:id/stream`) or one generic `subscribe` endpoint that takes a contract-defined query? The former is simpler; the latter mirrors Firestore's model more closely.
-
-### Phase 7 — Optional: split API into separate deployable
-
-Only if there's a real reason (scaling, non-Next clients, independent deploy cadence).
+Only if there's a real reason (scaling, non-Next clients, independent
+deploy cadence). Does NOT block ADR-0001 cutover.
 
 - Add `apps/api-server/` with a small HTTP runtime (Hono or Fastify) that mounts the platform-api handlers.
 - Deploy split: UI somewhere static (Vercel/CDN), API server somewhere with runtime (Cloud Run / Fly).
@@ -1130,13 +1209,13 @@ Honest self-review. `✅` = good template, `⚠️` = deliberately deferred, `�
 | Adapter | `createRouteAdapter` — 3 tests; `tasks/route.ts` — 5 tests (Filip-era mocks, stale but harmless) | ✅ Harmless mock debt called out in plan Phase 5 |
 | API client | `apiClient.tasks.list` — 6 tests, `apiFetch` mocked | ✅ |
 | Integration | apiClient ↔ adapter ↔ handler ↔ repo — 2 tests | ✅ First of kind; grow 1 per major feature, not per endpoint |
-| Hook | `useInstanceTasks` — 5 tests, incl. cancel-on-deps-change | ✅ Template for Phase 4 / 6 migrations |
+| Hook | `useInstanceTasks` — 5 tests, incl. cancel-on-deps-change | ✅ Template for Phase 4 migrations |
 | Component | `StepHistoryTabs` — 0 unit tests | ⚠️ Deliberately skipped; E2E covers, component logic trivial |
 | Structural | `api-boundaries.test.ts` (ours) + `api-auth-coverage.test.ts` (Filip's) | ✅ |
 | Engine | Existing, unchanged | ✅ |
 | Plugin unit | Existing, unchanged | ✅ |
 | Auto-runner integration | Existing, unchanged | ✅ |
-| E2E journey | Existing — no new journey for step-history migration (covered by existing process-detail journey) | ⚠️ Re-assess when Phase 6 migrates live hooks |
+| E2E journey | Existing — no new journey for step-history migration (covered by existing process-detail journey) | ⚠️ Re-assess when Phase 4 migrates live hooks |
 | E2E smoke | Existing, unchanged | ✅ |
 
 **Gaps to close in Phase 1** (noted, not blocking the pilot):

--- a/docs/headless-migration.md
+++ b/docs/headless-migration.md
@@ -1073,9 +1073,29 @@ choice + reasoning.
 
 | Option | Trade-off |
 |---|---|
-| **SWR** | Small. Stale-while-revalidate + focus-refetch + dedup out of box. Fits ADR-0001 §5's "lists move to polling 2-10s". No mutation-invalidation primitive. |
+| **SWR** | Small. Stale-while-revalidate + focus-refetch + dedup out of box. Fits ADR-0001 §5's "lists move to polling 2-10s". No mutation-invalidation primitive. Standard pick in Next.js ecosystem. |
 | **@tanstack/react-query** | Heavier. Covers mutation invalidation, which post-Phase 4 the UI starts to need (`mediforce.X.create` → invalidate relevant lists). |
-| **Custom helper** | Extend today's `useInstanceTasks` (`useState` + `useEffect` + cancelled flag). Smallest dep footprint; loses dedup + cache. |
+| **Custom helper** | Extend today's `useInstanceTasks` (`useState` + `useEffect` + cancelled flag). Smallest dep footprint; loses dedup + cache. Good fit if most hooks end up one-shot per the live-by-default-fallacy table above. |
+
+**Sane defaults if SWR / react-query picked** — Mediforce single-VPS
+Postgres after ADR-0001 means we have to think about query rate. Default
+config should be:
+
+- `refreshInterval: 0` — polling **off by default**; explicit override
+  per-hook only on the "truly live" list.
+- `revalidateOnFocus: false` — most data isn't time-critical; the user
+  refreshing the tab is the trigger.
+- `dedupingInterval: 1000` — multiple components asking for the same
+  resource within 1s = one request.
+- Conditional fetching for terminal states (e.g. completed runs) — pass
+  `null` key to skip; the polling is wasted on data that won't change.
+
+Postgres-load math at default-polling-off: a list-view tab with 3 live
+hooks × 1s polling = 3 RPS. 10 users × 3 tabs × that load = 90 RPS — well
+under Postgres single-VPS capacity for workspace-indexed `(workspace,
+status, created_at desc)` partial-index lookups. The risk only shows up
+if defaults flip to "polling on for every hook"; the policy above
+prevents that.
 
 **Client shape** — runtime-agnostic, Stripe-style. `Mediforce` class with
 exactly one of three config fields at construction:
@@ -1089,6 +1109,25 @@ Firebase is never imported by `platform-api/client`. Browser wrapper
 `getFirebaseIdToken()` (in `lib/firebase-id-token.ts`), which lazily imports
 Firebase Auth and reads `auth.currentUser.getIdToken()`. Same helper backs
 `apiFetch` — every browser call produces byte-identical auth headers.
+
+**Live-by-default fallacy — most hooks don't actually need live updates.**
+
+Today's hooks use `onSnapshot` not because UX requires live — because
+Firestore gave it for free. Audit each consumer before defaulting to
+polling: a lot of them are fine as one-shot fetch on mount, with manual
+refresh / focus-refetch / mutation-invalidate as the freshness mechanism.
+
+| Truly live (operator notices delay) | Live-by-accident (Firestore default; one-shot fetch is fine) |
+|---|---|
+| Active task list — new tasks appear from agents | Settings page |
+| Running process status — current step indicator | Namespace metadata / role |
+| Agent run page — log lines mid-execution | Workflow / agent definitions list |
+| Cowork chat turns — tool-call bubbles during blocking POST | Audit history |
+| Monitoring dashboard counts | User membership lists |
+| | Archived items |
+
+Default policy: **one-shot on mount, no polling**. Add polling only to the
+left-column hooks. Saves Postgres load + simplifies error surface.
 
 **Migration principle — preserve, don't upgrade.**
 


### PR DESCRIPTION
## Summary

- New PRD [`docs/headless-migration-phase-4-plan.md`](https://github.com/Appsilon/mediforce/blob/claude/hardcore-maxwell-6daeae/docs/headless-migration-phase-4-plan.md) — operational plan for Phase 4 (UI off Firestore). Endpoint inventory with Zod sketches, per-consumer migration table for ~22 firestore-importing files, six-PR per-resource tracer sizing, optimistic update playbook, cowork live-turn strategy, test layers, out-of-scope guardrails.
- New [`docs/adr/0006-client-side-server-state.md`](https://github.com/Appsilon/mediforce/blob/claude/hardcore-maxwell-6daeae/docs/adr/0006-client-side-server-state.md) — adopt `@tanstack/react-query` as project-wide cache lib. Cache key convention, default config, four-tier polling cadence, mutation lifecycle with entity-echo via `setQueryData`, SSE forward-compat slot. Considered alternatives (SWR, custom) rejected with reasoning.
- Amend [`docs/adr/0001-firestore-to-postgres.md`](https://github.com/Appsilon/mediforce/blob/claude/hardcore-maxwell-6daeae/docs/adr/0001-firestore-to-postgres.md) §5: SSE deferred from cutover. Everything moves to react-query polling (1–10s, terminal-state gating). SSE remains forward option tracked by #516. Consequences line updated to drop `/ SSE`.
- Update [`docs/headless-migration.md`](https://github.com/Appsilon/mediforce/blob/claude/hardcore-maxwell-6daeae/docs/headless-migration.md) Phase 4 section: locked-decisions block + pointer to PRD. Working-hypothesis prose preserved below as historical context until PR-final reduces it.

This is a **plan-only PR** — zero code changes. Unblocks the headless-migration Phase 4 implementation work and gives [#534](https://github.com/Appsilon/mediforce/pull/534) (ADR-0001 PR2) a concrete document to reference as its merge gate.

## Locked decisions (from grilling session 2026-05-28)

| # | Decision |
|---|---|
| Q1 | Polling everywhere at cutover, SSE deferred; ADR-0001 §5 amended in same PR |
| Q2 | `@tanstack/react-query` (full rationale in ADR-0006) |
| Q3 | `GET /api/users/me` hybrid bundle (light projection + roles) + separate `GET /api/namespaces/:handle` detail + lazy bootstrap as side-effect of `/me` |
| Q4 | Cowork: optimistic prepend + polling 1s gated on `useMutation.isPending`; chat handler return shape extended `+session+turns` (additive, backwards-compatible) |
| Q5 | `GET /api/namespaces/:handle/monitoring/summary` server-side SQL aggregates (don't copy Firestore "load all + aggregate in browser") |
| Q6 | `POST /api/namespaces` — preserve any-auth gate; atomic via new `NamespaceRepository.createNamespaceWithOwner` (Firestore `WriteBatch` / PG transaction) |
| Q7 | `GET /api/agent-runs` single endpoint with filter params; opaque cursor; pagination 50/200. Adds `AgentRunRepository.listInNamespaces` |
| Q8 | Drop `/api/audit-events` from inventory (covered by `/processes/:id/audit`); fold `use-collection.ts` consumers via extended `ListTasks +instanceId+stepId` |
| Q9 | 6 PR per-resource tracer: PR1 tasks + react-query foundation → PR2 agent-runs+monitoring → PR3 processes → PR4 namespaces+auth+workspaces/new → PR5 cowork → PR-final delete `lib/firebase.ts` |

## Endpoint inventory (6 new + 2 contract extensions)

| Endpoint | Status |
|---|---|
| `GET /api/users/me` | NEW (with lazy personal-namespace bootstrap side-effect) |
| `GET /api/namespaces/:handle` | NEW (detail with members) |
| `POST /api/namespaces` | NEW (workspace create) |
| `GET /api/agent-runs` | NEW (paginated, filter params) |
| `GET /api/agent-runs/:agentRunId` | NEW (single detail) |
| `GET /api/namespaces/:handle/monitoring/summary` | NEW (server-side aggregates) |
| `ListTasksInputSchema` | EXTEND `+instanceId, +stepId` (additive) |
| `POST /api/cowork/:sessionId/chat` | EXTEND return shape `+session, +turns` (additive) |
| ~~`GET /api/audit-events`~~ | NOT NEEDED (`/processes/:id/audit` covers all consumers) |
| ~~`GET /api/namespaces/:handle/role`~~ | NOT NEEDED (folded into `users/me.namespaces[].role`) |
| ~~`POST /api/users/me/ensure-personal-namespace`~~ | NOT NEEDED (side-effect of GET /me) |

## Out of scope

Plan-only. No implementation, no Firestore consumer rewires, no react-query install, no new endpoints shipped. Implementation lives in the six follow-up PRs scheduled in the PRD.

## Audit findings incorporated

- `chat-cowork-view.tsx` does **not** import `firebase/firestore` — Phase 4 doc previously listed it. Only 2 components affected, not 3.
- `use-user-namespace.ts` is **not** dead — used standalone for personal-namespace lookup. Folded as selector over `useUserMe()`.
- `processes/[instanceId]/resume-wait` route exists — flagged for PRD verification.
- `mediforce.users.listMembers` already shipped in Phase 2.6 — settings page already partly uses it; Phase 4 cleans up remaining `onSnapshot` on members subcollection.

## Test plan

- [ ] PRD reviewed by core team; locked decisions confirmed.
- [ ] ADR-0006 reviewed; cache key convention + default config accepted as project-wide canon.
- [ ] ADR-0001 §5 amendment accepted; #534 description updated to reference the PRD as the gate document (already does).
- [ ] Verify the open verification items in PRD § "Further notes" before PR1 (Phase 4 tasks) starts:
  - [ ] `users/{uid}.organizations` dead-code grep
  - [ ] `agents/[runId]/page.tsx` URL — agentRunId or workflowRunId?
  - [ ] `HandleSchema` existing constant location
  - [ ] Aspirational hook names sweep (`useSubcollection`, `useActiveTaskForInstance`, etc.)
  - [ ] Chat handler additive return-shape compatibility with existing callers