### PR TITLE
fix(workspace-selection): explicit error view + dev-infra preflight + Compose docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Changed
+- `pnpm dev` / `pnpm dev:queue` now preflight infra via `scripts/dev-infra.py`: it checks Docker is installed, the daemon is running, and the Compose v2 plugin exists, then brings up Postgres (and Redis) with `--wait` so the DB is healthy before migrations run. Missing prerequisites now stop with an actionable message (e.g. `sudo apt install docker-compose-v2`) instead of silently booting the app against a non-existent database and surfacing `ECONNREFUSED 127.0.0.1:5432` mid-request. Prerequisites + troubleshooting documented in GETTING-STARTED.md / dev-quickref.
 - Removed redundant `dev:postgres` script (use `pnpm dev`); `dev:no-docker` now sets `DATABASE_URL` so it boots post-#534; doc cleanup (ADR-0001 Accepted, `STORAGE_BACKEND` refs scrubbed, headless-migration docs marked Completed).
 
 ### Fixed
+- Workspace-selection page no longer renders a blank picker when `/api/users/me` fails — `useAllUserNamespaces` surfaces `isError`/`error` and the page shows an explicit error (with a Try-again) for an errored or empty bundle, redirects straight through for a single workspace, and only shows the picker for two or more. Previously a 500 was swallowed into an empty namespace list and rendered as "Choose a workspace" with no cards.
 - Forced password-change, workspace bio/profile edits, agent MCP-binding writes, and namespace member/delete mutations no longer 500 — their audit events now carry an FK-valid `workspace` (the acting/affected namespace) instead of throwing against the Postgres NOT NULL column; `namespace.deleted` emits before the cascade and is anchored to the owner's surviving personal namespace. [#534](https://github.com/Appsilon/mediforce/pull/534)
 - Cutover script maps agent-run `duration_ms` + token counts from the correct envelope keys (`duration_ms`, `tokenUsage.{inputTokens,outputTokens}`), so migrated runs keep their duration/token data. [#534](https://github.com/Appsilon/mediforce/pull/534)
 - Run History / `mediforce agent-run list` no longer 400 on null-envelope runs stored as `'{}'` instead of SQL NULL (read tolerates it, write stores NULL, migration `0015` backfills). [#534](https://github.com/Appsilon/mediforce/pull/534)

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -10,7 +10,10 @@ Agents / quick lookups: see [docs/dev-quickref.md](docs/dev-quickref.md).
 
 - **Node.js** 20+
 - **pnpm** 10+ (`corepack enable && corepack prepare pnpm@latest --activate`)
-- **Docker** (Docker Desktop or engine) — for the Postgres data layer and Docker agents
+- **Docker + Docker Compose v2** — for the Postgres data layer and Docker agents.
+  Docker Desktop (macOS/Windows) bundles Compose. On a Linux engine-only install
+  (Ubuntu's `docker.io`) Compose is a separate package — install both:
+  `sudo apt install docker.io docker-compose-v2`. Verify with `docker compose version`.
 - **Firebase service account** — only for cloud Auth/Storage (the optional path below).
   **Not** needed for data: all server data lives in Postgres (ADR-0001).
 
@@ -353,6 +356,19 @@ Or run on another port: `PORT=9999 pnpm dev`.
 ### `docker compose` hangs / Postgres won't start
 
 Docker isn't running — start Docker Desktop (or the engine), then retry.
+
+### `pnpm dev` exits with "Docker Compose v2 is not installed"
+
+`docker compose version` fails because the engine-only `docker.io` package ships
+without Compose. Install it:
+
+```bash
+sudo apt install docker-compose-v2   # Ubuntu / Debian
+```
+
+Docker Desktop (macOS/Windows) already includes Compose — make sure it's running
+and up to date. `pnpm dev` now preflight-checks this and stops with an
+actionable message instead of booting against a missing database.
 
 ### Migration error / `relation "..." does not exist`
 

--- a/docs/dev-quickref.md
+++ b/docs/dev-quickref.md
@@ -81,5 +81,6 @@ Branch-collision rename rule: [postgres-local-dev.md](postgres-local-dev.md).
 | `DATABASE_URL is required` FATAL at boot | Non-mock mode without a DB — run `pnpm dev`, or set `DATABASE_URL`. |
 | Port 9003 in use                         | `lsof -ti:9003 \| xargs kill -9` or `PORT=9999 pnpm dev`.        |
 | `docker compose` hangs                   | Docker Desktop isn't running — start it.                         |
+| `pnpm dev`: "Docker Compose v2 is not installed" | Engine-only `docker.io` lacks Compose — `sudo apt install docker-compose-v2` (Ubuntu); Docker Desktop bundles it. |
 | `relation "..." does not exist`          | `pnpm db:migrate`.                                               |
 | Stale / corrupt local data               | `docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v && pnpm dev` (wipes the pg volume). |

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "build": "pnpm -r run build",
     "typecheck": "tsc -b --noEmit",
-    "dev": "pnpm install --prefer-offline --silent && docker compose -f docker-compose.yml -f docker-compose.dev.yml up postgres -d && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce pnpm db:migrate && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce pnpm --filter @mediforce/platform-ui dev",
+    "dev": "pnpm install --prefer-offline --silent && python3 scripts/dev-infra.py && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce pnpm db:migrate && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce pnpm --filter @mediforce/platform-ui dev",
     "dev:mock": "pnpm install --prefer-offline --silent && pnpm --filter @mediforce/platform-ui dev:mock",
     "dev:no-docker": "pnpm install --prefer-offline --silent && DATABASE_URL=\"${DATABASE_URL:-postgresql://mediforce:mediforce@localhost:5432/mediforce}\" ALLOW_LOCAL_AGENTS=true pnpm --filter @mediforce/platform-ui dev",
-    "dev:queue": "pnpm install --prefer-offline --silent && docker compose -f docker-compose.yml -f docker-compose.dev.yml up postgres redis -d && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce pnpm db:migrate && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce REDIS_URL=redis://localhost:6379 pnpm --filter @mediforce/platform-ui dev",
+    "dev:queue": "pnpm install --prefer-offline --silent && python3 scripts/dev-infra.py --redis && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce pnpm db:migrate && DATABASE_URL=postgresql://mediforce:mediforce@localhost:5432/mediforce REDIS_URL=redis://localhost:6379 pnpm --filter @mediforce/platform-ui dev",
     "emulators": "pnpm --filter @mediforce/platform-ui emulators",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:unit": "vitest run",

--- a/packages/platform-ui/src/app/workspace-selection/__tests__/page.test.tsx
+++ b/packages/platform-ui/src/app/workspace-selection/__tests__/page.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { MeNamespace } from '@mediforce/platform-api/contract';
+
+const replaceMock = vi.fn();
+
+interface AuthState {
+  firebaseUser: { uid: string; displayName: string | null; email: string | null } | null;
+  loading: boolean;
+}
+interface NsState {
+  namespaces: MeNamespace[];
+  loading: boolean;
+  isError: boolean;
+  error: Error | null;
+}
+
+let authState: AuthState;
+let nsState: NsState;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ alt, ...rest }: { alt: string }) => <img alt={alt} {...rest} />,
+}));
+
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock('@/hooks/use-all-user-namespaces', () => ({
+  useAllUserNamespaces: () => nsState,
+}));
+
+import WorkspaceSelectionPage from '../page';
+
+function ns(overrides: Partial<MeNamespace> & Pick<MeNamespace, 'handle'>): MeNamespace {
+  return { type: 'organization', displayName: overrides.handle, role: 'owner', ...overrides };
+}
+
+beforeEach(() => {
+  replaceMock.mockClear();
+  localStorage.clear();
+  authState = {
+    firebaseUser: { uid: 'u1', displayName: 'Test User', email: 'test@mediforce.dev' },
+    loading: false,
+  };
+  nsState = { namespaces: [], loading: false, isError: false, error: null };
+});
+
+describe('WorkspaceSelectionPage', () => {
+  it('[>=2] shows the picker with a card per workspace and does not redirect', async () => {
+    nsState.namespaces = [
+      ns({ handle: 'me', type: 'personal', displayName: 'Me' }),
+      ns({ handle: 'acme-labs', displayName: 'Acme Labs' }),
+    ];
+
+    render(<WorkspaceSelectionPage />);
+
+    expect(await screen.findByText('Choose a workspace to continue')).toBeInTheDocument();
+    expect(screen.getByText('My workspace')).toBeInTheDocument();
+    expect(screen.getByText('Acme Labs')).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('[=1] redirects straight to the only workspace and never shows the picker', async () => {
+    nsState.namespaces = [ns({ handle: 'solo', displayName: 'Solo' })];
+
+    render(<WorkspaceSelectionPage />);
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/solo'));
+    expect(screen.queryByText('Choose a workspace to continue')).not.toBeInTheDocument();
+  });
+
+  it('[error] surfaces the explicit error message instead of an empty picker', async () => {
+    nsState.isError = true;
+    nsState.error = new Error('Internal Server Error');
+
+    render(<WorkspaceSelectionPage />);
+
+    expect(await screen.findByText(/Internal Server Error/)).toBeInTheDocument();
+    expect(screen.queryByText('Choose a workspace to continue')).not.toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('[0] shows an explicit empty-state message rather than a blank picker', async () => {
+    nsState.namespaces = [];
+
+    render(<WorkspaceSelectionPage />);
+
+    expect(await screen.findByText(/no workspaces are associated/i)).toBeInTheDocument();
+    expect(screen.queryByText('Choose a workspace to continue')).not.toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/platform-ui/src/app/workspace-selection/page.tsx
+++ b/packages/platform-ui/src/app/workspace-selection/page.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { User } from 'lucide-react';
+import { User, AlertCircle } from 'lucide-react';
 import { getWorkspaceIcon, WORKSPACE_DEFAULT_KEY } from '@/lib/workspace-icons';
 import { useAuth } from '@/contexts/auth-context';
 import { useAllUserNamespaces } from '@/hooks/use-all-user-namespaces';
@@ -71,10 +71,48 @@ function OrgCard({
   );
 }
 
+function LoadingScreen() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="text-sm text-muted-foreground animate-pulse">Loading…</div>
+    </div>
+  );
+}
+
+function WorkspaceLoadError({ error }: { error: Error | null }) {
+  const isEmpty = error === null;
+  const heading = isEmpty ? 'No workspaces available' : 'Couldn’t load your workspaces';
+  const message = isEmpty
+    ? 'No workspaces are associated with your account.'
+    : error.message !== '' ? error.message : 'An unexpected error occurred.';
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-6 py-12">
+      <div className="flex items-center gap-2 mb-10">
+        <Image src="/logo.png" alt="Mediforce logo" width={32} height={32} className="shrink-0" />
+        <span className="font-headline text-lg font-semibold text-primary">Mediforce</span>
+      </div>
+
+      <div className="max-w-md text-center space-y-3">
+        <AlertCircle className="mx-auto h-10 w-10 text-destructive" />
+        <h1 className="text-xl font-headline font-semibold tracking-tight">{heading}</h1>
+        <p className="text-sm text-muted-foreground break-words">{message}</p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="mt-2 inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function WorkspaceSelectionPage() {
   const router = useRouter();
   const { firebaseUser, loading: authLoading } = useAuth();
-  const { namespaces, loading: nsLoading } = useAllUserNamespaces(firebaseUser?.uid);
+  const { namespaces, loading: nsLoading, isError, error } = useAllUserNamespaces(firebaseUser?.uid);
   const [alwaysHandle, setAlwaysHandle] = React.useState<string | null>(null);
   const [ready, setReady] = React.useState(false);
 
@@ -84,16 +122,23 @@ export default function WorkspaceSelectionPage() {
     setReady(true);
   }, []);
 
+  const loading = authLoading || nsLoading || !ready;
+
   React.useEffect(() => {
-    if (authLoading || nsLoading || !ready) return;
+    if (loading) return;
 
     if (!firebaseUser) {
       router.replace('/login');
       return;
     }
 
-    // Single namespace — no choice needed, go straight there
-    if (namespaces.length <= 1) {
+    // A failed `/api/users/me`, or a genuinely empty namespace list, is shown
+    // as an explicit message in the render path below — never redirected and
+    // never rendered as a blank picker.
+    if (isError || namespaces.length === 0) return;
+
+    // Exactly one workspace — no choice to make, go straight there.
+    if (namespaces.length === 1) {
       const target = namespaces[0]?.handle;
       if (target !== undefined) {
         router.replace(`/${target}`);
@@ -101,12 +146,12 @@ export default function WorkspaceSelectionPage() {
       return;
     }
 
-    // Preferred workspace set — skip the picker
+    // Multiple workspaces with a saved default — skip the picker.
     const preferred = localStorage.getItem(ALWAYS_KEY);
     if (preferred !== null && preferred !== '' && namespaces.some((ns) => ns.handle === preferred)) {
       router.replace(`/${preferred}`);
     }
-  }, [authLoading, nsLoading, ready, firebaseUser, namespaces, router]);
+  }, [loading, firebaseUser, isError, namespaces, router]);
 
   function handleSelect(handle: string) {
     router.replace(`/${handle}`);
@@ -122,14 +167,20 @@ export default function WorkspaceSelectionPage() {
     }
   }
 
-  const loading = authLoading || nsLoading || !ready;
-
   if (loading || !firebaseUser) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <div className="text-sm text-muted-foreground animate-pulse">Loading…</div>
-      </div>
-    );
+    return <LoadingScreen />;
+  }
+
+  // Fail loud: a backend error or an account with zero workspaces gets an
+  // explicit message, never an empty picker that reads as "pick nothing".
+  if (isError || namespaces.length === 0) {
+    return <WorkspaceLoadError error={isError ? error : null} />;
+  }
+
+  // Exactly one workspace — the effect above is redirecting; render the loading
+  // screen rather than flashing a single-card picker.
+  if (namespaces.length === 1) {
+    return <LoadingScreen />;
   }
 
   const displayName = firebaseUser.displayName ?? firebaseUser.email ?? null;

--- a/packages/platform-ui/src/hooks/use-all-user-namespaces.ts
+++ b/packages/platform-ui/src/hooks/use-all-user-namespaces.ts
@@ -6,6 +6,8 @@ import type { MeNamespace } from '@mediforce/platform-api/contract';
 export interface UseAllUserNamespacesResult {
   namespaces: MeNamespace[];
   loading: boolean;
+  isError: boolean;
+  error: Error | null;
 }
 
 /**
@@ -14,11 +16,17 @@ export interface UseAllUserNamespacesResult {
  * accepted for source-compat with the pre-Phase-4 signature — the value is
  * ignored because the bundle is keyed off the verified bearer token, not a
  * client-supplied uid.
+ *
+ * `isError` / `error` are surfaced so callers can fail loud on a failed
+ * `/api/users/me` instead of treating it as an empty namespace list — an
+ * errored bundle and a genuinely empty one are different states.
  */
 export function useAllUserNamespaces(_uid?: string | null): UseAllUserNamespacesResult {
   const query = useUserMe();
   return {
     namespaces: query.data?.namespaces ?? [],
     loading: query.isLoading,
+    isError: query.isError,
+    error: query.error ?? null,
   };
 }

--- a/scripts/dev-infra.py
+++ b/scripts/dev-infra.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Bring up the local dev infrastructure (Postgres, optionally Redis) and fail
+loudly with an actionable message when a prerequisite is missing.
+
+`pnpm dev` / `pnpm dev:queue` call this before `pnpm db:migrate` and `next dev`.
+The old inline `docker compose up postgres -d` stopped the `&&` chain on a raw
+`docker: unknown command: docker compose` line that was easy to miss — the app
+then booted against a non-existent database and only surfaced
+`ECONNREFUSED 127.0.0.1:5432` deep in a request handler. This script checks each
+prerequisite up front and explains exactly what to install.
+
+Readiness is delegated to Compose's `--wait` flag, which blocks on the
+`pg_isready` healthcheck already defined for the postgres service in
+docker-compose.yml — so when this script exits 0, Postgres is accepting
+connections, not merely "container started".
+
+Usage:
+    python3 scripts/dev-infra.py            # postgres only (pnpm dev)
+    python3 scripts/dev-infra.py --redis    # postgres + redis (pnpm dev:queue)
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_FILES = ["-f", "docker-compose.yml", "-f", "docker-compose.dev.yml"]
+WAIT_TIMEOUT_SECONDS = 60
+
+
+def fail(message: str) -> None:
+    print(f"\n\033[31m✗ pnpm dev: {message}\033[0m\n", file=sys.stderr)
+    sys.exit(1)
+
+
+def check_docker_installed() -> None:
+    if shutil.which("docker") is None:
+        fail(
+            "Docker is not installed.\n"
+            "  • macOS / Windows: install Docker Desktop — https://docs.docker.com/desktop/\n"
+            "  • Ubuntu / Debian:  sudo apt install docker.io docker-compose-v2\n"
+            "Or use `pnpm dev:mock` for a no-Docker, in-memory stack."
+        )
+
+
+def check_docker_running() -> None:
+    result = subprocess.run(
+        ["docker", "info"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        fail(
+            "Docker is installed but the daemon is not reachable.\n"
+            "  • Docker Desktop: start the app and wait for it to report 'running'.\n"
+            "  • Linux engine:   sudo systemctl start docker\n"
+            f"docker info said: {result.stderr.strip().splitlines()[-1] if result.stderr.strip() else 'unknown error'}"
+        )
+
+
+def check_compose_installed() -> None:
+    result = subprocess.run(
+        ["docker", "compose", "version"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        fail(
+            "Docker Compose v2 is not installed — the `docker compose` subcommand is missing.\n"
+            "  • macOS / Windows: Docker Desktop bundles it; make sure Desktop is up to date.\n"
+            "  • Ubuntu / Debian (engine-only `docker.io`): sudo apt install docker-compose-v2\n"
+            "  • Other Linux: https://docs.docker.com/compose/install/linux/"
+        )
+
+
+def bring_up(services: list[str]) -> None:
+    cmd = (
+        ["docker", "compose"]
+        + COMPOSE_FILES
+        + ["up", *services, "-d", "--wait", "--wait-timeout", str(WAIT_TIMEOUT_SECONDS)]
+    )
+    print(f"→ {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=REPO_ROOT)
+    if result.returncode != 0:
+        fail(
+            f"Postgres did not become healthy within {WAIT_TIMEOUT_SECONDS}s "
+            f"(services: {', '.join(services)}).\n"
+            "Inspect it with:\n"
+            "  docker compose -f docker-compose.yml -f docker-compose.dev.yml logs postgres\n"
+            "If the data volume is corrupt, reset it:\n"
+            "  docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v && pnpm dev"
+        )
+
+
+def main() -> None:
+    services = ["postgres"]
+    if "--redis" in sys.argv[1:]:
+        services.append("redis")
+
+    check_docker_installed()
+    check_docker_running()
+    check_compose_installed()
+    bring_up(services)
+    print(f"\033[32m✓ Dev infra ready: {', '.join(services)} on localhost\033[0m")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Intention

While onboarding onto the new Postgres-backed local stack (post Firestore→Postgres migration), three rough edges surfaced. This PR addresses all three:

1. **Docs — install dependencies.** The setup docs assumed Docker Compose was always present. On an engine-only Docker install (Ubuntu's `docker.io`), Compose is a separate package, so `pnpm dev` failed in a confusing way with no documented fix.
2. **Explicit fail when the DB isn't running.** `pnpm dev` started Postgres inline; when Compose was missing the step errored quietly, the `&&` chain stopped, and the app booted anyway against a database that wasn't there — surfacing only as `ECONNREFUSED 127.0.0.1:5432` deep in a request handler.
3. **Error view when the endpoint returns 0 workspaces / errors.** The workspace-selection page swallowed a failed `/api/users/me` into an empty namespace list and rendered a blank picker ("Choose a workspace to continue" with no cards) — indistinguishable from a real empty state.

## Changes

### 1. Documentation
- `GETTING-STARTED.md` prerequisites now require **Docker + Docker Compose v2**, with the Ubuntu fix `sudo apt install docker-compose-v2` and a `docker compose version` check.
- New troubleshooting entries in `GETTING-STARTED.md` and `docs/dev-quickref.md` for the "Docker Compose v2 is not installed" failure.

### 2. `pnpm dev` fails loudly
- New `scripts/dev-infra.py` preflight, wired into `dev` and `dev:queue`. It checks, in order, with an actionable message + exit 1 at each gate: Docker installed → daemon running → **Compose v2 plugin present** → brings up Postgres (and Redis via `--redis`) using Compose's `--wait`, so the DB is healthy *before* migrations run (also removes a latent race where migrations ran before Postgres was ready).

### 3. Workspace-selection error view
- `useAllUserNamespaces` now exposes `isError`/`error` instead of collapsing failures into `[]`.
- `workspace-selection/page.tsx` is now an explicit state machine:
  - **≥2 workspaces** → show the picker
  - **exactly 1** → redirect straight through (no single-card flash)
  - **0 or error** → explicit `WorkspaceLoadError` screen (the real error message + a **Try again** button)
- Component test covers all four branches.

### Error view

> _Screenshot of the new error view goes here — `mediforce.users.me failed with status 500` + "Try again". (Drag the image into this description to upload it.)_

## Testing
- `pnpm vitest run src/app/workspace-selection` — 4/4 green (≥2 / =1 / error / 0).
- Verified end-to-end: with Compose missing, `pnpm dev` now stops with exit 1 and the install hint; after `apt install docker-compose-v2` the stack boots and the workspace bootstraps. The error view renders as intended when `/api/users/me` 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
