### PR TITLE
fix(deps): regenerate lockfile for @hono/node-server 2.0.4 override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   axios: '>=1.15.0'
   protobufjs: 8.4.2
   hono: 4.12.21
-  '@hono/node-server': 2.0.3
+  '@hono/node-server': 2.0.4
   fast-xml-parser: 5.8.0
   node-forge: 1.4.0
   follow-redirects: 1.16.0
@@ -1414,8 +1414,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@2.0.3':
-    resolution: {integrity: sha512-a0jV+/HRe3G5zjFID3zObAQFdkl6zpxTuqktdDDXS3MJKcrZIkB8OkLpNBlY/WXFqv2HF4a0takPej+aNFczWA==}
+  '@hono/node-server@2.0.4':
+    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: 4.12.21
@@ -5519,7 +5519,7 @@ snapshots:
       yargs: 17.7.2
     optional: true
 
-  '@hono/node-server@2.0.3(hono@4.12.21)':
+  '@hono/node-server@2.0.4(hono@4.12.21)':
     dependencies:
       hono: 4.12.21
 
@@ -5681,7 +5681,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.3(hono@4.12.21)
+      '@hono/node-server': 2.0.4(hono@4.12.21)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5


### PR DESCRIPTION
#631 bumped the `pnpm.overrides` pin of `@hono/node-server` to `2.0.4` in `package.json` but left `pnpm-lock.yaml` resolving `2.0.3`. As a result `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, turning CI red on every PR.

This regenerates only `pnpm-lock.yaml` (via `pnpm install --lockfile-only`) so it matches the override. The only change is `@hono/node-server` 2.0.3 -> 2.0.4 (version, integrity hash, and its single consumer). `pnpm install --frozen-lockfile` now succeeds.