### PR TITLE
chore: post-#534 cleanups — generic test namespace + ADR-0004 read-side wording

### DIFF
--- a/docs/adr/0004-scoped-data-access-authorization.md
+++ b/docs/adr/0004-scoped-data-access-authorization.md
@@ -60,10 +60,14 @@ visible to handlers.
    handler sees.
 2. **`Authorized<Entity>Repository` wrappers.** Each wraps the matching raw
    repository from `@mediforce/platform-core`'s interfaces and enforces, on
-   every read and write:
+   every **read**:
    (a) workspace membership (caller's reachable workspaces intersect the
    entity's workspace),
    (b) `WorkflowDefinition` visibility filtering (`public` vs `private`).
+   The wrappers expose read methods only — writes are not wrapper-mediated;
+   they call the raw repositories and are authorized at the handler layer.
+   This scoping is therefore read-side, so a write that bypasses its handler
+   check (e.g. a cascade matched by name) is not caught here.
 
    Soft-delete / archived filtering is **not** a wrapper concern. Each raw
    repository decides per-method whether tombstoned rows are excluded; the

--- a/packages/platform-ui/src/app/api/agents/[id]/mcp-servers/[name]/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/agents/[id]/mcp-servers/[name]/__tests__/route.test.ts
@@ -64,7 +64,7 @@ const coworkAgent = {
   outputDescription: '',
   skillFileNames: [],
   // Namespace owns the FK-valid workspace the binding audit event attributes to.
-  namespace: 'appsilon',
+  namespace: 'acme',
   mcpServers: {
     existing: { type: 'stdio' as const, catalogId: 'existing-mcp' },
   },


### PR DESCRIPTION
Two small follow-ups that landed on the #534 branch **after** it was squash-merged, so they didn't make the merge:

1. **`test:` generic namespace.** `agents/[id]/mcp-servers/[name]/route.test.ts` used a real org name (`appsilon`) as the seeded namespace fixture introduced for the RC2 audit-workspace fix. Switched to a generic `acme` (matching `api-integration.test.ts`'s convention). Test-only; assertions unchanged (route test 12/12 green). The pre-existing `appsilon` fixture in `mcp-integration.test.ts` is left as-is (not introduced here).
2. **`docs(adr-0004):` accuracy.** ADR-0004 claimed the `Authorized<Entity>Repository` wrappers enforce scoping on "every read **and write**", but the wrappers expose **read methods only** — writes call the raw repos and are authorized at the handler layer. Corrected to read-side, noting the gap (a write bypassing its handler check, e.g. a cascade matched by name — [#553](https://github.com/Appsilon/mediforce/issues/553) — is not caught here).

No behavior change. Branch off current `main` (post-#534).