### PR TITLE
fix(e2e): clean up cron workflow definition after heartbeat test

### DIFF
--- a/packages/platform-ui/e2e/api/cron-heartbeat.journey.ts
+++ b/packages/platform-ui/e2e/api/cron-heartbeat.journey.ts
@@ -11,6 +11,24 @@ import { TEST_ORG_HANDLE } from '../helpers/constants';
  */
 
 const API_KEY = process.env.PLATFORM_API_KEY ?? 'test-api-key';
+const AUTH_HEADERS = { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' };
+
+async function deleteWorkflowDefinition(
+  request: { delete: (url: string, opts?: object) => Promise<{ ok: boolean }>, get: (url: string, opts?: object) => Promise<{ ok: boolean, json: () => Promise<unknown> }> },
+  name: string,
+): Promise<void> {
+  const countRes = await request.get(
+    `/api/workflow-definitions/${encodeURIComponent(name)}/run-count?namespace=${TEST_ORG_HANDLE}`,
+    { headers: AUTH_HEADERS },
+  );
+  const expectedRunCount = countRes.ok
+    ? ((await countRes.json()) as { count: number }).count
+    : 0;
+  await request.delete(
+    `/api/workflow-definitions/${encodeURIComponent(name)}?namespace=${TEST_ORG_HANDLE}`,
+    { headers: AUTH_HEADERS, data: { expectedRunCount } },
+  );
+}
 
 test.describe('POST /api/cron/heartbeat — API E2E', () => {
   test('requires X-Api-Key (middleware 401)', async ({ request }) => {
@@ -48,32 +66,36 @@ test.describe('POST /api/cron/heartbeat — API E2E', () => {
     const createWdRes = await request.post(
       `/api/workflow-definitions?namespace=${TEST_ORG_HANDLE}`,
       {
-        headers: { 'X-Api-Key': API_KEY, 'Content-Type': 'application/json' },
+        headers: AUTH_HEADERS,
         data: cronWd,
       },
     );
     expect(createWdRes.status()).toBe(201);
 
-    // Prime trigger state — first heartbeat may fire or skip depending on
-    // isDue() semantics vs def.createdAt. We don't assert on the first
-    // result; the invariant under test is the second back-to-back call.
-    await request.post('/api/cron/heartbeat', {
-      headers: { 'X-Api-Key': API_KEY },
-    });
+    try {
+      // Prime trigger state — first heartbeat may fire or skip depending on
+      // isDue() semantics vs def.createdAt. We don't assert on the first
+      // result; the invariant under test is the second back-to-back call.
+      await request.post('/api/cron/heartbeat', {
+        headers: { 'X-Api-Key': API_KEY },
+      });
 
-    const second = await request.post('/api/cron/heartbeat', {
-      headers: { 'X-Api-Key': API_KEY },
-    });
-    expect(second.status()).toBe(200);
-    const body = (await second.json()) as {
-      triggered: Array<{ definitionName: string }>;
-      skipped: Array<{ definitionName: string; triggerName: string; reason: string }>;
-    };
-    const ourSkip = body.skipped.find(
-      (s) => s.definitionName === wdName && s.triggerName === 'every-15m',
-    );
-    expect(ourSkip?.reason).toBe('Not due');
-    const ourFire = body.triggered.find((t) => t.definitionName === wdName);
-    expect(ourFire).toBeUndefined();
+      const second = await request.post('/api/cron/heartbeat', {
+        headers: { 'X-Api-Key': API_KEY },
+      });
+      expect(second.status()).toBe(200);
+      const body = (await second.json()) as {
+        triggered: Array<{ definitionName: string }>;
+        skipped: Array<{ definitionName: string; triggerName: string; reason: string }>;
+      };
+      const ourSkip = body.skipped.find(
+        (s) => s.definitionName === wdName && s.triggerName === 'every-15m',
+      );
+      expect(ourSkip?.reason).toBe('Not due');
+      const ourFire = body.triggered.find((t) => t.definitionName === wdName);
+      expect(ourFire).toBeUndefined();
+    } finally {
+      await deleteWorkflowDefinition(request, wdName);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- The cron-heartbeat E2E test created a workflow definition with a `*/15 * * * *` cron trigger but never deleted it after the test
- When accidentally run against staging, the orphaned definition fired every 15 minutes — 242 runs, ~484 zombie "Action needed: Noop" tasks flooding the task list
- Wraps the test body in `try/finally` that soft-deletes the definition via `DELETE /api/workflow-definitions/:name`, ensuring cleanup even when assertions fail

**Also done (not in this PR):** deleted 3 orphaned E2E workflow definitions from staging via CLI (`e2e-p3-cron-1779828356`: 242 runs, `e2e-p3-verdict-1779828284`: 1 run, `e2e-docker-agent-log`: 1 run).

## Test plan
- [ ] Run cron-heartbeat E2E test with emulators — verify test passes and no orphaned workflow definition remains after
- [ ] Verify staging task list no longer shows Noop spam after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)