### PR TITLE
docs: fix first-run gaps - MEDIFORCE_API_KEY and local script images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
   - Built-in tool calls (`update_artifact`, `update_presentation`) now persist as live tool turns visible in the cowork chat UI.
   - Postgres migration 0018: `validation_result` (jsonb) + `presentation` (text) columns on `cowork_sessions`.
 
+### Changed
+- GETTING-STARTED now covers two first-run blockers that were previously only discoverable by hitting the error: setting `MEDIFORCE_API_KEY` for the CLI (must match `PLATFORM_API_KEY`), and building local `script`-executor images (`mediforce-golden-image`, `mediforce-node`) via `scripts/rebuild-docker-images.sh` before running workflows with `script` steps [#670](https://github.com/Appsilon/mediforce/pull/670).
+
 ## [2026-05-31]
 
 ### Changed

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -16,6 +16,11 @@ Agents / quick lookups: see [docs/dev-quickref.md](docs/dev-quickref.md).
   `sudo apt install docker.io docker-compose-v2`. Verify with `docker compose version`.
 - **Firebase service account** — only for cloud Auth/Storage (the optional path below).
   **Not** needed for data: all server data lives in Postgres (ADR-0001).
+- **`MEDIFORCE_API_KEY`** — only for the CLI (section 3) or calling the API
+  directly. Not needed for `pnpm dev:mock` UI-only exploration.
+- **Local agent images** — only if you'll run a workflow with `script`
+  executor steps (most workflows under `apps/`). See [Build images for
+  script-executor steps](#build-images-for-script-executor-steps).
 
 ---
 
@@ -68,6 +73,31 @@ below), use:
 
 A real Firebase project uses your own accounts.
 
+### Build images for script-executor steps
+
+Workflow steps with `"executor": "script"` (`plugin: script-container`) run
+inside Docker images that are **built locally, not pulled from a registry**.
+Most workflows under `apps/` use one or both of:
+
+- `mediforce-golden-image:latest` — Node + common tooling, the base for most
+  inline `runtime: javascript` script steps
+- `mediforce-node:latest` — plain Node runtime, the fallback image when a
+  script step omits `agent.image`
+
+Build everything in one go:
+
+```bash
+./scripts/rebuild-docker-images.sh
+```
+
+This also builds the per-app agent images (`protocol-to-tfl`, `tealflow`,
+`community-digest`, `landing-zone`). Re-run it after pulling changes to
+`packages/agent-runtime/container/` or any `apps/*/container/Dockerfile`.
+
+Skip this if you're only on `pnpm dev:mock` or running workflows with
+`human`/`agent` executor steps only — without it, starting a `script` step
+fails with `Unable to find image '...' locally`.
+
 ---
 
 ## Which dev command?
@@ -93,13 +123,26 @@ Full decision table + ports + migration steps: [docs/dev-quickref.md](docs/dev-q
 The `mediforce` CLI is the supported way to drive the platform from a terminal
 (dogfood rule: CLI > REST).
 
+### Authenticate (one-time)
+
+The CLI sends `MEDIFORCE_API_KEY` as the `X-Api-Key` header — it must match
+`PLATFORM_API_KEY` in `packages/platform-ui/.env.local` (the `.env.example`
+default is `test-api-key`). Add to your shell profile (`~/.zshrc` /
+`~/.bashrc`), then reload your shell:
+
+```bash
+export MEDIFORCE_API_KEY="test-api-key"   # match PLATFORM_API_KEY in .env.local
+export MEDIFORCE_BASE_URL="http://127.0.0.1:9003"
+# Use 127.0.0.1, not localhost — Node prefers IPv6 and the dev server binds
+# IPv4, which surfaces as a misleading "fetch failed".
+```
+
 ```bash
 pnpm exec mediforce --help
 pnpm exec mediforce workflow list
 ```
 
-Auth via `MEDIFORCE_API_KEY`; base URL defaults to `http://localhost:9003`. See
-the [use-mediforce skill](.claude/skills/use-mediforce/SKILL.md) for the full
+See the [use-mediforce skill](.claude/skills/use-mediforce/SKILL.md) for the full
 command list and the REST fallback ladder.
 
 ---
@@ -395,6 +438,17 @@ if Java is missing, `brew install openjdk@21` (macOS) or
 Check: `namespace` query param present, valid step `type`
 (`creation`/`review`/`decision`/`terminal`), required fields (`name`,
 `triggers`, `steps`, `transitions`).
+
+### `mediforce: missing API key`
+
+`MEDIFORCE_API_KEY` isn't set, or doesn't match `PLATFORM_API_KEY` in
+`packages/platform-ui/.env.local`. See [Authenticate](#3-run-the-cli) above.
+
+### Workflow run fails with `Unable to find image '...' locally`
+
+A `script` executor step needs a Docker image that's built locally, not
+pulled from a registry. Run `./scripts/rebuild-docker-images.sh` (see [Build
+images for script-executor steps](#build-images-for-script-executor-steps)).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -235,15 +235,17 @@ pnpm exec mediforce <command> --help                                     # per-c
 
 ### Building Docker images for script steps
 
-Workflows with `script` executor steps need Docker images built locally:
+Workflows with `script` executor steps need Docker images built locally — none
+are pulled from a registry. Build everything in one go:
 
 ```bash
-# Community Digest workflow
-docker build -t mediforce-agent:community-digest -f apps/community-digest/container/Dockerfile .
-
-# Protocol to TFL workflow
-docker build -t mediforce-agent:protocol-to-tfl -f apps/protocol-to-tfl/container/Dockerfile .
+./scripts/rebuild-docker-images.sh
 ```
+
+This builds `mediforce-golden-image` and `mediforce-node` (used by most inline
+`runtime: javascript` script steps, and as the fallback when a step omits
+`agent.image`), plus the per-app images (`community-digest`, `protocol-to-tfl`,
+`tealflow`, `landing-zone`).
 
 Skip this if you only use `human` or `agent` executor steps, or run with `MOCK_AGENT=true`.
 

--- a/docs/dev-quickref.md
+++ b/docs/dev-quickref.md
@@ -95,3 +95,5 @@ Requires SSH access to the staging host (uses `deploy` user by default, override
 | `pnpm dev`: "Docker Compose v2 is not installed" | Engine-only `docker.io` lacks Compose — `sudo apt install docker-compose-v2` (Ubuntu); Docker Desktop bundles it. |
 | `relation "..." does not exist`          | `pnpm db:migrate`.                                               |
 | Stale / corrupt local data               | `docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v && pnpm dev` (wipes the pg volume). |
+| `mediforce: missing API key`             | Set `MEDIFORCE_API_KEY` (see [GETTING-STARTED §3](../GETTING-STARTED.md#3-run-the-cli)). |
+| `Unable to find image '...' locally` (script step) | Build local agent images: `./scripts/rebuild-docker-images.sh` ([GETTING-STARTED](../GETTING-STARTED.md#build-images-for-script-executor-steps)). |


### PR DESCRIPTION
## Summary
- GETTING-STARTED now documents `MEDIFORCE_API_KEY` setup (must match `PLATFORM_API_KEY`) before the first CLI command, instead of just linking to a skill.
- New "Build images for script-executor steps" section covers `mediforce-golden-image` / `mediforce-node` and `./scripts/rebuild-docker-images.sh`, which was previously undocumented even though most `apps/*` workflows depend on it.
- Added matching troubleshooting entries (`mediforce: missing API key`, `Unable to find image '...' locally`) to GETTING-STARTED and dev-quickref.
- README's "Building Docker images for script steps" section now points at `rebuild-docker-images.sh` and lists all 5 images it builds (was missing 3).

## Test plan
- [x] Docs-only change, no code/tests affected
- [ ] New dev follows GETTING-STARTED end to end and confirms no surprise errors before first workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)