### PR TITLE
fix(adr-0001): unbreak Firestore-default standalone boot

### DIFF
--- a/packages/platform-infra/scripts/migrate.mjs
+++ b/packages/platform-infra/scripts/migrate.mjs
@@ -12,10 +12,13 @@
 // (non-zero exit) on any migration failure — fail-stop is the right
 // posture: an app boot against a half-migrated schema is worse than
 // "container failed to start".
+//
+// Static imports are limited to node: builtins so this script can be
+// loaded by the Next.js standalone runner even when `postgres` /
+// `drizzle-orm` are not in the standalone bundle. The flag check then
+// either exits 0 (Firestore mode) or dynamically imports the
+// driver-only-needed packages.
 
-import postgres from 'postgres';
-import { drizzle } from 'drizzle-orm/postgres-js';
-import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -29,6 +32,10 @@ if (typeof url !== 'string' || url.length === 0) {
   console.error('[migrate-postgres] STORAGE_BACKEND=postgres requires DATABASE_URL.');
   process.exit(1);
 }
+
+const { default: postgres } = await import('postgres');
+const { drizzle } = await import('drizzle-orm/postgres-js');
+const { migrate } = await import('drizzle-orm/postgres-js/migrator');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Script lives at packages/platform-infra/scripts/migrate.mjs; the

--- a/packages/platform-ui/next.config.mjs
+++ b/packages/platform-ui/next.config.mjs
@@ -8,7 +8,28 @@ const isVercel = process.env.VERCEL === '1';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  ...(isVercel ? {} : { output: 'standalone', outputFileTracingRoot: path.resolve(__dirname, '../..') }),
+  ...(isVercel
+    ? {}
+    : {
+        output: 'standalone',
+        outputFileTracingRoot: path.resolve(__dirname, '../..'),
+        // ADR-0001 — force `postgres` + `drizzle-orm` into the standalone
+        // bundle. Without this, Next.js may prune them: the postgres branch
+        // in platform-services.ts is gated by a runtime `process.env` check,
+        // which the tracer can fail to follow. migrate.mjs (executed by the
+        // Dockerfile CMD before server.js) needs these resolvable from
+        // /app/packages/platform-infra/scripts/migrate.mjs. Multiple paths
+        // listed because pnpm's monorepo layout symlinks deps in several
+        // places; nonexistent globs are silently ignored.
+        outputFileTracingIncludes: {
+          '*': [
+            '../../node_modules/postgres/**/*',
+            '../../node_modules/drizzle-orm/**/*',
+            '../platform-infra/node_modules/postgres/**/*',
+            '../platform-infra/node_modules/drizzle-orm/**/*',
+          ],
+        },
+      }),
   ...(process.env.NEXT_DIST_DIR ? { distDir: process.env.NEXT_DIST_DIR } : {}),
   // Trust loopback hostnames for HMR. Browsers that hit the dev server via
   // `127.0.0.1` (e.g. after a CLI command prints that form) otherwise fail


### PR DESCRIPTION
## Why

Staging deploy after PR #515 merged crash-loops `mediforce-platform-ui-1`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'postgres' imported from /app/packages/platform-infra/scripts/migrate.mjs
```

Dockerfile CMD: `node packages/platform-infra/scripts/migrate.mjs && node packages/platform-ui/server.js`. STORAGE_BACKEND is unset on staging (Firestore default — the safety invariant). `migrate.mjs` had `import postgres from 'postgres'` at the top; ESM resolves imports *before* the `STORAGE_BACKEND !== 'postgres' → exit 0` guard runs. The Next.js standalone bundle does not include `postgres` because the postgres branch in `platform-services.ts` is gated by a runtime `process.env` check the tracer can fail to follow.

## What

Two small fixes:

1. **`packages/platform-infra/scripts/migrate.mjs`** — move the `STORAGE_BACKEND` + `DATABASE_URL` guards above the driver imports, and switch `postgres` / `drizzle-orm/postgres-js` / `drizzle-orm/postgres-js/migrator` to dynamic `await import()` inside the guard. Firestore-default boots exit 0 without ever touching the missing packages.

2. **`packages/platform-ui/next.config.mjs`** — add `outputFileTracingIncludes` for `postgres` + `drizzle-orm` (multiple candidate paths in pnpm symlink layout, nonexistent globs are silently ignored). This is for the future flip to `STORAGE_BACKEND=postgres` on staging — without it, `migrate.mjs` would crash the same way once the flag is set, just with the guard passing through to the dynamic import.

## Verification

- [ ] CI typecheck / unit / postgres-tests / e2e-tests / e2e-tests-postgres green
- [ ] After merge + deploy: `ssh mediforce-staging 'docker compose logs platform-ui | tail -20'` shows `[migrate-postgres] STORAGE_BACKEND != postgres — skipping migrations.` and platform-ui boots `Up (healthy)`
- [ ] `docker compose ps` shows no restart loop

## Out of scope

- Validating the postgres-flip path against the real standalone build. CI's `e2e-tests-postgres` job uses `pnpm db:migrate` against the workspace dev tree (where `postgres` is in `node_modules`), not the standalone bundle. (B) above is a best-effort defensive measure; full validation will happen during the actual cutover (ADR-0001 Phase C).