### PR TITLE
fix(migration-0017): delete __ duplicates before PK update

### DIFF
--- a/packages/platform-infra/src/postgres/migrations/0017_normalize_model_ids.sql
+++ b/packages/platform-infra/src/postgres/migrations/0017_normalize_model_ids.sql
@@ -14,7 +14,20 @@
 --
 -- All replacements are idempotent: rows already using "/" are untouched.
 
--- 1. model_registry_entries — PK update
+-- 1a. model_registry_entries — delete __ duplicates where / version exists
+DELETE FROM "model_registry_entries" AS old
+WHERE old."id" LIKE '%\_\_%' ESCAPE '\'
+  AND old."id" NOT LIKE '%/%'
+  AND EXISTS (
+    SELECT 1 FROM "model_registry_entries" AS canonical
+    WHERE canonical."id" = CONCAT(
+      SUBSTRING(old."id" FROM 1 FOR POSITION('__' IN old."id") - 1),
+      '/',
+      SUBSTRING(old."id" FROM POSITION('__' IN old."id") + 2)
+    )
+  );
+
+-- 1b. model_registry_entries — update remaining __ rows (no / conflict)
 UPDATE "model_registry_entries"
 SET "id" = CONCAT(
       SUBSTRING("id" FROM 1 FOR POSITION('__' IN "id") - 1),


### PR DESCRIPTION
## Summary

- Staging deploy failed: migration 0017 hung trying to UPDATE model_registry_entries PK
- **Root cause:** Both `deepseek__model` (Firebase migration) and `deepseek/model` (OpenRouter sync) rows exist — PK UPDATE hits unique violation
- **Fix:** DELETE the `__` duplicate first when the canonical `/` version exists, then UPDATE remaining orphans
- Verified via SSH: 0017 was NOT recorded in `__drizzle_migrations` (Drizzle rolled back), so re-deploy applies cleanly

## Test plan

- [x] Confirmed on staging DB: both `__` and `/` rows coexist for deepseek models
- [x] Confirmed Drizzle journal clean: 0017 not recorded, will re-run
- [ ] Merge → staging deploy → verify migration completes
- [ ] Retry workflow run `105b1bda`

🤖 Generated with [Claude Code](https://claude.com/claude-code)