### PR TITLE
fix(migrations): correct out-of-order journal timestamps

### DIFF
--- a/packages/platform-infra/src/postgres/migrations/meta/_journal.json
+++ b/packages/platform-infra/src/postgres/migrations/meta/_journal.json
@@ -138,28 +138,28 @@
     {
       "idx": 19,
       "version": "7",
-      "when": 1780401748745,
+      "when": 1780588800001,
       "tag": "0019_add_retired_at",
       "breakpoints": true
     },
     {
       "idx": 20,
       "version": "7",
-      "when": 1780418027000,
+      "when": 1780588800002,
       "tag": "0020_platform_settings",
       "breakpoints": true
     },
     {
       "idx": 21,
       "version": "7",
-      "when": 1780502400000,
+      "when": 1780588800003,
       "tag": "0021_system_workspace",
       "breakpoints": true
     },
     {
       "idx": 22,
       "version": "7",
-      "when": 1780588800000,
+      "when": 1780588800004,
       "tag": "0022_platform_settings_trigger",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

- **Root cause**: migrations 0019-0022 (from PR #650) had journal timestamps EARLIER than 0018, because they were generated on a separate branch. drizzle-kit uses timestamps to determine pending migrations — out-of-order entries get silently skipped.
- Fix: bump 0019-0022 timestamps to be strictly ascending after 0018
- Tested locally: from clean DB (23/23 applied) and from staging-like state (19→23 applied)

Without this fix, `retired_at` column never gets created → all model_registry queries 500.

**Staging also needs manual column add** (migrations won't re-run for already-ledgered entries):
```sql
ALTER TABLE model_registry_entries ADD COLUMN IF NOT EXISTS retired_at TIMESTAMP WITH TIME ZONE;
```

## Test plan

- [x] Clean DB: all 23 migrations apply
- [x] Staging-like DB (19 ledger entries): 0019-0022 correctly detected and applied
- [ ] Staging deploy applies pending migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)