### PR TITLE
fix(human-task): accept widget-hint StepParam.type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Fixed
+- `StepParamSchema.type` widened from a strict enum to `z.string().min(1).default('string')` so human-task GETs no longer 400 when the param uses a widget hint the UI already renders (e.g. `textarea`, `multiselect`). Non-string `type` still fails parsing — only the enum was the bug. Route adapter also `console.error`s handler ZodErrors so similar mismatches are debuggable from the server log.
+
 ### Changed
 - ADR-0005 Phase 2.5 — 18 endpoints (workflow-definition mutations, agents, secret read companions, processes archive/bulk) migrated to headless handlers; `actions/processes.ts` and `actions/definitions.ts` deleted. `transferWorkflow` now gates both source and target namespace, `deleteWorkflow` audit actor fixed, and archive / setDefault / register / copy / setVisibility now emit audit events.
 - ADR-0005 Phase 2.5 — workflow-secret value reveal + atomic bulk save migrated to headless handlers (`getWorkflowSecretsFull`, `saveWorkflowSecrets`) behind `GET`/`PUT /api/workflow-secrets/values`; `getWorkflowSecrets` / `saveWorkflowSecrets` Server Actions deleted; UI uses `mediforce.workflowSecrets.values()` / `.save()`; new audit actions `workflow_secret.values_revealed` and `workflow_secret.bulk_saved`.

--- a/docs/adr/0006-client-side-server-state.md
+++ b/docs/adr/0006-client-side-server-state.md
@@ -270,6 +270,37 @@ remains an opt-in per hook; nothing in this ADR commits the app to
 Suspense as the default loading-state mechanism. The two co-exist
 fine.
 
+#### 8a. Stop polling on persistent error (terminal errors)
+
+Some HTTP failures are *not* worth retrying — retrying just produces a
+tight loop that swamps the server and burns the user's tab.
+
+The hook-level rule: a `useQuery` whose `error` is a 4xx (other than
+explicit transient codes — none today) **must not be re-polled by
+`refetchInterval`**. `useTask` ([`packages/platform-ui/src/hooks/use-task.ts`](../../packages/platform-ui/src/hooks/use-task.ts))
+is the reference: `refetchInterval` returns `false` when `query.state.error`
+is set, distinguishing 404 (drop the row from the list) from any other
+4xx (surface inline, but stop hammering the endpoint). All Phase 4
+hooks that poll inherit this pattern. New hooks copy from `useTask`.
+
+Discovered the hard way: a `humanTasks/*` doc with a `params[i].type`
+outside the (then-strict) `StepParamSchema.type` enum returned a
+generic 400 from the route adapter, no server log, and React Query's
+default `refetchInterval` re-fired the failing GET every 2 s. The
+client-side fix (terminal-on-error) shipped in Phase 4 PR1; the
+schema fix shipped as [#562](https://github.com/Appsilon/mediforce/pull/562)
+(see plan §9).
+
+#### 8b. Route adapter logs handler ZodErrors
+
+[`packages/platform-ui/src/lib/route-adapter.ts`](../../packages/platform-ui/src/lib/route-adapter.ts)
+now `console.error`s any `ZodError` thrown from inside a handler
+(typically a repo-boundary `Schema.parse(snap.data())`). Before, the
+adapter mapped the error to a 400 envelope with no log line, so
+data/schema drift was invisible until a user opened the network tab.
+ADR-0005's error-envelope contract is unchanged; only the dev/prod
+log line is new.
+
 ## Considered alternatives
 
 - **SWR (vercel/swr).** Rejected. SWR covers polling + dedup + focus-refetch

--- a/docs/headless-migration-phase-4-plan.md
+++ b/docs/headless-migration-phase-4-plan.md
@@ -575,7 +575,9 @@ non-string corruption, accepts unknown widget hints).
 `StepParamSchema.type` and `TriggerInputFieldSchema.type` behind one
 shared widget-type constant. Bundling this with PR3 (processes/runs,
 which already touches step/trigger surface) keeps the merge sequence
