### PR TITLE
fix(adr-0001): derive migrate stage from deps, not builder — unbreak staging deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Fixed
+- Staging deploy broke after [#572](https://github.com/Appsilon/mediforce/pull/572): the `migrate` init-container stage derived `FROM builder`, so its arg-less build re-ran `next build` whose `/workspaces/new` prerender failed with `auth/invalid-api-key` (Firebase build args reach only the `platform-ui` service). Migrate stage now derives from `deps` + source, skipping the Next build entirely.
 - Flaky `forced-password-change.journey.ts` ([#578](https://github.com/Appsilon/mediforce/pull/578)) — `updatePassword` revokes the session's ID token, so the forced-reset flow now re-authenticates and `clearMustChangePassword` retries on a revoked-token 401 (forcing a token refresh) before clearing the gate, instead of letting the stale-token 401 fail the gate closed and bounce the user back to `/change-password`.
 - `useProcessNameMap` now scopes its `runs.list` poll to the active workspace handle (`namespace: handle`) instead of fetching across every visible workspace every 5 s — a cross-workspace data-scope leak.
 - `useAgentEvents` polls incrementally via a new `afterSequence` cursor on `processes.agentEvents` instead of re-reading the entire `agentEvents` subcollection every 1.5 s — the Phase-4 cutover lost `onSnapshot` deltas and turned a chatty open run into ~20k Firestore reads/min.

--- a/packages/platform-ui/Dockerfile
+++ b/packages/platform-ui/Dockerfile
@@ -56,10 +56,17 @@ RUN pnpm --filter @mediforce/platform-ui build
 # inside the CMD so the service still exits 0 in Firestore mode and the
 # init-container gate fires.
 #
-# Derived from `builder` (not `deps`) because the builder already has the
-# full workspace + devDeps including `drizzle-kit` installed. The image
-# is short-lived; size is not a concern.
-FROM builder AS migrate
+# Derived from `deps` + source rather than `builder`: the migration container
+# needs only the workspace, devDeps (`drizzle-kit`), and migration files — not
+# the Next.js build. Deriving from `builder` would force the arg-less `migrate`
+# service build to run `pnpm build`, whose `/workspaces/new` prerender
+# initializes the Firebase client and fails with `auth/invalid-api-key` because
+# the `NEXT_PUBLIC_FIREBASE_*` build args are only passed to the `platform-ui`
+# service. The image is short-lived; size is not a concern.
+FROM base AS migrate
+WORKDIR /app
+COPY --from=deps /app ./
+COPY . .
 WORKDIR /app/packages/platform-infra
 CMD ["sh", "-c", "if [ \"$STORAGE_BACKEND\" != \"postgres\" ]; then echo '[migrate] STORAGE_BACKEND != postgres — skipping.'; exit 0; fi; pnpm exec drizzle-kit migrate"]
 


### PR DESCRIPTION
## Why

#572 broke the staging deploy. The new `migrate` init-container stage derived `FROM builder`. Building the `migrate` compose service (which passes **no** `NEXT_PUBLIC_FIREBASE_*` build args — those go only to the `platform-ui` service) forced Docker to build the `builder` stage, re-running `pnpm --filter @mediforce/platform-ui build`. The `/workspaces/new` prerender initializes the Firebase client at build time, so with an empty API key it failed:

```
Error [FirebaseError]: Firebase: Error (auth/invalid-api-key).
Export encountered an error on /(app)/workspaces/new/page: /workspaces/new, exiting the build.
 > [migrate builder 4/4] RUN pnpm --filter @mediforce/platform-ui build
```

Staging stayed on the pre-#572 image (`aa6c3ba8`). All prior `Deploy to Staging` runs were green; `a10378a1` (#572) was the first failure.

`e2e-tests-postgres` passed because it doesn't build the `migrate` service the arg-less way staging does — that's the CI gap that let #572 through.

## What

`migrate` stage now derives `FROM base` + `COPY --from=deps` + `COPY . .` instead of `FROM builder`. The migration container needs only the workspace, devDeps (`drizzle-kit`), and migration files — **not** the Next.js build. No prerender → no Firebase args needed.

## Test plan

Validated locally (Docker buildx):
- [x] `docker buildx build --target migrate` with **no** Firebase args → **exit 0** (this is the exact mode that failed on staging).
- [x] Firestore mode (`STORAGE_BACKEND=firestore`) → `[migrate] STORAGE_BACKEND != postgres — skipping.` exit 0 — init-container gate still fires.
- [x] `drizzle-kit v0.31.10` + `drizzle-orm v0.45.2` resolve inside the image → postgres-mode `drizzle-kit migrate` will run.

Refs: #572, #570, #515