### PR TITLE
fix: count cached input tokens in agent run cost estimate (#654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
   - Built-in tool calls (`update_artifact`, `update_presentation`) now persist as live tool turns visible in the cowork chat UI.
   - Postgres migration 0018: `validation_result` (jsonb) + `presentation` (text) columns on `cowork_sessions`.
 
+### Fixed
+- **Run cost under-reported for cached agent runs** — the container-agent token extractor read only `input_tokens`/`output_tokens` from the CLI result event and dropped `cache_read_input_tokens` and `cache_creation_input_tokens`, so prompt-cached runs (where cache reads dominate input) showed costs many times lower than OpenRouter actually charged. Cache-creation tokens now fold into `inputTokens` and cache-read tokens are tracked as `cachedInputTokens`, priced at the registry `cacheRead` rate (falling back to the input rate). (#654)
+
 ## [2026-05-31]
 
 ### Changed

--- a/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
@@ -240,6 +240,38 @@ describe('ClaudeCodeAgentPlugin', () => {
       expect(statusEvents[0].payload).toContain('trial-metadata-extractor');
     });
 
+    it('[DATA] folds cache_creation into input tokens and captures cache_read for cost', async () => {
+      const context = buildMockContext();
+      await plugin.initialize(context);
+
+      const { emit, events } = buildEmitSpy();
+      mockReadSkill(plugin).mockResolvedValue('# Trial Metadata Extractor');
+      mockSpawn(plugin).mockResolvedValue({
+        cliOutput: JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          result: JSON.stringify({ summary: 'done' }),
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 20,
+            cache_read_input_tokens: 30,
+          },
+        }),
+        gitMetadata: null,
+        presentation: null,
+        outputDir: '/tmp/mock-output',
+        injectedEnvVars: [],
+      });
+
+      await plugin.run(emit);
+
+      const resultEvent = events.find((e) => e.type === 'result');
+      expect(resultEvent?.payload).toMatchObject({
+        tokenUsage: { inputTokens: 120, outputTokens: 50, cachedInputTokens: 30 },
+      });
+    });
+
     it('[DATA] builds prompt from SKILL.md content and input data', async () => {
       const context = buildMockContext();
       await plugin.initialize(context);

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -897,24 +897,33 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         ? parsedResult.confidence_rationale
         : undefined;
 
-      let tokenUsage: { inputTokens: number; outputTokens: number } | undefined;
+      let tokenUsage: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } | undefined;
 
       // First: check if agent reported tokenUsage in its result
       if (parsedResult.tokenUsage !== null
         && typeof parsedResult.tokenUsage === 'object'
         && typeof (parsedResult.tokenUsage as Record<string, unknown>).inputTokens === 'number'
         && typeof (parsedResult.tokenUsage as Record<string, unknown>).outputTokens === 'number') {
-        tokenUsage = parsedResult.tokenUsage as { inputTokens: number; outputTokens: number };
+        tokenUsage = parsedResult.tokenUsage as { inputTokens: number; outputTokens: number; cachedInputTokens?: number };
       }
 
       // Second: check stream event for CLI-reported usage (e.g. Claude Code stream-json result event)
       // parseAgentOutput() returns a single JSON object for the final result event.
+      // Cache-creation tokens are billed at (roughly) the input rate, so they fold into
+      // inputTokens; cache-read tokens are billed at the cheaper cacheRead rate, so they are
+      // tracked separately. Dropping either — as the previous version did — under-reports cost.
       if (!tokenUsage) {
         try {
           const rawEvent = JSON.parse(spawnResult.cliOutput) as Record<string, unknown>;
           const usage = rawEvent.usage as Record<string, number> | undefined;
           if (usage && typeof usage.input_tokens === 'number' && typeof usage.output_tokens === 'number') {
-            tokenUsage = { inputTokens: usage.input_tokens, outputTokens: usage.output_tokens };
+            const cacheCreationTokens = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
+            const cacheReadTokens = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
+            tokenUsage = {
+              inputTokens: usage.input_tokens + cacheCreationTokens,
+              outputTokens: usage.output_tokens,
+              ...(cacheReadTokens > 0 ? { cachedInputTokens: cacheReadTokens } : {}),
+            };
           }
         } catch {
           agentLog('cost.tokenExtraction', 'could not extract token usage from CLI output', {

--- a/packages/platform-core/src/schemas/agent-output-envelope.ts
+++ b/packages/platform-core/src/schemas/agent-output-envelope.ts
@@ -16,6 +16,9 @@ export const GitMetadataSchema = z.object({
 export const TokenUsageSchema = z.object({
   inputTokens: z.number().int().nonnegative(),
   outputTokens: z.number().int().nonnegative(),
+  // Cache-read input tokens are billed at the (much cheaper) cacheRead rate,
+  // so they are tracked separately from full-price input tokens.
+  cachedInputTokens: z.number().int().nonnegative().optional(),
 });
 
 /** A reviewer-facing preview rendered by the platform. `markdown` flows

--- a/packages/platform-core/src/utils/__tests__/cost.test.ts
+++ b/packages/platform-core/src/utils/__tests__/cost.test.ts
@@ -27,4 +27,22 @@ describe('calculateEstimatedCost', () => {
     // 100000 * 0.000003 + 50000 * 0.000015 = 0.3 + 0.75 = 1.05
     expect(result).toBeCloseTo(1.05);
   });
+
+  it('prices cached input tokens at the cache-read rate', () => {
+    const result = calculateEstimatedCost(
+      { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 8000 },
+      { input: 0.000003, output: 0.000015, cacheRead: 0.0000003 },
+    );
+    // 1000*0.000003 + 8000*0.0000003 + 500*0.000015 = 0.003 + 0.0024 + 0.0075
+    expect(result).toBeCloseTo(0.0129);
+  });
+
+  it('falls back to the input rate for cached tokens when cacheRead is absent', () => {
+    const result = calculateEstimatedCost(
+      { inputTokens: 1000, outputTokens: 0, cachedInputTokens: 2000 },
+      { input: 0.000003, output: 0.000015 },
+    );
+    // (1000 + 2000) * 0.000003 = 0.009
+    expect(result).toBeCloseTo(0.009);
+  });
 });

--- a/packages/platform-core/src/utils/cost.ts
+++ b/packages/platform-core/src/utils/cost.ts
@@ -1,6 +1,12 @@
 export function calculateEstimatedCost(
-  tokenUsage: { inputTokens: number; outputTokens: number },
-  pricing: { input: number; output: number },
+  tokenUsage: { inputTokens: number; outputTokens: number; cachedInputTokens?: number },
+  pricing: { input: number; output: number; cacheRead?: number },
 ): number {
-  return tokenUsage.inputTokens * pricing.input + tokenUsage.outputTokens * pricing.output;
+  const cachedInputTokens = tokenUsage.cachedInputTokens ?? 0;
+  const cacheReadPrice = pricing.cacheRead ?? pricing.input;
+  return (
+    tokenUsage.inputTokens * pricing.input +
+    cachedInputTokens * cacheReadPrice +
+    tokenUsage.outputTokens * pricing.output
+  );
 }

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -577,8 +577,8 @@ async function loadOAuthTokens(
 }
 
 async function estimateCostField(
-  envelope: { model: string | null; tokenUsage?: { inputTokens: number; outputTokens: number } },
-  modelRegistryRepo: { getById(id: string): Promise<{ pricing: { input: number; output: number } } | null> },
+  envelope: { model: string | null; tokenUsage?: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } },
+  modelRegistryRepo: { getById(id: string): Promise<{ pricing: { input: number; output: number; cacheRead?: number } } | null> },
 ): Promise<{ estimatedCostUsd: number } | Record<string, never>> {
   if (!envelope.tokenUsage || !envelope.model) return {};
   const entry = await modelRegistryRepo.getById(envelope.model);


### PR DESCRIPTION
## Why

Closes the investigation in #654: Mediforce displayed a run cost ~24× lower than what OpenRouter actually charged for a Submission Readiness run ($0.0088 vs $0.211).

**Root cause (confirmed in code, not the units theory):** the container-agent token extractor read only `input_tokens`/`output_tokens` from the Claude Code stream-json `result` event and **dropped `cache_read_input_tokens` and `cache_creation_input_tokens`** (`base-container-agent-plugin.ts`). In a prompt-cached agentic run, cache-read tokens dominate the billed input, so the self-computed estimate came out far below the real charge. The math direction (lower) and magnitude (10–50× depending on cache hit rate) match the report. OpenRouter's `/api/v1/models` pricing is per-token and was already stored/displayed correctly — there is **no** per-1M units bug.

## What

- **Extraction** (`base-container-agent-plugin.ts`): fold `cache_creation_input_tokens` into `inputTokens` (billed ≈ input rate) and track `cache_read_input_tokens` as a new optional `cachedInputTokens` field. Missing fields default to 0, so behaviour for non-caching agents is byte-identical.
- **Pricing** (`platform-core/utils/cost.ts`): `calculateEstimatedCost` now prices `cachedInputTokens` at the registry `cacheRead` rate, falling back to the input rate when `cacheRead` is absent. The `cacheRead` price was already synced from OpenRouter and stored — it just wasn't used.
- **Schema** (`agent-output-envelope.ts`): `TokenUsageSchema` gains an optional `cachedInputTokens`. Additive, no migration.
- Widened the `estimateCostField` types in `execute-agent-step.ts` to thread the new field + `cacheRead` price through.

## Tests (RED → GREEN)

- `cost.test.ts`: cache-read priced at `cacheRead`; fallback to input rate when `cacheRead` absent.
- `claude-code-agent-plugin.test.ts`: result event with `cache_creation_input_tokens: 20` + `cache_read_input_tokens: 30` now yields `{ inputTokens: 120, outputTokens: 50, cachedInputTokens: 30 }` (pre-fix: `{ inputTokens: 100, outputTokens: 50 }`).

Workspace `typecheck` clean; 766 unit tests pass. (3 unrelated failures in `claude-code-agent-plugin.workspace.integration.test.ts` are environmental — the sandbox commit-signing server rejects with `missing source → failed to write commit object`; they reproduce identically on a clean tree and this diff touches no workspace/git code.)

## Known follow-ups (out of scope, pre-existing)

- `agent-run-repository` persists `tokenUsage` via dedicated `prompt_tokens`/`completion_tokens` columns, so a Postgres re-read drops `cachedInputTokens` from the *displayed* token breakdown. This does **not** affect cost — `totalCostUsd` is computed at write-time from the full in-memory `tokenUsage` and stored separately.
- The in-process `OpenRouterLlmClient` (`llm-client.ts`) still reads only `prompt_tokens`/`completion_tokens` (ignores `cached_tokens` and OpenRouter's authoritative `usage.cost`). It doesn't feed this run-cost path, but the ideal long-term fix is to trust the provider-reported cost rather than re-estimate. Worth a separate issue if desired.

Refs #654

https://claude.ai/code/session_016kNajqmAVxH8nWGnWuNU37

---
_Generated by [Claude Code](https://claude.ai/code/session_016kNajqmAVxH8nWGnWuNU37)_