### PR TITLE
fix(cron): skip soft-deleted definitions in heartbeat handler

### DIFF
--- a/packages/platform-api/src/handlers/cron/heartbeat.ts
+++ b/packages/platform-api/src/handlers/cron/heartbeat.ts
@@ -55,6 +55,7 @@ export async function heartbeat(
   const cronDefinitions = definitionGroups
     .map((group) => group.versions.find((v) => v.version === group.latestVersion))
     .filter((def): def is WorkflowDefinition => def !== undefined)
+    .filter((def) => !def.deleted)
     .filter((def) => def.triggers.some((t: Trigger) => t.type === 'cron'));
 
   for (const def of cronDefinitions) {


### PR DESCRIPTION
## Summary
- Heartbeat handler scanned all workflow definitions with cron triggers but never checked the `deleted` flag
- Soft-deleted definitions kept firing on schedule, creating zombie process instances and tasks
- One-line fix: add `.filter((def) => !def.deleted)` to the definition scan chain

Follow-up to #598 — that PR added E2E test cleanup but this bug (heartbeat ignoring soft-delete) was merged after the PR was already closed.

## Test plan
- [ ] Deploy to staging — verify no new Noop tasks appear after next heartbeat cycle (15 min)
- [ ] Soft-delete a workflow with a cron trigger, call heartbeat, confirm it's in `skipped` not `triggered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)