### PR TITLE
fix: move model sync from migrate to app boot (fire-and-forget)

### DIFF
--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -90,6 +90,7 @@ import { createHttpSelfFetchRunKicker } from '../runtime/run-kicker';
 import { WebhookRouter } from '@mediforce/workflow-engine';
 import { seedBuiltinAgentDefinitions } from './seed-agent-definitions';
 import { seedBuiltinToolCatalog } from './seed-tool-catalog';
+import { eagerSyncIfStale } from '@mediforce/platform-infra';
 
 let services: PlatformServices | null = null;
 let seedingStarted = false;
@@ -424,6 +425,9 @@ export function getPlatformServices(): PlatformServices {
     });
     seedBuiltinToolCatalog(toolCatalogRepo).catch((err) => {
       console.error('[platform-services] Failed to seed built-in tool catalog:', err);
+    });
+    eagerSyncIfStale(modelRegistryRepo, { auditRepo }).catch((err) => {
+      console.error('[platform-services] Model registry eager sync failed:', err);
     });
   }
 

--- a/packages/platform-infra/src/sync/openrouter-sync.ts
+++ b/packages/platform-infra/src/sync/openrouter-sync.ts
@@ -72,7 +72,9 @@ function transformModel(model: OpenRouterModel): CreateModelRegistryEntryInput {
 export async function syncFromOpenRouter(
   repo: ModelRegistryRepository,
 ): Promise<SyncResult> {
-  const response = await fetch(OPENROUTER_MODELS_URL);
+  const response = await fetch(OPENROUTER_MODELS_URL, {
+    signal: AbortSignal.timeout(15_000),
+  });
   if (!response.ok) {
     throw new Error(`OpenRouter API returned ${response.status}: ${response.statusText}`);
   }

--- a/packages/platform-ui/Dockerfile
+++ b/packages/platform-ui/Dockerfile
@@ -67,7 +67,7 @@ WORKDIR /app
 COPY --from=deps /app ./
 COPY . .
 WORKDIR /app/packages/platform-infra
-CMD ["sh", "-c", "pnpm exec drizzle-kit migrate && pnpm exec tsx src/sync/migrate-with-sync.ts"]
+CMD ["pnpm", "exec", "drizzle-kit", "migrate"]
 
 # --- Runner ---
 FROM node:24-slim AS runner


### PR DESCRIPTION
## Summary

- **Root cause**: PR #650 added `migrate-with-sync.ts` to migrate container CMD. On staging, OpenRouter sync blocked the container → drizzle-kit migrations 0019-0022 never applied → `retired_at` column missing → **all model_registry queries 500** (including workflow register)
- Move `eagerSyncIfStale()` to `getPlatformServices()` as fire-and-forget (same pattern as seed calls)
- Add 15s `AbortSignal.timeout` on OpenRouter fetch
- Migrate container now runs only `drizzle-kit migrate` (schema only, seconds not minutes)

Sync failure → log + audit entry, daily cron retries at 3:00 AM. App works fine with empty registry.

## Test plan

- [x] Typecheck passes
- [x] Sync unit tests pass
- [x] Local: workflow register + run start works after migration applied
- [ ] Staging deploy completes within 15min timeout
- [ ] Migrations 0019-0022 apply on staging
- [ ] Model registry populates after boot (check `[eager-sync]` logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)