-intact.
+intact. Tracked as [#563](https://github.com/Appsilon/mediforce/issues/563)
+with the proposed `PARAM_WIDGET_TYPES` const shape and an exhaustive-
+switch contract for the 6 current consumers.
 
 ## Testing decisions
 

--- a/docs/headless-migration-phase-4-plan.md
+++ b/docs/headless-migration-phase-4-plan.md
@@ -518,6 +518,65 @@ serialization — at most 2–3 PRs in parallel review.
 Once PR-final merges, PG PR2 ([#534](https://github.com/Appsilon/mediforce/pull/534))
 is unblocked.
 
+### 9. Read-path schema drift — discovered during PR1 smoke
+
+PR1 smoke surfaced a class of bug worth calling out before PRs 2–6:
+
+**The pattern.** A Firestore document satisfies the *write-time* Zod
+schema in force the day it was registered. The *read-time* schema
+later narrows (enum tightened, field made required, discriminator
+added). Now every read of that document throws `ZodError` at the repo
+boundary. The route adapter maps it to a 400 envelope; React Query
+re-polls because 400 is not a terminal status by default.
+Reference incident: `humanTasks/*` docs with `params[i].type = 'textarea'`
+( a widget hint the UI already renders) blew up `GET /api/tasks/:taskId`
+in a tight 400 loop once `StepParamSchema.type` was tightened to a
+strict enum. Fixed in [#562](https://github.com/Appsilon/mediforce/pull/562)
+by widening to `z.string().min(1).default('string')` (still rejects
+non-string corruption, accepts unknown widget hints).
+
+**Five rules for PRs 2–6.**
+
+1. **One vocabulary, one schema.** If two schemas claim to validate
+   the same field (today: `StepParamSchema.type` is strict 4-enum,
+   `TriggerInputFieldSchema.type` extends to 7 values incl.
+   `textarea`/`multiselect`) the registration path and the read path
+   *will* drift. Pick a single source of truth and re-export. The
+   widget-type vocabulary should land in one constant referenced
+   from both schemas (follow-up — out of scope for #562). Same rule
+   applies to any new shared vocabulary introduced in PRs 2–6.
+2. **Prefer open strings to enums at the storage boundary** for
+   anything that's a UI hint, plugin name, or extensibility point.
+   Enums are right when the *engine* branches on the value
+   (`executor: human|agent|script|cowork|action`); they are wrong
+   when the *UI* renders by the value (`type: textarea`) — the UI
+   already has a default branch, the schema doesn't need a wall.
+3. **Repo-boundary parsing must log.** `XSchema.parse(snap.data())`
+   throwing a `ZodError` is the single most common silent failure
+   mode in this codebase. Either log the path + doc id before
+   re-throwing, or `safeParse` and convert to a structured handler
+   error (`NotFoundError` if the doc is unrecoverable). PR1 added a
+   `console.error` in `route-adapter` for handler-thrown ZodErrors;
+   that is the *catch* — the *cause* still belongs at the repo.
+4. **Hooks must terminate on 4xx.** `useTask`'s `refetchInterval`
+   returns `false` on `query.state.error`. Copy this pattern into
+   every polling hook PRs 2–6 introduce — `useAgentRuns`,
+   `useProcessInstance`, `useMonitoring`. A 400 / 403 / 404 from the
+   server means the user's intent does not match server state; no
+   amount of retrying will reconcile that.
+5. **Add a repo-level "legacy shape" test** for any schema where you
+   intentionally accept old data. `step-param.test.ts` covers
+   canonical, widget-hint, default, and non-string-corruption cases.
+   When PR3 touches `humanTasks` repo or PR4 touches `users`, mirror
+   that pattern with a `__tests__/legacy-shape.test.ts` per schema
+   that has any data already in production.
+
+**Schema convergence — out of scope for PR1, queued for PR3.** Unify
+`StepParamSchema.type` and `TriggerInputFieldSchema.type` behind one
+shared widget-type constant. Bundling this with PR3 (processes/runs,
+which already touches step/trigger surface) keeps the merge sequence
+intact.
+
 ## Testing decisions
 
 Mediforce's test taxonomy from [`docs/headless-migration.md`](./headless-migration.md) §"Testing

--- a/packages/platform-core/src/schemas/__tests__/step-param.test.ts
+++ b/packages/platform-core/src/schemas/__tests__/step-param.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { StepParamSchema } from '../process-definition.js';
+
+describe('StepParamSchema.type', () => {
+  it.each(['string', 'number', 'boolean', 'date'])('accepts canonical data type %s', (type) => {
+    const parsed = StepParamSchema.parse({ name: 'p', type });
+    expect(parsed.type).toBe(type);
+  });
+
+  it.each(['textarea', 'multiselect'])('accepts widget hint %s', (type) => {
+    const parsed = StepParamSchema.parse({ name: 'p', type });
+    expect(parsed.type).toBe(type);
+  });
+
+  it('defaults to "string" when type is missing', () => {
+    const parsed = StepParamSchema.parse({ name: 'p' });
+    expect(parsed.type).toBe('string');
+  });
+
+  it('rejects empty string (min(1))', () => {
+    expect(() => StepParamSchema.parse({ name: 'p', type: '' })).toThrow();
+  });
+
+  it('passes through unknown future hint instead of throwing', () => {
+    const parsed = StepParamSchema.parse({ name: 'p', type: 'slider' });
+    expect(parsed.type).toBe('slider');
+  });
+
+  it('rejects non-string type — corruption surfaces loudly', () => {
+    expect(() => StepParamSchema.parse({ name: 'p', type: 42 })).toThrow();
+    expect(() => StepParamSchema.parse({ name: 'p', type: null })).toThrow();
+  });
+});

--- a/packages/platform-core/src/schemas/process-definition.ts
+++ b/packages/platform-core/src/schemas/process-definition.ts
@@ -14,7 +14,14 @@ export const StepUiSchema = z.object({
 
 export const StepParamSchema = z.object({
   name: z.string().min(1),
-  type: z.enum(['string', 'number', 'boolean', 'date']).default('string'),
+  // Data-or-widget hint consumed by `ParamField` to pick a form widget.
+  // `string|number|boolean|date` are canonical data types; `textarea`,
+  // `multiselect` are widget hints the UI already renders. Kept as an
+  // open string (not an enum) so legacy/future workflow definitions don't
+  // 400 when a task lands with a new hint — `ParamField` falls back to a
+  // text input for unknown values. Non-string `type` (genuine corruption)
+  // still fails parsing loudly.
+  type: z.string().min(1).default('string'),
   required: z.boolean().default(false),
   description: z.string().optional(),
   default: z.unknown().optional(),

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -110,6 +110,7 @@ export function createRouteAdapter<
     } catch (err) {
       if (err instanceof HandlerError) return jsonErrorResponse(err);
       if (err instanceof z.ZodError) {
+        console.error('[route-adapter] handler ZodError:', err.issues);
         return jsonErrorResponse(new HandlerError('validation', 'Invalid input', err.issues));
       }
       console.error('[route-adapter] handler error:', err);


### PR DESCRIPTION
## Summary
- `GET /api/tasks/:taskId` returned 400 in a tight loop for tasks whose `params[i].type` was a widget hint outside the legacy `string|number|boolean|date` enum (real repro: `gather-perspective` v3, `type: "textarea"` — surfaced during Phase 4 PR1 smoke).
- The UI's `ParamField` already renders `textarea` and `multiselect`; only `StepParamSchema` was still strict, so reads of valid documents kept throwing `ZodError` (caught by the route adapter and mapped to a generic 400, with no server log).
- Fix: widen `StepParamSchema.type` to `z.string().min(1).default('string')`. Non-string `type` (real corruption) still fails parsing loudly — only the over-tight enum was the bug.
- Route adapter now `console.error`s any `ZodError` it catches from a handler, so future schema/data mismatches are debuggable from the dev/prod log instead of silent.

## Doc updates (lessons for Phase 4 PRs 2–6)
- **ADR-0006 §8a** — every polling hook must terminate on persistent error (`refetchInterval: false` when `query.state.error` set). Reference: `useTask`.
- **ADR-0006 §8b** — route adapter logs handler-thrown ZodErrors.
- **Phase 4 plan §9** — five rules for read-path schema drift: one vocabulary, prefer open strings to enums at storage boundaries for UI hints, repo-boundary parsing must log, hooks must terminate on 4xx, add a legacy-shape test per schema with prod data. Queued PR3 follow-up: converge `StepParamSchema.type` + `TriggerInputFieldSchema.type` behind a shared widget-type constant.

## Test plan
- [x] New `packages/platform-core/src/schemas/__tests__/step-param.test.ts` (9 cases: canonical types, widget hints, default, `min(1)` reject, unknown-future-hint passthrough, non-string corruption reject)
- [x] `pnpm vitest run packages/platform-core packages/workflow-engine` — 804 pass / 8 skip
- [x] `pnpm vitest run packages/platform-api packages/platform-infra` — 580 pass
- [x] `pnpm vitest run packages/platform-ui/src/test/integration/api-boundaries.test.ts` — 12 pass
- [x] `pnpm typecheck` — clean
- [x] Manual smoke (dev → staging Firebase): `curl -H "X-Api-Key: …" /api/tasks/f41a2c2c-…` returns 200 with `type: "textarea"` preserved (was 400 before)