### PR TITLE
chore(renovate): ignore one-off Firestore migration script deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "config:recommended"
   ],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "ignorePaths": [
+    "scripts/migrate-firestore-to-postgres/requirements.txt"
+  ]
 }


### PR DESCRIPTION
Renovate keeps raising bumps for the deps pinned by the completed
\`scripts/migrate-firestore-to-postgres\` cutover script (firebase-admin,
psycopg2-binary, google-cloud-firestore). ADR-0001 shipped (#534); these
are deliberately pinned one-off tool deps. A major firebase-admin v7 (#632)
could break the cutover script for no benefit.

Adds \`ignorePaths\` for that requirements file. Lets us close #628 and #632.