### PR TITLE
feat(phase-4-pr1): tasks domain + react-query foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Fixed
+- `StepParamSchema.type` widened from a strict enum to `z.string().min(1).default('string')` so human-task GETs no longer 400 when the param uses a widget hint the UI already renders (e.g. `textarea`, `multiselect`). Non-string `type` still fails parsing — only the enum was the bug. Route adapter also `console.error`s handler ZodErrors so similar mismatches are debuggable from the server log.
+
 ### Changed
 - Phase 4 PR1 — react-query foundation (ADR-0006) + tasks domain migrated off `firebase/firestore` (task detail page, claim button optimistic, role-scoped queues). New `mediforce task` CLI subcommand.
 - ADR-0005 Phase 2.5 — 18 endpoints (workflow-definition mutations, agents, secret read companions, processes archive/bulk) migrated to headless handlers; `actions/processes.ts` and `actions/definitions.ts` deleted. `transferWorkflow` now gates both source and target namespace, `deleteWorkflow` audit actor fixed, and archive / setDefault / register / copy / setVisibility now emit audit events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Changed
+- Phase 4 PR1 — react-query foundation (ADR-0006) + tasks domain migrated off `firebase/firestore` (task detail page, claim button optimistic, role-scoped queues). New `mediforce task` CLI subcommand.
 - ADR-0005 Phase 2.5 — 18 endpoints (workflow-definition mutations, agents, secret read companions, processes archive/bulk) migrated to headless handlers; `actions/processes.ts` and `actions/definitions.ts` deleted. `transferWorkflow` now gates both source and target namespace, `deleteWorkflow` audit actor fixed, and archive / setDefault / register / copy / setVisibility now emit audit events.
 - ADR-0005 Phase 2.5 — workflow-secret value reveal + atomic bulk save migrated to headless handlers (`getWorkflowSecretsFull`, `saveWorkflowSecrets`) behind `GET`/`PUT /api/workflow-secrets/values`; `getWorkflowSecrets` / `saveWorkflowSecrets` Server Actions deleted; UI uses `mediforce.workflowSecrets.values()` / `.save()`; new audit actions `workflow_secret.values_revealed` and `workflow_secret.bulk_saved`.
 - ADR-0005 Phase 2.6 — six admin/users endpoints (oauth-providers, tool-catalog, docker-images, users/members, users/invite, users/resend-invite) migrated to headless handlers; role-gate plumbing + `PLATFORM_*_API_KEY` collapsed (closes [#218](https://github.com/Appsilon/mediforce/issues/218)).

--- a/docs/adr/0006-client-side-server-state.md
+++ b/docs/adr/0006-client-side-server-state.md
@@ -270,6 +270,37 @@ remains an opt-in per hook; nothing in this ADR commits the app to
 Suspense as the default loading-state mechanism. The two co-exist
 fine.
 
+#### 8a. Stop polling on persistent error (terminal errors)
+
+Some HTTP failures are *not* worth retrying — retrying just produces a
+tight loop that swamps the server and burns the user's tab.
+
+The hook-level rule: a `useQuery` whose `error` is a 4xx (other than
+explicit transient codes — none today) **must not be re-polled by
+`refetchInterval`**. `useTask` ([`packages/platform-ui/src/hooks/use-task.ts`](../../packages/platform-ui/src/hooks/use-task.ts))
+is the reference: `refetchInterval` returns `false` when `query.state.error`
+is set, distinguishing 404 (drop the row from the list) from any other
+4xx (surface inline, but stop hammering the endpoint). All Phase 4
+hooks that poll inherit this pattern. New hooks copy from `useTask`.
+
+Discovered the hard way: a `humanTasks/*` doc with a `params[i].type`
+outside the (then-strict) `StepParamSchema.type` enum returned a
+generic 400 from the route adapter, no server log, and React Query's
+default `refetchInterval` re-fired the failing GET every 2 s. The
+client-side fix (terminal-on-error) shipped in Phase 4 PR1; the
+schema fix shipped as [#562](https://github.com/Appsilon/mediforce/pull/562)
+(see plan §9).
+
+#### 8b. Route adapter logs handler ZodErrors
+
+[`packages/platform-ui/src/lib/route-adapter.ts`](../../packages/platform-ui/src/lib/route-adapter.ts)
+now `console.error`s any `ZodError` thrown from inside a handler
+(typically a repo-boundary `Schema.parse(snap.data())`). Before, the
+adapter mapped the error to a 400 envelope with no log line, so
+data/schema drift was invisible until a user opened the network tab.
+ADR-0005's error-envelope contract is unchanged; only the dev/prod
+log line is new.
+
 ## Considered alternatives
 
 - **SWR (vercel/swr).** Rejected. SWR covers polling + dedup + focus-refetch

--- a/docs/headless-migration-phase-4-plan.md
+++ b/docs/headless-migration-phase-4-plan.md
@@ -575,7 +575,9 @@ non-string corruption, accepts unknown widget hints).
 `StepParamSchema.type` and `TriggerInputFieldSchema.type` behind one
 shared widget-type constant. Bundling this with PR3 (processes/runs,
 which already touches step/trigger surface) keeps the merge sequence
-intact.
+intact. Tracked as [#563](https://github.com/Appsilon/mediforce/issues/563)
+with the proposed `PARAM_WIDGET_TYPES` const shape and an exhaustive-
+switch contract for the 6 current consumers.
 
 ## Testing decisions
 

--- a/docs/headless-migration-phase-4-plan.md
+++ b/docs/headless-migration-phase-4-plan.md
@@ -518,6 +518,65 @@ serialization — at most 2–3 PRs in parallel review.
 Once PR-final merges, PG PR2 ([#534](https://github.com/Appsilon/mediforce/pull/534))
 is unblocked.
 
+### 9. Read-path schema drift — discovered during PR1 smoke
+
+PR1 smoke surfaced a class of bug worth calling out before PRs 2–6:
+
+**The pattern.** A Firestore document satisfies the *write-time* Zod
+schema in force the day it was registered. The *read-time* schema
+later narrows (enum tightened, field made required, discriminator
+added). Now every read of that document throws `ZodError` at the repo
+boundary. The route adapter maps it to a 400 envelope; React Query
+re-polls because 400 is not a terminal status by default.
+Reference incident: `humanTasks/*` docs with `params[i].type = 'textarea'`
+( a widget hint the UI already renders) blew up `GET /api/tasks/:taskId`
+in a tight 400 loop once `StepParamSchema.type` was tightened to a
+strict enum. Fixed in [#562](https://github.com/Appsilon/mediforce/pull/562)
+by widening to `z.string().min(1).default('string')` (still rejects
+non-string corruption, accepts unknown widget hints).
+
+**Five rules for PRs 2–6.**
+
+1. **One vocabulary, one schema.** If two schemas claim to validate
+   the same field (today: `StepParamSchema.type` is strict 4-enum,
+   `TriggerInputFieldSchema.type` extends to 7 values incl.
+   `textarea`/`multiselect`) the registration path and the read path
+   *will* drift. Pick a single source of truth and re-export. The
+   widget-type vocabulary should land in one constant referenced
+   from both schemas (follow-up — out of scope for #562). Same rule
+   applies to any new shared vocabulary introduced in PRs 2–6.
+2. **Prefer open strings to enums at the storage boundary** for
+   anything that's a UI hint, plugin name, or extensibility point.
+   Enums are right when the *engine* branches on the value
+   (`executor: human|agent|script|cowork|action`); they are wrong
+   when the *UI* renders by the value (`type: textarea`) — the UI
+   already has a default branch, the schema doesn't need a wall.
+3. **Repo-boundary parsing must log.** `XSchema.parse(snap.data())`
+   throwing a `ZodError` is the single most common silent failure
+   mode in this codebase. Either log the path + doc id before
+   re-throwing, or `safeParse` and convert to a structured handler
+   error (`NotFoundError` if the doc is unrecoverable). PR1 added a
+   `console.error` in `route-adapter` for handler-thrown ZodErrors;
+   that is the *catch* — the *cause* still belongs at the repo.
+4. **Hooks must terminate on 4xx.** `useTask`'s `refetchInterval`
+   returns `false` on `query.state.error`. Copy this pattern into
+   every polling hook PRs 2–6 introduce — `useAgentRuns`,
+   `useProcessInstance`, `useMonitoring`. A 400 / 403 / 404 from the
+   server means the user's intent does not match server state; no
+   amount of retrying will reconcile that.
+5. **Add a repo-level "legacy shape" test** for any schema where you
+   intentionally accept old data. `step-param.test.ts` covers
+   canonical, widget-hint, default, and non-string-corruption cases.
+   When PR3 touches `humanTasks` repo or PR4 touches `users`, mirror
+   that pattern with a `__tests__/legacy-shape.test.ts` per schema
+   that has any data already in production.
+
+**Schema convergence — out of scope for PR1, queued for PR3.** Unify
+`StepParamSchema.type` and `TriggerInputFieldSchema.type` behind one
+shared widget-type constant. Bundling this with PR3 (processes/runs,
+which already touches step/trigger surface) keeps the merge sequence
+intact.
+
 ## Testing decisions
 
 Mediforce's test taxonomy from [`docs/headless-migration.md`](./headless-migration.md) §"Testing

--- a/packages/cli/src/__tests__/print-kv.test.ts
+++ b/packages/cli/src/__tests__/print-kv.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { printKv } from '../output.js';
+import { captureOutput } from './test-helpers.js';
+
+describe('printKv', () => {
+  it('pads labels to the max label width across rows', () => {
+    const output = captureOutput();
+    printKv(output, [
+      ['status', 'claimed'],
+      ['assignedUser', 'alice'],
+    ]);
+    expect(output.stdoutLines).toEqual([
+      '  status:        claimed',
+      '  assignedUser:  alice',
+    ]);
+  });
+
+  it('renders null as the nullDisplay (default `(none)`)', () => {
+    const output = captureOutput();
+    printKv(output, [
+      ['status', 'cancelled'],
+      ['reason', null],
+    ]);
+    expect(output.stdoutLines).toEqual([
+      '  status:  cancelled',
+      '  reason:  (none)',
+    ]);
+  });
+
+  it('skips undefined rows unless nullDisplay is set', () => {
+    const skipping = captureOutput();
+    printKv(skipping, [
+      ['status', 'done'],
+      ['completed', undefined],
+    ]);
+    expect(skipping.stdoutLines).toEqual(['  status:  done']);
+
+    const showing = captureOutput();
+    printKv(showing, [
+      ['status', 'done'],
+      ['completed', undefined],
+    ], { nullDisplay: '(missing)' });
+    expect(showing.stdoutLines).toEqual([
+      '  status:     done',
+      '  completed:  (missing)',
+    ]);
+  });
+});

--- a/packages/cli/src/__tests__/task-commands.test.ts
+++ b/packages/cli/src/__tests__/task-commands.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { taskListCommand } from '../commands/task-list.js';
+import { taskGetCommand } from '../commands/task-get.js';
+import { taskClaimCommand } from '../commands/task-claim.js';
+import { captureOutput, jsonResponse } from './test-helpers.js';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const SAMPLE_TASK = {
+  id: 'task-1',
+  processInstanceId: 'inst-a',
+  stepId: 'step-review',
+  assignedRole: 'reviewer',
+  assignedUserId: null,
+  status: 'pending',
+  payload: {},
+  createdAt: '2026-05-28T10:00:00.000Z',
+  updatedAt: '2026-05-28T10:00:00.000Z',
+  completedAt: null,
+  deleted: false,
+  deadline: null,
+  completionData: null,
+  cancelReason: null,
+};
+
+describe('task list command', () => {
+  it('GETs /api/tasks with role filter and prints task rows', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ tasks: [SAMPLE_TASK] }),
+    );
+    const output = captureOutput();
+    const code = await taskListCommand({
+      argv: ['--role', 'reviewer', '--base-url', 'http://localhost:5555'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/http:\/\/localhost:5555\/api\/tasks.*role=reviewer/);
+    expect(output.stdoutLines.join('\n')).toMatch(/task-1/);
+  });
+
+  it('passes --instance-id + --step-id + --status as query params', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ tasks: [] }),
+    );
+    await taskListCommand({
+      argv: ['--instance-id', 'inst-a', '--step-id', 'step-review', '--status', 'pending'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output: captureOutput(),
+    });
+    const url = fetchSpy.mock.calls[0]?.[0] as string;
+    expect(url).toMatch(/instanceId=inst-a/);
+    expect(url).toMatch(/stepId=step-review/);
+    expect(url).toMatch(/status=pending/);
+  });
+
+  it('exits 2 when neither --role nor --instance-id is given', async () => {
+    const output = captureOutput();
+    const code = await taskListCommand({
+      argv: [],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(/Exactly one of --role or --instance-id/);
+  });
+
+  it('exits 2 when both --role and --instance-id are given', async () => {
+    const output = captureOutput();
+    const code = await taskListCommand({
+      argv: ['--role', 'reviewer', '--instance-id', 'inst-a'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(2);
+  });
+});
+
+describe('task get command', () => {
+  it('GETs /api/tasks/:taskId and prints the entity', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(SAMPLE_TASK),
+    );
+    const output = captureOutput();
+    const code = await taskGetCommand({
+      argv: ['task-1'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/\/api\/tasks\/task-1/);
+    expect(output.stdoutLines.join('\n')).toMatch(/Task task-1/);
+  });
+});
+
+describe('task claim command', () => {
+  it('POSTs /api/tasks/:taskId/claim and prints the claimed entity', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ task: { ...SAMPLE_TASK, status: 'claimed', assignedUserId: 'u-1' } }),
+    );
+    const output = captureOutput();
+    const code = await taskClaimCommand({
+      argv: ['task-1'],
+      env: { MEDIFORCE_API_KEY: 'k' },
+      output,
+    });
+    expect(code).toBe(0);
+    const [url, init] = fetchSpy.mock.calls[0] ?? [];
+    expect(url).toMatch(/\/api\/tasks\/task-1\/claim/);
+    expect((init as { method?: string } | undefined)?.method).toBe('POST');
+    expect(output.stdoutLines.join('\n')).toMatch(/claimed/);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -43,6 +43,9 @@ import { modelSyncCommand } from './commands/model-sync.js';
 import { secretSetCommand } from './commands/secret-set.js';
 import { secretListCommand } from './commands/secret-list.js';
 import { secretDeleteCommand } from './commands/secret-delete.js';
+import { taskListCommand } from './commands/task-list.js';
+import { taskGetCommand } from './commands/task-get.js';
+import { taskClaimCommand } from './commands/task-claim.js';
 import { type CommandFn } from './define-command.js';
 import { consoleOutput, type OutputSink } from './output.js';
 
@@ -85,6 +88,14 @@ export const TREE: Record<string, BranchEntry> = {
       archive: { description: 'Soft-archive (or restore) a run', fn: runArchiveCommand },
       'bulk-cancel': { description: 'Cancel multiple runs in one call', fn: runBulkCancelCommand },
       'bulk-archive': { description: 'Archive multiple runs in one call', fn: runBulkArchiveCommand },
+    },
+  },
+  task: {
+    description: 'Human tasks (list, get, claim)',
+    leaves: {
+      list: { description: 'List tasks by role or instance', fn: taskListCommand },
+      get: { description: 'Fetch a single task', fn: taskGetCommand },
+      claim: { description: 'Claim a pending task', fn: taskClaimCommand },
     },
   },
   agent: {

--- a/packages/cli/src/commands/agent-get.ts
+++ b/packages/cli/src/commands/agent-get.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../define-command.js';
-import { printJson } from '../output.js';
+import { printJson, printKv } from '../output.js';
 
 export const agentGetCommand = defineCommand({
   name: 'mediforce agent get',
@@ -19,22 +19,16 @@ export const agentGetCommand = defineCommand({
     }
     const agent = result.agent;
     output.stdout(`Agent ${agent.id}`);
-    output.stdout(`  name:          ${agent.name}`);
-    output.stdout(`  kind:          ${agent.kind}`);
-    output.stdout(`  model:         ${agent.foundationModel}`);
-    output.stdout(`  description:   ${agent.description}`);
-    if (agent.runtimeId !== undefined) {
-      output.stdout(`  runtimeId:     ${agent.runtimeId}`);
-    }
-    if (agent.visibility !== undefined) {
-      output.stdout(`  visibility:    ${agent.visibility}`);
-    }
-    if (agent.namespace !== undefined) {
-      output.stdout(`  namespace:     ${agent.namespace}`);
-    }
-    if (agent.skillFileNames.length > 0) {
-      output.stdout(`  skills:        ${agent.skillFileNames.join(', ')}`);
-    }
+    printKv(output, [
+      ['name', agent.name],
+      ['kind', agent.kind],
+      ['model', agent.foundationModel],
+      ['description', agent.description],
+      ['runtimeId', agent.runtimeId],
+      ['visibility', agent.visibility],
+      ['namespace', agent.namespace],
+      ['skills', agent.skillFileNames.length > 0 ? agent.skillFileNames.join(', ') : undefined],
+    ]);
     return 0;
   },
 });

--- a/packages/cli/src/commands/run-cancel.ts
+++ b/packages/cli/src/commands/run-cancel.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../define-command.js';
-import { printJson } from '../output.js';
+import { printJson, printKv } from '../output.js';
 
 export const runCancelCommand = defineCommand({
   name: 'mediforce run cancel',
@@ -22,8 +22,10 @@ export const runCancelCommand = defineCommand({
       return 0;
     }
     output.stdout(`Run ${result.run.id} cancelled`);
-    output.stdout(`  status:  ${result.run.status}`);
-    output.stdout(`  reason:  ${result.run.error ?? '(none)'}`);
+    printKv(output, [
+      ['status', result.run.status],
+      ['reason', result.run.error],
+    ]);
     return 0;
   },
 });

--- a/packages/cli/src/commands/run-get.ts
+++ b/packages/cli/src/commands/run-get.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../define-command.js';
-import { printJson } from '../output.js';
+import { printJson, printKv } from '../output.js';
 
 export const runGetCommand = defineCommand({
   name: 'mediforce run get',
@@ -17,27 +17,31 @@ export const runGetCommand = defineCommand({
       printJson(output, result);
       return 0;
     }
-    output.stdout(`Run ${result.runId}`);
-    output.stdout(`  status:        ${result.status}`);
-    output.stdout(`  currentStep:   ${result.currentStepId ?? '(none)'}`);
-    output.stdout(`  error:         ${result.error ?? '(none)'}`);
-    if (
+    const hasDefinition =
       typeof result.definitionNamespace === 'string' &&
       result.definitionNamespace.length > 0 &&
       typeof result.definitionName === 'string' &&
-      result.definitionName.length > 0
-    ) {
-      output.stdout(
-        `  url:           ${config.baseUrl}/${result.definitionNamespace}/workflows/${encodeURIComponent(result.definitionName)}/runs/${result.runId}`,
-      );
-    }
-    if (result.totalCostUsd != null) {
-      const isTerminal = result.status === 'completed' || result.status === 'failed';
-      output.stdout(`  cost:          $${result.totalCostUsd.toFixed(4)}${isTerminal ? '' : '+'}`);
-    }
-    if (result.finalOutput !== null && result.finalOutput !== undefined) {
-      output.stdout(`  finalOutput:   ${JSON.stringify(result.finalOutput)}`);
-    }
+      result.definitionName.length > 0;
+    const url = hasDefinition
+      ? `${config.baseUrl}/${result.definitionNamespace ?? ''}/workflows/${encodeURIComponent(result.definitionName ?? '')}/runs/${result.runId}`
+      : undefined;
+    const cost =
+      result.totalCostUsd != null
+        ? `$${result.totalCostUsd.toFixed(4)}${result.status === 'completed' || result.status === 'failed' ? '' : '+'}`
+        : undefined;
+    const finalOutput =
+      result.finalOutput !== null && result.finalOutput !== undefined
+        ? JSON.stringify(result.finalOutput)
+        : undefined;
+    output.stdout(`Run ${result.runId}`);
+    printKv(output, [
+      ['status', result.status],
+      ['currentStep', result.currentStepId],
+      ['error', result.error],
+      ['url', url],
+      ['cost', cost],
+      ['finalOutput', finalOutput],
+    ]);
     return 0;
   },
 });

--- a/packages/cli/src/commands/run-start.ts
+++ b/packages/cli/src/commands/run-start.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { defineCommand } from '../define-command.js';
-import { printJson, printError } from '../output.js';
+import { printJson, printError, printKv } from '../output.js';
 
 export const runStartCommand = defineCommand({
   name: 'mediforce run start',
@@ -105,8 +105,10 @@ export const runStartCommand = defineCommand({
       return 0;
     }
     output.stdout(`Run started`);
-    output.stdout(`  instanceId: ${result.run.id}`);
-    output.stdout(`  status:     ${result.run.status}`);
+    printKv(output, [
+      ['instanceId', result.run.id],
+      ['status', result.run.status],
+    ]);
     output.stdout('');
     output.stdout(`Follow with: mediforce run get ${result.run.id}`);
     return 0;

--- a/packages/cli/src/commands/system-credits.ts
+++ b/packages/cli/src/commands/system-credits.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../define-command.js';
-import { printJson } from '../output.js';
+import { printJson, printKv } from '../output.js';
 
 export const systemCreditsCommand = defineCommand({
   name: 'mediforce system credits',
@@ -22,9 +22,11 @@ export const systemCreditsCommand = defineCommand({
     }
 
     output.stdout(`OpenRouter credits for namespace "${args.namespace}":\n`);
-    output.stdout(`  Remaining:  $${data.remaining.toFixed(2)}`);
-    output.stdout(`  Used:       $${data.usage.toFixed(2)}`);
-    output.stdout(`  Limit:      $${data.limit.toFixed(2)}`);
+    printKv(output, [
+      ['Remaining', `$${data.remaining.toFixed(2)}`],
+      ['Used', `$${data.usage.toFixed(2)}`],
+      ['Limit', `$${data.limit.toFixed(2)}`],
+    ]);
     return 0;
   },
 });

--- a/packages/cli/src/commands/task-claim.ts
+++ b/packages/cli/src/commands/task-claim.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../define-command.js';
-import { printJson } from '../output.js';
+import { printJson, printKv } from '../output.js';
 
 export const taskClaimCommand = defineCommand({
   name: 'mediforce task claim',
@@ -14,8 +14,10 @@ export const taskClaimCommand = defineCommand({
       return 0;
     }
     output.stdout(`Task ${result.task.id} claimed`);
-    output.stdout(`  status:        ${result.task.status}`);
-    output.stdout(`  assignedUser:  ${result.task.assignedUserId ?? '(unassigned)'}`);
+    printKv(output, [
+      ['status', result.task.status],
+      ['assignedUser', result.task.assignedUserId ?? '(unassigned)'],
+    ]);
     return 0;
   },
 });

--- a/packages/cli/src/commands/task-claim.ts
+++ b/packages/cli/src/commands/task-claim.ts
@@ -1,0 +1,21 @@
+import { defineCommand } from '../define-command.js';
+import { printJson } from '../output.js';
+
+export const taskClaimCommand = defineCommand({
+  name: 'mediforce task claim',
+  description: 'Claim a pending human task for the caller.',
+  args: {
+    taskId: { type: 'positional', required: true, description: 'Task id' },
+  },
+  async run({ args, output, mediforce, jsonMode }) {
+    const result = await mediforce.tasks.claim({ taskId: args.taskId });
+    if (jsonMode) {
+      printJson(output, result);
+      return 0;
+    }
+    output.stdout(`Task ${result.task.id} claimed`);
+    output.stdout(`  status:        ${result.task.status}`);
+    output.stdout(`  assignedUser:  ${result.task.assignedUserId ?? '(unassigned)'}`);
+    return 0;
+  },
+});

--- a/packages/cli/src/commands/task-get.ts
+++ b/packages/cli/src/commands/task-get.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from '../define-command.js';
-import { printJson } from '../output.js';
+import { printJson, printKv } from '../output.js';
 
 export const taskGetCommand = defineCommand({
   name: 'mediforce task get',
@@ -14,15 +14,15 @@ export const taskGetCommand = defineCommand({
       return 0;
     }
     output.stdout(`Task ${task.id}`);
-    output.stdout(`  status:        ${task.status}`);
-    output.stdout(`  role:          ${task.assignedRole}`);
-    output.stdout(`  assignedUser:  ${task.assignedUserId ?? '(unassigned)'}`);
-    output.stdout(`  instance:      ${task.processInstanceId}`);
-    output.stdout(`  step:          ${task.stepId}`);
-    output.stdout(`  created:       ${task.createdAt}`);
-    if (task.completedAt !== null) {
-      output.stdout(`  completed:     ${task.completedAt}`);
-    }
+    printKv(output, [
+      ['status', task.status],
+      ['role', task.assignedRole],
+      ['assignedUser', task.assignedUserId ?? '(unassigned)'],
+      ['instance', task.processInstanceId],
+      ['step', task.stepId],
+      ['created', task.createdAt],
+      ['completed', task.completedAt ?? undefined],
+    ]);
     return 0;
   },
 });

--- a/packages/cli/src/commands/task-get.ts
+++ b/packages/cli/src/commands/task-get.ts
@@ -1,0 +1,28 @@
+import { defineCommand } from '../define-command.js';
+import { printJson } from '../output.js';
+
+export const taskGetCommand = defineCommand({
+  name: 'mediforce task get',
+  description: 'Fetch a single human task by id.',
+  args: {
+    taskId: { type: 'positional', required: true, description: 'Task id' },
+  },
+  async run({ args, output, mediforce, jsonMode }) {
+    const task = await mediforce.tasks.get({ taskId: args.taskId });
+    if (jsonMode) {
+      printJson(output, task);
+      return 0;
+    }
+    output.stdout(`Task ${task.id}`);
+    output.stdout(`  status:        ${task.status}`);
+    output.stdout(`  role:          ${task.assignedRole}`);
+    output.stdout(`  assignedUser:  ${task.assignedUserId ?? '(unassigned)'}`);
+    output.stdout(`  instance:      ${task.processInstanceId}`);
+    output.stdout(`  step:          ${task.stepId}`);
+    output.stdout(`  created:       ${task.createdAt}`);
+    if (task.completedAt !== null) {
+      output.stdout(`  completed:     ${task.completedAt}`);
+    }
+    return 0;
+  },
+});

--- a/packages/cli/src/commands/task-list.ts
+++ b/packages/cli/src/commands/task-list.ts
@@ -1,0 +1,56 @@
+import { defineCommand, enumArg } from '../define-command.js';
+import { printJson } from '../output.js';
+
+const STATUS_ICONS: Record<string, string> = {
+  pending: '○',
+  claimed: '●',
+  completed: '✓',
+  cancelled: '✗',
+};
+
+export const taskListCommand = defineCommand({
+  name: 'mediforce task list',
+  description: 'List human tasks by role or process instance.',
+  args: {
+    role: { type: 'string', description: 'Filter by assignedRole (mutually exclusive with --instance-id)' },
+    'instance-id': { type: 'string', description: 'Filter by process instance (mutually exclusive with --role)' },
+    'step-id': { type: 'string', description: 'Narrow to a specific step within the instance/role' },
+    status: enumArg(['pending', 'claimed', 'completed', 'cancelled'] as const, {
+      description: 'Filter by status (repeat for multiple)',
+    }),
+  },
+  async run({ args, output, mediforce, jsonMode }) {
+    const role = args.role;
+    const instanceId = args['instance-id'];
+    if ((role === undefined) === (instanceId === undefined)) {
+      output.stderr('Exactly one of --role or --instance-id is required.');
+      return 2;
+    }
+    const status = args.status !== undefined ? [args.status] : undefined;
+    const stepId = args['step-id'];
+
+    const input =
+      instanceId !== undefined
+        ? { instanceId, ...(stepId !== undefined ? { stepId } : {}), ...(status !== undefined ? { status } : {}) }
+        : { role: role as string, ...(stepId !== undefined ? { stepId } : {}), ...(status !== undefined ? { status } : {}) };
+
+    const result = await mediforce.tasks.list(input);
+
+    if (jsonMode) {
+      printJson(output, result);
+      return 0;
+    }
+    if (result.tasks.length === 0) {
+      output.stdout('No tasks found.');
+      return 0;
+    }
+    for (const task of result.tasks) {
+      const icon = STATUS_ICONS[task.status] ?? '?';
+      const assigned = task.assignedUserId !== null ? ` (${task.assignedUserId})` : '';
+      output.stdout(
+        `${icon} ${task.status.padEnd(10)} ${task.id}  step:${task.stepId}  role:${task.assignedRole}${assigned}`,
+      );
+    }
+    return 0;
+  },
+});

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -38,6 +38,33 @@ export function printJson(sink: OutputSink, payload: unknown): void {
 }
 
 /**
+ * Print a list of `label: value` rows with the labels padded to the widest
+ * label in the array. Used by `*-get` / `*-claim` / `*-cancel` commands to
+ * keep their human-mode output visually consistent across the CLI.
+ *
+ * `undefined` rows are skipped unless `nullDisplay` is set — that lets a
+ * caller opt into "show even when the field is missing". `null` always
+ * renders as `nullDisplay` (default `(none)`).
+ */
+export function printKv(
+  sink: OutputSink,
+  rows: ReadonlyArray<readonly [label: string, value: string | number | null | undefined]>,
+  options?: { nullDisplay?: string; indent?: number },
+): void {
+  const nullDisplay = options?.nullDisplay ?? '(none)';
+  const indent = ' '.repeat(options?.indent ?? 2);
+  const visible = rows.filter(
+    ([, value]) => value !== undefined || options?.nullDisplay !== undefined,
+  );
+  if (visible.length === 0) return;
+  const width = Math.max(...visible.map(([label]) => label.length));
+  for (const [label, value] of visible) {
+    const rendered = value === null || value === undefined ? nullDisplay : String(value);
+    sink.stdout(`${indent}${`${label}:`.padEnd(width + 1)}  ${rendered}`);
+  }
+}
+
+/**
  * Stream contract — load-bearing, do not change without updating tests:
  *
  *   --json mode:  error payload is written to STDOUT (single channel for

--- a/packages/platform-api/src/handlers/tasks/__tests__/contract.test.ts
+++ b/packages/platform-api/src/handlers/tasks/__tests__/contract.test.ts
@@ -35,11 +35,11 @@ describe('ListTasksInputSchema — filter exclusivity refine (instanceId XOR rol
   });
 });
 
-describe('ListTasksInputSchema — stepId narrowing (Phase 4 PR1 consumers)', () => {
-  // The Phase 4 PRD §3 proposed a refine "stepId requires instanceId" but the
-  // schema already allowed `role + stepId`. Per the PRD amendment recorded in
-  // Phase 4 PR1: leave the schema permissive — no consumer needs the constraint
-  // and `role + stepId` is a semantically valid cross-instance bottleneck view.
+describe('ListTasksInputSchema — stepId narrowing', () => {
+  // The Phase 4 PRD proposed a refine "stepId requires instanceId" but the
+  // schema already allowed `role + stepId`. Decision recorded: leave the
+  // schema permissive — no consumer needs the constraint and `role + stepId`
+  // is a semantically valid cross-instance bottleneck view.
 
   it('accepts instanceId + stepId (next-step-card pattern)', () => {
     expect(

--- a/packages/platform-api/src/handlers/tasks/__tests__/contract.test.ts
+++ b/packages/platform-api/src/handlers/tasks/__tests__/contract.test.ts
@@ -35,6 +35,43 @@ describe('ListTasksInputSchema — filter exclusivity refine (instanceId XOR rol
   });
 });
 
+describe('ListTasksInputSchema — stepId narrowing (Phase 4 PR1 consumers)', () => {
+  // The Phase 4 PRD §3 proposed a refine "stepId requires instanceId" but the
+  // schema already allowed `role + stepId`. Per the PRD amendment recorded in
+  // Phase 4 PR1: leave the schema permissive — no consumer needs the constraint
+  // and `role + stepId` is a semantically valid cross-instance bottleneck view.
+
+  it('accepts instanceId + stepId (next-step-card pattern)', () => {
+    expect(
+      ListTasksInputSchema.safeParse({ instanceId: 'inst-1', stepId: 'step-a' }).success,
+    ).toBe(true);
+  });
+
+  it('accepts role + stepId (cross-instance step inspection, allowed by design)', () => {
+    expect(
+      ListTasksInputSchema.safeParse({ role: 'reviewer', stepId: 'step-a' }).success,
+    ).toBe(true);
+  });
+
+  it('accepts instanceId + stepId + status (full narrowing)', () => {
+    expect(
+      ListTasksInputSchema.safeParse({
+        instanceId: 'inst-1',
+        stepId: 'step-a',
+        status: ['pending'],
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects stepId alone (no axis — fails XOR refine)', () => {
+    expect(ListTasksInputSchema.safeParse({ stepId: 'step-a' }).success).toBe(false);
+  });
+
+  it('rejects status alone (no axis — fails XOR refine)', () => {
+    expect(ListTasksInputSchema.safeParse({ status: ['pending'] }).success).toBe(false);
+  });
+});
+
 describe('ACTIONABLE_STATUSES', () => {
   it('is [pending, claimed]', () => {
     expect([...ACTIONABLE_STATUSES]).toEqual(['pending', 'claimed']);

--- a/packages/platform-core/src/schemas/__tests__/step-param.test.ts
+++ b/packages/platform-core/src/schemas/__tests__/step-param.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { StepParamSchema } from '../process-definition.js';
+
+describe('StepParamSchema.type', () => {
+  it.each(['string', 'number', 'boolean', 'date'])('accepts canonical data type %s', (type) => {
+    const parsed = StepParamSchema.parse({ name: 'p', type });
+    expect(parsed.type).toBe(type);
+  });
+
+  it.each(['textarea', 'multiselect'])('accepts widget hint %s', (type) => {
+    const parsed = StepParamSchema.parse({ name: 'p', type });
+    expect(parsed.type).toBe(type);
+  });
+
+  it('defaults to "string" when type is missing', () => {
+    const parsed = StepParamSchema.parse({ name: 'p' });
+    expect(parsed.type).toBe('string');
+  });
+
+  it('rejects empty string (min(1))', () => {
+    expect(() => StepParamSchema.parse({ name: 'p', type: '' })).toThrow();
+  });
+
+  it('passes through unknown future hint instead of throwing', () => {
+    const parsed = StepParamSchema.parse({ name: 'p', type: 'slider' });
+    expect(parsed.type).toBe('slider');
+  });
+
+  it('rejects non-string type — corruption surfaces loudly', () => {
+    expect(() => StepParamSchema.parse({ name: 'p', type: 42 })).toThrow();
+    expect(() => StepParamSchema.parse({ name: 'p', type: null })).toThrow();
+  });
+});

--- a/packages/platform-core/src/schemas/process-definition.ts
+++ b/packages/platform-core/src/schemas/process-definition.ts
@@ -14,7 +14,14 @@ export const StepUiSchema = z.object({
 
 export const StepParamSchema = z.object({
   name: z.string().min(1),
-  type: z.enum(['string', 'number', 'boolean', 'date']).default('string'),
+  // Data-or-widget hint consumed by `ParamField` to pick a form widget.
+  // `string|number|boolean|date` are canonical data types; `textarea`,
+  // `multiselect` are widget hints the UI already renders. Kept as an
+  // open string (not an enum) so legacy/future workflow definitions don't
+  // 400 when a task lands with a new hint — `ParamField` falls back to a
+  // text input for unknown values. Non-string `type` (genuine corruption)
+  // still fails parsing loudly.
+  type: z.string().min(1).default('string'),
   required: z.boolean().default(false),
   description: z.string().optional(),
   default: z.unknown().optional(),

--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -56,6 +56,8 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@tanstack/react-query": "^5.100.11",
+    "@tanstack/react-query-devtools": "^5.100.11",
     "@xyflow/react": "^12.10.1",
     "bullmq": "^5.71.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/platform-ui/src/app/(app)/[handle]/tasks/[taskId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/tasks/[taskId]/page.tsx
@@ -1,29 +1,12 @@
 'use client';
 
-import * as React from 'react';
 import { useParams } from 'next/navigation';
-import { doc, onSnapshot } from 'firebase/firestore';
-import type { HumanTask } from '@mediforce/platform-core';
-import { db } from '@/lib/firebase';
+import { useTask } from '@/hooks/use-task';
 import { TaskDetail } from '@/components/tasks/task-detail';
 
 export default function TaskDetailPage() {
   const { taskId } = useParams<{ taskId: string }>();
-  const [task, setTask] = React.useState<HumanTask | null>(null);
-  const [loading, setLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    if (!taskId) return;
-    const unsub = onSnapshot(doc(db, 'humanTasks', taskId), (snap) => {
-      if (snap.exists()) {
-        setTask({ id: snap.id, ...snap.data() } as HumanTask);
-      } else {
-        setTask(null);
-      }
-      setLoading(false);
-    });
-    return unsub;
-  }, [taskId]);
+  const { task, loading } = useTask(taskId);
 
   if (loading) {
     return (

--- a/packages/platform-ui/src/app/(app)/[handle]/tasks/[taskId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/tasks/[taskId]/page.tsx
@@ -6,7 +6,7 @@ import { TaskDetail } from '@/components/tasks/task-detail';
 
 export default function TaskDetailPage() {
   const { taskId } = useParams<{ taskId: string }>();
-  const { task, loading } = useTask(taskId);
+  const { task, loading, error, notFound } = useTask(taskId);
 
   if (loading) {
     return (
@@ -14,6 +14,23 @@ export default function TaskDetailPage() {
         <div className="h-4 w-20 rounded bg-muted animate-pulse" />
         <div className="h-8 w-2/3 rounded bg-muted animate-pulse" />
         <div className="h-32 rounded bg-muted animate-pulse" />
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="p-6 text-center text-sm text-muted-foreground">
+        Task not found.
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 space-y-2">
+        <p className="text-sm font-medium text-destructive">Failed to load task.</p>
+        <p className="text-xs text-muted-foreground font-mono break-all">{error.message}</p>
       </div>
     );
   }

--- a/packages/platform-ui/src/components/providers.tsx
+++ b/packages/platform-ui/src/components/providers.tsx
@@ -1,12 +1,21 @@
 'use client';
 
+import { useState } from 'react';
 import { ThemeProvider } from 'next-themes';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AuthProvider } from '@/contexts/auth-context';
+import { createQueryClient } from '@/lib/query-client';
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => createQueryClient());
+
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-      <AuthProvider>{children}</AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+        {process.env.NODE_ENV !== 'production' && <ReactQueryDevtools initialIsOpen={false} />}
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }

--- a/packages/platform-ui/src/components/tasks/__tests__/task-detail-upload.test.tsx
+++ b/packages/platform-ui/src/components/tasks/__tests__/task-detail-upload.test.tsx
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { HumanTask } from '@mediforce/platform-core';
 import { buildHumanTask } from '@mediforce/platform-core/testing';
+import { createQueryWrapper } from '@/test/react-query';
+
+function render(ui: React.ReactElement) {
+  const { wrapper } = createQueryWrapper();
+  return rtlRender(ui, { wrapper });
+}
 
 // Mock Firebase — must come before any component imports
 vi.mock('@/lib/firebase', () => ({

--- a/packages/platform-ui/src/components/tasks/claim-button.tsx
+++ b/packages/platform-ui/src/components/tasks/claim-button.tsx
@@ -2,9 +2,27 @@
 
 import * as React from 'react';
 import { Loader2 } from 'lucide-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { HumanTask } from '@mediforce/platform-core';
 import { mediforce } from '@/lib/mediforce';
+import { queryKeys } from '@/lib/query-keys';
+import { snapshotCache } from '@/lib/optimistic';
 import { cn } from '@/lib/utils';
 
+/**
+ * State-transition optimistic update template per ADR-0006 §6:
+ *
+ * - `onMutate` cancels in-flight queries for the affected keys, snapshots
+ *   the detail entity, and patches it locally to `status: 'claimed'` so
+ *   the UI reflects the click instantly.
+ * - `onSuccess` overwrites the detail key with the server entity-echo
+ *   (`data.task`) — no refetch round trip — and invalidates the
+ *   `['tasks']` list prefix so every role / instance slice picks the new
+ *   state up on its next tick (tag-prefix invalidation per ADR-0006 §2).
+ * - `onError` restores the snapshot and surfaces a message inline. The
+ *   `['tasks']` prefix is also invalidated so any stale optimistic flicker
+ *   on adjacent list views recovers.
+ */
 export function ClaimButton({
   taskId,
   fullWidth = false,
@@ -16,21 +34,41 @@ export function ClaimButton({
   variant?: 'default' | 'inline';
   onClaimed?: () => void;
 }) {
-  const [pending, setPending] = React.useState(false);
+  const qc = useQueryClient();
   const [error, setError] = React.useState<string | null>(null);
 
-  async function handleClaim() {
-    setPending(true);
-    setError(null);
-    try {
-      await mediforce.tasks.claim({ taskId });
+  const claim = useMutation({
+    mutationFn: () => mediforce.tasks.claim({ taskId }),
+    onMutate: async () => {
+      const detailKey = queryKeys.task(taskId);
+      await qc.cancelQueries({ queryKey: detailKey });
+      await qc.cancelQueries({ queryKey: queryKeys.tasks.all() });
+
+      const { restore } = snapshotCache(qc, [detailKey]);
+      qc.setQueryData<HumanTask | undefined>(detailKey, (old) =>
+        old ? { ...old, status: 'claimed' } : old,
+      );
+      return { restore };
+    },
+    onSuccess: (data) => {
+      qc.setQueryData(queryKeys.task(data.task.id), data.task);
       onClaimed?.();
-    } catch (err) {
+    },
+    onError: (err, _input, ctx) => {
+      ctx?.restore();
       setError(err instanceof Error ? err.message : 'Failed to claim task');
-    } finally {
-      setPending(false);
-    }
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.tasks.all() });
+    },
+  });
+
+  function handleClaim() {
+    setError(null);
+    claim.mutate();
   }
+
+  const pending = claim.isPending;
 
   if (variant === 'inline') {
     return (

--- a/packages/platform-ui/src/components/tasks/task-detail.tsx
+++ b/packages/platform-ui/src/components/tasks/task-detail.tsx
@@ -2,17 +2,15 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { useMemo } from 'react';
 import { format } from 'date-fns';
 import { ArrowLeft } from 'lucide-react';
-import { where, orderBy } from 'firebase/firestore';
 import type { HumanTask, ProcessInstance } from '@mediforce/platform-core';
 import { TaskContextPanel } from './task-context-panel';
 import { AgentOutputReviewPanel } from './agent-output-review-panel';
 import { NextStepCard } from './next-step-card';
 import { resolveTaskBody } from './task-body-registry';
 import { getTaskDisplayTitle, isAgentReviewTask, getAgentOutput, getAgentOutputFromSiblings } from './task-utils';
-import { useCollection } from '@/hooks/use-collection';
+import { useMyActionableTasksByRole } from '@/hooks/use-tasks';
 import { useInstanceTasks } from '@/hooks/use-instance-tasks';
 import { useProcessInstance } from '@/hooks/use-process-instances';
 import { cn } from '@/lib/utils';
@@ -36,21 +34,7 @@ export function TaskDetail({
   const { goBack } = useBackNavigation(`/${handle}/tasks`);
   const { data: processInstance } = useProcessInstance(task.processInstanceId);
 
-  const remainingConstraints = useMemo(
-    () =>
-      task.assignedRole
-        ? [
-            where('assignedRole', '==', task.assignedRole),
-            where('status', 'in', ['pending', 'claimed']),
-            orderBy('createdAt', 'asc'),
-          ]
-        : [],
-    [task.assignedRole],
-  );
-  const { data: remainingTasks } = useCollection<HumanTask>(
-    'humanTasks',
-    remainingConstraints,
-  );
+  const { data: remainingTasks } = useMyActionableTasksByRole(task.assignedRole ?? undefined);
   const remainingTaskCount = remainingTasks.filter((t) => t.id !== task.id).length;
 
   const { tasks: siblingTasks } = useInstanceTasks(task.processInstanceId);

--- a/packages/platform-ui/src/hooks/__tests__/claim-task-optimistic.test.tsx
+++ b/packages/platform-ui/src/hooks/__tests__/claim-task-optimistic.test.tsx
@@ -18,8 +18,9 @@ const { mediforce } = await import('@/lib/mediforce');
 /**
  * Mirrors the state-transition wiring in `components/tasks/claim-button.tsx`
  * so the test exercises the canonical optimistic template, not a parallel
- * implementation. PR2-5 mutations are expected to follow the same shape;
- * this test is the contract for "optimistic update behaves correctly".
+ * implementation. Future mutations on other domains are expected to follow
+ * the same shape; this test is the contract for "optimistic update behaves
+ * correctly".
  */
 function useClaimMutation(qc: import('@tanstack/react-query').QueryClient, taskId: string) {
   return useMutation({

--- a/packages/platform-ui/src/hooks/__tests__/claim-task-optimistic.test.tsx
+++ b/packages/platform-ui/src/hooks/__tests__/claim-task-optimistic.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useMutation } from '@tanstack/react-query';
+import type { HumanTask } from '@mediforce/platform-core';
+import { buildHumanTask } from '@mediforce/platform-core/testing';
+import { createQueryWrapper } from '@/test/react-query';
+import { queryKeys } from '@/lib/query-keys';
+import { snapshotCache } from '@/lib/optimistic';
+
+const claimMock = vi.fn<(...args: unknown[]) => Promise<{ task: HumanTask }>>();
+vi.mock('@/lib/mediforce', () => ({
+  mediforce: { tasks: { claim: claimMock } },
+  ApiError: class ApiError extends Error {},
+}));
+
+const { mediforce } = await import('@/lib/mediforce');
+
+/**
+ * Mirrors the state-transition wiring in `components/tasks/claim-button.tsx`
+ * so the test exercises the canonical optimistic template, not a parallel
+ * implementation. PR2-5 mutations are expected to follow the same shape;
+ * this test is the contract for "optimistic update behaves correctly".
+ */
+function useClaimMutation(qc: import('@tanstack/react-query').QueryClient, taskId: string) {
+  return useMutation({
+    mutationFn: () => mediforce.tasks.claim({ taskId }),
+    onMutate: async () => {
+      const detailKey = queryKeys.task(taskId);
+      await qc.cancelQueries({ queryKey: detailKey });
+      const { restore } = snapshotCache(qc, [detailKey]);
+      qc.setQueryData<HumanTask | undefined>(detailKey, (old) =>
+        old ? { ...old, status: 'claimed' } : old,
+      );
+      return { restore };
+    },
+    onSuccess: (data) => {
+      qc.setQueryData(queryKeys.task(data.task.id), data.task);
+    },
+    onError: (_err, _input, ctx) => {
+      ctx?.restore();
+    },
+  });
+}
+
+describe('claim mutation — state-transition optimistic template (ADR-0006 §6)', () => {
+  beforeEach(() => {
+    claimMock.mockReset();
+  });
+
+  it('patches the detail cache to status=claimed on mutate', async () => {
+    const { wrapper, queryClient } = createQueryWrapper();
+    queryClient.setQueryData(queryKeys.task('t-1'), buildHumanTask({ id: 't-1', status: 'pending' }));
+    let resolveClaim: (value: { task: HumanTask }) => void = () => undefined;
+    claimMock.mockImplementation(() => new Promise((resolve) => { resolveClaim = resolve; }));
+
+    const { result } = renderHook(() => useClaimMutation(queryClient, 't-1'), { wrapper });
+
+    await act(async () => { result.current.mutate(); });
+
+    const cached = queryClient.getQueryData<HumanTask>(queryKeys.task('t-1'));
+    expect(cached?.status).toBe('claimed');
+
+    // Let the in-flight mutation resolve so the test doesn't leak a promise.
+    await act(async () => { resolveClaim({ task: buildHumanTask({ id: 't-1', status: 'claimed' }) }); });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+  });
+
+  it('replaces the detail cache with the server entity-echo on success', async () => {
+    const { wrapper, queryClient } = createQueryWrapper();
+    queryClient.setQueryData(queryKeys.task('t-1'), buildHumanTask({ id: 't-1', status: 'pending' }));
+    const serverEntity = buildHumanTask({ id: 't-1', status: 'claimed', assignedUserId: 'u-server' });
+    claimMock.mockResolvedValue({ task: serverEntity });
+
+    const { result } = renderHook(() => useClaimMutation(queryClient, 't-1'), { wrapper });
+
+    await act(async () => { result.current.mutate(); });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryData<HumanTask>(queryKeys.task('t-1'))).toEqual(serverEntity);
+  });
+
+  it('restores the snapshot when the mutation throws', async () => {
+    const { wrapper, queryClient } = createQueryWrapper();
+    const original = buildHumanTask({ id: 't-1', status: 'pending', assignedUserId: null });
+    queryClient.setQueryData(queryKeys.task('t-1'), original);
+    claimMock.mockRejectedValue(new Error('precondition_failed'));
+
+    const { result } = renderHook(() => useClaimMutation(queryClient, 't-1'), { wrapper });
+
+    await act(async () => { result.current.mutate(); });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(queryClient.getQueryData<HumanTask>(queryKeys.task('t-1'))).toEqual(original);
+  });
+});

--- a/packages/platform-ui/src/hooks/__tests__/use-instance-tasks.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-instance-tasks.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import type { HumanTask } from '@mediforce/platform-core';
 import { buildHumanTask } from '@mediforce/platform-core/testing';
+import { createQueryWrapper } from '@/test/react-query';
 
 const listMock = vi.fn<(...args: unknown[]) => Promise<{ tasks: HumanTask[] }>>();
 vi.mock('@/lib/mediforce', () => ({
@@ -21,7 +22,8 @@ describe('useInstanceTasks', () => {
   });
 
   it('does not call the API when instanceId is undefined', async () => {
-    const { result } = renderHook(() => useInstanceTasks(undefined));
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useInstanceTasks(undefined), { wrapper });
 
     expect(result.current.tasks).toEqual([]);
     expect(result.current.loading).toBe(false);
@@ -31,13 +33,14 @@ describe('useInstanceTasks', () => {
 
   it('fetches, populates and clears loading when instanceId is provided', async () => {
     listMock.mockResolvedValue({ tasks: [buildHumanTask({ id: 't1' }), buildHumanTask({ id: 't2' })] });
+    const { wrapper } = createQueryWrapper();
 
-    const { result } = renderHook(() => useInstanceTasks('inst-a'));
+    const { result } = renderHook(() => useInstanceTasks('inst-a'), { wrapper });
 
     expect(result.current.loading).toBe(true);
-    expect(listMock).toHaveBeenCalledWith({ instanceId: 'inst-a' });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listMock).toHaveBeenCalledWith({ instanceId: 'inst-a' });
     expect(result.current.tasks.map((t) => t.id)).toEqual(['t1', 't2']);
     expect(result.current.error).toBeNull();
   });
@@ -45,46 +48,44 @@ describe('useInstanceTasks', () => {
   it('surfaces errors without leaving loading stuck', async () => {
     const err = new Error('boom');
     listMock.mockRejectedValue(err);
+    const { wrapper } = createQueryWrapper();
 
-    const { result } = renderHook(() => useInstanceTasks('inst-a'));
+    const { result } = renderHook(() => useInstanceTasks('inst-a'), { wrapper });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBe(err);
     expect(result.current.tasks).toEqual([]);
   });
 
-  it('ignores a stale response when instanceId changed before it resolved', async () => {
-    // First fetch — never resolves in time
+  it('cancels in-flight requests when instanceId changes (no stale data leak)', async () => {
     let resolveFirst: ((value: { tasks: HumanTask[] }) => void) | null = null;
     listMock.mockImplementationOnce(
       () => new Promise((resolve) => { resolveFirst = resolve; }),
     );
+    listMock.mockResolvedValueOnce({ tasks: [buildHumanTask({ id: 't-new', processInstanceId: 'inst-b' })] });
 
+    const { wrapper } = createQueryWrapper();
     const { result, rerender } = renderHook(
       ({ id }: { id: string }) => useInstanceTasks(id),
-      { initialProps: { id: 'inst-a' } },
+      { wrapper, initialProps: { id: 'inst-a' } },
     );
 
-    // Second fetch — resolves immediately with different data
-    listMock.mockResolvedValueOnce({ tasks: [buildHumanTask({ id: 't-new', processInstanceId: 'inst-b' })] });
     rerender({ id: 'inst-b' });
 
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.tasks.map((t) => t.id)).toEqual(['t-new']);
+    await waitFor(() => expect(result.current.tasks.map((t) => t.id)).toEqual(['t-new']));
 
-    // Late first response arrives — must be ignored.
-    await act(async () => {
-      resolveFirst?.({ tasks: [buildHumanTask({ id: 'stale' })] });
-    });
+    // Late first response — react-query keys it under `inst-a`, never bleeds into the active `inst-b` view.
+    resolveFirst?.({ tasks: [buildHumanTask({ id: 'stale' })] });
     expect(result.current.tasks.map((t) => t.id)).toEqual(['t-new']);
   });
 
   it('clears state when instanceId becomes undefined again', async () => {
     listMock.mockResolvedValue({ tasks: [buildHumanTask({ id: 't1' })] });
+    const { wrapper } = createQueryWrapper();
 
     const { result, rerender } = renderHook(
       ({ id }: { id: string | undefined }) => useInstanceTasks(id),
-      { initialProps: { id: 'inst-a' as string | undefined } },
+      { wrapper, initialProps: { id: 'inst-a' as string | undefined } },
     );
 
     await waitFor(() => expect(result.current.tasks).toHaveLength(1));

--- a/packages/platform-ui/src/hooks/__tests__/use-task.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-task.test.ts
@@ -5,9 +5,12 @@ import { buildHumanTask } from '@mediforce/platform-core/testing';
 import { createQueryWrapper } from '@/test/react-query';
 
 const getMock = vi.fn<(...args: unknown[]) => Promise<HumanTask>>();
+class ApiError extends Error {
+  constructor(public status: number, message: string) { super(message); }
+}
 vi.mock('@/lib/mediforce', () => ({
   mediforce: { tasks: { get: getMock } },
-  ApiError: class ApiError extends Error {},
+  ApiError,
 }));
 
 const { useTask } = await import('../use-task');
@@ -46,8 +49,9 @@ describe('useTask', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('surfaces errors without leaving loading stuck', async () => {
-    const err = new Error('not found');
+  it('surfaces non-404 errors without leaving loading stuck', async () => {
+    // 4xx (non-404) — fast-fail per the retry policy, no transient-retry wait.
+    const err = new ApiError(403, 'forbidden');
     getMock.mockRejectedValue(err);
     const { wrapper } = createQueryWrapper();
 
@@ -55,7 +59,43 @@ describe('useTask', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBe(err);
+    expect(result.current.notFound).toBe(false);
     expect(result.current.task).toBeNull();
+  });
+
+  it('signals notFound=true for 404 without surfacing the error', async () => {
+    getMock.mockRejectedValue(new ApiError(404, 'Task not found'));
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useTask('t-1'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.notFound).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.task).toBeNull();
+  });
+
+  it('stops polling once the query has errored', async () => {
+    getMock.mockRejectedValue(new ApiError(400, 'Invalid input'));
+    const { wrapper } = createQueryWrapper();
+
+    renderHook(() => useTask('t-1'), { wrapper });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on 4xx (fast-fail)', async () => {
+    getMock.mockRejectedValue(new ApiError(400, 'Invalid input'));
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useTask('t-1'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Default retry would call 3x (1 + 2 retries). Custom retry returns false
+    // for 4xx, so call count is 1.
+    expect(getMock).toHaveBeenCalledTimes(1);
   });
 
   it('keeps polling while the task is non-terminal (CRITICAL LIVE 1.5s)', async () => {

--- a/packages/platform-ui/src/hooks/__tests__/use-task.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-task.test.ts
@@ -71,7 +71,7 @@ describe('useTask', () => {
     await waitFor(() => expect(getMock).toHaveBeenCalledTimes(3));
   });
 
-  it('stops polling once the task reaches a terminal status', async () => {
+  it('stops polling once the task reaches a terminal status (completed)', async () => {
     getMock.mockResolvedValueOnce(buildHumanTask({ id: 't-1', status: 'pending' }));
     getMock.mockResolvedValue(buildHumanTask({ id: 't-1', status: 'completed' }));
     const { wrapper } = createQueryWrapper();
@@ -82,7 +82,21 @@ describe('useTask', () => {
     await vi.advanceTimersByTimeAsync(1600);
     await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
 
-    // Second fetch returned 'completed' — polling should now stop.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops polling once the task reaches a terminal status (cancelled)', async () => {
+    getMock.mockResolvedValueOnce(buildHumanTask({ id: 't-1', status: 'pending' }));
+    getMock.mockResolvedValue(buildHumanTask({ id: 't-1', status: 'cancelled' }));
+    const { wrapper } = createQueryWrapper();
+
+    renderHook(() => useTask('t-1'), { wrapper });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(1600);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+
     await vi.advanceTimersByTimeAsync(5_000);
     expect(getMock).toHaveBeenCalledTimes(2);
   });

--- a/packages/platform-ui/src/hooks/__tests__/use-task.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-task.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { HumanTask } from '@mediforce/platform-core';
+import { buildHumanTask } from '@mediforce/platform-core/testing';
+import { createQueryWrapper } from '@/test/react-query';
+
+const getMock = vi.fn<(...args: unknown[]) => Promise<HumanTask>>();
+vi.mock('@/lib/mediforce', () => ({
+  mediforce: { tasks: { get: getMock } },
+  ApiError: class ApiError extends Error {},
+}));
+
+const { useTask } = await import('../use-task');
+
+describe('useTask', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not call the API when taskId is undefined', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useTask(undefined), { wrapper });
+
+    expect(result.current.task).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches and exposes the task once the request resolves', async () => {
+    getMock.mockResolvedValue(buildHumanTask({ id: 't-1', status: 'pending' }));
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useTask('t-1'), { wrapper });
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(getMock).toHaveBeenCalledWith({ taskId: 't-1' });
+    expect(result.current.task?.id).toBe('t-1');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces errors without leaving loading stuck', async () => {
+    const err = new Error('not found');
+    getMock.mockRejectedValue(err);
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useTask('t-1'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(err);
+    expect(result.current.task).toBeNull();
+  });
+
+  it('keeps polling while the task is non-terminal (CRITICAL LIVE 1.5s)', async () => {
+    getMock.mockResolvedValue(buildHumanTask({ id: 't-1', status: 'pending' }));
+    const { wrapper } = createQueryWrapper();
+
+    renderHook(() => useTask('t-1'), { wrapper });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(1600);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(1600);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(3));
+  });
+
+  it('stops polling once the task reaches a terminal status', async () => {
+    getMock.mockResolvedValueOnce(buildHumanTask({ id: 't-1', status: 'pending' }));
+    getMock.mockResolvedValue(buildHumanTask({ id: 't-1', status: 'completed' }));
+    const { wrapper } = createQueryWrapper();
+
+    renderHook(() => useTask('t-1'), { wrapper });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(1600);
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+
+    // Second fetch returned 'completed' — polling should now stop.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/platform-ui/src/hooks/__tests__/use-tasks-by-role.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-tasks-by-role.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { HumanTask } from '@mediforce/platform-core';
+import { buildHumanTask } from '@mediforce/platform-core/testing';
+import { createQueryWrapper } from '@/test/react-query';
+
+const listMock = vi.fn<(...args: unknown[]) => Promise<{ tasks: HumanTask[] }>>();
+vi.mock('@/lib/mediforce', () => ({
+  mediforce: { tasks: { list: listMock } },
+  ApiError: class ApiError extends Error {},
+}));
+
+// Stub use-collection so loading the module doesn't pull Firestore SDK in.
+vi.mock('../use-collection', () => ({
+  useCollection: () => ({ data: [], loading: false, error: null }),
+}));
+
+const { useMyActionableTasksByRole, useCompletedTasksByRole } = await import('../use-tasks');
+
+describe('useMyActionableTasksByRole', () => {
+  beforeEach(() => {
+    listMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /api/tasks with the role + ACTIONABLE_STATUSES filter', async () => {
+    listMock.mockResolvedValue({
+      tasks: [
+        buildHumanTask({ id: 't1', assignedUserId: null }),
+        buildHumanTask({ id: 't2', assignedUserId: 'u-other' }),
+      ],
+    });
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useMyActionableTasksByRole('reviewer'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listMock).toHaveBeenCalledWith({
+      role: 'reviewer',
+      status: ['pending', 'claimed'],
+    });
+    expect(result.current.data.map((t) => t.id)).toEqual(['t1', 't2']);
+  });
+
+  it('filters out tasks claimed by other users when currentUserId is set', async () => {
+    listMock.mockResolvedValue({
+      tasks: [
+        buildHumanTask({ id: 't1', assignedUserId: null }),
+        buildHumanTask({ id: 't2', assignedUserId: 'u-me' }),
+        buildHumanTask({ id: 't3', assignedUserId: 'u-other' }),
+      ],
+    });
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(
+      () => useMyActionableTasksByRole('reviewer', 'u-me'),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data.map((t) => t.id)).toEqual(['t1', 't2']);
+  });
+
+  it('strips deleted tasks regardless of currentUserId', async () => {
+    listMock.mockResolvedValue({
+      tasks: [
+        buildHumanTask({ id: 't1', deleted: true }),
+        buildHumanTask({ id: 't2', deleted: false }),
+      ],
+    });
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useMyActionableTasksByRole('reviewer'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data.map((t) => t.id)).toEqual(['t2']);
+  });
+
+  it('surfaces errors without leaving loading stuck', async () => {
+    const err = new Error('boom');
+    listMock.mockRejectedValue(err);
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useMyActionableTasksByRole('reviewer'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe(err);
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe('useCompletedTasksByRole', () => {
+  beforeEach(() => {
+    listMock.mockReset();
+  });
+
+  it('GETs with status=completed and sorts by completedAt desc', async () => {
+    listMock.mockResolvedValue({
+      tasks: [
+        buildHumanTask({ id: 'older', completedAt: '2026-04-01T00:00:00.000Z' }),
+        buildHumanTask({ id: 'newer', completedAt: '2026-05-01T00:00:00.000Z' }),
+      ],
+    });
+    const { wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(() => useCompletedTasksByRole('reviewer'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listMock).toHaveBeenCalledWith({ role: 'reviewer', status: ['completed'] });
+    expect(result.current.data.map((t) => t.id)).toEqual(['newer', 'older']);
+  });
+});

--- a/packages/platform-ui/src/hooks/use-instance-tasks.ts
+++ b/packages/platform-ui/src/hooks/use-instance-tasks.ts
@@ -1,60 +1,35 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import type { HumanTask } from '@mediforce/platform-core';
-import { mediforce, ApiError } from '@/lib/mediforce';
+import { mediforce } from '@/lib/mediforce';
+import { queryKeys } from '@/lib/query-keys';
 
 /**
- * Fetches the full set of human tasks belonging to a single process instance
- * through `mediforce.tasks.list`. One-shot read (no real-time subscription) —
- * intended for historical / contextual views where a stale read is acceptable.
+ * Fetches every human task belonging to a single process instance.
  *
- * For live task lists (badge counts, active-task inboxes) keep using the
- * Firestore-backed `useCollection` hooks until Phase 6 lands a streaming
- * replacement — see `docs/headless-migration.md`.
+ * One-shot read: `refetchInterval: 0` (the project default per ADR-0006 §3).
+ * Intended for historical / contextual views where stale data is acceptable —
+ * task detail's sibling list, post-completion next-step lookup. For live task
+ * inboxes use the role-scoped hooks (`useMyTasks`).
  */
 export function useInstanceTasks(instanceId: string | undefined): {
   tasks: HumanTask[];
   loading: boolean;
   error: Error | null;
 } {
-  const [tasks, setTasks] = useState<HumanTask[]>([]);
-  const [loading, setLoading] = useState<boolean>(instanceId !== undefined);
-  const [error, setError] = useState<Error | null>(null);
+  const query = useQuery({
+    queryKey: queryKeys.tasks.byInstance(instanceId ?? ''),
+    queryFn: async () => {
+      const result = await mediforce.tasks.list({ instanceId: instanceId as string });
+      return result.tasks;
+    },
+    enabled: instanceId !== undefined,
+  });
 
-  useEffect(() => {
-    if (instanceId === undefined) {
-      setTasks([]);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-
-    mediforce.tasks
-      .list({ instanceId })
-      .then((result) => {
-        if (!cancelled) setTasks(result.tasks);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const normalised = err instanceof ApiError || err instanceof Error
-          ? err
-          : new Error(String(err));
-        setError(normalised);
-        setTasks([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [instanceId]);
-
-  return { tasks, loading, error };
+  return {
+    tasks: instanceId === undefined ? [] : query.data ?? [],
+    loading: query.isLoading && instanceId !== undefined,
+    error: instanceId === undefined ? null : (query.error as Error | null) ?? null,
+  };
 }

--- a/packages/platform-ui/src/hooks/use-task.ts
+++ b/packages/platform-ui/src/hooks/use-task.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { HumanTask, HumanTaskStatus } from '@mediforce/platform-core';
+import { mediforce } from '@/lib/mediforce';
+import { queryKeys } from '@/lib/query-keys';
+
+const TERMINAL: ReadonlySet<HumanTaskStatus> = new Set(['completed', 'cancelled']);
+const CRITICAL_LIVE_INTERVAL_MS = 1500;
+
+/**
+ * Single-task detail fetch (`mediforce.tasks.get`) keyed under `['task', id]`.
+ *
+ * CRITICAL LIVE per ADR-0006 §4: polls at 1.5s while the task is non-terminal
+ * (operator is watching execution), then stops polling once the task reaches
+ * `completed` or `cancelled`. Cache stays warm for cross-route navigation.
+ */
+export function useTask(taskId: string | undefined): {
+  task: HumanTask | null;
+  loading: boolean;
+  error: Error | null;
+} {
+  const query = useQuery({
+    queryKey: queryKeys.task(taskId ?? ''),
+    queryFn: () => mediforce.tasks.get({ taskId: taskId as string }),
+    enabled: taskId !== undefined,
+    refetchInterval: (q) => {
+      const status = q.state.data?.status;
+      if (status === undefined) return CRITICAL_LIVE_INTERVAL_MS;
+      return TERMINAL.has(status) ? false : CRITICAL_LIVE_INTERVAL_MS;
+    },
+  });
+
+  return {
+    task: taskId === undefined ? null : query.data ?? null,
+    loading: query.isLoading && taskId !== undefined,
+    error: taskId === undefined ? null : (query.error as Error | null) ?? null,
+  };
+}

--- a/packages/platform-ui/src/hooks/use-task.ts
+++ b/packages/platform-ui/src/hooks/use-task.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import type { HumanTask, HumanTaskStatus } from '@mediforce/platform-core';
-import { mediforce } from '@/lib/mediforce';
+import { ApiError, mediforce } from '@/lib/mediforce';
 import { queryKeys } from '@/lib/query-keys';
 
 const TERMINAL: ReadonlySet<HumanTaskStatus> = new Set(['completed', 'cancelled']);
@@ -19,21 +19,35 @@ export function useTask(taskId: string | undefined): {
   task: HumanTask | null;
   loading: boolean;
   error: Error | null;
+  notFound: boolean;
 } {
   const query = useQuery({
     queryKey: queryKeys.task(taskId ?? ''),
     queryFn: () => mediforce.tasks.get({ taskId: taskId as string }),
     enabled: taskId !== undefined,
+    // Validation / authorisation failures are not transient — a 4xx will keep
+    // failing. Don't waste two retry attempts before showing the error.
+    retry: (failureCount, err) => {
+      if (err instanceof ApiError && err.status >= 400 && err.status < 500) return false;
+      return failureCount < 2;
+    },
     refetchInterval: (q) => {
+      // Stop polling once the query has errored — a persistent 4xx (validation,
+      // not-found, forbidden) does not recover on its own, and a 1.5s retry
+      // loop spams the backend + flickers the UI.
+      if (q.state.error !== null) return false;
       const status = q.state.data?.status;
       if (status === undefined) return CRITICAL_LIVE_INTERVAL_MS;
       return TERMINAL.has(status) ? false : CRITICAL_LIVE_INTERVAL_MS;
     },
   });
 
+  const err = taskId === undefined ? null : (query.error as Error | null) ?? null;
+  const notFound = err instanceof ApiError && err.status === 404;
   return {
     task: taskId === undefined ? null : query.data ?? null,
     loading: query.isLoading && taskId !== undefined,
-    error: taskId === undefined ? null : (query.error as Error | null) ?? null,
+    error: notFound ? null : err,
+    notFound,
   };
 }

--- a/packages/platform-ui/src/hooks/use-tasks.ts
+++ b/packages/platform-ui/src/hooks/use-tasks.ts
@@ -1,10 +1,93 @@
 'use client';
 
 import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { where, orderBy } from 'firebase/firestore';
 import type { HumanTask, CoworkSession } from '@mediforce/platform-core';
+import { ACTIONABLE_STATUSES } from '@mediforce/platform-api/contract';
+import { mediforce } from '@/lib/mediforce';
+import { queryKeys } from '@/lib/query-keys';
 import { useCollection } from './use-collection';
 
+const STANDARD_LIVE_INTERVAL_MS = 5_000;
+
+/**
+ * Role-scoped actionable task queue, react-query backed (STANDARD LIVE per
+ * ADR-0006 §4). Returns the same `{ data, loading, error }` shape as the
+ * Firestore-backed `useMyTasks(null, …)` fallback below so callers swap
+ * in mechanically once an "all my visible tasks" endpoint axis exists.
+ */
+export function useMyActionableTasksByRole(
+  assignedRole: string,
+  currentUserId?: string | null,
+): { data: HumanTask[]; loading: boolean; error: Error | null } {
+  const query = useQuery({
+    queryKey: queryKeys.tasks.byRole(assignedRole, { status: [...ACTIONABLE_STATUSES] }),
+    queryFn: async () => {
+      const result = await mediforce.tasks.list({
+        role: assignedRole,
+        status: [...ACTIONABLE_STATUSES],
+      });
+      return result.tasks;
+    },
+    refetchInterval: STANDARD_LIVE_INTERVAL_MS,
+  });
+
+  const filtered = useMemo(() => {
+    const tasks = query.data ?? [];
+    const notDeleted = tasks.filter((t) => !t.deleted);
+    if (currentUserId === undefined || currentUserId === null) return notDeleted;
+    return notDeleted.filter(
+      (t) => t.assignedUserId === null || t.assignedUserId === currentUserId,
+    );
+  }, [query.data, currentUserId]);
+
+  return {
+    data: filtered,
+    loading: query.isLoading,
+    error: (query.error as Error | null) ?? null,
+  };
+}
+
+/**
+ * Role-scoped completed task list, react-query backed (STANDARD LIVE).
+ * Sorts `completedAt` desc client-side — the API does not promise an order.
+ */
+export function useCompletedTasksByRole(
+  assignedRole: string,
+): { data: HumanTask[]; loading: boolean; error: Error | null } {
+  const query = useQuery({
+    queryKey: queryKeys.tasks.byRole(assignedRole, { status: ['completed'] }),
+    queryFn: async () => {
+      const result = await mediforce.tasks.list({
+        role: assignedRole,
+        status: ['completed'],
+      });
+      return result.tasks;
+    },
+    refetchInterval: STANDARD_LIVE_INTERVAL_MS,
+  });
+
+  const filtered = useMemo(() => {
+    const tasks = (query.data ?? []).filter((t) => !t.deleted);
+    return [...tasks].sort((a, b) => (b.completedAt ?? '').localeCompare(a.completedAt ?? ''));
+  }, [query.data]);
+
+  return {
+    data: filtered,
+    loading: query.isLoading,
+    error: (query.error as Error | null) ?? null,
+  };
+}
+
+/**
+ * @deprecated PR3 — Firestore `onSnapshot` fallback. The `role === null`
+ * caller pattern (workspace home / workflow detail / runs list) needs an
+ * "all tasks visible to me" axis on `mediforce.tasks.list` before it can
+ * migrate to react-query; that endpoint extension lands with PR3. PR1
+ * keeps this hook intact so PR3 pages keep working without regression.
+ * For the role-provided path, use `useMyActionableTasksByRole` instead.
+ */
 export function useMyTasks(assignedRole: string | null, currentUserId?: string | null) {
   const constraints = useMemo(
     () =>
@@ -42,6 +125,10 @@ export function useMyTasks(assignedRole: string | null, currentUserId?: string |
   return { data: filtered, loading, error };
 }
 
+/**
+ * @deprecated PR3 — Firestore fallback for the `role === null` branch.
+ * For the role-provided path, use `useCompletedTasksByRole` instead.
+ */
 export function useCompletedTasks(assignedRole: string | null) {
   const constraints = useMemo(
     () =>
@@ -68,13 +155,6 @@ export function useCompletedTasks(assignedRole: string | null) {
   );
 
   return { data: filtered, loading, error };
-}
-
-export function useAllTasks() {
-  const constraints = useMemo(() => [orderBy('createdAt', 'desc')], []);
-  const result = useCollection<HumanTask>('humanTasks', constraints);
-  const data = useMemo(() => result.data.filter((task) => !task.deleted), [result.data]);
-  return { ...result, data };
 }
 
 export function useActiveTaskForInstance(processInstanceId: string | null) {

--- a/packages/platform-ui/src/hooks/use-tasks.ts
+++ b/packages/platform-ui/src/hooks/use-tasks.ts
@@ -18,18 +18,19 @@ const STANDARD_LIVE_INTERVAL_MS = 5_000;
  * in mechanically once an "all my visible tasks" endpoint axis exists.
  */
 export function useMyActionableTasksByRole(
-  assignedRole: string,
+  assignedRole: string | undefined,
   currentUserId?: string | null,
 ): { data: HumanTask[]; loading: boolean; error: Error | null } {
   const query = useQuery({
-    queryKey: queryKeys.tasks.byRole(assignedRole, { status: [...ACTIONABLE_STATUSES] }),
+    queryKey: queryKeys.tasks.byRole(assignedRole ?? '', { status: [...ACTIONABLE_STATUSES] }),
     queryFn: async () => {
       const result = await mediforce.tasks.list({
-        role: assignedRole,
+        role: assignedRole as string,
         status: [...ACTIONABLE_STATUSES],
       });
       return result.tasks;
     },
+    enabled: assignedRole !== undefined && assignedRole.length > 0,
     refetchInterval: STANDARD_LIVE_INTERVAL_MS,
   });
 
@@ -44,7 +45,7 @@ export function useMyActionableTasksByRole(
 
   return {
     data: filtered,
-    loading: query.isLoading,
+    loading: query.isLoading && assignedRole !== undefined && assignedRole.length > 0,
     error: (query.error as Error | null) ?? null,
   };
 }

--- a/packages/platform-ui/src/hooks/use-tasks.ts
+++ b/packages/platform-ui/src/hooks/use-tasks.ts
@@ -82,12 +82,13 @@ export function useCompletedTasksByRole(
 }
 
 /**
- * @deprecated PR3 — Firestore `onSnapshot` fallback. The `role === null`
- * caller pattern (workspace home / workflow detail / runs list) needs an
- * "all tasks visible to me" axis on `mediforce.tasks.list` before it can
- * migrate to react-query; that endpoint extension lands with PR3. PR1
- * keeps this hook intact so PR3 pages keep working without regression.
- * For the role-provided path, use `useMyActionableTasksByRole` instead.
+ * @deprecated Firestore `onSnapshot` fallback retained only for the
+ * `role === null` caller pattern (cross-role aggregation on workspace home,
+ * workflow detail, runs list). Those call sites need an "all tasks visible
+ * to me" axis on `mediforce.tasks.list` before they can migrate to
+ * react-query — until that endpoint extension lands they keep working
+ * against this hook unchanged. For the role-provided path, use
+ * `useMyActionableTasksByRole` instead.
  */
 export function useMyTasks(assignedRole: string | null, currentUserId?: string | null) {
   const constraints = useMemo(
@@ -127,8 +128,9 @@ export function useMyTasks(assignedRole: string | null, currentUserId?: string |
 }
 
 /**
- * @deprecated PR3 — Firestore fallback for the `role === null` branch.
- * For the role-provided path, use `useCompletedTasksByRole` instead.
+ * @deprecated Firestore fallback retained only for the `role === null` branch
+ * — see `useMyTasks` for the rationale. For the role-provided path, use
+ * `useCompletedTasksByRole` instead.
  */
 export function useCompletedTasks(assignedRole: string | null) {
   const constraints = useMemo(

--- a/packages/platform-ui/src/lib/__tests__/optimistic.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/optimistic.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { snapshotCache } from '../optimistic';
+
+describe('snapshotCache', () => {
+  it('restores every snapshotted key when restore() is called', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(['task', 't1'], { id: 't1', status: 'pending' });
+    qc.setQueryData(['tasks', { role: 'reviewer' }], [{ id: 't1' }, { id: 't2' }]);
+
+    const { restore } = snapshotCache(qc, [
+      ['task', 't1'],
+      ['tasks', { role: 'reviewer' }],
+    ]);
+
+    // Mutate optimistically
+    qc.setQueryData(['task', 't1'], { id: 't1', status: 'claimed' });
+    qc.setQueryData(['tasks', { role: 'reviewer' }], [{ id: 't2' }]);
+
+    restore();
+
+    expect(qc.getQueryData(['task', 't1'])).toEqual({ id: 't1', status: 'pending' });
+    expect(qc.getQueryData(['tasks', { role: 'reviewer' }])).toEqual([{ id: 't1' }, { id: 't2' }]);
+  });
+
+  it('restores undefined for a key that had no prior value', () => {
+    const qc = new QueryClient();
+
+    const { restore } = snapshotCache(qc, [['task', 't-new']]);
+
+    qc.setQueryData(['task', 't-new'], { id: 't-new' });
+    restore();
+
+    expect(qc.getQueryData(['task', 't-new'])).toBeUndefined();
+  });
+});

--- a/packages/platform-ui/src/lib/__tests__/query-client.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/query-client.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { createQueryClient } from '../query-client';
+
+describe('createQueryClient', () => {
+  it('returns a QueryClient with ADR-0006 §3 defaults applied', () => {
+    const qc = createQueryClient();
+    const q = qc.getDefaultOptions().queries ?? {};
+    const m = qc.getDefaultOptions().mutations ?? {};
+
+    expect(q.refetchInterval).toBe(0);
+    expect(q.refetchOnWindowFocus).toBe(false);
+    expect(q.refetchOnReconnect).toBe(true);
+    expect(q.staleTime).toBe(0);
+    expect(q.gcTime).toBe(5 * 60 * 1000);
+    expect(q.retry).toBe(2);
+    expect(m.retry).toBe(0);
+  });
+
+  it('returns a fresh instance per call (test isolation)', () => {
+    const a = createQueryClient();
+    const b = createQueryClient();
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/platform-ui/src/lib/__tests__/query-keys.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/query-keys.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { queryKeys } from '../query-keys';
+
+describe('queryKeys', () => {
+  it('tasks.all is the bare prefix', () => {
+    expect(queryKeys.tasks.all()).toEqual(['tasks']);
+  });
+
+  it('tasks.byInstance puts the instanceId in a filter object on the tail', () => {
+    expect(queryKeys.tasks.byInstance('inst-1')).toEqual(['tasks', { instanceId: 'inst-1' }]);
+  });
+
+  it('tasks.byInstance carries optional stepId + status filters', () => {
+    expect(
+      queryKeys.tasks.byInstance('inst-1', { stepId: 'step-x', status: ['pending'] }),
+    ).toEqual(['tasks', { instanceId: 'inst-1', stepId: 'step-x', status: ['pending'] }]);
+  });
+
+  it('tasks.byRole puts the role in a filter object on the tail', () => {
+    expect(queryKeys.tasks.byRole('reviewer')).toEqual(['tasks', { role: 'reviewer' }]);
+  });
+
+  it('tasks.byRole carries optional status', () => {
+    expect(queryKeys.tasks.byRole('reviewer', { status: ['completed'] })).toEqual([
+      'tasks',
+      { role: 'reviewer', status: ['completed'] },
+    ]);
+  });
+
+  it('task (singular) keys the detail cache under a distinct prefix from the list', () => {
+    expect(queryKeys.task('t-1')).toEqual(['task', 't-1']);
+    expect(queryKeys.task('t-1')[0]).not.toBe(queryKeys.tasks.all()[0]);
+  });
+});

--- a/packages/platform-ui/src/lib/optimistic.ts
+++ b/packages/platform-ui/src/lib/optimistic.ts
@@ -1,0 +1,36 @@
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+
+/**
+ * Snapshot a set of cache entries for rollback per ADR-0006 §6 templates.
+ *
+ * Pattern (state-transition template, called from `useMutation.onMutate`):
+ *
+ *   await Promise.all(keys.map((k) => qc.cancelQueries({ queryKey: k })));
+ *   const { restore } = snapshotCache(qc, keys);
+ *   qc.setQueryData(detailKey, optimisticEntity);
+ *   qc.setQueryData(listKey, (old) => patch(old));
+ *   return { restore };
+ *
+ * Then in `onError(_e, _input, ctx)` call `ctx.restore()`; in `onSuccess`
+ * replace with the server entity-echo via `setQueryData`.
+ *
+ * Why a helper at all: forgetting to restore one of the affected keys is
+ * the recurring bug in hand-rolled optimistic flows. Snapshotting in one
+ * place eliminates that class of mistake.
+ */
+export function snapshotCache(qc: QueryClient, keys: readonly QueryKey[]): {
+  restore: () => void;
+} {
+  const entries = keys.map((key) => [key, qc.getQueryData(key)] as const);
+  return {
+    restore: () => {
+      for (const [key, value] of entries) {
+        if (value === undefined) {
+          qc.removeQueries({ queryKey: key, exact: true });
+        } else {
+          qc.setQueryData(key, value);
+        }
+      }
+    },
+  };
+}

--- a/packages/platform-ui/src/lib/query-client.ts
+++ b/packages/platform-ui/src/lib/query-client.ts
@@ -1,0 +1,26 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Project-wide defaults per ADR-0006 §3.
+ *
+ * Polling is OFF by default; per-hook opt-in via `refetchInterval` (or the
+ * four-tier `refetchInterval` matrix in §4). Mutations never auto-retry.
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchInterval: 0,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: true,
+        staleTime: 0,
+        gcTime: 5 * 60 * 1000,
+        retry: 2,
+        retryDelay: (n) => Math.min(1000 * 2 ** n, 8000),
+      },
+      mutations: {
+        retry: 0,
+      },
+    },
+  });
+}

--- a/packages/platform-ui/src/lib/query-keys.ts
+++ b/packages/platform-ui/src/lib/query-keys.ts
@@ -8,8 +8,9 @@ import type { HumanTaskStatus } from '@mediforce/platform-core';
  * every variant under the prefix. Plain values for top-level filters; object
  * literal at the tail when the filter set has multiple fields.
  *
- * PR1 adds the `tasks` domain. Future PRs extend with `runs`, `workflows`,
- * `agent-runs`, `cowork`, `audit`, `namespace`, `users`, `monitoring`.
+ * Currently covers the `tasks` domain. Future work extends with `runs`,
+ * `workflows`, `agent-runs`, `cowork`, `audit`, `namespace`, `users`,
+ * `monitoring`.
  */
 export const queryKeys = {
   tasks: {

--- a/packages/platform-ui/src/lib/query-keys.ts
+++ b/packages/platform-ui/src/lib/query-keys.ts
@@ -1,0 +1,31 @@
+import type { HumanTaskStatus } from '@mediforce/platform-core';
+
+/**
+ * Cache key factories per ADR-0006 §2.
+ *
+ * Convention: `[domain, scopeKey?, ...filters]` — string-prefix-first arrays
+ * so `qc.invalidateQueries({ queryKey: queryKeys.tasks.all() })` catches
+ * every variant under the prefix. Plain values for top-level filters; object
+ * literal at the tail when the filter set has multiple fields.
+ *
+ * PR1 adds the `tasks` domain. Future PRs extend with `runs`, `workflows`,
+ * `agent-runs`, `cowork`, `audit`, `namespace`, `users`, `monitoring`.
+ */
+export const queryKeys = {
+  tasks: {
+    /** Prefix matcher — `['tasks']` invalidates every list slice. */
+    all: () => ['tasks'] as const,
+    /** All tasks for a process instance, optionally narrowed by stepId. */
+    byInstance: (instanceId: string, filters?: { stepId?: string; status?: HumanTaskStatus[] }) =>
+      ['tasks', { instanceId, ...filters }] as const,
+    /** All tasks for a role, optionally narrowed by status. */
+    byRole: (role: string, filters?: { status?: HumanTaskStatus[] }) =>
+      ['tasks', { role, ...filters }] as const,
+  },
+  /**
+   * Single-task detail key. Lives under its own domain (`'task'` singular)
+   * so list-prefix invalidation of `['tasks']` does not clobber the detail
+   * cache — detail and list are different cache surfaces.
+   */
+  task: (taskId: string) => ['task', taskId] as const,
+} as const;

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -110,6 +110,7 @@ export function createRouteAdapter<
     } catch (err) {
       if (err instanceof HandlerError) return jsonErrorResponse(err);
       if (err instanceof z.ZodError) {
+        console.error('[route-adapter] handler ZodError:', err.issues);
         return jsonErrorResponse(new HandlerError('validation', 'Invalid input', err.issues));
       }
       console.error('[route-adapter] handler error:', err);

--- a/packages/platform-ui/src/test/react-query.tsx
+++ b/packages/platform-ui/src/test/react-query.tsx
@@ -11,7 +11,7 @@ export function createQueryWrapper(): {
   queryClient: QueryClient;
 } {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    defaultOptions: { queries: { retry: false } },
   });
   function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/packages/platform-ui/src/test/react-query.tsx
+++ b/packages/platform-ui/src/test/react-query.tsx
@@ -1,0 +1,20 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+/**
+ * Wraps `renderHook(...)` so the hook under test sees a fresh `QueryClient`.
+ * `retry: false` so a thrown query surfaces immediately instead of triggering
+ * the project default of `retry: 2`.
+ */
+export function createQueryWrapper(): {
+  wrapper: ({ children }: { children: ReactNode }) => JSX.Element;
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return { wrapper: Wrapper, queryClient };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,12 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-query':
+        specifier: ^5.100.11
+        version: 5.100.11(react@19.2.6)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.100.11
+        version: 5.100.11(@tanstack/react-query@5.100.11(react@19.2.6))(react@19.2.6)
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.2(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2147,6 +2153,23 @@ packages:
     resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
+  '@tanstack/query-core@5.100.11':
+    resolution: {integrity: sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==}
+
+  '@tanstack/query-devtools@5.100.11':
+    resolution: {integrity: sha512-47rVBDuGMW/A4ekt3YQdz+q0JSIwktwGnWCYyQUvSs2/g/Oa+6Fi2/IQk4/Y4vf6u1uwI7hOogHslgMC8f3X/Q==}
+
+  '@tanstack/react-query-devtools@5.100.11':
+    resolution: {integrity: sha512-75RFlJEG53Ed/Cxe5WLmgIpOElPNpgLZq7h0fLFnM5XwTYxSTk1rX/gC6MqGVXsSdrbP7zn7hPSJx9MinwiUHA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.100.11
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.100.11':
+    resolution: {integrity: sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5783,6 +5806,21 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
+
+  '@tanstack/query-core@5.100.11': {}
+
+  '@tanstack/query-devtools@5.100.11': {}
+
+  '@tanstack/react-query-devtools@5.100.11(@tanstack/react-query@5.100.11(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-devtools': 5.100.11
+      '@tanstack/react-query': 5.100.11(react@19.2.6)
+      react: 19.2.6
+
+  '@tanstack/react-query@5.100.11(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.11
+      react: 19.2.6
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

First implementation PR of [Phase 4 of the headless migration](docs/headless-migration-phase-4-plan.md) (PRD merged via #558). Tracer-bullet PR that establishes the react-query foundation per [ADR-0006](docs/adr/0006-client-side-server-state.md) and migrates the tasks domain end-to-end. PRs 2-5 mechanically adopt this pattern per their slice.

### Foundation (used by every subsequent PR — gets it right once)
- `@tanstack/react-query` v5 + `@tanstack/react-query-devtools` installed in `packages/platform-ui`.
- `lib/query-client.ts` — `createQueryClient()` with ADR-0006 §3 defaults (polling off, focus-refetch off, retry 2, mutations retry 0).
- `lib/query-keys.ts` — typed key factory matching ADR-0006 §2 (`[domain, scopeKey?, ...filters]`). PR1 adds the tasks domain; future PRs extend.
- `lib/optimistic.ts` — `snapshotCache(qc, keys)` primitive for the §6 state-transition rollback path.
- `components/providers.tsx` wires `<QueryClientProvider>` with a stable per-app `useState(() => createQueryClient())` instance + devtools gated on `NODE_ENV !== 'production'`.

### Tasks domain migration
- `use-instance-tasks.ts` — ported to `useQuery` (canonical 5-case test preserved, wrapped in fresh `QueryClient` per test).
- `use-task.ts` (new) — CRITICAL LIVE 1.5s polling, terminal-state gate (`completed` / `cancelled`).
- `use-tasks.ts` — new role-scoped `useMyActionableTasksByRole` / `useCompletedTasksByRole` hooks (STANDARD LIVE 5s). Firestore-backed `useMyTasks` / `useCompletedTasks` retained with `@deprecated PR3` markers (see PRD deviation below).
- `components/tasks/task-detail.tsx` — drops the Firestore `useCollection` lookup; uses `useMyActionableTasksByRole`.
- `components/tasks/claim-button.tsx` — `useMutation` + state-transition optimistic template (§6); consumes entity-echo via `setQueryData(['task', id], data.task)`; tag-prefix invalidates `['tasks']` on settle.
- `app/(app)/[handle]/tasks/[taskId]/page.tsx` — `onSnapshot(humanTasks/:id)` replaced with `useTask`.

### Contract + CLI
- `mediforce task list / get / claim` CLI subcommand (was missing; per AGENTS.md rule 3).
- Contract test extension for `ListTasksInputSchema` covering the `instanceId + stepId`, `role + stepId`, `instanceId + stepId + status` combinations Phase 4 consumers exercise.

### PRD deviations (documented in-line)
1. **No `stepId requires instanceId` refine.** Existing schema already permits `stepId` with either axis; no consumer in PR1-5 needs the constraint and `role + stepId` is a semantically valid cross-instance bottleneck view. PRD update folded into the contract test comment.
2. **`use-tasks.ts` Firestore-backed `useMyTasks`/`useCompletedTasks` retained** with `@deprecated PR3` markers. Their `role=null` callers (workspace home, workflow detail, runs list — all PR3 scope) need an "all tasks visible to me" axis on `mediforce.tasks.list` that's natural to land alongside the process pages in PR3, not here. The role-provided code path migrates today via the new `useMyActionableTasksByRole`.

### Out of scope (per PRD § PR sizing)
- Other domains: agent-runs/monitoring (PR2), processes (PR3), namespaces/auth/workspaces-new (PR4), cowork (PR5).
- `use-collection.ts` deletion — `next-step-card.tsx` still consumes it (PR3).
- `lib/firebase.ts` delete + uninstall — PR-final.

### Test scope
- 3× foundation smoke tests (query-client defaults, key factory, snapshotCache).
- 5-case hook tests for `useInstanceTasks`, 6-case for `useTask` (incl. terminal-state gating for both `completed` and `cancelled`), 5-case for `useMyActionableTasksByRole`/`useCompletedTasksByRole`.
- Optimistic mutation contract: snapshot patch, entity-echo replace, snapshot restore on error.
- CLI: list (role/instance/step/status filters + mutex validation), get, claim.
- Contract: schema permissiveness around `role + stepId`.
- Existing `api-integration.test.ts` (L3 cross-layer round-trips) and `api-boundaries.test.ts` still green untouched.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test` per affected package green.
- [x] `api-boundaries.test.ts` still passes (no forbidden handler imports introduced).
- [x] `api-integration.test.ts` (L3 list + claim round-trip) still green.
- [x] Self-review subagent verdict: SHIP.
- [ ] Smoke the dev server `pnpm dev:local`, claim a task, watch the task detail page poll down once status flips.

## References

- PRD: [docs/headless-migration-phase-4-plan.md](docs/headless-migration-phase-4-plan.md) § PR sizing PR1, § 3 endpoint inventory, § 6 optimistic playbook
- ADR: [docs/adr/0006-client-side-server-state.md](docs/adr/0006-client-side-server-state.md) §2 keys, §3 defaults, §4 cadence, §5 lifecycle, §6 templates
- Phase 4 gate for [PG PR2 (#534)](https://github.com/Appsilon/mediforce/pull/534)

🤖 Generated with [Claude Code](https://claude.com/claude-code)