### PR TITLE
chore(skills): self-review v4 — concrete spawn command, two-section report

### DIFF
--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -3,7 +3,7 @@ name: self-review
 description: Final check on your own changes before reporting a task done, opening a PR, or asking for review. Spawns a subagent that runs `/code-review` on the current branch — clean context, no "I just wrote this, it must be good" bias. Returns SHIP / ITERATE verdict. Triggers include "self review", "review my changes", "check my diff", "ready to commit", "ready for PR", "I'm done", "before I ship".
 allowed-tools: Agent
 metadata:
-  version: "3.0"
+  version: "4.0"
   domain: development
   complexity: intermediate
   tags: review, quality, pre-pr
@@ -11,4 +11,27 @@ metadata:
 
 # Self-Review
 
-Spawn a subagent (general-purpose) and tell it to run `/code-review` on the current branch — fresh context reviews honestly.
+## Step 1 — spawn the reviewer
+
+Run this exact `Agent` call. `run_in_background: true` is non-negotiable — foreground blocks the harness.
+
+```
+Agent({
+  subagent_type: "general-purpose",
+  description: "Self-review current branch",
+  run_in_background: true,
+  prompt: "Run /code-review on the current branch. Return the full review verbatim plus a one-line SHIP or ITERATE verdict at the end."
+})
+```
+
+While it runs, do not poll — you will be notified on completion.
+
+## Step 2 — report back to the user
+
+When the subagent returns, your reply MUST have two sections:
+
+**What the reviewer said** — paste the subagent's findings verbatim (or a faithful summary if very long). Do not silently drop items you disagree with.
+
+**My recommendations** — for each finding, state: address / defer / ignore, with a one-line reason. End with your own SHIP / ITERATE call.
+
+The user decides what to act on. Your job is to surface everything the reviewer raised, then advise.


### PR DESCRIPTION
## Summary

- Replace abstract 'background required' guideline with exact `Agent({...})` invocation including `run_in_background: true`. Main thread sometimes ignored the requirement; concrete command leaves less room.
- Require two-section reply when reviewer returns: findings verbatim + own per-finding recommendations (address/defer/ignore) with a final SHIP/ITERATE call. Stops silent dropping of comments the main thread disagrees with — user sees everything and decides.
- Bump version 3.0 → 4.0.

## Why

Two recurring problems with current self-review:
1. Spawning agent foreground blocks harness — happened despite the rule.
2. Main thread filtered reviewer output to only what it agreed with — user loses signal.

## Test plan

- [ ] Trigger `/self-review` on a real diff and verify main thread uses background spawn
- [ ] Verify reply contains both sections (reviewer verbatim + recommendations)