### PR TITLE
feat(ui): render HTML output as iframe preview in workflow results

### DIFF
--- a/packages/platform-ui/src/components/agents/agent-output-display.tsx
+++ b/packages/platform-ui/src/components/agents/agent-output-display.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import * as Tabs from '@radix-ui/react-tabs';
 import * as Collapsible from '@radix-ui/react-collapsible';
-import { useTheme } from 'next-themes';
 import {
   ChevronDown,
   Clock,
@@ -16,7 +15,7 @@ import {
   MonitorPlay,
 } from 'lucide-react';
 import type { AgentOutputData } from '@/components/tasks/task-utils';
-import { buildSrcdoc, clampIframeHeight, isIframeResizeMessage } from '@/components/tasks/iframe-helpers';
+import { SandboxedHtmlIframe } from '@/components/tasks/sandboxed-html-iframe';
 import { MarkdownPresentation } from '@/components/tasks/markdown-presentation';
 import { apiFetch } from '@/lib/api-fetch';
 import { formatCostUsd, formatDuration } from '@/lib/format';
@@ -59,38 +58,7 @@ export function AgentOutputDisplay({
 }: AgentOutputDisplayProps) {
   const presentation = agentOutput.presentation;
   const hasPresentation = presentation !== null;
-  // Iframe path is only used for the HTML branch. Markdown renders inline
-  // via MarkdownPresentation and ignores the iframe resize/theme dance.
-  const needsIframe = presentation?.kind === 'html';
   const result = agentOutput.result ?? {};
-  const iframeRef = React.useRef<HTMLIFrameElement>(null);
-  const [iframeHeight, setIframeHeight] = React.useState(300);
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
-
-  React.useEffect(() => {
-    if (!needsIframe) return;
-    const handler = (event: MessageEvent) => {
-      if (
-        isIframeResizeMessage(event.data) &&
-        iframeRef.current &&
-        event.source === iframeRef.current.contentWindow
-      ) {
-        setIframeHeight((prev) => {
-          const next = clampIframeHeight(event.data.height);
-          return next > 0 ? next : prev;
-        });
-      }
-    };
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  }, [needsIframe]);
-
-  // Sync theme changes to iframe
-  React.useEffect(() => {
-    if (!needsIframe) return;
-    iframeRef.current?.contentWindow?.postMessage({ type: 'theme', dark: isDark }, '*');
-  }, [isDark, needsIframe]);
 
   const hasResult = agentOutput.result !== null && Object.keys(agentOutput.result).length > 0;
   const hasContent = hasResult || hasPresentation;
@@ -190,11 +158,9 @@ export function AgentOutputDisplay({
             {presentation.kind === 'markdown' ? (
               <MarkdownPresentation content={presentation.content} />
             ) : (
-              <iframe
-                ref={iframeRef}
-                srcDoc={buildSrcdoc(presentation.content, agentOutput.result, isDark)}
-                sandbox="allow-scripts"
-                style={{ width: '100%', height: iframeHeight, border: 'none' }}
+              <SandboxedHtmlIframe
+                html={presentation.content}
+                result={agentOutput.result}
                 title="Agent presentation"
               />
             )}

--- a/packages/platform-ui/src/components/processes/run-results-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-results-panel.tsx
@@ -2,9 +2,11 @@
 
 import * as React from 'react';
 import { CheckCircle2, ExternalLink, Gauge, GitBranch, Clock, FileText, DollarSign } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import type { StepExecution, AgentOutputSnapshot } from '@mediforce/platform-core';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
 import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
+import { buildSrcdoc, clampIframeHeight, isIframeResizeMessage } from '@/components/tasks/iframe-helpers';
 
 interface RunResultsPanelProps {
   stepExecutions: StepExecution[];
@@ -45,6 +47,49 @@ function isEmptyResultValue(value: unknown): boolean {
   return false;
 }
 
+function isHtmlString(value: string): boolean {
+  const trimmed = value.trimStart().toLowerCase();
+  return trimmed.startsWith('<!doctype html') || trimmed.startsWith('<html');
+}
+
+function HtmlPreview({ html }: { html: string }) {
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = React.useState(300);
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  React.useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (
+        isIframeResizeMessage(event.data) &&
+        iframeRef.current &&
+        event.source === iframeRef.current.contentWindow
+      ) {
+        setHeight((prev) => {
+          const next = clampIframeHeight(event.data.height);
+          return next > 0 ? next : prev;
+        });
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
+  React.useEffect(() => {
+    iframeRef.current?.contentWindow?.postMessage({ type: 'theme', dark: isDark }, '*');
+  }, [isDark]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={buildSrcdoc(html, null, isDark)}
+      sandbox="allow-scripts"
+      style={{ width: '100%', height, border: 'none' }}
+      title="HTML output preview"
+    />
+  );
+}
+
 function ResultValue({ value }: { value: unknown }) {
   if (typeof value === 'boolean') {
     return <span className="text-sm">{value ? 'Yes' : 'No'}</span>;
@@ -62,6 +107,9 @@ function ResultValue({ value }: { value: unknown }) {
           <ExternalLink className="h-3 w-3 shrink-0" />
         </a>
       );
+    }
+    if (isHtmlString(value)) {
+      return <HtmlPreview html={value} />;
     }
     return <span className="text-sm font-mono break-all">{value}</span>;
   }
@@ -310,14 +358,17 @@ export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
                     Output
                   </h4>
                   <dl className="space-y-1.5">
-                    {remainingEntries.map(([key, value]) => (
-                      <div key={key} className="flex flex-wrap items-baseline gap-2 text-sm">
-                        <dt className="text-muted-foreground">{formatResultKey(key)}:</dt>
-                        <dd className="min-w-0 flex-1">
-                          <ResultValue value={value} />
-                        </dd>
-                      </div>
-                    ))}
+                    {remainingEntries.map(([key, value]) => {
+                      const isHtml = typeof value === 'string' && isHtmlString(value);
+                      return (
+                        <div key={key} className={isHtml ? 'space-y-1 text-sm' : 'flex flex-wrap items-baseline gap-2 text-sm'}>
+                          <dt className="text-muted-foreground">{formatResultKey(key)}:</dt>
+                          <dd className="min-w-0 flex-1">
+                            <ResultValue value={value} />
+                          </dd>
+                        </div>
+                      );
+                    })}
                   </dl>
                 </div>
               )}

--- a/packages/platform-ui/src/components/processes/run-results-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-results-panel.tsx
@@ -2,11 +2,10 @@
 
 import * as React from 'react';
 import { CheckCircle2, ExternalLink, Gauge, GitBranch, Clock, FileText, DollarSign } from 'lucide-react';
-import { useTheme } from 'next-themes';
 import type { StepExecution, AgentOutputSnapshot } from '@mediforce/platform-core';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
 import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
-import { buildSrcdoc, clampIframeHeight, isIframeResizeMessage } from '@/components/tasks/iframe-helpers';
+import { SandboxedHtmlIframe } from '@/components/tasks/sandboxed-html-iframe';
 
 interface RunResultsPanelProps {
   stepExecutions: StepExecution[];
@@ -49,44 +48,10 @@ function isEmptyResultValue(value: unknown): boolean {
 
 function isHtmlString(value: string): boolean {
   const trimmed = value.trimStart().toLowerCase();
-  return trimmed.startsWith('<!doctype html') || trimmed.startsWith('<html');
-}
-
-function HtmlPreview({ html }: { html: string }) {
-  const iframeRef = React.useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = React.useState(300);
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
-
-  React.useEffect(() => {
-    const handler = (event: MessageEvent) => {
-      if (
-        isIframeResizeMessage(event.data) &&
-        iframeRef.current &&
-        event.source === iframeRef.current.contentWindow
-      ) {
-        setHeight((prev) => {
-          const next = clampIframeHeight(event.data.height);
-          return next > 0 ? next : prev;
-        });
-      }
-    };
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  }, []);
-
-  React.useEffect(() => {
-    iframeRef.current?.contentWindow?.postMessage({ type: 'theme', dark: isDark }, '*');
-  }, [isDark]);
-
   return (
-    <iframe
-      ref={iframeRef}
-      srcDoc={buildSrcdoc(html, null, isDark)}
-      sandbox="allow-scripts"
-      style={{ width: '100%', height, border: 'none' }}
-      title="HTML output preview"
-    />
+    trimmed.startsWith('<!doctype html') ||
+    trimmed.startsWith('<html>') ||
+    trimmed.startsWith('<html ')
   );
 }
 
@@ -109,7 +74,7 @@ function ResultValue({ value }: { value: unknown }) {
       );
     }
     if (isHtmlString(value)) {
-      return <HtmlPreview html={value} />;
+      return <SandboxedHtmlIframe html={value} title="HTML output preview" />;
     }
     return <span className="text-sm font-mono break-all">{value}</span>;
   }

--- a/packages/platform-ui/src/components/tasks/sandboxed-html-iframe.tsx
+++ b/packages/platform-ui/src/components/tasks/sandboxed-html-iframe.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import * as React from 'react';
+import { useTheme } from 'next-themes';
+import { buildSrcdoc, clampIframeHeight, isIframeResizeMessage } from './iframe-helpers';
+
+interface SandboxedHtmlIframeProps {
+  html: string;
+  result?: Record<string, unknown> | null;
+  title?: string;
+}
+
+export function SandboxedHtmlIframe({
+  html,
+  result = null,
+  title = 'HTML preview',
+}: SandboxedHtmlIframeProps) {
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = React.useState(300);
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  React.useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (
+        isIframeResizeMessage(event.data) &&
+        iframeRef.current &&
+        event.source === iframeRef.current.contentWindow
+      ) {
+        setHeight((prev) => {
+          const next = clampIframeHeight(event.data.height);
+          return next > 0 ? next : prev;
+        });
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
+  React.useEffect(() => {
+    iframeRef.current?.contentWindow?.postMessage({ type: 'theme', dark: isDark }, '*');
+  }, [isDark]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      srcDoc={buildSrcdoc(html, result, isDark)}
+      sandbox="allow-scripts"
+      style={{ width: '100%', height, border: 'none' }}
+      title={title}
+    />
+  );
+}

--- a/packages/platform-ui/src/components/tasks/task-context-panel.tsx
+++ b/packages/platform-ui/src/components/tasks/task-context-panel.tsx
@@ -3,14 +3,13 @@
 import * as React from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import * as Tabs from '@radix-ui/react-tabs';
-import { useTheme } from 'next-themes';
 import { ChevronDown, Code, FileText, MonitorPlay } from 'lucide-react';
 import type { Presentation } from '@mediforce/platform-core';
 import { useProcessInstance } from '@/hooks/use-process-instances';
 import { useStepExecutions } from '@/hooks/use-step-executions';
 import { apiFetch } from '@/lib/api-fetch';
 import { cn } from '@/lib/utils';
-import { buildSrcdoc, clampIframeHeight, isIframeResizeMessage } from './iframe-helpers';
+import { SandboxedHtmlIframe } from './sandboxed-html-iframe';
 import { MarkdownPresentation } from './markdown-presentation';
 import { normalizePresentation } from './task-utils';
 
@@ -275,43 +274,6 @@ interface ReportPaneProps {
 }
 
 function ReportPane({ presentation, loading, error, result }: ReportPaneProps) {
-  const iframeRef = React.useRef<HTMLIFrameElement>(null);
-  const [iframeHeight, setIframeHeight] = React.useState(300);
-  const { resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === 'dark';
-
-  const html = presentation?.kind === 'html' ? presentation.content : null;
-
-  // Listen for resize messages from the iframe
-  React.useEffect(() => {
-    if (html === null) return;
-    const handler = (event: MessageEvent) => {
-      if (
-        isIframeResizeMessage(event.data) &&
-        iframeRef.current &&
-        event.source === iframeRef.current.contentWindow
-      ) {
-        setIframeHeight((prev) => {
-          const next = clampIframeHeight(event.data.height);
-          return next > 0 ? next : prev;
-        });
-      }
-    };
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
-  }, [html]);
-
-  // Sync theme changes to iframe. Iframe is sandboxed without
-  // `allow-same-origin`, so its origin is null. `postMessage` rejects the
-  // literal string 'null' as targetOrigin and we can't compute the parent
-  // origin from inside the iframe — '*' is the only valid value here. The
-  // payload is benign (theme bool only), and the iframe-side handler does
-  // not act on sensitive data, so wildcard is acceptable.
-  React.useEffect(() => {
-    if (html === null) return;
-    iframeRef.current?.contentWindow?.postMessage({ type: 'theme', dark: isDark }, '*');
-  }, [isDark, html]);
-
   if (loading) {
     return (
       <div className="space-y-3">
@@ -342,11 +304,9 @@ function ReportPane({ presentation, loading, error, result }: ReportPaneProps) {
   }
 
   return (
-    <iframe
-      ref={iframeRef}
-      srcDoc={buildSrcdoc(presentation.content, result, isDark)}
-      sandbox="allow-scripts"
-      style={{ width: '100%', height: iframeHeight, border: 'none' }}
+    <SandboxedHtmlIframe
+      html={presentation.content}
+      result={result}
       title="Previous step report"
     />
   );


### PR DESCRIPTION
## Summary
- Workflow steps producing HTML (e.g. email formatters) were shown as raw markup text in the results panel
- Detect HTML strings (`<!DOCTYPE` / `<html` prefix) and render in a sandboxed iframe with auto-resize and dark mode sync
- Reuses existing `buildSrcdoc` infrastructure from `iframe-helpers.ts` — generic, any workflow outputting HTML benefits automatically

## Test plan
- [ ] Run a workflow that outputs HTML (e.g. media-monitoring email) — verify rendered preview instead of raw text
- [ ] Toggle dark mode — iframe syncs theme
- [ ] Non-HTML output fields still render as before (text, URLs, numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)