### PR TITLE
feat(platform-ui): show git branch next to SHA in sidebar on dev

### DIFF
--- a/packages/platform-ui/package.json
+++ b/packages/platform-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack -p 9003",
+    "dev": "NEXT_PUBLIC_GIT_SHA=$(git rev-parse --short HEAD) NEXT_PUBLIC_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) next dev --webpack -p 9003",
     "dev:mock": "python3 scripts/dev-mock.py",
     "build": "rm -rf .next && next build --webpack",
     "build:e2e": "NEXT_PUBLIC_USE_EMULATORS=true NEXT_PUBLIC_FIREBASE_PROJECT_ID=demo-mediforce NEXT_PUBLIC_APP_URL=http://localhost:9007 next build --webpack",

--- a/packages/platform-ui/src/components/app-shell.tsx
+++ b/packages/platform-ui/src/components/app-shell.tsx
@@ -317,11 +317,14 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         />
       </nav>
 
-      {/* Bottom — git SHA only */}
+      {/* Bottom — git SHA + optional branch */}
       {process.env.NEXT_PUBLIC_GIT_SHA && (
         <div className="border-t px-4 py-2">
           <span className="font-mono text-[10px] text-muted-foreground">
             {process.env.NEXT_PUBLIC_GIT_SHA}
+            {process.env.NEXT_PUBLIC_GIT_BRANCH && (
+              <span> · {process.env.NEXT_PUBLIC_GIT_BRANCH}</span>
+            )}
           </span>
         </div>
       )}


### PR DESCRIPTION
## What

Sidebar footer already renders `NEXT_PUBLIC_GIT_SHA` when set (visible on staging/prod via deploy scripts). This adds the branch next to it when `NEXT_PUBLIC_GIT_BRANCH` is set — and wires the platform-ui `dev` script to export both, so `pnpm dev` shows e.g. `abc1234 · main` in the bottom-left.

## Why

When juggling local branches it's useful to see at a glance which one the running dev server is on. Staging/prod stay SHA-only (branch unset there, no point — always `main`).

## Notes

- Single source of truth: exports live in [packages/platform-ui/package.json](packages/platform-ui/package.json) `dev`, inherited by all root `dev*` variants (they all `--filter` into it).
- `NEXT_PUBLIC_*` is inlined at dev-server start → branch switch needs a restart.
- Deploy scripts / Dockerfile / compose untouched.

## Test plan

- [ ] `pnpm dev` → sidebar shows `<sha> · <branch>`
- [ ] Staging/prod sidebar still shows SHA only