### PR TITLE
Output Files: preserve agent-produced artifacts on run branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Added
+- Output Files are now downloadable over the API — `GET /api/runs/<runId>/files` lists what a run committed under `.mediforce/output/<stepId>/` and `GET /api/runs/<runId>/files/<path>` serves the bytes (binary-safe, RFC 6266 attachment), with `mediforce.runs.listOutputFiles` / `downloadOutputFile` client methods.
 - `verdict-with-params` task kind lets a single human step collect structured param values and a verdict together — previously required two separate steps [#658](https://github.com/Appsilon/mediforce/pull/658). Includes `ParamVerdictView` component and `datetime` param type support.
 - **Merged workflow designer** — consolidated `workflow-designer` (v21), `workflow-designer-2` (v3), and `cowork-workflow-designer` (v5) into a single cowork-based `workflow-designer` with create/edit mode support, live validation, HTML diagram previews, and a rich system prompt covering the full WorkflowDefinition schema.
   - Cowork sessions now validate artifacts live on every `update_artifact` call (wires up the previously unused `validateOutputSchema`), with results shown in the artifact panel and enforced as a gate on finalize.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Added
-- Output Files are now downloadable over the API — `GET /api/runs/<runId>/files` lists what a run committed under `.mediforce/output/<stepId>/` and `GET /api/runs/<runId>/files/<path>` serves the bytes (binary-safe, RFC 6266 attachment), with `mediforce.runs.listOutputFiles` / `downloadOutputFile` client methods.
+- Agent-produced files are no longer lost — everything an agent step leaves in `/output` is preserved as **Output Files** on the run branch (`.mediforce/output/<stepId>/`, ADR-0007) and is reviewable and downloadable:
+  - API: `GET /api/runs/<runId>/files` lists a run's files; `GET /api/runs/<runId>/files/<path>` serves the bytes (binary-safe, RFC 6266 attachment); `mediforce.runs.listOutputFiles` / `downloadOutputFile` client methods.
+  - UI: "Files" card on the run detail page (grouped by step, hidden when empty) + per-step paperclip chips expanding to that step's files.
+  - CLI: `mediforce run files <runId>` and `mediforce run download <runId> [path] [-o dir]`.
 - `verdict-with-params` task kind lets a single human step collect structured param values and a verdict together — previously required two separate steps [#658](https://github.com/Appsilon/mediforce/pull/658). Includes `ParamVerdictView` component and `datetime` param type support.
 - **Merged workflow designer** — consolidated `workflow-designer` (v21), `workflow-designer-2` (v3), and `cowork-workflow-designer` (v5) into a single cowork-based `workflow-designer` with create/edit mode support, live validation, HTML diagram previews, and a rich system prompt covering the full WorkflowDefinition schema.
   - Cowork sessions now validate artifacts live on every `update_artifact` call (wires up the previously unused `validateOutputSchema`), with results shown in the artifact panel and enforced as a gate on finalize.
@@ -22,6 +25,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
   - Artifact panel: collapsible JSON tree explorer replaces raw `JSON.stringify`; tabbed Data/Preview view.
   - Built-in tool calls (`update_artifact`, `update_presentation`) now persist as live tool turns visible in the cowork chat UI.
   - Postgres migration 0018: `validation_result` (jsonb) + `presentation` (text) columns on `cowork_sessions`.
+
+### Fixed
+- Queued (BullMQ) Docker execution no longer corrupts binary files (PDF, XLSX, ZIP) and now preserves nested output directories — file payloads cross Redis as base64 keyed by POSIX relative path, matching local-mode behaviour.
 
 ## [2026-05-31]
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -86,6 +86,14 @@ Structured deliverable that a human and an agent build collaboratively across
 the turns of a Cowork Session. **Not** the same as Output or Variables —
 finalized artifact is promoted to Output only when the cowork step completes.
 
+**Output Files** (per Step Execution):
+Files a Step Execution leaves behind alongside its Output (reports, exports,
+generated documents) — preserved per Workflow Run on success and failure
+alike, listable and downloadable by Run members (UI + CLI).
+_Avoid_: Artifact (= Cowork Session deliverable), "deliverable"/`deliverableFile`
+(legacy single-file mechanism), conflating with Output (= the structured result;
+Output Files are its file siblings).
+
 ### Agent + human work
 
 **Agent Run**:
@@ -225,7 +233,7 @@ the user-facing immutable log.
   (`name`+`version` identifies which version of which Workflow).
 - A **Workflow Run** has many **Step Executions**.
 - A **Step Execution** has 0..1 **Agent Run**, 0..1 **Cowork Session**,
-  0..N **Human Tasks** attached.
+  0..N **Human Tasks** attached, and produces 0..N **Output Files**.
 - An **Agent Run** may produce 0..N **Handoffs**.
 - An **Agent** has many **Agent MCP Bindings** (per server) and
   many **Agent OAuth Tokens** (per server).
@@ -255,11 +263,13 @@ the user-facing immutable log.
   drop the suffix is pending in a follow-up PR. If we ever introduce
   agent versioning, the suffix will earn its keep — see the **Agent**
   glossary entry.
-- **Output vs Variables vs Artifact**: three distinct concepts, often
-  confused. Output = one step's immediate result. Variables = accumulated
-  outputs forwarded across steps. Artifact = collaboratively built
-  deliverable inside a cowork session (promoted to Output only on cowork
-  finalize). Keep the distinction in storage too.
+- **Output vs Variables vs Artifact vs Output Files**: four distinct
+  concepts, often confused. Output = one step's immediate result.
+  Variables = accumulated outputs forwarded across steps. Artifact =
+  collaboratively built deliverable inside a cowork session (promoted to
+  Output only on cowork finalize). Output Files = files a step leaves
+  behind alongside its Output (resolved 2026-06-10, ADR-0007). Keep the
+  distinction in storage too.
 - **Workflow visibility (`public` vs `private`)**: Defined in PR #346 — a
   `public` Workflow Definition is **read-discoverable from other
   Namespaces**; `private` is members-only. **Workflow Runs (runs) are

--- a/docs/adr/0007-output-files-on-run-branch.md
+++ b/docs/adr/0007-output-files-on-run-branch.md
@@ -1,0 +1,42 @@
+# Output Files live on the run branch of the git workspace
+
+Status: accepted (2026-06-10)
+
+Container agents write files into an ephemeral `/output` mount that is
+deleted after each step — everything except one whitelisted-extension
+"deliverable" was lost, and users had no way to list or download what an
+agent produced. Meanwhile every Workflow Run already provisions a git
+worktree (`/workspace`) backed by a local bare repo, committed after every
+step (success or failure) on a never-pushed run branch.
+
+**Decision:** after each agent step, copy the contents of `/output` —
+minus internal runtime files (`auth.json`, `prompt.txt`, `result.json`,
+`git-result.json`, `mock-result.json`, `opencode.json`) and minus files
+over a per-file size cap (platform config, default 100 MB) — into
+`.mediforce/output/<stepId>/` inside the workspace, so the existing
+per-step commit captures them on the run branch. Listing reads
+`git ls-tree` and downloads read `git show` against the bare repo; no new
+storage system is introduced. `.mediforce/` is a reserved namespace, so
+repos that legitimately contain an `output/` directory never conflict.
+
+## Considered options
+
+- **Object storage (S3 / GCS / Firebase Storage):** new infrastructure,
+  credentials, and lock-in for a single-tenant, on-prem-capable product —
+  rejected for v1; the git workspace already exists on every deployment.
+- **File metadata persisted in the agent envelope / DB:** creates a second
+  source of truth next to the git tree; rejected — git is the single
+  source, one `ls-tree` per run page serves both the Files section and
+  per-step counts.
+
+## Consequences
+
+- Output Files become part of the run's audit trail: versioned per step,
+  captured even for failed steps (✗ commits), immutable.
+- Large binaries enter the immutable history of the *local* bare repo —
+  disk-only impact today because run branches are never pushed. If run
+  branches ever get pushed to a remote, revisit (exclude `.mediforce/`
+  from the push, or git-lfs).
+- The platform API host must share a filesystem with
+  `~/.mediforce/bare-repos` (already an existing assumption — the
+  deliverable-file route reads host tmpdir today).

--- a/docs/adr/0007-output-files-on-run-branch.md
+++ b/docs/adr/0007-output-files-on-run-branch.md
@@ -11,11 +11,16 @@ step (success or failure) on a never-pushed run branch.
 
 **Decision:** after each agent step, copy the contents of `/output` —
 minus internal runtime files (`auth.json`, `prompt.txt`, `result.json`,
-`git-result.json`, `mock-result.json`, `opencode.json`) and minus files
-over a per-file size cap (platform config, default 100 MB) — into
+`git-result.json`, `mock-result.json`, `opencode.json`, `input.json`,
+`previous_run.json`, `mcp-config.json`, `script.{mjs,py,R,sh}`; source of
+truth: `INTERNAL_OUTPUT_FILE_NAMES` in
+`packages/agent-runtime/src/workspace/output-files.ts`) and minus files
+over a per-file size cap (`MEDIFORCE_OUTPUT_FILE_MAX_BYTES`, default
+100 MiB) — into
 `.mediforce/output/<stepId>/` inside the workspace, so the existing
 per-step commit captures them on the run branch. Listing reads
-`git ls-tree` and downloads read `git show` against the bare repo; no new
+`git ls-tree` and downloads read `git cat-file blob` against the bare
+repo; no new
 storage system is introduced. `.mediforce/` is a reserved namespace, so
 repos that legitimately contain an `output/` directory never conflict.
 
@@ -40,3 +45,7 @@ repos that legitimately contain an `output/` directory never conflict.
 - The platform API host must share a filesystem with
   `~/.mediforce/bare-repos` (already an existing assumption — the
   deliverable-file route reads host tmpdir today).
+- `MEDIFORCE_OUTPUT_FILE_MAX_BYTES` must be configured identically on the
+  runtime and API hosts — the reader sizes its git buffer from the same
+  env, so a smaller value on the API side would truncate downloads of
+  files the runtime legitimately committed.

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -87,6 +87,14 @@ export type {
   CommitStepOptions,
   CommitStepResult,
 } from './workspace/workspace-manager';
+export { WorkspaceReader } from './workspace/workspace-reader';
+export type { OutputFileEntry, WorkspaceReaderInit } from './workspace/workspace-reader';
+export {
+  copyOutputFilesIntoWorkspace,
+  INTERNAL_OUTPUT_FILE_NAMES,
+  PRESENTATION_FILE_NAMES,
+  OUTPUT_FILES_REPO_ROOT,
+} from './workspace/output-files';
 
 // Testing utilities
 export {

--- a/packages/agent-runtime/src/plugins/__tests__/docker-spawn-strategy.queued.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/docker-spawn-strategy.queued.test.ts
@@ -1,0 +1,97 @@
+/**
+ * QueuedDockerSpawnStrategy ships outputDir contents through Redis (JSON) to a
+ * remote worker and writes the worker's output files back. These tests pin the
+ * wire format: base64 values keyed by POSIX relative paths, so binary files and
+ * nested directories survive the round-trip exactly like on the local path.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { QueuedDockerSpawnStrategy } from '../docker-spawn-strategy';
+import type { DockerSpawnRequest } from '../docker-spawn-strategy';
+import { enqueueDockerJob } from '@mediforce/container-worker';
+import type { DockerJobData, DockerJobResult } from '@mediforce/container-worker';
+
+vi.mock('@mediforce/container-worker', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mediforce/container-worker')>();
+  return { ...actual, enqueueDockerJob: vi.fn() };
+});
+
+const mockEnqueue = vi.mocked(enqueueDockerJob);
+
+/** Every possible byte value — catches any lossy text-encoding round-trip. */
+const allBytes = Buffer.from(Array.from({ length: 256 }, (_, index) => index));
+
+function buildRequest(outputDir: string): DockerSpawnRequest {
+  return {
+    dockerArgs: ['run', '--rm', 'test-image'],
+    stdinPayload: null,
+    timeoutMs: 1_000,
+    containerName: 'test-container',
+    processInstanceId: 'pi-1',
+    stepId: 'step-1',
+    outputDir,
+    logFile: null,
+  };
+}
+
+function buildResult(overrides: Partial<DockerJobResult> = {}): DockerJobResult {
+  return { stdout: '', stderr: '', exitCode: 0, signal: null, ...overrides };
+}
+
+describe('QueuedDockerSpawnStrategy file transport', () => {
+  let outputDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    outputDir = await mkdtemp(join(tmpdir(), 'queued-strategy-'));
+  });
+
+  afterEach(async () => {
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('sends binary and nested input files as base64 with POSIX relative-path keys', async () => {
+    await writeFile(join(outputDir, 'input.pdf'), allBytes);
+    await mkdir(join(outputDir, 'data', 'raw'), { recursive: true });
+    await writeFile(join(outputDir, 'data', 'raw', 'samples.bin'), allBytes);
+    mockEnqueue.mockResolvedValue(buildResult());
+
+    await new QueuedDockerSpawnStrategy().spawn(buildRequest(outputDir));
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const jobData: DockerJobData = mockEnqueue.mock.calls[0][0];
+    expect(Object.keys(jobData.inputFiles ?? {}).sort()).toEqual(['data/raw/samples.bin', 'input.pdf']);
+    expect(Buffer.from(jobData.inputFiles!['input.pdf'], 'base64').equals(allBytes)).toBe(true);
+    expect(Buffer.from(jobData.inputFiles!['data/raw/samples.bin'], 'base64').equals(allBytes)).toBe(true);
+  });
+
+  it('writes returned base64 output files back byte-for-byte, recreating nested directories', async () => {
+    mockEnqueue.mockResolvedValue(
+      buildResult({
+        outputFiles: {
+          'report.xlsx': allBytes.toString('base64'),
+          'charts/q1/plot.png': allBytes.toString('base64'),
+        },
+      }),
+    );
+
+    await new QueuedDockerSpawnStrategy().spawn(buildRequest(outputDir));
+
+    const restoredReport = await readFile(join(outputDir, 'report.xlsx'));
+    expect(restoredReport.equals(allBytes)).toBe(true);
+    const restoredPlot = await readFile(join(outputDir, 'charts', 'q1', 'plot.png'));
+    expect(restoredPlot.equals(allBytes)).toBe(true);
+  });
+
+  it('returns the worker result unchanged', async () => {
+    mockEnqueue.mockResolvedValue(buildResult({ stdout: 'hello\n', exitCode: 3 }));
+
+    const result = await new QueuedDockerSpawnStrategy().spawn(buildRequest(outputDir));
+
+    expect(result.stdout).toBe('hello\n');
+    expect(result.exitCode).toBe(3);
+    expect(result.signal).toBeNull();
+  });
+});

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -8,6 +8,7 @@ import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata, Mc
 import { resolveStepEnv, resolveValue, type ResolvedEnv } from './resolve-env';
 import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy';
 import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, resolveRepoToken, normalizeRepoUrls, formatExitInfo, type ContainerPluginInit } from './container-plugin';
+import { INTERNAL_OUTPUT_FILE_NAMES, PRESENTATION_FILE_NAMES } from '../workspace/output-files';
 import { renderOAuthHeader } from '../oauth/resolve-oauth-token';
 import { createLineStreamReader } from '@mediforce/platform-core';
 
@@ -531,11 +532,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
     instanceId: string,
     stepId: string,
   ): Promise<string | null> {
-    const INTERNAL_NAMES = new Set([
-      'opencode.json', 'auth.json', 'prompt.txt', 'result.json',
-      'git-result.json', 'mock-result.json',
-      'presentation.html', 'presentation.md',
-    ]);
+    const INTERNAL_NAMES = new Set([...INTERNAL_OUTPUT_FILE_NAMES, ...PRESENTATION_FILE_NAMES]);
     const DELIVERABLE_EXTS = new Set(['.html', '.htm', '.pdf', '.csv', '.xlsx', '.md']);
 
     let entries: string[];
@@ -566,7 +563,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
     // Also handle presentation.{md,html} — already read into
     // spawnResult.presentation but a persisted path is needed for the
     // Download Report button. Markdown wins on tie.
-    for (const filename of ['presentation.md', 'presentation.html']) {
+    for (const filename of PRESENTATION_FILE_NAMES) {
       const presentationPath = join(outputDir, filename);
       try {
         const destDir = join(tmpdir(), 'mediforce-deliverables', instanceId);

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -65,6 +65,7 @@ import type { GitMetadata } from '@mediforce/platform-core';
 import { resolveStepEnv, type ResolvedEnv } from './resolve-env';
 import type { ImageBuildMeta } from './docker-spawn-strategy';
 import { WorkspaceManager, type RunWorkspaceHandle } from '../workspace/workspace-manager';
+import { copyOutputFilesIntoWorkspace } from '../workspace/output-files';
 
 let preparedDeployKeyPath: string | null = null;
 
@@ -297,6 +298,10 @@ export abstract class ContainerPlugin implements AgentPlugin {
    *   ✓ last agent step of the run (no more agents will touch the workspace)
    *   ✗ failed — commits whatever the step produced before the error
    *
+   * Before committing, copies the step's `/output` deliverables into
+   * `.mediforce/output/<stepId>/` in the worktree (best-effort) so the same
+   * commit captures them — see `copyOutputFilesIntoWorkspace`.
+   *
    * Writes `git-result.json` into `outputDir` for downstream consumers.
    * Never pushes — run branches stay local for now.
    */
@@ -305,6 +310,8 @@ export abstract class ContainerPlugin implements AgentPlugin {
     opts: CommitRunWorkspaceOptions = {},
   ): Promise<GitMetadata | null> {
     if (!this.runWorkspaceHandle || !this.workspaceManager) return null;
+
+    await copyOutputFilesIntoWorkspace(outputDir, this.runWorkspaceHandle.path, this.context.stepId);
 
     const commit = await this.workspaceManager.commitStep(this.runWorkspaceHandle, {
       stepId: this.context.stepId,

--- a/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
+++ b/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
@@ -8,8 +8,8 @@
  * The queued strategy is activated when REDIS_URL is set.
  */
 import { spawn } from 'node:child_process';
-import { appendFile, readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { appendFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { ensureImage } from './docker-image-builder';
 import { createLineStreamReader } from '@mediforce/platform-core';
 
@@ -210,7 +210,9 @@ export class LocalDockerSpawnStrategy implements DockerSpawnStrategy {
  * Files from outputDir are sent through Redis as inputFiles so the worker can
  * recreate them locally (caller and worker may not share a filesystem).
  * Output files produced by the container are returned through Redis and
- * written back to the caller's outputDir.
+ * written back to the caller's outputDir. File contents cross the queue as
+ * base64 keyed by POSIX relative path (see container-worker's file-payload.ts),
+ * so binary files and nested directories survive intact.
  *
  * Function callbacks (`onStdoutLine`, `onStderrLine`) cannot cross the Redis
  * boundary, so live streaming is unavailable. The strategy compensates by replaying
@@ -223,16 +225,12 @@ export class QueuedDockerSpawnStrategy implements DockerSpawnStrategy {
   readonly supportsLiveStreaming = false;
 
   async spawn(request: DockerSpawnRequest): Promise<DockerSpawnResult> {
-    const { enqueueDockerJob } = await import('@mediforce/container-worker');
+    const { enqueueDockerJob, encodeFilePayload, decodeFilePayload } = await import('@mediforce/container-worker');
 
-    // Collect all files from outputDir to send through Redis
-    const inputFiles: Record<string, string> = {};
+    // Collect all files from outputDir (base64, nested paths included) to send through Redis
+    let inputFiles: Record<string, string> = {};
     try {
-      const entries = await readdir(request.outputDir);
-      for (const entry of entries) {
-        const content = await readFile(join(request.outputDir, entry), 'utf-8');
-        inputFiles[entry] = content;
-      }
+      inputFiles = await encodeFilePayload(request.outputDir);
       console.log(`[queued-strategy] Collected ${Object.keys(inputFiles).length} input file(s) from ${request.outputDir}: ${Object.keys(inputFiles).join(', ')}`);
     } catch (err) {
       console.warn(`[queued-strategy] Could not read outputDir '${request.outputDir}': ${err instanceof Error ? err.message : err}`);
@@ -284,10 +282,7 @@ export class QueuedDockerSpawnStrategy implements DockerSpawnStrategy {
 
     // Write output files from worker back to caller's outputDir
     if (result.outputFiles) {
-      await mkdir(request.outputDir, { recursive: true });
-      for (const [name, content] of Object.entries(result.outputFiles)) {
-        await writeFile(join(request.outputDir, name), content, 'utf-8');
-      }
+      await decodeFilePayload(result.outputFiles, request.outputDir);
     }
 
     return result;

--- a/packages/agent-runtime/src/workspace/__tests__/output-files.test.ts
+++ b/packages/agent-runtime/src/workspace/__tests__/output-files.test.ts
@@ -4,7 +4,7 @@
  * against temp dirs — no network, no Docker.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, rm, writeFile, mkdir, readFile, stat } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, readFile, stat, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -105,6 +105,27 @@ describe('copyOutputFilesIntoWorkspace', () => {
     expect(warned).toContain('huge.bin');
     expect(warned).toContain('32');
     expect(warned).toContain('8');
+  });
+
+  it('never follows symlinks — an agent-written link to a host path must not be copied', async () => {
+    const hostDir = await mkdtemp(join(tmpdir(), 'outfiles-host-'));
+    try {
+      await writeFile(join(hostDir, 'secret.txt'), 'host-sentinel-do-not-leak');
+      await mkdir(join(hostDir, 'secrets-dir'));
+      await writeFile(join(hostDir, 'secrets-dir', 'inner.txt'), 'host-sentinel-dir');
+      await symlink(join(hostDir, 'secret.txt'), join(outputDir, 'leak'));
+      await symlink(join(hostDir, 'secrets-dir'), join(outputDir, 'leak-dir'));
+      await writeFile(join(outputDir, 'legit.txt'), 'fine');
+
+      await copyOutputFilesIntoWorkspace(outputDir, worktreeDir, 'step-1');
+
+      const destDir = join(worktreeDir, '.mediforce', 'output', 'step-1');
+      await expect(readFile(join(destDir, 'legit.txt'), 'utf-8')).resolves.toBe('fine');
+      await expect(stat(join(destDir, 'leak'))).rejects.toThrow();
+      await expect(stat(join(destDir, 'leak-dir'))).rejects.toThrow();
+    } finally {
+      await rm(hostDir, { recursive: true, force: true }).catch(() => {});
+    }
   });
 
   it('does nothing when outputDir does not exist', async () => {

--- a/packages/agent-runtime/src/workspace/__tests__/output-files.test.ts
+++ b/packages/agent-runtime/src/workspace/__tests__/output-files.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for copyOutputFilesIntoWorkspace and its wiring into
+ * ContainerPlugin.commitRunWorkspace. Real git via WorkspaceManager
+ * against temp dirs — no network, no Docker.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile, mkdir, readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { PluginCapabilityMetadata, WorkflowDefinition, WorkflowStep, WorkflowWorkspace } from '@mediforce/platform-core';
+import { WorkspaceManager, type RunWorkspaceHandle } from '../workspace-manager';
+import { copyOutputFilesIntoWorkspace } from '../output-files';
+import { ContainerPlugin, type CommitRunWorkspaceOptions, type WorkspaceManagerLike } from '../../plugins/container-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../../interfaces/agent-plugin';
+import type { GitMetadata } from '@mediforce/platform-core';
+
+const MAX_BYTES_ENV = 'MEDIFORCE_OUTPUT_FILE_MAX_BYTES';
+
+describe('copyOutputFilesIntoWorkspace', () => {
+  let outputDir: string;
+  let worktreeDir: string;
+  const originalMaxBytes = process.env[MAX_BYTES_ENV];
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(join(tmpdir(), 'outfiles-output-'));
+    worktreeDir = await mkdtemp(join(tmpdir(), 'outfiles-worktree-'));
+  });
+
+  afterEach(async () => {
+    await rm(outputDir, { recursive: true, force: true }).catch(() => {});
+    await rm(worktreeDir, { recursive: true, force: true }).catch(() => {});
+    if (originalMaxBytes === undefined) delete process.env[MAX_BYTES_ENV];
+    else process.env[MAX_BYTES_ENV] = originalMaxBytes;
+    vi.restoreAllMocks();
+  });
+
+  it('copies top-level files into .mediforce/output/<stepId>/', async () => {
+    await writeFile(join(outputDir, 'report.csv'), 'a,b\n1,2\n');
+    await copyOutputFilesIntoWorkspace(outputDir, worktreeDir, 'extract');
+
+    const copied = await readFile(join(worktreeDir, '.mediforce', 'output', 'extract', 'report.csv'), 'utf-8');
+    expect(copied).toBe('a,b\n1,2\n');
+  });
+
+  it('filters internal runtime files by name but copies presentation files', async () => {
+    const internals = [
+      'auth.json', 'prompt.txt', 'result.json', 'git-result.json', 'mock-result.json', 'opencode.json',
+      'input.json', 'previous_run.json', 'mcp-config.json',
+      'script.mjs', 'script.py', 'script.R', 'script.sh',
+    ];
+    for (const name of internals) {
+      await writeFile(join(outputDir, name), '{}');
+    }
+    await writeFile(join(outputDir, 'presentation.md'), '# deck');
+    await writeFile(join(outputDir, 'presentation.html'), '<h1>deck</h1>');
+    await writeFile(join(outputDir, 'findings.json'), '{"ok":true}');
+
+    await copyOutputFilesIntoWorkspace(outputDir, worktreeDir, 'step-1');
+
+    const destDir = join(worktreeDir, '.mediforce', 'output', 'step-1');
+    await expect(readFile(join(destDir, 'presentation.md'), 'utf-8')).resolves.toBe('# deck');
+    await expect(readFile(join(destDir, 'presentation.html'), 'utf-8')).resolves.toBe('<h1>deck</h1>');
+    await expect(readFile(join(destDir, 'findings.json'), 'utf-8')).resolves.toBe('{"ok":true}');
+    for (const name of internals) {
+      await expect(stat(join(destDir, name))).rejects.toThrow();
+    }
+  });
+
+  it('skips dotfiles at the top level', async () => {
+    await writeFile(join(outputDir, '.hidden'), 'nope');
+    await writeFile(join(outputDir, 'visible.txt'), 'yes');
+
+    await copyOutputFilesIntoWorkspace(outputDir, worktreeDir, 'step-1');
+
+    const destDir = join(worktreeDir, '.mediforce', 'output', 'step-1');
+    await expect(readFile(join(destDir, 'visible.txt'), 'utf-8')).resolves.toBe('yes');
+    await expect(stat(join(destDir, '.hidden'))).rejects.toThrow();
+  });
+
+  it('copies nested directories recursively; internal-name filtering applies only at the top level', async () => {
+    await mkdir(join(outputDir, 'charts', 'q1'), { recursive: true });
+    await writeFile(join(outputDir, 'charts', 'q1', 'plot.svg'), '<svg/>');
+    await writeFile(join(outputDir, 'charts', 'result.json'), '{"nested":true}');
+
+    await copyOutputFilesIntoWorkspace(outputDir, worktreeDir, 'step-1');
+
+    const destDir = join(worktreeDir, '.mediforce', 'output', 'step-1');
+    await expect(readFile(join(destDir, 'charts', 'q1', 'plot.svg'), 'utf-8')).resolves.toBe('<svg/>');
+    await expect(readFile(join(destDir, 'charts', 'result.json'), 'utf-8')).resolves.toBe('{"nested":true}');
+  });
+
+  it('skips files over the MEDIFORCE_OUTPUT_FILE_MAX_BYTES cap with a warning', async () => {
+    process.env[MAX_BYTES_ENV] = '8';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await writeFile(join(outputDir, 'huge.bin'), 'x'.repeat(32));
+    await writeFile(join(outputDir, 'tiny.txt'), 'ok');
+
+    await copyOutputFilesIntoWorkspace(outputDir, worktreeDir, 'step-1');
+
+    const destDir = join(worktreeDir, '.mediforce', 'output', 'step-1');
+    await expect(readFile(join(destDir, 'tiny.txt'), 'utf-8')).resolves.toBe('ok');
+    await expect(stat(join(destDir, 'huge.bin'))).rejects.toThrow();
+    const warned = warnSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(warned).toContain('huge.bin');
+    expect(warned).toContain('32');
+    expect(warned).toContain('8');
+  });
+
+  it('does nothing when outputDir does not exist', async () => {
+    await expect(
+      copyOutputFilesIntoWorkspace(join(outputDir, 'missing-subdir'), worktreeDir, 'step-1'),
+    ).resolves.toBeUndefined();
+    await expect(stat(join(worktreeDir, '.mediforce'))).rejects.toThrow();
+  });
+
+  it('does not create an empty .mediforce/output/<stepId>/ dir when nothing is copyable', async () => {
+    await writeFile(join(outputDir, 'result.json'), '{}');
+    await writeFile(join(outputDir, '.dotfile'), 'skip');
+
+    await copyOutputFilesIntoWorkspace(outputDir, worktreeDir, 'step-1');
+
+    await expect(stat(join(worktreeDir, '.mediforce'))).rejects.toThrow();
+  });
+});
+
+class TestContainerPlugin extends ContainerPlugin {
+  readonly metadata: PluginCapabilityMetadata = {
+    name: 'test-container',
+    description: 'test double for commitRunWorkspace',
+    inputDescription: 'none',
+    outputDescription: 'none',
+    roles: ['executor'],
+  };
+
+  async initialize(context: AgentContext | WorkflowAgentContext): Promise<void> {
+    this.context = context;
+  }
+
+  async run(_emit: EmitFn): Promise<void> {}
+
+  attachWorkspace(handle: RunWorkspaceHandle, manager: WorkspaceManagerLike): void {
+    this.runWorkspaceHandle = handle;
+    this.workspaceManager = manager;
+  }
+
+  commit(outputDir: string, opts?: CommitRunWorkspaceOptions): Promise<GitMetadata | null> {
+    return this.commitRunWorkspace(outputDir, opts);
+  }
+}
+
+function buildWorkflowContext(stepId: string): WorkflowAgentContext {
+  const step: WorkflowStep = {
+    id: stepId,
+    name: 'Test Step',
+    type: 'creation',
+    executor: 'agent',
+    plugin: 'test-container',
+    agent: { skill: 'noop' },
+  };
+  const workflowDefinition: WorkflowDefinition = {
+    name: `wd-outfiles-${Math.random().toString(36).slice(2, 8)}`,
+    namespace: '_default',
+    version: 1,
+    visibility: 'private',
+    steps: [step],
+    transitions: [],
+    triggers: [{ type: 'manual', name: 'start' }],
+    workspace: {},
+  };
+  return {
+    stepId,
+    processInstanceId: `pi-${Date.now().toString()}-${Math.random().toString(36).slice(2, 6)}`,
+    runNamespace: 'test',
+    definitionVersion: 'v1',
+    stepInput: {},
+    autonomyLevel: 'L4',
+    workflowDefinition,
+    step,
+    llm: { complete: vi.fn() },
+    getPreviousStepOutputs: vi.fn().mockResolvedValue({}),
+  };
+}
+
+describe('ContainerPlugin.commitRunWorkspace output-file capture', () => {
+  let dataDir: string;
+  let outputDir: string;
+  let manager: WorkspaceManager;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'outfiles-commit-data-'));
+    outputDir = await mkdtemp(join(tmpdir(), 'outfiles-commit-output-'));
+    manager = new WorkspaceManager({ dataDir });
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+    await rm(outputDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function setupPlugin(stepId: string): Promise<{ plugin: TestContainerPlugin; handle: RunWorkspaceHandle; context: WorkflowAgentContext }> {
+    const context = buildWorkflowContext(stepId);
+    const plugin = new TestContainerPlugin();
+    await plugin.initialize(context);
+    const handle = await manager.createRunWorkspace(
+      { name: context.workflowDefinition.name, namespace: context.workflowDefinition.namespace, workspace: {} as WorkflowWorkspace },
+      context.processInstanceId,
+    );
+    plugin.attachWorkspace(handle, manager);
+    return { plugin, handle, context };
+  }
+
+  it('copies output files into the workspace so the step commit captures them (success)', async () => {
+    const { plugin, handle } = await setupPlugin('extract');
+    await writeFile(join(outputDir, 'report.csv'), 'a,b\n');
+    await writeFile(join(outputDir, 'result.json'), '{"internal":true}');
+
+    const metadata = await plugin.commit(outputDir);
+
+    expect(metadata).not.toBeNull();
+    const committedFiles = execFileSync(
+      'git', ['diff-tree', '--no-commit-id', '--name-only', '-r', metadata!.commitSha],
+      { cwd: handle.path, encoding: 'utf-8' },
+    ).trim().split('\n');
+    expect(committedFiles).toContain('.mediforce/output/extract/report.csv');
+    expect(committedFiles).not.toContain('.mediforce/output/extract/result.json');
+
+    // git-result.json is still written into outputDir post-commit (existing contract)
+    const gitResult = JSON.parse(await readFile(join(outputDir, 'git-result.json'), 'utf-8')) as GitMetadata;
+    expect(gitResult.commitSha).toBe(metadata!.commitSha);
+  });
+
+  it('copies output files on failed-step commits too', async () => {
+    const { plugin, handle } = await setupPlugin('doomed');
+    await writeFile(join(outputDir, 'partial.log'), 'got this far');
+
+    const metadata = await plugin.commit(outputDir, { status: 'failed', error: 'boom' });
+
+    expect(metadata).not.toBeNull();
+    const committedFiles = execFileSync(
+      'git', ['diff-tree', '--no-commit-id', '--name-only', '-r', metadata!.commitSha],
+      { cwd: handle.path, encoding: 'utf-8' },
+    ).trim().split('\n');
+    expect(committedFiles).toContain('.mediforce/output/doomed/partial.log');
+
+    const subject = execFileSync('git', ['log', '-1', '--format=%s'], { cwd: handle.path, encoding: 'utf-8' }).trim();
+    expect(subject).toContain('✗');
+  });
+});

--- a/packages/agent-runtime/src/workspace/__tests__/workspace-reader.test.ts
+++ b/packages/agent-runtime/src/workspace/__tests__/workspace-reader.test.ts
@@ -121,6 +121,17 @@ describe('WorkspaceReader', () => {
       expect(result!.equals(binary)).toBe(true);
     });
 
+    it('returns null for a directory path instead of serving a tree listing', async () => {
+      const workflow = { name: 'wd-dir-path' };
+      await commitOutputFiles(workflow, 'run-dir', 'step-x', { 'sub/file.txt': 'nested content' });
+
+      expect(await reader.readOutputFile(workflow, 'run-dir', '.mediforce/output/step-x')).toBeNull();
+      expect(await reader.readOutputFile(workflow, 'run-dir', '.mediforce/output/step-x/sub')).toBeNull();
+      // The blob itself stays readable.
+      const blob = await reader.readOutputFile(workflow, 'run-dir', '.mediforce/output/step-x/sub/file.txt');
+      expect(blob!.toString('utf-8')).toBe('nested content');
+    });
+
     it('returns null for a missing file', async () => {
       const workflow = { name: 'wd-missing-file' };
       await commitOutputFiles(workflow, 'run-1', 'step-1', { 'real.txt': 'x' });

--- a/packages/agent-runtime/src/workspace/__tests__/workspace-reader.test.ts
+++ b/packages/agent-runtime/src/workspace/__tests__/workspace-reader.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for WorkspaceReader — read-only access to Output Files on run
+ * branches in the bare repo. Real git via WorkspaceManager against temp dirs.
+ */
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { WorkflowWorkspace } from '@mediforce/platform-core';
+import { WorkspaceManager } from '../workspace-manager';
+import { WorkspaceReader } from '../workspace-reader';
+
+describe('WorkspaceReader', () => {
+  let dataDir: string;
+  let manager: WorkspaceManager;
+  let reader: WorkspaceReader;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'wsreader-data-'));
+    manager = new WorkspaceManager({ dataDir });
+    reader = new WorkspaceReader({ dataDir });
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function commitOutputFiles(
+    workflow: { name: string; namespace?: string },
+    runId: string,
+    stepId: string,
+    files: Record<string, Buffer | string>,
+  ): Promise<void> {
+    const ws = await manager.createRunWorkspace(
+      { ...workflow, workspace: {} as WorkflowWorkspace },
+      runId,
+    );
+    for (const [relativePath, content] of Object.entries(files)) {
+      const destPath = join(ws.path, '.mediforce', 'output', stepId, relativePath);
+      await mkdir(dirname(destPath), { recursive: true });
+      await writeFile(destPath, content);
+    }
+    await manager.commitStep(ws, { stepId });
+  }
+
+  describe('listOutputFiles', () => {
+    it('returns entries with stepId, name, path, and size across two steps', async () => {
+      const workflow = { name: 'wd-list' };
+      await commitOutputFiles(workflow, 'run-1', 'extract', {
+        'report.csv': 'a,b\n1,2\n',
+        'charts/plot.svg': '<svg/>',
+      });
+      await commitOutputFiles(workflow, 'run-1', 'summarize', {
+        'summary.md': '# done',
+      });
+
+      const entries = await reader.listOutputFiles(workflow, 'run-1');
+      const sorted = entries.sort((left, right) => left.path.localeCompare(right.path));
+
+      expect(sorted).toEqual([
+        {
+          stepId: 'extract',
+          name: 'charts/plot.svg',
+          path: '.mediforce/output/extract/charts/plot.svg',
+          size: Buffer.byteLength('<svg/>'),
+        },
+        {
+          stepId: 'extract',
+          name: 'report.csv',
+          path: '.mediforce/output/extract/report.csv',
+          size: Buffer.byteLength('a,b\n1,2\n'),
+        },
+        {
+          stepId: 'summarize',
+          name: 'summary.md',
+          path: '.mediforce/output/summarize/summary.md',
+          size: Buffer.byteLength('# done'),
+        },
+      ]);
+    });
+
+    it('resolves namespaced workflows to the right bare repo', async () => {
+      const workflow = { name: 'wd-ns', namespace: 'team' };
+      await commitOutputFiles(workflow, 'run-ns', 'step-1', { 'out.txt': 'hello' });
+
+      const entries = await reader.listOutputFiles(workflow, 'run-ns');
+      expect(entries).toHaveLength(1);
+      expect(entries[0].path).toBe('.mediforce/output/step-1/out.txt');
+    });
+
+    it('returns [] for an unknown run on an existing repo', async () => {
+      const workflow = { name: 'wd-known' };
+      await commitOutputFiles(workflow, 'run-real', 'step-1', { 'out.txt': 'x' });
+
+      expect(await reader.listOutputFiles(workflow, 'run-ghost')).toEqual([]);
+    });
+
+    it('returns [] when the bare repo does not exist', async () => {
+      expect(await reader.listOutputFiles({ name: 'never-created' }, 'run-1')).toEqual([]);
+    });
+
+    it('returns [] when the run has no output files', async () => {
+      const workflow = { name: 'wd-empty' };
+      const ws = await manager.createRunWorkspace({ ...workflow, workspace: {} as WorkflowWorkspace }, 'run-empty');
+      await writeFile(join(ws.path, 'unrelated.txt'), 'not an output file');
+      await manager.commitStep(ws, { stepId: 'step-1' });
+
+      expect(await reader.listOutputFiles(workflow, 'run-empty')).toEqual([]);
+    });
+  });
+
+  describe('readOutputFile', () => {
+    it('round-trips binary content byte-identically', async () => {
+      const binary = Buffer.from(Array.from({ length: 256 }, (_, byteValue) => byteValue));
+      const workflow = { name: 'wd-binary' };
+      await commitOutputFiles(workflow, 'run-bin', 'render', { 'data.bin': binary });
+
+      const result = await reader.readOutputFile(workflow, 'run-bin', '.mediforce/output/render/data.bin');
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result!.equals(binary)).toBe(true);
+    });
+
+    it('returns null for a missing file', async () => {
+      const workflow = { name: 'wd-missing-file' };
+      await commitOutputFiles(workflow, 'run-1', 'step-1', { 'real.txt': 'x' });
+
+      expect(await reader.readOutputFile(workflow, 'run-1', '.mediforce/output/step-1/ghost.txt')).toBeNull();
+    });
+
+    it('returns null when the bare repo does not exist', async () => {
+      expect(
+        await reader.readOutputFile({ name: 'never-created' }, 'run-1', '.mediforce/output/s/x.txt'),
+      ).toBeNull();
+    });
+
+    it('rejects paths containing .. segments', async () => {
+      const workflow = { name: 'wd-traversal' };
+      await expect(
+        reader.readOutputFile(workflow, 'run-1', '.mediforce/output/step-1/../../../.git/config'),
+      ).rejects.toThrow();
+    });
+
+    it('rejects paths outside .mediforce/output/', async () => {
+      const workflow = { name: 'wd-outside' };
+      await commitOutputFiles(workflow, 'run-1', 'step-1', { 'real.txt': 'x' });
+      const ws = await manager.createRunWorkspace({ ...workflow, workspace: {} as WorkflowWorkspace }, 'run-1');
+      await writeFile(join(ws.path, 'tracked-but-not-output.txt'), 'secret-ish');
+      await manager.commitStep(ws, { stepId: 'step-2' });
+
+      await expect(reader.readOutputFile(workflow, 'run-1', 'tracked-but-not-output.txt')).rejects.toThrow();
+      await expect(reader.readOutputFile(workflow, 'run-1', '.mediforce/outputs/step-1/x.txt')).rejects.toThrow();
+      await expect(reader.readOutputFile(workflow, 'run-1', '.mediforce/output/')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/agent-runtime/src/workspace/output-files.ts
+++ b/packages/agent-runtime/src/workspace/output-files.ts
@@ -1,0 +1,146 @@
+/**
+ * Output Files — copy a step's `/output` deliverables into the run worktree
+ * under `.mediforce/output/<stepId>/` so the per-step commit captures them.
+ *
+ * The `/output` dir is an ephemeral host↔container I/O channel (deleted after
+ * every step). Anything the agent leaves there besides the engine-owned
+ * control files becomes a durable Output File on the run branch.
+ */
+import { copyFile, mkdir, readdir, stat } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+/**
+ * Engine-owned control files that must never become Output Files. Shared with
+ * `persistDeliverableFile`, which additionally excludes the presentation
+ * files — derive from these constants so the two lists cannot drift apart.
+ */
+export const INTERNAL_OUTPUT_FILE_NAMES: ReadonlySet<string> = new Set([
+  'auth.json',
+  'prompt.txt',
+  'result.json',
+  'git-result.json',
+  'mock-result.json',
+  'opencode.json',
+  'input.json',
+  'previous_run.json',
+  'mcp-config.json',
+  // Inline-script payloads seeded by ScriptContainerPlugin — one per
+  // RUNTIME_CONFIG extension (script-container-plugin.ts).
+  'script.mjs',
+  'script.py',
+  'script.R',
+  'script.sh',
+]);
+
+/** Presentation files — already surfaced via spawnResult.presentation, but
+ *  still copied as Output Files (product decision). Markdown first: order
+ *  matters for the persistDeliverableFile fallback. */
+export const PRESENTATION_FILE_NAMES: readonly string[] = ['presentation.md', 'presentation.html'];
+
+/** Repo-relative root under which Output Files live on the run branch. */
+export const OUTPUT_FILES_REPO_ROOT = '.mediforce/output';
+
+export const DEFAULT_OUTPUT_FILE_MAX_BYTES = 100 * 1024 * 1024;
+
+export function resolveOutputFileMaxBytes(): number {
+  const raw = process.env.MEDIFORCE_OUTPUT_FILE_MAX_BYTES;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_OUTPUT_FILE_MAX_BYTES;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) === false || parsed <= 0) return DEFAULT_OUTPUT_FILE_MAX_BYTES;
+  return parsed;
+}
+
+interface PendingCopy {
+  sourcePath: string;
+  relativePath: string;
+}
+
+async function collectCopyableFile(
+  sourcePath: string,
+  relativePath: string,
+  maxBytes: number,
+  pending: PendingCopy[],
+): Promise<void> {
+  const info = await stat(sourcePath);
+  if (info.isFile() === false) return;
+  if (info.size > maxBytes) {
+    console.warn(
+      `[output-files] Skipping ${relativePath} (${info.size} bytes) — exceeds the ` +
+      `MEDIFORCE_OUTPUT_FILE_MAX_BYTES cap of ${maxBytes} bytes`,
+    );
+    return;
+  }
+  pending.push({ sourcePath, relativePath });
+}
+
+async function collectDirectory(
+  dir: string,
+  relativePrefix: string,
+  maxBytes: number,
+  pending: PendingCopy[],
+): Promise<void> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const sourcePath = join(dir, entry.name);
+    const relativePath = join(relativePrefix, entry.name);
+    if (entry.isDirectory()) {
+      await collectDirectory(sourcePath, relativePath, maxBytes, pending);
+    } else if (entry.isFile()) {
+      await collectCopyableFile(sourcePath, relativePath, maxBytes, pending);
+    }
+  }
+}
+
+/**
+ * Copy the step's Output Files from `outputDir` into
+ * `<worktreePath>/.mediforce/output/<stepId>/`.
+ *
+ * - Internal runtime files and dotfiles are skipped at the top level only;
+ *   nested directories are copied recursively as-is.
+ * - Files over the per-file size cap (`MEDIFORCE_OUTPUT_FILE_MAX_BYTES`,
+ *   default 100 MiB) are skipped with a warning.
+ * - Best-effort: never throws — a copy failure must not fail the step commit.
+ * - Creates no directory when there is nothing to copy.
+ */
+export async function copyOutputFilesIntoWorkspace(
+  outputDir: string,
+  worktreePath: string,
+  stepId: string,
+): Promise<void> {
+  try {
+    let topLevelEntries;
+    try {
+      topLevelEntries = await readdir(outputDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const maxBytes = resolveOutputFileMaxBytes();
+    const pending: PendingCopy[] = [];
+
+    for (const entry of topLevelEntries) {
+      if (entry.name.startsWith('.')) continue;
+      if (INTERNAL_OUTPUT_FILE_NAMES.has(entry.name)) continue;
+      const sourcePath = join(outputDir, entry.name);
+      if (entry.isDirectory()) {
+        await collectDirectory(sourcePath, entry.name, maxBytes, pending);
+      } else if (entry.isFile()) {
+        await collectCopyableFile(sourcePath, entry.name, maxBytes, pending);
+      }
+    }
+
+    if (pending.length === 0) return;
+
+    const destRoot = join(worktreePath, OUTPUT_FILES_REPO_ROOT, stepId);
+    for (const { sourcePath, relativePath } of pending) {
+      try {
+        const destPath = join(destRoot, relativePath);
+        await mkdir(dirname(destPath), { recursive: true });
+        await copyFile(sourcePath, destPath);
+      } catch (copyError) {
+        console.warn(`[output-files] Failed to copy ${relativePath} into the workspace:`, copyError);
+      }
+    }
+  } catch (collectError) {
+    console.warn('[output-files] Failed to copy output files into the workspace:', collectError);
+  }
+}

--- a/packages/agent-runtime/src/workspace/workspace-manager.ts
+++ b/packages/agent-runtime/src/workspace/workspace-manager.ts
@@ -27,6 +27,9 @@ import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import type { WorkflowWorkspace } from '@mediforce/platform-core';
 import { normalizeRepoUrls, toHttpsWithToken } from '../plugins/container-plugin';
+import { bareRepoPathFor, defaultDataDir, runBranchName, worktreePathFor, type WorkflowIdentity } from './workspace-paths';
+
+export type { WorkflowIdentity } from './workspace-paths';
 
 /**
  * Baseline gitignore-style patterns applied to every workspace via `.git/info/exclude`.
@@ -75,11 +78,6 @@ export class SecretDetectedError extends Error {
     );
     this.name = 'SecretDetectedError';
   }
-}
-
-export interface WorkflowIdentity {
-  name: string;
-  namespace?: string;
 }
 
 export interface WorkspaceManagerInit {
@@ -249,15 +247,6 @@ export function formatStepCommitMessage(
   return sections.join('\n\n');
 }
 
-function sanitizeSegment(segment: string): string {
-  // Allow alphanumerics, dashes, underscores, dots. Replace anything else with an underscore.
-  return segment.replace(/[^a-zA-Z0-9._-]/g, '_');
-}
-
-function defaultDataDir(): string {
-  return process.env.MEDIFORCE_DATA_DIR ?? join(homedir(), '.mediforce');
-}
-
 function resolveDeployKeyPath(override?: string): string {
   return override ?? process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
 }
@@ -343,11 +332,11 @@ export class WorkspaceManager {
   }
 
   private bareRepoPath(workflow: WorkflowIdentity): string {
-    return join(this.dataDir, 'bare-repos', sanitizeSegment(workflow.namespace ?? '_default'), `${sanitizeSegment(workflow.name)}.git`);
+    return bareRepoPathFor(this.dataDir, workflow);
   }
 
   private worktreePath(workflow: WorkflowIdentity, runId: string): string {
-    return join(this.dataDir, 'worktrees', sanitizeSegment(workflow.namespace ?? '_default'), sanitizeSegment(workflow.name), sanitizeSegment(runId));
+    return worktreePathFor(this.dataDir, workflow, runId);
   }
 
   private fetchLockPath(bareRepoPath: string): string {
@@ -608,7 +597,7 @@ export class WorkspaceManager {
   ): Promise<RunWorkspaceHandle> {
     const bare = await this.ensureBareRepo(workflow, opts);
     const wtPath = this.worktreePath(workflow, runId);
-    const branch = `run/${runId}`;
+    const branch = runBranchName(runId);
 
     if (await pathExists(join(wtPath, '.git'))) {
       // Worktree already set up — step N>1 of an already-started run
@@ -775,7 +764,7 @@ export class WorkspaceManager {
       const nsDir = join(worktreesRoot, namespace);
       for (const name of await readdir(nsDir).catch(() => [])) {
         const wdDir = join(nsDir, name);
-        const bareRepoPath = join(this.dataDir, 'bare-repos', namespace, `${name}.git`);
+        const bareRepoPath = bareRepoPathFor(this.dataDir, { name, namespace });
         for (const runId of await readdir(wdDir).catch(() => [])) {
           const wtPath = join(wdDir, runId);
           const info = await stat(wtPath).catch(() => null);

--- a/packages/agent-runtime/src/workspace/workspace-paths.ts
+++ b/packages/agent-runtime/src/workspace/workspace-paths.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared path/branch conventions for the run-workspace storage layout.
+ * Used by WorkspaceManager (read-write) and WorkspaceReader (read-only) —
+ * single source of truth so the two can never drift apart.
+ *
+ * Layout (under `dataDir`, defaulting to `${MEDIFORCE_DATA_DIR ?? ~/.mediforce}`):
+ *
+ *   bare-repos/<namespace>/<name>.git/
+ *   worktrees/<namespace>/<name>/<runId>/
+ *
+ * Run branches are named `run/<runId>` (raw runId — only filesystem path
+ * segments are sanitized).
+ */
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+export interface WorkflowIdentity {
+  name: string;
+  namespace?: string;
+}
+
+export function sanitizeSegment(segment: string): string {
+  // Allow alphanumerics, dashes, underscores, dots. Replace anything else with an underscore.
+  return segment.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+export function defaultDataDir(): string {
+  return process.env.MEDIFORCE_DATA_DIR ?? join(homedir(), '.mediforce');
+}
+
+export function bareRepoPathFor(dataDir: string, workflow: WorkflowIdentity): string {
+  return join(dataDir, 'bare-repos', sanitizeSegment(workflow.namespace ?? '_default'), `${sanitizeSegment(workflow.name)}.git`);
+}
+
+export function worktreePathFor(dataDir: string, workflow: WorkflowIdentity, runId: string): string {
+  return join(dataDir, 'worktrees', sanitizeSegment(workflow.namespace ?? '_default'), sanitizeSegment(workflow.name), sanitizeSegment(runId));
+}
+
+export function runBranchName(runId: string): string {
+  return `run/${runId}`;
+}

--- a/packages/agent-runtime/src/workspace/workspace-reader.ts
+++ b/packages/agent-runtime/src/workspace/workspace-reader.ts
@@ -13,7 +13,7 @@ const execFileAsync = promisify(execFile);
 const OUTPUT_FILES_PATH_PREFIX = `${OUTPUT_FILES_REPO_ROOT}/`;
 
 // Generous stdout cap for git: at least 256 MiB, and never below the
-// configured per-file Output File size cap (binary `git show` payloads).
+// configured per-file Output File size cap (binary `git cat-file` payloads).
 function gitMaxBuffer(): number {
   return Math.max(256 * 1024 * 1024, resolveOutputFileMaxBytes());
 }
@@ -93,10 +93,11 @@ export class WorkspaceReader {
   }
 
   /**
-   * One file's bytes via `git show run/<runId>:<path>` — binary-safe (stdout
-   * captured as a Buffer). Returns null when the repo, branch, or file is
-   * missing. Throws on paths outside `.mediforce/output/` or containing
-   * `..` segments.
+   * One file's bytes via `git cat-file blob run/<runId>:<path>` — binary-safe
+   * (stdout captured as a Buffer). Returns null when the repo, branch, or
+   * file is missing, or when the path names a tree (`git show` would render
+   * a textual directory listing instead; `cat-file blob` refuses non-blobs).
+   * Throws on paths outside `.mediforce/output/` or containing `..` segments.
    */
   async readOutputFile(workflow: WorkflowIdentity, runId: string, path: string): Promise<Buffer | null> {
     assertOutputFilePath(path);
@@ -104,7 +105,7 @@ export class WorkspaceReader {
     try {
       const { stdout } = await execFileAsync(
         'git',
-        ['show', `${runBranchName(runId)}:${path}`],
+        ['cat-file', 'blob', `${runBranchName(runId)}:${path}`],
         { cwd: bareRepoPath, encoding: 'buffer', maxBuffer: gitMaxBuffer() },
       );
       return stdout;

--- a/packages/agent-runtime/src/workspace/workspace-reader.ts
+++ b/packages/agent-runtime/src/workspace/workspace-reader.ts
@@ -1,0 +1,115 @@
+/**
+ * Read-only access to Output Files committed on run branches, straight from
+ * the bare repo — no worktree required, so it works after the worktree has
+ * been swept. Consumed by @mediforce/platform-api for listing and download.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { bareRepoPathFor, defaultDataDir, runBranchName, type WorkflowIdentity } from './workspace-paths';
+import { OUTPUT_FILES_REPO_ROOT, resolveOutputFileMaxBytes } from './output-files';
+
+const execFileAsync = promisify(execFile);
+
+const OUTPUT_FILES_PATH_PREFIX = `${OUTPUT_FILES_REPO_ROOT}/`;
+
+// Generous stdout cap for git: at least 256 MiB, and never below the
+// configured per-file Output File size cap (binary `git show` payloads).
+function gitMaxBuffer(): number {
+  return Math.max(256 * 1024 * 1024, resolveOutputFileMaxBytes());
+}
+
+export interface OutputFileEntry {
+  stepId: string;
+  /** Path relative to `.mediforce/output/<stepId>/` (may contain slashes for nested dirs). */
+  name: string;
+  /** Repo-relative path: `.mediforce/output/<stepId>/<name>` — the download key. */
+  path: string;
+  /** Blob size in bytes. */
+  size: number;
+}
+
+export interface WorkspaceReaderInit {
+  /** Root dir for bare repos. Defaults to `${MEDIFORCE_DATA_DIR ?? ~/.mediforce}`. */
+  dataDir?: string;
+}
+
+function assertOutputFilePath(path: string): void {
+  const isUnderOutputRoot = path.startsWith(OUTPUT_FILES_PATH_PREFIX) && path.length > OUTPUT_FILES_PATH_PREFIX.length;
+  const hasTraversalSegment = path.split('/').includes('..');
+  if (isUnderOutputRoot === false || hasTraversalSegment === true) {
+    throw new Error(
+      `Refusing to read "${path}" — only paths under ${OUTPUT_FILES_PATH_PREFIX} without ".." segments are readable`,
+    );
+  }
+}
+
+export class WorkspaceReader {
+  private readonly dataDir: string;
+
+  constructor(options: WorkspaceReaderInit = {}) {
+    this.dataDir = options.dataDir ?? defaultDataDir();
+  }
+
+  /**
+   * All Output Files of one run, read from
+   * `git ls-tree -r -l run/<runId> -- .mediforce/output/` on the bare repo.
+   * Returns [] when the repo, branch, or directory doesn't exist.
+   */
+  async listOutputFiles(workflow: WorkflowIdentity, runId: string): Promise<OutputFileEntry[]> {
+    const bareRepoPath = bareRepoPathFor(this.dataDir, workflow);
+    let stdout: string;
+    try {
+      const result = await execFileAsync(
+        'git',
+        ['ls-tree', '-r', '-l', '-z', runBranchName(runId), '--', OUTPUT_FILES_PATH_PREFIX],
+        { cwd: bareRepoPath, encoding: 'utf-8', maxBuffer: gitMaxBuffer() },
+      );
+      stdout = result.stdout;
+    } catch {
+      return [];
+    }
+
+    const entries: OutputFileEntry[] = [];
+    for (const record of stdout.split('\0')) {
+      if (record === '') continue;
+      const tabIndex = record.indexOf('\t');
+      if (tabIndex < 0) continue;
+      // Record format: `<mode> <type> <object> <size>\t<path>` (size padded).
+      const [, objectType, , sizeText] = record.slice(0, tabIndex).trim().split(/\s+/);
+      if (objectType !== 'blob') continue;
+      const repoPath = record.slice(tabIndex + 1);
+      if (repoPath.startsWith(OUTPUT_FILES_PATH_PREFIX) === false) continue;
+      const stepRelativePath = repoPath.slice(OUTPUT_FILES_PATH_PREFIX.length);
+      const slashIndex = stepRelativePath.indexOf('/');
+      if (slashIndex <= 0 || slashIndex === stepRelativePath.length - 1) continue;
+      entries.push({
+        stepId: stepRelativePath.slice(0, slashIndex),
+        name: stepRelativePath.slice(slashIndex + 1),
+        path: repoPath,
+        size: Number(sizeText),
+      });
+    }
+    return entries;
+  }
+
+  /**
+   * One file's bytes via `git show run/<runId>:<path>` — binary-safe (stdout
+   * captured as a Buffer). Returns null when the repo, branch, or file is
+   * missing. Throws on paths outside `.mediforce/output/` or containing
+   * `..` segments.
+   */
+  async readOutputFile(workflow: WorkflowIdentity, runId: string, path: string): Promise<Buffer | null> {
+    assertOutputFilePath(path);
+    const bareRepoPath = bareRepoPathFor(this.dataDir, workflow);
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['show', `${runBranchName(runId)}:${path}`],
+        { cwd: bareRepoPath, encoding: 'buffer', maxBuffer: gitMaxBuffer() },
+      );
+      return stdout;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/cli/src/__tests__/run-download.test.ts
+++ b/packages/cli/src/__tests__/run-download.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runDownloadCommand } from '../commands/run-download';
+import { captureOutput, jsonResponse } from './test-helpers';
+
+const BASE_ENV = { MEDIFORCE_API_KEY: 'k' };
+const BASE_ARGS = ['--base-url', 'http://localhost:5555'];
+
+const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x00, 0xff, 0x80, 0xfe]);
+const CSV_BYTES = new Uint8Array([0x67, 0x72, 0x61, 0x64, 0x65, 0x2c, 0x35, 0x0a]);
+
+function binaryResponse(bytes: Uint8Array, fileName: string): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${fileName}"`,
+    },
+  });
+}
+
+const TWO_STEP_LISTING = {
+  files: [
+    {
+      stepId: 'extract',
+      name: 'report.pdf',
+      path: '.mediforce/output/extract/report.pdf',
+      size: PDF_BYTES.length,
+    },
+    {
+      stepId: 'grade',
+      name: 'report.pdf',
+      path: '.mediforce/output/grade/report.pdf',
+      size: CSV_BYTES.length,
+    },
+  ],
+};
+
+function mockRunFilesApi(): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith('/api/runs/run-1/files')) {
+      return jsonResponse(TWO_STEP_LISTING);
+    }
+    if (url.endsWith('/files/.mediforce/output/extract/report.pdf')) {
+      return binaryResponse(PDF_BYTES, 'report.pdf');
+    }
+    if (url.endsWith('/files/.mediforce/output/grade/report.pdf')) {
+      return binaryResponse(CSV_BYTES, 'report.pdf');
+    }
+    return jsonResponse({ error: `Unexpected URL: ${url}` }, 404);
+  });
+}
+
+let tempDir: string;
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  tempDir = await mkdtemp(join(tmpdir(), 'mediforce-run-download-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('run download command', () => {
+  it('exits 2 when no runId positional is given', async () => {
+    const output = captureOutput();
+    const code = await runDownloadCommand({ argv: [], env: BASE_ENV, output });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(
+      /Missing required positional argument: RUNID/,
+    );
+  });
+
+  it('downloads a single file byte-identically to <outDir>/<fileName>', async () => {
+    mockRunFilesApi();
+    const output = captureOutput();
+    const code = await runDownloadCommand({
+      argv: [
+        ...BASE_ARGS,
+        'run-1',
+        '.mediforce/output/extract/report.pdf',
+        '--output',
+        tempDir,
+      ],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    const destination = join(tempDir, 'report.pdf');
+    expect(output.stdoutLines).toEqual([destination]);
+    const writtenBytes = new Uint8Array(await readFile(destination));
+    expect(writtenBytes).toEqual(PDF_BYTES);
+  });
+
+  it('accepts -o as alias for --output', async () => {
+    mockRunFilesApi();
+    const output = captureOutput();
+    const code = await runDownloadCommand({
+      argv: [...BASE_ARGS, 'run-1', '.mediforce/output/extract/report.pdf', '-o', tempDir],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    const writtenBytes = new Uint8Array(await readFile(join(tempDir, 'report.pdf')));
+    expect(writtenBytes).toEqual(PDF_BYTES);
+  });
+
+  it('downloads all files into per-step directories and prints a count', async () => {
+    mockRunFilesApi();
+    const output = captureOutput();
+    const code = await runDownloadCommand({
+      argv: [...BASE_ARGS, 'run-1', '--output', tempDir],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    const extractDestination = join(tempDir, 'extract', 'report.pdf');
+    const gradeDestination = join(tempDir, 'grade', 'report.pdf');
+    expect(output.stdoutLines).toEqual([
+      extractDestination,
+      gradeDestination,
+      `Downloaded 2 file(s) to ${tempDir}`,
+    ]);
+    expect(new Uint8Array(await readFile(extractDestination))).toEqual(PDF_BYTES);
+    expect(new Uint8Array(await readFile(gradeDestination))).toEqual(CSV_BYTES);
+  });
+
+  it('prints a friendly message and exits 0 when the run has no files', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ files: [] }));
+    const output = captureOutput();
+    const code = await runDownloadCommand({
+      argv: [...BASE_ARGS, 'run-1', '--output', tempDir],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(output.stdoutLines).toEqual(['No output files.']);
+  });
+
+  it('emits { written } JSON for download-all when --json is set', async () => {
+    mockRunFilesApi();
+    const output = captureOutput();
+    const code = await runDownloadCommand({
+      argv: [...BASE_ARGS, 'run-1', '--output', tempDir, '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toEqual({
+      written: [join(tempDir, 'extract', 'report.pdf'), join(tempDir, 'grade', 'report.pdf')],
+    });
+  });
+
+  it('emits { written } JSON for a single-file download when --json is set', async () => {
+    mockRunFilesApi();
+    const output = captureOutput();
+    const code = await runDownloadCommand({
+      argv: [
+        ...BASE_ARGS,
+        'run-1',
+        '.mediforce/output/grade/report.pdf',
+        '--output',
+        tempDir,
+        '--json',
+      ],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toEqual({ written: [join(tempDir, 'report.pdf')] });
+  });
+
+  it('exits 1 with structured error JSON on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Run not found' }, 404),
+    );
+    const output = captureOutput();
+    const code = await runDownloadCommand({
+      argv: [...BASE_ARGS, 'nope', '--output', tempDir, '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ status: 404 });
+  });
+});

--- a/packages/cli/src/__tests__/run-download.test.ts
+++ b/packages/cli/src/__tests__/run-download.test.ts
@@ -12,7 +12,7 @@ const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x00, 0xff, 0x80, 0xfe
 const CSV_BYTES = new Uint8Array([0x67, 0x72, 0x61, 0x64, 0x65, 0x2c, 0x35, 0x0a]);
 
 function binaryResponse(bytes: Uint8Array, fileName: string): Response {
-  return new Response(bytes, {
+  return new Response(bytes.slice(), {
     status: 200,
     headers: {
       'Content-Type': 'application/octet-stream',

--- a/packages/cli/src/__tests__/run-files.test.ts
+++ b/packages/cli/src/__tests__/run-files.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runFilesCommand, formatSize } from '../commands/run-files';
+import { captureOutput, jsonResponse } from './test-helpers';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BASE_ENV = { MEDIFORCE_API_KEY: 'k' };
+
+const TWO_STEP_LISTING = {
+  files: [
+    {
+      stepId: 'extract',
+      name: 'report.pdf',
+      path: '.mediforce/output/extract/report.pdf',
+      size: 2048,
+    },
+    {
+      stepId: 'extract',
+      name: 'tables/ae.csv',
+      path: '.mediforce/output/extract/tables/ae.csv',
+      size: 17,
+    },
+    {
+      stepId: 'summarize',
+      name: 'summary.md',
+      path: '.mediforce/output/summarize/summary.md',
+      size: 300,
+    },
+  ],
+};
+
+describe('formatSize', () => {
+  it('renders byte counts below 1024 as-is', () => {
+    expect(formatSize(0)).toBe('0 B');
+    expect(formatSize(1023)).toBe('1023 B');
+  });
+
+  it('scales to KB / MB / GB with one decimal', () => {
+    expect(formatSize(1024)).toBe('1.0 KB');
+    expect(formatSize(1536)).toBe('1.5 KB');
+    expect(formatSize(5 * 1024 * 1024)).toBe('5.0 MB');
+    expect(formatSize(3 * 1024 * 1024 * 1024)).toBe('3.0 GB');
+  });
+});
+
+describe('run files command', () => {
+  it('exits 2 when no runId positional is given', async () => {
+    const output = captureOutput();
+    const code = await runFilesCommand({ argv: [], env: BASE_ENV, output });
+    expect(code).toBe(2);
+    expect(output.stderrLines.join('\n')).toMatch(
+      /Missing required positional argument: RUNID/,
+    );
+  });
+
+  it('GETs /api/runs/<runId>/files and prints files grouped by step', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse(TWO_STEP_LISTING));
+    const output = captureOutput();
+    const code = await runFilesCommand({
+      argv: ['run-1', '--base-url', 'http://localhost:5555'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://localhost:5555/api/runs/run-1/files');
+    expect(output.stdoutLines).toEqual([
+      'extract:',
+      '  report.pdf  2.0 KB  .mediforce/output/extract/report.pdf',
+      '  tables/ae.csv  17 B  .mediforce/output/extract/tables/ae.csv',
+      'summarize:',
+      '  summary.md  300 B  .mediforce/output/summarize/summary.md',
+    ]);
+  });
+
+  it('prints a friendly message and exits 0 when the run has no files', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ files: [] }));
+    const output = captureOutput();
+    const code = await runFilesCommand({ argv: ['run-1'], env: BASE_ENV, output });
+    expect(code).toBe(0);
+    expect(output.stdoutLines).toEqual(['No output files.']);
+  });
+
+  it('emits the raw API response when --json is set', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(TWO_STEP_LISTING));
+    const output = captureOutput();
+    const code = await runFilesCommand({
+      argv: ['run-1', '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(0);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toEqual(TWO_STEP_LISTING);
+  });
+
+  it('exits 1 with structured error JSON on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ error: 'Run not found' }, 404),
+    );
+    const output = captureOutput();
+    const code = await runFilesCommand({
+      argv: ['nope', '--json'],
+      env: BASE_ENV,
+      output,
+    });
+    expect(code).toBe(1);
+    const parsed: unknown = JSON.parse(output.stdoutLines.join('\n'));
+    expect(parsed).toMatchObject({ status: 404 });
+  });
+});

--- a/packages/cli/src/__tests__/run-files.test.ts
+++ b/packages/cli/src/__tests__/run-files.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { runFilesCommand, formatSize } from '../commands/run-files';
+import { runFilesCommand } from '../commands/run-files';
 import { captureOutput, jsonResponse } from './test-helpers';
 
 beforeEach(() => {
@@ -31,19 +31,8 @@ const TWO_STEP_LISTING = {
   ],
 };
 
-describe('formatSize', () => {
-  it('renders byte counts below 1024 as-is', () => {
-    expect(formatSize(0)).toBe('0 B');
-    expect(formatSize(1023)).toBe('1023 B');
-  });
-
-  it('scales to KB / MB / GB with one decimal', () => {
-    expect(formatSize(1024)).toBe('1.0 KB');
-    expect(formatSize(1536)).toBe('1.5 KB');
-    expect(formatSize(5 * 1024 * 1024)).toBe('5.0 MB');
-    expect(formatSize(3 * 1024 * 1024 * 1024)).toBe('3.0 GB');
-  });
-});
+// Size formatting is the shared @mediforce/platform-core formatBytes,
+// tested in platform-core (src/utils/__tests__/format.test.ts).
 
 describe('run files command', () => {
   it('exits 2 when no runId positional is given', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,6 +18,8 @@ import { workflowListVersionsCommand } from './commands/workflow-list-versions';
 import { workflowGetCommand } from './commands/workflow-get';
 import { runGetCommand } from './commands/run-get';
 import { runListCommand } from './commands/run-list';
+import { runFilesCommand } from './commands/run-files';
+import { runDownloadCommand } from './commands/run-download';
 import { runStartCommand } from './commands/run-start';
 import { runCancelCommand } from './commands/run-cancel';
 import { runArchiveCommand } from './commands/run-archive';
@@ -103,11 +105,13 @@ export const TREE: Record<string, BranchEntry> = {
     },
   },
   run: {
-    description: 'Workflow runs (list, start, get, cancel, archive, bulk)',
+    description: 'Workflow runs (list, start, get, files, download, cancel, archive, bulk)',
     leaves: {
       list: { description: 'List recent runs', fn: runListCommand },
       start: { description: 'Start a new run (manual trigger)', fn: runStartCommand },
       get: { description: "Fetch a single run's status", fn: runGetCommand },
+      files: { description: "List a run's Output Files", fn: runFilesCommand },
+      download: { description: "Download a run's Output Files (one or all)", fn: runDownloadCommand },
       cancel: { description: 'Cancel a running or paused run', fn: runCancelCommand },
       archive: { description: 'Soft-archive (or restore) a run', fn: runArchiveCommand },
       'bulk-cancel': { description: 'Cancel multiple runs in one call', fn: runBulkCancelCommand },

--- a/packages/cli/src/commands/run-download.ts
+++ b/packages/cli/src/commands/run-download.ts
@@ -1,0 +1,79 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { defineCommand } from '../define-command';
+import { printJson } from '../output';
+
+export const runDownloadCommand = defineCommand({
+  name: 'mediforce run download',
+  description:
+    "Download a run's Output Files. With PATH (the repo-relative key from `run files`) fetches that single file into the output directory; without it downloads every Output File into <dir>/<stepId>/<name>. Existing files are overwritten.",
+  args: {
+    runId: {
+      type: 'positional',
+      required: true,
+      description: 'Run identifier',
+    },
+    path: {
+      type: 'positional',
+      required: false,
+      description: 'Repo-relative file path from `run files` (omit to download all)',
+    },
+    output: {
+      type: 'string',
+      alias: 'o',
+      description: 'Directory to write files into (default: current directory)',
+    },
+  },
+  async run({ args, output, mediforce, jsonMode }) {
+    const outDir = resolve(
+      typeof args.output === 'string' && args.output.length > 0 ? args.output : '.',
+    );
+    const downloadAll = typeof args.path !== 'string' || args.path.length === 0;
+    const written: string[] = [];
+
+    if (downloadAll) {
+      const listed = await mediforce.runs.listOutputFiles({ runId: args.runId });
+      if (listed.files.length === 0) {
+        if (jsonMode) {
+          printJson(output, { written });
+        } else {
+          output.stdout('No output files.');
+        }
+        return 0;
+      }
+      for (const file of listed.files) {
+        const downloaded = await mediforce.runs.downloadOutputFile({
+          runId: args.runId,
+          path: file.path,
+        });
+        // <outDir>/<stepId>/<name> mirrors the run-branch layout and keeps
+        // same-named files from different steps from colliding.
+        const destination = join(outDir, file.stepId, file.name);
+        await mkdir(dirname(destination), { recursive: true });
+        await writeFile(destination, downloaded.bytes);
+        written.push(destination);
+      }
+    } else {
+      const downloaded = await mediforce.runs.downloadOutputFile({
+        runId: args.runId,
+        path: args.path,
+      });
+      const destination = join(outDir, downloaded.fileName);
+      await mkdir(dirname(destination), { recursive: true });
+      await writeFile(destination, downloaded.bytes);
+      written.push(destination);
+    }
+
+    if (jsonMode) {
+      printJson(output, { written });
+      return 0;
+    }
+    for (const destination of written) {
+      output.stdout(destination);
+    }
+    if (downloadAll) {
+      output.stdout(`Downloaded ${String(written.length)} file(s) to ${outDir}`);
+    }
+    return 0;
+  },
+});

--- a/packages/cli/src/commands/run-download.ts
+++ b/packages/cli/src/commands/run-download.ts
@@ -28,10 +28,11 @@ export const runDownloadCommand = defineCommand({
     const outDir = resolve(
       typeof args.output === 'string' && args.output.length > 0 ? args.output : '.',
     );
-    const downloadAll = typeof args.path !== 'string' || args.path.length === 0;
+    const requestedPath = typeof args.path === 'string' && args.path.length > 0 ? args.path : null;
+    const downloadAll = requestedPath === null;
     const written: string[] = [];
 
-    if (downloadAll) {
+    if (requestedPath === null) {
       const listed = await mediforce.runs.listOutputFiles({ runId: args.runId });
       if (listed.files.length === 0) {
         if (jsonMode) {
@@ -56,7 +57,7 @@ export const runDownloadCommand = defineCommand({
     } else {
       const downloaded = await mediforce.runs.downloadOutputFile({
         runId: args.runId,
-        path: args.path,
+        path: requestedPath,
       });
       const destination = join(outDir, downloaded.fileName);
       await mkdir(dirname(destination), { recursive: true });

--- a/packages/cli/src/commands/run-files.ts
+++ b/packages/cli/src/commands/run-files.ts
@@ -1,0 +1,55 @@
+import { defineCommand } from '../define-command';
+import { printJson } from '../output';
+
+const SIZE_UNITS = ['KB', 'MB', 'GB', 'TB'] as const;
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${String(bytes)} B`;
+  let value = bytes;
+  let unitIndex = -1;
+  while (value >= 1024 && unitIndex < SIZE_UNITS.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(1)} ${SIZE_UNITS[unitIndex]}`;
+}
+
+export const runFilesCommand = defineCommand({
+  name: 'mediforce run files',
+  description:
+    "List a run's Output Files (artifacts agent steps committed under `.mediforce/output/<stepId>/`). Each line shows the repo-relative path — the download key for `run download`.",
+  args: {
+    runId: {
+      type: 'positional',
+      required: true,
+      description: 'Run identifier',
+    },
+  },
+  async run({ args, output, mediforce, jsonMode }) {
+    const result = await mediforce.runs.listOutputFiles({ runId: args.runId });
+    if (jsonMode) {
+      printJson(output, result);
+      return 0;
+    }
+    if (result.files.length === 0) {
+      output.stdout('No output files.');
+      return 0;
+    }
+    const filesByStep = new Map<string, typeof result.files>();
+    for (const file of result.files) {
+      const group = filesByStep.get(file.stepId);
+      if (group !== undefined) {
+        group.push(file);
+      } else {
+        filesByStep.set(file.stepId, [file]);
+      }
+    }
+    for (const [stepId, files] of filesByStep) {
+      output.stdout(`${stepId}:`);
+      for (const file of files) {
+        output.stdout(`  ${file.name}  ${formatSize(file.size)}  ${file.path}`);
+      }
+    }
+    return 0;
+  },
+});

--- a/packages/cli/src/commands/run-files.ts
+++ b/packages/cli/src/commands/run-files.ts
@@ -1,18 +1,6 @@
+import { formatBytes } from '@mediforce/platform-core';
 import { defineCommand } from '../define-command';
 import { printJson } from '../output';
-
-const SIZE_UNITS = ['KB', 'MB', 'GB', 'TB'] as const;
-
-export function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${String(bytes)} B`;
-  let value = bytes;
-  let unitIndex = -1;
-  while (value >= 1024 && unitIndex < SIZE_UNITS.length - 1) {
-    value /= 1024;
-    unitIndex += 1;
-  }
-  return `${value.toFixed(1)} ${SIZE_UNITS[unitIndex]}`;
-}
 
 export const runFilesCommand = defineCommand({
   name: 'mediforce run files',
@@ -47,7 +35,7 @@ export const runFilesCommand = defineCommand({
     for (const [stepId, files] of filesByStep) {
       output.stdout(`${stepId}:`);
       for (const file of files) {
-        output.stdout(`  ${file.name}  ${formatSize(file.size)}  ${file.path}`);
+        output.stdout(`  ${file.name}  ${formatBytes(file.size)}  ${file.path}`);
       }
     }
     return 0;

--- a/packages/container-worker/src/__tests__/file-payload.test.ts
+++ b/packages/container-worker/src/__tests__/file-payload.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { encodeFilePayload, decodeFilePayload } from '../file-payload';
+
+/** Every possible byte value — catches any lossy text-encoding round-trip. */
+const allBytes = Buffer.from(Array.from({ length: 256 }, (_, index) => index));
+
+describe('encodeFilePayload / decodeFilePayload', () => {
+  let sourceDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    sourceDir = await mkdtemp(join(tmpdir(), 'file-payload-src-'));
+    targetDir = await mkdtemp(join(tmpdir(), 'file-payload-dst-'));
+  });
+
+  afterEach(async () => {
+    await rm(sourceDir, { recursive: true, force: true });
+    await rm(targetDir, { recursive: true, force: true });
+  });
+
+  it('round-trips binary content byte-for-byte', async () => {
+    await writeFile(join(sourceDir, 'report.pdf'), allBytes);
+
+    const payload = await encodeFilePayload(sourceDir);
+    await decodeFilePayload(payload, targetDir);
+
+    const restored = await readFile(join(targetDir, 'report.pdf'));
+    expect(restored.equals(allBytes)).toBe(true);
+  });
+
+  it('survives JSON serialization (the BullMQ/Redis transit format)', async () => {
+    await writeFile(join(sourceDir, 'archive.zip'), allBytes);
+
+    const payload = await encodeFilePayload(sourceDir);
+    const afterRedisTransit = JSON.parse(JSON.stringify(payload)) as Record<string, string>;
+    await decodeFilePayload(afterRedisTransit, targetDir);
+
+    const restored = await readFile(join(targetDir, 'archive.zip'));
+    expect(restored.equals(allBytes)).toBe(true);
+  });
+
+  it('round-trips nested directories using POSIX relative-path keys', async () => {
+    await mkdir(join(sourceDir, 'charts', 'q1'), { recursive: true });
+    await writeFile(join(sourceDir, 'charts', 'q1', 'plot.png'), allBytes);
+    await writeFile(join(sourceDir, 'summary.txt'), 'plain text', 'utf-8');
+
+    const payload = await encodeFilePayload(sourceDir);
+    expect(Object.keys(payload).sort()).toEqual(['charts/q1/plot.png', 'summary.txt']);
+
+    await decodeFilePayload(payload, targetDir);
+
+    const restoredPlot = await readFile(join(targetDir, 'charts', 'q1', 'plot.png'));
+    expect(restoredPlot.equals(allBytes)).toBe(true);
+    expect(await readFile(join(targetDir, 'summary.txt'), 'utf-8')).toBe('plain text');
+  });
+
+  it('returns an empty payload for an empty directory', async () => {
+    expect(await encodeFilePayload(sourceDir)).toEqual({});
+  });
+
+  it('creates the target directory even for an empty payload', async () => {
+    const nestedTarget = join(targetDir, 'not-yet-created');
+    await decodeFilePayload({}, nestedTarget);
+    await expect(readFile(nestedTarget)).rejects.toMatchObject({ code: 'EISDIR' });
+  });
+
+  it('rejects payload keys that escape the target directory', async () => {
+    const harmless = Buffer.from('hi').toString('base64');
+    await expect(decodeFilePayload({ '../escape.txt': harmless }, targetDir)).rejects.toThrow(/escapes/);
+    await expect(decodeFilePayload({ '/etc/escape.txt': harmless }, targetDir)).rejects.toThrow(/escapes/);
+  });
+
+  it('rejects a missing source directory so callers can decide how to degrade', async () => {
+    await expect(encodeFilePayload(join(sourceDir, 'does-not-exist'))).rejects.toThrow();
+  });
+});

--- a/packages/container-worker/src/file-payload.ts
+++ b/packages/container-worker/src/file-payload.ts
@@ -1,0 +1,47 @@
+/**
+ * File transport for the BullMQ queue. BullMQ serializes job data and results
+ * as JSON, so file contents cross Redis as base64 strings — raw Buffers would
+ * be mangled into `{type:'Buffer',data:[...]}` blobs and utf-8 strings corrupt
+ * binary files (PDF, XLSX, PNG, ZIP).
+ *
+ * Payload keys are POSIX relative paths inside the directory (nested allowed,
+ * e.g. `charts/q1/plot.png`), so directory structure survives the queue the
+ * same way it does on the local spawn path.
+ */
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+
+/** POSIX relative path → base64-encoded file content. */
+export type FilePayload = Record<string, string>;
+
+/** Recursively read every file under `dir` into a JSON-safe payload.
+ *  Throws when `dir` does not exist; unreadable individual files are skipped. */
+export async function encodeFilePayload(dir: string): Promise<FilePayload> {
+  const payload: FilePayload = {};
+  const entries = await readdir(dir, { withFileTypes: true, recursive: true });
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const absolutePath = join(entry.parentPath, entry.name);
+    const key = relative(dir, absolutePath).split(sep).join('/');
+    try {
+      payload[key] = (await readFile(absolutePath)).toString('base64');
+    } catch (err) {
+      console.warn(`[file-payload] Skipping unreadable file '${key}': ${err instanceof Error ? err.message : err}`);
+    }
+  }
+  return payload;
+}
+
+/** Write a payload into `dir`, creating it and any nested directories. */
+export async function decodeFilePayload(payload: FilePayload, dir: string): Promise<void> {
+  const root = resolve(dir);
+  await mkdir(root, { recursive: true });
+  for (const [relativePath, base64Content] of Object.entries(payload)) {
+    const absolutePath = resolve(root, relativePath);
+    if (!absolutePath.startsWith(root + sep)) {
+      throw new Error(`File payload key '${relativePath}' escapes target directory '${dir}'`);
+    }
+    await mkdir(dirname(absolutePath), { recursive: true });
+    await writeFile(absolutePath, Buffer.from(base64Content, 'base64'));
+  }
+}

--- a/packages/container-worker/src/index.ts
+++ b/packages/container-worker/src/index.ts
@@ -1,4 +1,5 @@
 export { enqueueDockerJob, closeQueueClient } from './queue-client';
+export { encodeFilePayload, decodeFilePayload, type FilePayload } from './file-payload';
 export { getRedisConnection, pingRedis } from './connection';
 export {
   DockerJobDataSchema,

--- a/packages/container-worker/src/schemas.ts
+++ b/packages/container-worker/src/schemas.ts
@@ -26,8 +26,9 @@ export const DockerJobDataSchema = z.object({
   outputDir: z.string(),
   /** Host-side log file path for realtime activity streaming (null = no logging). */
   logFile: z.string().nullable(),
-  /** Files from outputDir, keyed by filename. Sent through Redis when caller
-   *  and worker don't share a filesystem (e.g. Vercel → VPS). */
+  /** Files from outputDir, keyed by POSIX relative path with base64-encoded
+   *  content (see file-payload.ts). Sent through Redis when caller and worker
+   *  don't share a filesystem (e.g. Vercel → VPS). */
   inputFiles: z.record(z.string(), z.string()).optional(),
   /** Image build metadata — when present, worker ensures image exists before docker run. */
   imageBuild: z.object({
@@ -46,7 +47,8 @@ export const DockerJobResultSchema = z.object({
   stderr: z.string(),
   exitCode: z.number().nullable(),
   signal: z.string().nullable(),
-  /** Files from the worker's outputDir after docker run completes.
+  /** Files from the worker's outputDir after docker run completes, keyed by
+   *  POSIX relative path with base64-encoded content (see file-payload.ts).
    *  Returned through Redis so the caller can recreate them locally. */
   outputFiles: z.record(z.string(), z.string()).optional(),
 });

--- a/packages/container-worker/src/worker-entry.ts
+++ b/packages/container-worker/src/worker-entry.ts
@@ -5,12 +5,13 @@
  */
 import { Worker } from 'bullmq';
 import { spawn } from 'node:child_process';
-import { appendFile, mkdir, mkdtemp, writeFile, readdir, readFile } from 'node:fs/promises';
+import { appendFile, mkdir, mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { getRedisConnection } from './connection';
 import { QUEUE_NAME, DockerJobDataSchema } from './schemas';
 import type { DockerJobResult } from './schemas';
+import { encodeFilePayload, decodeFilePayload } from './file-payload';
 import { ensureImage } from './docker-image-builder';
 import { startHttpServer } from './http-server';
 import { createLineStreamReader } from '@mediforce/platform-core';
@@ -27,12 +28,9 @@ async function prepareLocalOutputDir(data: { inputFiles?: Record<string, string>
   }
 
   const localOutputDir = await mkdtemp(join(tmpdir(), 'mediforce-worker-'));
-  const fileCount = Object.keys(data.inputFiles).length;
-  console.log(`[worker] Remote caller — recreating ${fileCount} input file(s) in ${localOutputDir}`);
-  for (const [name, content] of Object.entries(data.inputFiles)) {
-    await writeFile(join(localOutputDir, name), content, 'utf-8');
-    console.log(`[worker]   wrote ${name} (${content.length} bytes)`);
-  }
+  const fileNames = Object.keys(data.inputFiles);
+  console.log(`[worker] Remote caller — recreating ${fileNames.length} input file(s) in ${localOutputDir}: ${fileNames.join(', ')}`);
+  await decodeFilePayload(data.inputFiles, localOutputDir);
 
   // Replace the remote outputDir path in dockerArgs with local path
   const remoteDir = data.outputDir;
@@ -42,25 +40,6 @@ async function prepareLocalOutputDir(data: { inputFiles?: Record<string, string>
   console.log(`[worker] Patched outputDir: ${remoteDir} → ${localOutputDir}`);
 
   return { localOutputDir, patchedArgs };
-}
-
-/** Collect all files from outputDir after docker run completes. */
-async function collectOutputFiles(outputDir: string): Promise<Record<string, string>> {
-  const files: Record<string, string> = {};
-  try {
-    const entries = await readdir(outputDir);
-    for (const entry of entries) {
-      try {
-        const content = await readFile(join(outputDir, entry), 'utf-8');
-        files[entry] = content;
-      } catch (err) {
-        console.warn(`[worker] Skipping unreadable output file '${entry}': ${err instanceof Error ? err.message : err}`);
-      }
-    }
-  } catch (err) {
-    console.warn(`[worker] Could not read outputDir '${outputDir}': ${err instanceof Error ? err.message : err}`);
-  }
-  return files;
 }
 
 async function processDockerJob(rawData: unknown): Promise<DockerJobResult> {
@@ -143,7 +122,7 @@ async function processDockerJob(rawData: unknown): Promise<DockerJobResult> {
 
       // If remote caller sent inputFiles, collect output files to return through Redis
       if (hasInputFiles) {
-        collectOutputFiles(localOutputDir).then((outputFiles) => {
+        encodeFilePayload(localOutputDir).then((outputFiles) => {
           resolve({ stdout, stderr, exitCode: code, signal: signal ?? null, outputFiles });
         }).catch((err) => {
           console.warn(`[worker] Failed to collect output files: ${err instanceof Error ? err.message : err}`);

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -19,6 +19,9 @@ import {
   ListRunsOutputSchema,
   ListRunNamesInputSchema,
   ListRunNamesOutputSchema,
+  ListRunOutputFilesInputSchema,
+  ListRunOutputFilesOutputSchema,
+  DownloadRunOutputFileInputSchema,
   ArchiveVersionInputSchema,
   ArchiveVersionOutputSchema,
   ArchiveAllInputSchema,
@@ -250,6 +253,9 @@ import {
   type ListRunsOutput,
   type ListRunNamesInput,
   type ListRunNamesOutput,
+  type ListRunOutputFilesInput,
+  type ListRunOutputFilesOutput,
+  type DownloadRunOutputFileInput,
   type DockerInfoResponse,
   type OpenRouterCreditsInput,
   type OpenRouterCreditsOutput,
@@ -427,6 +433,17 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * One downloaded Output File. `bytes` is the raw body (binary-safe);
+ * `fileName` comes from the RFC 6266 `Content-Disposition` header with the
+ * last path segment as fallback.
+ */
+export interface DownloadedRunOutputFile {
+  fileName: string;
+  contentType: string;
+  bytes: Uint8Array;
+}
+
 export class Mediforce {
   readonly tasks: {
     list: (input: ListTasksInput) => Promise<ListTasksOutput>;
@@ -486,6 +503,8 @@ export class Mediforce {
     list: (input?: ListRunsInput) => Promise<ListRunsOutput>;
     listNames: (input: ListRunNamesInput) => Promise<ListRunNamesOutput>;
     get: (input: GetRunInput) => Promise<GetRunOutput>;
+    listOutputFiles: (input: ListRunOutputFilesInput) => Promise<ListRunOutputFilesOutput>;
+    downloadOutputFile: (input: DownloadRunOutputFileInput) => Promise<DownloadedRunOutputFile>;
     start: (input: StartRunInput) => Promise<StartRunOutput>;
     cancel: (input: CancelRunInput) => Promise<CancelRunOutput>;
     resume: (input: ResumeRunInput) => Promise<ResumeRunOutput>;
@@ -1115,6 +1134,40 @@ export class Mediforce {
         const body = await parseJsonOrThrow(res, 'mediforce.runs.get');
         return GetRunOutputSchema.parse(body);
       },
+      listOutputFiles: async (input) => {
+        const validated = ListRunOutputFilesInputSchema.parse(input);
+        const res = await this.request(
+          `/api/runs/${encodeURIComponent(validated.runId)}/files`,
+        );
+        const body = await parseJsonOrThrow(res, 'mediforce.runs.listOutputFiles');
+        return ListRunOutputFilesOutputSchema.parse(body);
+      },
+      downloadOutputFile: async (input) => {
+        const validated = DownloadRunOutputFileInputSchema.parse(input);
+        // `path` is repo-relative with meaningful slashes (`.mediforce/output/<stepId>/<name>`)
+        // — encode each segment, keep the separators.
+        const encodedPath = validated.path
+          .split('/')
+          .map(encodeURIComponent)
+          .join('/');
+        const res = await this.request(
+          `/api/runs/${encodeURIComponent(validated.runId)}/files/${encodedPath}`,
+        );
+        if (res.ok === false) {
+          // Error responses are the JSON envelope — parseJsonOrThrow always
+          // throws ApiError on non-OK.
+          await parseJsonOrThrow(res, 'mediforce.runs.downloadOutputFile');
+        }
+        const fileName =
+          fileNameFromContentDisposition(res.headers.get('Content-Disposition')) ??
+          validated.path.split('/').pop() ??
+          'download';
+        return {
+          fileName,
+          contentType: res.headers.get('Content-Type') ?? 'application/octet-stream',
+          bytes: new Uint8Array(await res.arrayBuffer()),
+        };
+      },
       start: async (input) => {
         const validated = StartRunInputSchema.parse(input);
         const res = await this.request('/api/processes', {
@@ -1672,6 +1725,28 @@ function toSearchParams(
   }
   const qs = params.toString();
   return qs.length > 0 ? `?${qs}` : '';
+}
+
+/**
+ * Extract the file name from an RFC 6266 `Content-Disposition` header.
+ * Prefers the percent-encoded `filename*` parameter (full Unicode), falls
+ * back to the quoted `filename`, returns null when neither parses.
+ */
+function fileNameFromContentDisposition(header: string | null): string | null {
+  if (header === null) return null;
+  const extendedMatch = header.match(/filename\*=UTF-8''([^;]+)/i);
+  if (extendedMatch !== null) {
+    try {
+      return decodeURIComponent(extendedMatch[1]);
+    } catch {
+      return null;
+    }
+  }
+  const quotedMatch = header.match(/filename="((?:[^"\\]|\\.)*)"/);
+  if (quotedMatch !== null) {
+    return quotedMatch[1].replace(/\\(.)/g, '$1');
+  }
+  return null;
 }
 
 async function parseJsonOrThrow(res: Response, context: string): Promise<unknown> {

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -162,6 +162,10 @@ export {
   ListRunsOutputSchema,
   ListRunNamesInputSchema,
   ListRunNamesOutputSchema,
+  ListRunOutputFilesInputSchema,
+  RunOutputFileEntrySchema,
+  ListRunOutputFilesOutputSchema,
+  DownloadRunOutputFileInputSchema,
   type GetRunInput,
   type GetRunOutput,
   type StartRunInput,
@@ -170,6 +174,10 @@ export {
   type ListRunsOutput,
   type ListRunNamesInput,
   type ListRunNamesOutput,
+  type ListRunOutputFilesInput,
+  type RunOutputFileEntry,
+  type ListRunOutputFilesOutput,
+  type DownloadRunOutputFileInput,
 } from './runs';
 
 export {

--- a/packages/platform-api/src/contract/runs.ts
+++ b/packages/platform-api/src/contract/runs.ts
@@ -112,3 +112,48 @@ export const ListRunNamesOutputSchema = z.object({
 
 export type ListRunNamesInput = z.infer<typeof ListRunNamesInputSchema>;
 export type ListRunNamesOutput = z.infer<typeof ListRunNamesOutputSchema>;
+
+/**
+ * Contract for `GET /api/runs/<runId>/files`.
+ *
+ * Output Files: artifacts the runtime committed under
+ * `.mediforce/output/<stepId>/` on the run branch of the workflow's bare
+ * repo. `path` is the repo-relative download key for
+ * `GET /api/runs/<runId>/files/<path>` (binary route, not part of this
+ * JSON contract).
+ */
+export const ListRunOutputFilesInputSchema = z.object({
+  runId: z.string().min(1),
+});
+
+export const RunOutputFileEntrySchema = z.object({
+  stepId: z.string().min(1),
+  /** Path relative to `.mediforce/output/<stepId>/` (may contain slashes). */
+  name: z.string().min(1),
+  /** Repo-relative path `.mediforce/output/<stepId>/<name>` — the download key. */
+  path: z.string().min(1),
+  /** Blob size in bytes. */
+  size: z.number().int().nonnegative(),
+});
+
+export const ListRunOutputFilesOutputSchema = z.object({
+  files: z.array(RunOutputFileEntrySchema),
+});
+
+export type ListRunOutputFilesInput = z.infer<typeof ListRunOutputFilesInputSchema>;
+export type RunOutputFileEntry = z.infer<typeof RunOutputFileEntrySchema>;
+export type ListRunOutputFilesOutput = z.infer<typeof ListRunOutputFilesOutputSchema>;
+
+/**
+ * Client-side input for `GET /api/runs/<runId>/files/<path>` (binary
+ * download). The response is raw bytes, so there is no output schema —
+ * `mediforce.runs.downloadOutputFile` returns `{ fileName, contentType,
+ * bytes }` assembled from headers + body.
+ */
+export const DownloadRunOutputFileInputSchema = z.object({
+  runId: z.string().min(1),
+  /** Repo-relative path from `RunOutputFileEntry.path` (incl. `.mediforce/output/` prefix). */
+  path: z.string().min(1),
+});
+
+export type DownloadRunOutputFileInput = z.infer<typeof DownloadRunOutputFileInputSchema>;

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -62,6 +62,7 @@ export { listRuns } from './runs/list-runs';
 export { listRunNames } from './runs/list-run-names';
 export { getRun } from './runs/get-run';
 export { startRun } from './runs/start-run';
+export { listRunOutputFiles } from './runs/list-output-files';
 
 export { listSecretKeys } from './secrets/list-secret-keys';
 export { setSecret } from './secrets/set-secret';

--- a/packages/platform-api/src/handlers/runs/__tests__/list-output-files.test.ts
+++ b/packages/platform-api/src/handlers/runs/__tests__/list-output-files.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  InMemoryProcessInstanceRepository,
+  buildProcessInstance,
+  resetFactorySequence,
+} from '@mediforce/platform-core/testing';
+import type { OutputFileEntry } from '@mediforce/agent-runtime';
+import { listRunOutputFiles } from '../list-output-files';
+import { NotFoundError } from '../../../errors';
+import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope';
+
+interface ReaderCall {
+  workflow: { name: string; namespace?: string };
+  runId: string;
+}
+
+function stubReader(entries: OutputFileEntry[]) {
+  const calls: ReaderCall[] = [];
+  return {
+    calls,
+    listOutputFiles: async (workflow: { name: string; namespace?: string }, runId: string) => {
+      calls.push({ workflow, runId });
+      return entries;
+    },
+  };
+}
+
+describe('listRunOutputFiles handler', () => {
+  let instanceRepo: InMemoryProcessInstanceRepository;
+
+  beforeEach(() => {
+    resetFactorySequence();
+    instanceRepo = new InMemoryProcessInstanceRepository();
+  });
+
+  it('returns the Output Files for the run, addressing the workspace by run identity', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({
+        id: 'r1',
+        namespace: 'alpha',
+        definitionName: 'wf',
+        status: 'completed',
+      }),
+    );
+    const entries: OutputFileEntry[] = [
+      { stepId: 'extract', name: 'report.csv', path: '.mediforce/output/extract/report.csv', size: 12 },
+      { stepId: 'render', name: 'charts/plot.svg', path: '.mediforce/output/render/charts/plot.svg', size: 7 },
+    ];
+    const reader = stubReader(entries);
+
+    const scope = createTestScope({ instanceRepo });
+    const result = await listRunOutputFiles({ runId: 'r1' }, scope, reader);
+
+    expect(result).toEqual({ files: entries });
+    expect(reader.calls).toEqual([
+      { workflow: { name: 'wf', namespace: 'alpha' }, runId: 'r1' },
+    ]);
+  });
+
+  it('returns an empty list when the run has no Output Files', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'r1', namespace: 'alpha', definitionName: 'wf' }),
+    );
+
+    const scope = createTestScope({ instanceRepo });
+    const result = await listRunOutputFiles({ runId: 'r1' }, scope, stubReader([]));
+
+    expect(result).toEqual({ files: [] });
+  });
+
+  it('throws NotFoundError for a truly missing runId without touching the reader', async () => {
+    const reader = stubReader([]);
+    const scope = createTestScope({ instanceRepo });
+
+    await expect(listRunOutputFiles({ runId: 'missing' }, scope, reader)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+    expect(reader.calls).toEqual([]);
+  });
+
+  it('throws NotFoundError for a foreign-workspace runId (anti-enumeration) without touching the reader', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'r1', namespace: 'alpha', definitionName: 'wf' }),
+    );
+    const reader = stubReader([]);
+
+    const scope = createTestScope({
+      instanceRepo,
+      caller: userCaller('u-2', ['beta']),
+    });
+
+    await expect(listRunOutputFiles({ runId: 'r1' }, scope, reader)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+    expect(reader.calls).toEqual([]);
+  });
+
+  it('returns the files for a user caller in the namespace', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({ id: 'r1', namespace: 'alpha', definitionName: 'wf' }),
+    );
+    const entries: OutputFileEntry[] = [
+      { stepId: 's1', name: 'out.txt', path: '.mediforce/output/s1/out.txt', size: 3 },
+    ];
+
+    const scope = createTestScope({
+      instanceRepo,
+      caller: userCaller('u-1', ['alpha']),
+    });
+    const result = await listRunOutputFiles({ runId: 'r1' }, scope, stubReader(entries));
+
+    expect(result.files).toEqual(entries);
+  });
+});

--- a/packages/platform-api/src/handlers/runs/list-output-files.ts
+++ b/packages/platform-api/src/handlers/runs/list-output-files.ts
@@ -1,0 +1,42 @@
+import { WorkspaceReader, type OutputFileEntry } from '@mediforce/agent-runtime';
+import type { CallerScope } from '../../repositories/index';
+import { NotFoundError } from '../../errors';
+import type {
+  ListRunOutputFilesInput,
+  ListRunOutputFilesOutput,
+} from '../../contract/runs';
+
+/**
+ * List the Output Files of one run — artifacts the runtime committed under
+ * `.mediforce/output/<stepId>/` on the run branch `run/<runId>` of the
+ * workflow's bare repo. Read straight from git, no worktree needed.
+ *
+ * Out-of-scope ids surface as 404 (anti-enumeration — same shape as a truly
+ * missing run, so non-members cannot probe ownership). Runs that never
+ * produced Output Files (or pre-date the workspace runtime) return `[]`.
+ *
+ * `workspaceReader` is injectable for unit tests; production callers (the
+ * route adapter) pass only `(input, scope)` and get the default reader,
+ * which resolves the bare repo under `MEDIFORCE_DATA_DIR ?? ~/.mediforce`.
+ */
+export async function listRunOutputFiles(
+  input: ListRunOutputFilesInput,
+  scope: CallerScope,
+  workspaceReader: {
+    listOutputFiles: (
+      workflow: { name: string; namespace?: string },
+      runId: string,
+    ) => Promise<OutputFileEntry[]>;
+  } = new WorkspaceReader(),
+): Promise<ListRunOutputFilesOutput> {
+  const run = await scope.runs.getById(input.runId);
+  if (run === null) {
+    throw new NotFoundError(`Run ${input.runId} not found`);
+  }
+
+  const files = await workspaceReader.listOutputFiles(
+    { name: run.definitionName, namespace: run.namespace },
+    input.runId,
+  );
+  return { files };
+}

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -377,4 +377,5 @@ export {
 export { createLineStreamReader } from './utils/line-stream';
 export type { LineStreamReader } from './utils/line-stream';
 export { calculateEstimatedCost } from './utils/cost';
+export { formatBytes } from './utils/format';
 export { compact, parseRow } from './utils/compact';

--- a/packages/platform-core/src/utils/__tests__/format.test.ts
+++ b/packages/platform-core/src/utils/__tests__/format.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from '../format';
+
+describe('formatBytes', () => {
+  it('[DATA] formats zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('[DATA] formats bytes without a decimal', () => {
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('[DATA] formats kilobytes with one decimal (1024-based)', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('[DATA] formats megabytes', () => {
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+
+  it('[DATA] caps the unit at GB', () => {
+    expect(formatBytes(3 * 1024 ** 4)).toBe('3072.0 GB');
+  });
+});

--- a/packages/platform-core/src/utils/format.ts
+++ b/packages/platform-core/src/utils/format.ts
@@ -1,0 +1,8 @@
+/** Human-readable byte count: 1024-based, B/KB/MB/GB, one decimal above bytes. */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const size = bytes / Math.pow(1024, exponent);
+  return `${size.toFixed(exponent > 0 ? 1 : 0)} ${units[exponent]}`;
+}

--- a/packages/platform-ui/e2e/api/run-output-files.journey.ts
+++ b/packages/platform-ui/e2e/api/run-output-files.journey.ts
@@ -1,0 +1,266 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { APIRequestContext } from '@playwright/test';
+import { test, expect } from '../helpers/test-fixtures';
+import { TEST_ORG_HANDLE } from '../helpers/constants';
+
+/**
+ * API E2E for Output Files: list (`GET /api/runs/<runId>/files`) and download
+ * (`GET /api/runs/<runId>/files/<path>`).
+ *
+ * The run itself is driven end-to-end through the platform (agent step under
+ * MOCK_AGENT=true), but the Output Files are SEEDED into the bare repo with
+ * git directly. Why: MOCK_AGENT swaps in MockClaudeCodeAgentPlugin, which
+ * only emits a result envelope — the workspace/commit machinery lives in the
+ * container plugins (Docker), so the mock path never commits anything under
+ * `.mediforce/output/<stepId>/`. Seeding writes the exact layout the real
+ * runtime produces (bare repo `<MEDIFORCE_DATA_DIR>/bare-repos/<ns>/<wd>.git`,
+ * branch `run/<runId>`, files under `.mediforce/output/<stepId>/`).
+ */
+
+const API_KEY = process.env.PLATFORM_API_KEY ?? 'test-api-key';
+const AUTH_HEADERS = { 'X-Api-Key': API_KEY };
+
+// Must match the server's MEDIFORCE_DATA_DIR (playwright.config.ts webServer command).
+const SERVER_DATA_DIR = '/tmp/mediforce-e2e-data';
+
+// Neutralize host-level git config (e.g. enforced commit signing) — the seed
+// commits are test fixtures, not provenance-bearing artifacts.
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+};
+
+const execFileAsync = promisify(execFile);
+
+async function git(args: string[], cwd?: string): Promise<void> {
+  await execFileAsync('git', args, { cwd, env: GIT_ENV });
+}
+
+async function seedOutputFiles(
+  workflowName: string,
+  runId: string,
+  filesByStep: Record<string, Record<string, Buffer | string>>,
+): Promise<void> {
+  const bareRepoPath = join(SERVER_DATA_DIR, 'bare-repos', TEST_ORG_HANDLE, `${workflowName}.git`);
+  await mkdir(dirname(bareRepoPath), { recursive: true });
+  await git(['init', '--bare', bareRepoPath]);
+
+  const workDir = await mkdtemp(join(tmpdir(), 'output-files-seed-'));
+  try {
+    await git(['init'], workDir);
+    for (const [stepId, files] of Object.entries(filesByStep)) {
+      for (const [name, content] of Object.entries(files)) {
+        const destination = join(workDir, '.mediforce', 'output', stepId, name);
+        await mkdir(dirname(destination), { recursive: true });
+        await writeFile(destination, content);
+      }
+    }
+    await git(['add', '-A'], workDir);
+    await git(
+      [
+        '-c', 'user.name=e2e',
+        '-c', 'user.email=e2e@example.com',
+        '-c', 'commit.gpgsign=false',
+        'commit', '-m', `Seed Output Files for ${runId}`,
+      ],
+      workDir,
+    );
+    await git(['push', bareRepoPath, `HEAD:refs/heads/run/${runId}`], workDir);
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+async function pollUntil<T>(
+  fn: () => Promise<T | null>,
+  {
+    timeoutMs = 20_000,
+    intervalMs = 250,
+    description = 'condition',
+  }: { timeoutMs?: number; intervalMs?: number; description?: string } = {},
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let last: T | null = null;
+  while (Date.now() < deadline) {
+    last = await fn();
+    if (last !== null) return last;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out waiting for ${description} (${timeoutMs}ms)`);
+}
+
+interface OutputFileEntry {
+  stepId: string;
+  name: string;
+  path: string;
+  size: number;
+}
+
+test.describe('Run Output Files — API E2E', () => {
+  const wdName = `e2e-output-files-${Date.now()}`;
+
+  const csvContent = 'study,grade\nS-001,2\n';
+  const svgContent = '<svg xmlns="http://www.w3.org/2000/svg"/>';
+  // Every byte value 0–255 — proves non-utf8 bytes survive the round-trip.
+  const binaryContent = Buffer.from(Array.from({ length: 256 }, (_, byteValue) => byteValue));
+
+  async function registerWorkflowDefinition(request: APIRequestContext): Promise<void> {
+    const wd = {
+      name: wdName,
+      title: 'E2E Output Files',
+      steps: [
+        {
+          id: 'generate',
+          name: 'Generate artifacts',
+          type: 'creation',
+          executor: 'agent',
+          autonomyLevel: 'L2',
+        },
+        { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },
+      ],
+      transitions: [{ from: 'generate', to: 'done' }],
+      triggers: [{ type: 'manual', name: 'Start' }],
+    };
+    const createWdRes = await request.post(
+      `/api/workflow-definitions?namespace=${TEST_ORG_HANDLE}`,
+      { headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' }, data: wd },
+    );
+    expect(createWdRes.status(), await createWdRes.text()).toBe(201);
+  }
+
+  async function startRunAndAwaitTerminal(request: APIRequestContext): Promise<string> {
+    const triggerRes = await request.post('/api/processes', {
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      data: {
+        namespace: TEST_ORG_HANDLE,
+        definitionName: wdName,
+        triggeredBy: 'e2e-test',
+        triggerName: 'Start',
+      },
+    });
+    expect(triggerRes.status(), await triggerRes.text()).toBe(201);
+    const { run } = (await triggerRes.json()) as { run: { id: string } };
+
+    await pollUntil(
+      async () => {
+        const res = await request.get(`/api/runs/${run.id}`, { headers: AUTH_HEADERS });
+        if (res.status() !== 200) return null;
+        const body = (await res.json()) as { status: string };
+        return body.status === 'completed' || body.status === 'failed' ? body : null;
+      },
+      { description: `run ${run.id} to reach a terminal status` },
+    );
+    return run.id;
+  }
+
+  test('lists, downloads, and guards Output Files across the run lifecycle', async ({ request }) => {
+    await registerWorkflowDefinition(request);
+    const runId = await startRunAndAwaitTerminal(request);
+
+    // -------- A run with no Output Files lists as empty, 200 --------
+    const emptyListRes = await request.get(`/api/runs/${runId}/files`, { headers: AUTH_HEADERS });
+    expect(emptyListRes.status(), await emptyListRes.text()).toBe(200);
+    expect(await emptyListRes.json()).toEqual({ files: [] });
+
+    // -------- Seed the git side for this runId (see module doc) --------
+    await seedOutputFiles(wdName, runId, {
+      generate: {
+        'report.csv': csvContent,
+        'charts/plot.svg': svgContent,
+        'data.bin': binaryContent,
+      },
+    });
+
+    // -------- List --------
+    const listRes = await request.get(`/api/runs/${runId}/files`, { headers: AUTH_HEADERS });
+    expect(listRes.status(), await listRes.text()).toBe(200);
+    const { files } = (await listRes.json()) as { files: OutputFileEntry[] };
+    const sorted = [...files].sort((left, right) => left.path.localeCompare(right.path));
+    expect(sorted).toEqual([
+      {
+        stepId: 'generate',
+        name: 'charts/plot.svg',
+        path: '.mediforce/output/generate/charts/plot.svg',
+        size: Buffer.byteLength(svgContent),
+      },
+      {
+        stepId: 'generate',
+        name: 'data.bin',
+        path: '.mediforce/output/generate/data.bin',
+        size: binaryContent.byteLength,
+      },
+      {
+        stepId: 'generate',
+        name: 'report.csv',
+        path: '.mediforce/output/generate/report.csv',
+        size: Buffer.byteLength(csvContent),
+      },
+    ]);
+
+    // -------- Download: text + nested + binary byte-identity --------
+    const csvRes = await request.get(`/api/runs/${runId}/files/.mediforce/output/generate/report.csv`, {
+      headers: AUTH_HEADERS,
+    });
+    expect(csvRes.status(), await csvRes.text()).toBe(200);
+    expect((await csvRes.body()).toString('utf-8')).toBe(csvContent);
+    expect(csvRes.headers()['content-type']).toBe('text/csv; charset=utf-8');
+    expect(csvRes.headers()['content-disposition']).toBe(
+      `attachment; filename="report.csv"; filename*=UTF-8''report.csv`,
+    );
+
+    const svgRes = await request.get(
+      `/api/runs/${runId}/files/.mediforce/output/generate/charts/plot.svg`,
+      { headers: AUTH_HEADERS },
+    );
+    expect(svgRes.status()).toBe(200);
+    expect((await svgRes.body()).toString('utf-8')).toBe(svgContent);
+    expect(svgRes.headers()['content-type']).toBe('image/svg+xml');
+
+    const binRes = await request.get(`/api/runs/${runId}/files/.mediforce/output/generate/data.bin`, {
+      headers: AUTH_HEADERS,
+    });
+    expect(binRes.status()).toBe(200);
+    expect((await binRes.body()).equals(binaryContent)).toBe(true);
+    expect(binRes.headers()['content-type']).toBe('application/octet-stream');
+
+    // -------- Missing file under the output root → 404, not bytes --------
+    const ghostRes = await request.get(`/api/runs/${runId}/files/.mediforce/output/generate/ghost.txt`, {
+      headers: AUTH_HEADERS,
+    });
+    expect(ghostRes.status()).toBe(404);
+
+    // -------- Path traversal / outside-root → rejected, never file content --------
+    // `..` percent-encoded so the HTTP layer can't normalize it away before
+    // the route sees it. Accept any 4xx rejection; assert no leak either way.
+    const traversalRes = await request.get(
+      `/api/runs/${runId}/files/.mediforce/output/%2E%2E/%2E%2E/secret`,
+      { headers: AUTH_HEADERS },
+    );
+    expect(traversalRes.status()).toBeGreaterThanOrEqual(400);
+    expect(traversalRes.status()).toBeLessThan(500);
+    expect(await traversalRes.text()).not.toContain('study,grade');
+
+    const outsideRootRes = await request.get(`/api/runs/${runId}/files/etc/passwd`, {
+      headers: AUTH_HEADERS,
+    });
+    expect(outsideRootRes.status()).toBe(400);
+    expect(await outsideRootRes.text()).not.toContain('root:');
+
+    // -------- Listing a missing run → 404 (anti-enumeration) --------
+    const missingRunRes = await request.get('/api/runs/no-such-run/files', { headers: AUTH_HEADERS });
+    expect(missingRunRes.status()).toBe(404);
+  });
+
+  test('rejects unauthenticated access to both routes with 401', async ({ request }) => {
+    const listRes = await request.get('/api/runs/any-run/files');
+    expect(listRes.status()).toBe(401);
+
+    const downloadRes = await request.get('/api/runs/any-run/files/.mediforce/output/step/file.txt');
+    expect(downloadRes.status()).toBe(401);
+  });
+});

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
@@ -16,7 +16,7 @@ import { getAgentOutput, type AgentOutputData } from '@/components/tasks/task-ut
 import { AgentOutputDisplay } from '@/components/agents/agent-output-display';
 import { agentOutputFromEnvelope } from './agent-output-from-envelope';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
-import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
+import { formatBytes, formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
 
 function StatusIcon({ status }: { status: string }) {
   switch (status) {
@@ -554,14 +554,6 @@ function isFileArray(arr: unknown[]): boolean {
       'size' in item &&
       'type' in item,
   );
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B';
-  const units = ['B', 'KB', 'MB', 'GB'];
-  const exp = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const size = bytes / Math.pow(1024, exp);
-  return `${size.toFixed(exp > 0 ? 1 : 0)} ${units[exp]}`;
 }
 
 function FileList({ files }: { files: FileItem[] }) {

--- a/packages/platform-ui/src/app/api/agent-output-file/route.ts
+++ b/packages/platform-ui/src/app/api/agent-output-file/route.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { getAdminAuth } from '@mediforce/platform-infra';
+import { attachmentContentDisposition, contentTypeForFilePath } from '@/lib/file-content-type';
 
 /**
  * Serves agent output files from allowed directories.
@@ -87,24 +88,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   try {
     const buffer = await readFile(resolved);
-    const ext = resolved.split('.').pop()?.toLowerCase() ?? '';
-    const contentTypeMap: Record<string, string> = {
-      html: 'text/html; charset=utf-8',
-      htm: 'text/html; charset=utf-8',
-      pdf: 'application/pdf',
-      csv: 'text/csv; charset=utf-8',
-      md: 'text/markdown; charset=utf-8',
-      xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    };
-    const contentType = contentTypeMap[ext] ?? 'application/octet-stream';
+    const contentType = contentTypeForFilePath(resolved);
     const filename = resolved.split('/').pop() ?? 'download';
-    // RFC 6266: use filename* with percent-encoding for full Unicode and special-char safety.
-    const encodedFilename = encodeURIComponent(filename);
 
     const contentDisposition =
-      disposition === 'inline'
-        ? 'inline'
-        : `attachment; filename="${filename.replace(/"/g, '\\"')}"; filename*=UTF-8''${encodedFilename}`;
+      disposition === 'inline' ? 'inline' : attachmentContentDisposition(filename);
 
     return new NextResponse(buffer, {
       headers: {

--- a/packages/platform-ui/src/app/api/runs/[runId]/files/[...path]/route.ts
+++ b/packages/platform-ui/src/app/api/runs/[runId]/files/[...path]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { WorkspaceReader, OUTPUT_FILES_REPO_ROOT } from '@mediforce/agent-runtime';
+import { NotFoundError, ValidationError, type HandlerError } from '@mediforce/platform-api/errors';
+import { defaultBuildScope, defaultResolveCaller } from '@/lib/route-adapter';
+import { attachmentContentDisposition, contentTypeForFilePath } from '@/lib/file-content-type';
+
+interface RouteContext {
+  params: Promise<{ runId: string; path: string[] }>;
+}
+
+const OUTPUT_FILES_PATH_PREFIX = `${OUTPUT_FILES_REPO_ROOT}/`;
+
+/**
+ * GET /api/runs/<runId>/files/<...path>
+ *
+ * Serves one Output File's bytes from the run branch of the workflow's bare
+ * repo. Deliberately NOT on `createRouteAdapter` — the response is binary,
+ * not the JSON envelope — but the auth + scope pipeline is byte-identical:
+ * `defaultResolveCaller` / `defaultBuildScope` are the adapter's own
+ * defaults, exported for exactly this route.
+ *
+ * `<...path>` is the repo-relative download key from
+ * `GET /api/runs/<runId>/files` (`.mediforce/output/<stepId>/<name>`).
+ * Paths outside `.mediforce/output/` or containing `..` segments are
+ * rejected with 400 before any git invocation (defense in depth — the
+ * `WorkspaceReader` enforces the same boundary).
+ *
+ * Workspace gating lives in `scope.runs.getById` — out-of-scope runs surface
+ * as 404 (anti-enumeration), same as the JSON routes.
+ */
+export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const callerOrResponse = await defaultResolveCaller(req);
+  if (callerOrResponse instanceof NextResponse) return callerOrResponse;
+  const scope = defaultBuildScope(callerOrResponse);
+
+  const { runId, path: pathSegments } = await ctx.params;
+  const repoRelativePath = pathSegments.join('/');
+
+  const hasTraversalSegment = repoRelativePath.split('/').includes('..');
+  const isUnderOutputRoot =
+    repoRelativePath.startsWith(OUTPUT_FILES_PATH_PREFIX) &&
+    repoRelativePath.length > OUTPUT_FILES_PATH_PREFIX.length;
+  if (hasTraversalSegment === true || isUnderOutputRoot === false) {
+    return errorResponse(
+      new ValidationError(
+        `Output File paths must live under ${OUTPUT_FILES_PATH_PREFIX} and contain no ".." segments`,
+      ),
+    );
+  }
+
+  const run = await scope.runs.getById(runId);
+  if (run === null) {
+    return errorResponse(new NotFoundError(`Run ${runId} not found`));
+  }
+
+  const fileBytes = await new WorkspaceReader().readOutputFile(
+    { name: run.definitionName, namespace: run.namespace },
+    runId,
+    repoRelativePath,
+  );
+  if (fileBytes === null) {
+    return errorResponse(new NotFoundError(`Output File ${repoRelativePath} not found for run ${runId}`));
+  }
+
+  const fileName = repoRelativePath.split('/').pop() ?? 'download';
+  return new NextResponse(new Uint8Array(fileBytes), {
+    headers: {
+      'Content-Type': contentTypeForFilePath(fileName),
+      'Content-Disposition': attachmentContentDisposition(fileName),
+      'Content-Length': String(fileBytes.byteLength),
+    },
+  });
+}
+
+function errorResponse(err: HandlerError): NextResponse {
+  return NextResponse.json(err.toEnvelope(), { status: err.statusCode });
+}

--- a/packages/platform-ui/src/app/api/runs/[runId]/files/[...path]/route.ts
+++ b/packages/platform-ui/src/app/api/runs/[runId]/files/[...path]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { WorkspaceReader, OUTPUT_FILES_REPO_ROOT } from '@mediforce/agent-runtime';
-import { NotFoundError, ValidationError, type HandlerError } from '@mediforce/platform-api/errors';
+import { HandlerError, NotFoundError, ValidationError } from '@mediforce/platform-api/errors';
 import { defaultBuildScope, defaultResolveCaller } from '@/lib/route-adapter';
 import { attachmentContentDisposition, contentTypeForFilePath } from '@/lib/file-content-type';
 
@@ -33,43 +33,52 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
   if (callerOrResponse instanceof NextResponse) return callerOrResponse;
   const scope = defaultBuildScope(callerOrResponse);
 
-  const { runId, path: pathSegments } = await ctx.params;
-  const repoRelativePath = pathSegments.join('/');
+  // Same error tail as createRouteAdapter (src/lib/route-adapter.ts): a
+  // HandlerError maps to the ADR-0005 envelope, anything else is logged and
+  // becomes a 500 'internal' envelope — never Next's default 500 page.
+  try {
+    const { runId, path: pathSegments } = await ctx.params;
+    const repoRelativePath = pathSegments.join('/');
 
-  const hasTraversalSegment = repoRelativePath.split('/').includes('..');
-  const isUnderOutputRoot =
-    repoRelativePath.startsWith(OUTPUT_FILES_PATH_PREFIX) &&
-    repoRelativePath.length > OUTPUT_FILES_PATH_PREFIX.length;
-  if (hasTraversalSegment === true || isUnderOutputRoot === false) {
-    return errorResponse(
-      new ValidationError(
-        `Output File paths must live under ${OUTPUT_FILES_PATH_PREFIX} and contain no ".." segments`,
-      ),
+    const hasTraversalSegment = repoRelativePath.split('/').includes('..');
+    const isUnderOutputRoot =
+      repoRelativePath.startsWith(OUTPUT_FILES_PATH_PREFIX) &&
+      repoRelativePath.length > OUTPUT_FILES_PATH_PREFIX.length;
+    if (hasTraversalSegment === true || isUnderOutputRoot === false) {
+      return errorResponse(
+        new ValidationError(
+          `Output File paths must live under ${OUTPUT_FILES_PATH_PREFIX} and contain no ".." segments`,
+        ),
+      );
+    }
+
+    const run = await scope.runs.getById(runId);
+    if (run === null) {
+      return errorResponse(new NotFoundError(`Run ${runId} not found`));
+    }
+
+    const fileBytes = await new WorkspaceReader().readOutputFile(
+      { name: run.definitionName, namespace: run.namespace },
+      runId,
+      repoRelativePath,
     );
-  }
+    if (fileBytes === null) {
+      return errorResponse(new NotFoundError(`Output File ${repoRelativePath} not found for run ${runId}`));
+    }
 
-  const run = await scope.runs.getById(runId);
-  if (run === null) {
-    return errorResponse(new NotFoundError(`Run ${runId} not found`));
+    const fileName = repoRelativePath.split('/').pop() ?? 'download';
+    return new NextResponse(new Uint8Array(fileBytes), {
+      headers: {
+        'Content-Type': contentTypeForFilePath(fileName),
+        'Content-Disposition': attachmentContentDisposition(fileName),
+        'Content-Length': String(fileBytes.byteLength),
+      },
+    });
+  } catch (err) {
+    if (err instanceof HandlerError) return errorResponse(err);
+    console.error('[run-output-file-route] handler error:', err);
+    return errorResponse(new HandlerError('internal', 'Internal error'));
   }
-
-  const fileBytes = await new WorkspaceReader().readOutputFile(
-    { name: run.definitionName, namespace: run.namespace },
-    runId,
-    repoRelativePath,
-  );
-  if (fileBytes === null) {
-    return errorResponse(new NotFoundError(`Output File ${repoRelativePath} not found for run ${runId}`));
-  }
-
-  const fileName = repoRelativePath.split('/').pop() ?? 'download';
-  return new NextResponse(new Uint8Array(fileBytes), {
-    headers: {
-      'Content-Type': contentTypeForFilePath(fileName),
-      'Content-Disposition': attachmentContentDisposition(fileName),
-      'Content-Length': String(fileBytes.byteLength),
-    },
-  });
 }
 
 function errorResponse(err: HandlerError): NextResponse {

--- a/packages/platform-ui/src/app/api/runs/[runId]/files/route.ts
+++ b/packages/platform-ui/src/app/api/runs/[runId]/files/route.ts
@@ -1,0 +1,32 @@
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { listRunOutputFiles } from '@mediforce/platform-api/handlers';
+import {
+  ListRunOutputFilesInputSchema,
+  type ListRunOutputFilesInput,
+} from '@mediforce/platform-api/contract';
+
+interface RouteContext {
+  params: Promise<{ runId: string }>;
+}
+
+/**
+ * GET /api/runs/<runId>/files
+ *
+ * Lists the run's Output Files — artifacts committed under
+ * `.mediforce/output/<stepId>/` on the run branch of the workflow's bare
+ * repo. Each entry's `path` is the download key for
+ * `GET /api/runs/<runId>/files/<path>`.
+ *
+ * Workspace gating lives in `scope.runs.getById` — out-of-scope runs surface
+ * as 404 (anti-enumeration). Runs without Output Files return `{ files: [] }`.
+ */
+export const GET = createRouteAdapter<
+  typeof ListRunOutputFilesInputSchema,
+  ListRunOutputFilesInput,
+  unknown,
+  RouteContext
+>(
+  ListRunOutputFilesInputSchema,
+  async (_req, ctx) => ({ runId: (await ctx.params).runId }),
+  listRunOutputFiles,
+);

--- a/packages/platform-ui/src/components/processes/__tests__/run-output-files-panel.test.ts
+++ b/packages/platform-ui/src/components/processes/__tests__/run-output-files-panel.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { Step } from '@mediforce/platform-core';
+import type { RunOutputFileEntry } from '@mediforce/platform-api/contract';
+import { groupOutputFilesByStep } from '../run-output-files-panel';
+
+function step(id: string, name: string): Step {
+  return { id, name, type: 'creation' };
+}
+
+function file(stepId: string, name: string, size = 100): RunOutputFileEntry {
+  return { stepId, name, path: `.mediforce/output/${stepId}/${name}`, size };
+}
+
+describe('groupOutputFilesByStep', () => {
+  const definitionSteps = [
+    step('intake', 'Intake'),
+    step('analyze-data', 'Analyze Data'),
+    step('report', 'Final Report'),
+  ];
+
+  it('returns no groups for an empty listing', () => {
+    expect(groupOutputFilesByStep([], definitionSteps)).toEqual([]);
+  });
+
+  it('groups files by step in workflow definition order', () => {
+    const grouped = groupOutputFilesByStep(
+      [file('report', 'summary.pdf'), file('intake', 'manifest.json'), file('report', 'tables.csv')],
+      definitionSteps,
+    );
+    expect(grouped.map((group) => group.stepId)).toEqual(['intake', 'report']);
+    expect(grouped[1].files.map((entry) => entry.name)).toEqual(['summary.pdf', 'tables.csv']);
+  });
+
+  it('resolves group headers from the definition step name', () => {
+    const grouped = groupOutputFilesByStep([file('analyze-data', 'stats.csv')], definitionSteps);
+    expect(grouped[0].stepName).toBe('Analyze Data');
+  });
+
+  it('appends unknown step IDs after definition steps with a title-cased fallback name', () => {
+    const grouped = groupOutputFilesByStep(
+      [file('removed-step', 'orphan.txt'), file('intake', 'manifest.json')],
+      definitionSteps,
+    );
+    expect(grouped.map((group) => group.stepId)).toEqual(['intake', 'removed-step']);
+    expect(grouped[1].stepName).toBe('Removed Step');
+  });
+
+  it('sorts files within a group by name', () => {
+    const grouped = groupOutputFilesByStep(
+      [file('intake', 'zeta.csv'), file('intake', 'alpha.csv')],
+      definitionSteps,
+    );
+    expect(grouped[0].files.map((entry) => entry.name)).toEqual(['alpha.csv', 'zeta.csv']);
+  });
+});

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -10,9 +10,11 @@ import { AuditLogTab } from './audit-log-tab';
 import { StepStatusPanel } from './step-status-panel';
 import { AgentLogViewer } from './agent-log-viewer';
 import { RunResultsPanel } from './run-results-panel';
+import { RunOutputFilesPanel } from './run-output-files-panel';
 import { ApiError } from '@mediforce/platform-api/client';
 import { useActiveCoworkSession } from '@/hooks/use-tasks';
 import { useProcessInstance } from '@/hooks/use-process-instances';
+import { useRunOutputFiles } from '@/hooks/use-run-output-files';
 import { useArchiveRun, useCancelRun } from '@/hooks/use-run-mutations';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
 import { routes } from '@/lib/routes';
@@ -187,6 +189,8 @@ export function ProcessDetail({
 
   const isTerminal = instance.status === 'completed' || instance.status === 'failed';
 
+  const { data: outputFiles } = useRunOutputFiles(instance.id, instance.status);
+
   // Scroll audit log to bottom when events change
   const auditScrollRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
@@ -359,6 +363,13 @@ export function ProcessDetail({
           <RunResultsPanel stepExecutions={stepExecutions} />
         )}
 
+        {/* Output Files — hidden until the run has at least one */}
+        <RunOutputFilesPanel
+          runId={instance.id}
+          files={outputFiles}
+          definitionSteps={definitionSteps}
+        />
+
         {/* Step Status Panel */}
         {definitionSteps.length > 0 && (
           <StepStatusPanel
@@ -367,6 +378,7 @@ export function ProcessDetail({
             stepExecutions={stepExecutions}
             agentEvents={agentEvents}
             stepConfigMap={stepConfigMap}
+            outputFiles={outputFiles}
             stepDetailBaseHref={runDetailHref}
             onAgentLogClick={agentLogFiles.length > 0 ? (stepId: string) => {
               setAgentLogStepId(stepId);

--- a/packages/platform-ui/src/components/processes/run-output-files-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-output-files-panel.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import * as React from 'react';
+import { Download, File, FileArchive, FileImage, FileSpreadsheet, FileText, type LucideIcon } from 'lucide-react';
+import type { Step } from '@mediforce/platform-core';
+import type { RunOutputFileEntry } from '@mediforce/platform-api/contract';
+import { mediforce } from '@/lib/mediforce';
+import { formatBytes, formatStepName } from '@/lib/format';
+import { saveBlobToDevice } from '@/lib/save-blob';
+
+export interface OutputFileGroup {
+  stepId: string;
+  stepName: string;
+  files: RunOutputFileEntry[];
+}
+
+/**
+ * Group a flat Output Files listing by step, ordered by the workflow
+ * definition's step order (unknown step IDs append in first-seen order).
+ * Step names resolve from the definition; missing steps fall back to a
+ * title-cased step ID, matching the step labels elsewhere on the page.
+ */
+export function groupOutputFilesByStep(
+  files: RunOutputFileEntry[],
+  definitionSteps: Step[],
+): OutputFileGroup[] {
+  const byStepId = new Map<string, RunOutputFileEntry[]>();
+  for (const file of files) {
+    const existing = byStepId.get(file.stepId);
+    if (existing) {
+      existing.push(file);
+    } else {
+      byStepId.set(file.stepId, [file]);
+    }
+  }
+
+  const definitionOrder = definitionSteps
+    .map((step) => step.id)
+    .filter((stepId) => byStepId.has(stepId));
+  const unknownOrder = [...byStepId.keys()].filter(
+    (stepId) => definitionSteps.some((step) => step.id === stepId) === false,
+  );
+
+  return [...definitionOrder, ...unknownOrder].map((stepId) => ({
+    stepId,
+    stepName:
+      definitionSteps.find((step) => step.id === stepId)?.name ?? formatStepName(stepId),
+    files: [...(byStepId.get(stepId) ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+  }));
+}
+
+const DOCUMENT_EXTENSIONS = new Set(['txt', 'md', 'pdf', 'doc', 'docx', 'rtf', 'html']);
+const TABLE_EXTENSIONS = new Set(['csv', 'tsv', 'xls', 'xlsx', 'parquet']);
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp']);
+const ARCHIVE_EXTENSIONS = new Set(['zip', 'tar', 'gz', 'tgz', '7z']);
+
+function fileTypeIcon(fileName: string): LucideIcon {
+  const lastSegment = fileName.split('/').pop() ?? fileName;
+  const extension = lastSegment.includes('.')
+    ? (lastSegment.split('.').pop() ?? '').toLowerCase()
+    : '';
+  if (DOCUMENT_EXTENSIONS.has(extension)) return FileText;
+  if (TABLE_EXTENSIONS.has(extension)) return FileSpreadsheet;
+  if (IMAGE_EXTENSIONS.has(extension)) return FileImage;
+  if (ARCHIVE_EXTENSIONS.has(extension)) return FileArchive;
+  return File;
+}
+
+export function OutputFileRow({ runId, file }: { runId: string; file: RunOutputFileEntry }) {
+  const [downloading, setDownloading] = React.useState(false);
+  const [downloadError, setDownloadError] = React.useState<string | null>(null);
+  const Icon = fileTypeIcon(file.name);
+
+  async function handleDownload() {
+    setDownloading(true);
+    setDownloadError(null);
+    try {
+      const downloaded = await mediforce.runs.downloadOutputFile({ runId, path: file.path });
+      // `.slice()` re-types the view as Uint8Array<ArrayBuffer> (BlobPart
+      // rejects the wider ArrayBufferLike the client returns).
+      saveBlobToDevice(
+        new Blob([downloaded.bytes.slice()], { type: downloaded.contentType }),
+        downloaded.fileName,
+      );
+    } catch (err) {
+      setDownloadError(err instanceof Error ? err.message : 'Download failed');
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <li className="flex items-center gap-2 text-sm min-w-0">
+      <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+      <span className="truncate" title={file.name}>{file.name}</span>
+      <span className="text-xs text-muted-foreground shrink-0">{formatBytes(file.size)}</span>
+      {downloadError && (
+        <span className="text-xs text-destructive truncate">{downloadError}</span>
+      )}
+      <button
+        onClick={handleDownload}
+        disabled={downloading}
+        className="ml-auto inline-flex items-center gap-1 text-xs text-primary hover:underline disabled:opacity-50 shrink-0"
+      >
+        <Download className="h-3 w-3" />
+        {downloading ? 'Downloading...' : 'Download'}
+      </button>
+    </li>
+  );
+}
+
+/**
+ * "Files" card on the run detail page — the run's Output Files grouped by
+ * step. Renders nothing while the run has no output files (zero noise).
+ */
+export function RunOutputFilesPanel({
+  runId,
+  files,
+  definitionSteps,
+}: {
+  runId: string;
+  files: RunOutputFileEntry[];
+  definitionSteps: Step[];
+}) {
+  const groups = React.useMemo(
+    () => groupOutputFilesByStep(files, definitionSteps),
+    [files, definitionSteps],
+  );
+
+  if (groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <h3 className="text-sm font-medium mb-3">Files</h3>
+      <div className="space-y-3">
+        {groups.map((group) => (
+          <div key={group.stepId}>
+            <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1.5">
+              {group.stepName}
+            </h4>
+            <ul className="space-y-1">
+              {group.files.map((file) => (
+                <OutputFileRow key={file.path} runId={runId} file={file} />
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -3,10 +3,12 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { CheckCircle2, Clock, XCircle, Circle, Pause, User, Bot, Cog, ChevronDown, ChevronRight, FileText, FileCode } from 'lucide-react';
+import { CheckCircle2, Clock, XCircle, Circle, Pause, User, Bot, Cog, ChevronDown, ChevronRight, FileText, FileCode, Paperclip } from 'lucide-react';
 import type { ProcessInstance, StepExecution, Step } from '@mediforce/platform-core';
+import type { RunOutputFileEntry } from '@mediforce/platform-api/contract';
 import { AutonomyBadge } from '../agents/autonomy-badge';
 import { RetryStepButton } from './retry-step-button';
+import { OutputFileRow } from './run-output-files-panel';
 import { cn } from '@/lib/utils';
 import { getWorkflowStatus } from '@/lib/workflow-status';
 import { formatDuration, formatCostUsd } from '@/lib/format';
@@ -48,6 +50,8 @@ interface StepStatusPanelProps {
   stepExecutions: StepExecution[];
   agentEvents?: AgentEventItem[];
   stepConfigMap?: Map<string, StepConfigInfo>;
+  /** The run's Output Files — steps with files get a paperclip chip that expands to download links. */
+  outputFiles?: RunOutputFileEntry[];
   onAgentLogClick?: (stepId: string) => void;
   /** Base href for step detail links, e.g. "/workflows/foo/runs/abc". Steps link to `{base}/steps/{stepId}`. */
   stepDetailBaseHref?: string;
@@ -358,11 +362,26 @@ export function StepStatusPanel({
   stepExecutions,
   agentEvents = [],
   stepConfigMap,
+  outputFiles = [],
   onAgentLogClick,
   stepDetailBaseHref,
 }: StepStatusPanelProps) {
   const [expandedStepId, setExpandedStepId] = React.useState<string | null>(null);
+  const [filesExpandedStepId, setFilesExpandedStepId] = React.useState<string | null>(null);
   const wfStatus = getWorkflowStatus(instance);
+
+  const outputFilesByStep = React.useMemo(() => {
+    const byStepId = new Map<string, RunOutputFileEntry[]>();
+    for (const file of outputFiles) {
+      const existing = byStepId.get(file.stepId);
+      if (existing) {
+        existing.push(file);
+      } else {
+        byStepId.set(file.stepId, [file]);
+      }
+    }
+    return byStepId;
+  }, [outputFiles]);
 
   // Filter out terminal steps — they aren't meaningful to display
   const visibleSteps = definitionSteps.filter((s) => s.type !== 'terminal');
@@ -404,6 +423,8 @@ export function StepStatusPanel({
             (e) => e.stepId === step.id && e.type === 'prompt',
           );
           const assembledPrompt = promptEvent ? String(promptEvent.payload) : undefined;
+          const stepOutputFiles = outputFilesByStep.get(step.id) ?? [];
+          const isFilesExpanded = filesExpandedStepId === step.id;
 
           return (
             <li
@@ -453,6 +474,19 @@ export function StepStatusPanel({
                     <AutonomyBadge level={stepConfigMap.get(step.id)!.autonomyLevel!} />
                   )}
                   <StatusLabel status={status} />
+                  {stepOutputFiles.length > 0 && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setFilesExpandedStepId(isFilesExpanded ? null : step.id);
+                      }}
+                      title={`${stepOutputFiles.length} output file${stepOutputFiles.length === 1 ? '' : 's'}`}
+                      className="inline-flex items-center gap-0.5 text-xs bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 hover:text-foreground transition-colors"
+                    >
+                      <Paperclip className="h-3 w-3" />
+                      {stepOutputFiles.length}
+                    </button>
+                  )}
                   {hasConfig && (
                     isExpanded
                       ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
@@ -526,6 +560,20 @@ export function StepStatusPanel({
                         </div>
                       );
                     })}
+                  </div>
+                )}
+
+                {/* Expandable Output Files list (paperclip chip) */}
+                {isFilesExpanded && stepOutputFiles.length > 0 && (
+                  <div
+                    className="mt-2 rounded-md bg-muted/50 border px-3 py-2"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <ul className="space-y-1">
+                      {stepOutputFiles.map((file) => (
+                        <OutputFileRow key={file.path} runId={instance.id} file={file} />
+                      ))}
+                    </ul>
                   </div>
                 )}
 

--- a/packages/platform-ui/src/components/reports/run-report.tsx
+++ b/packages/platform-ui/src/components/reports/run-report.tsx
@@ -35,6 +35,7 @@ import {
   computeActiveProcessingTime,
 } from '@/lib/format';
 import { cn, isBrowsableRepoUrl } from '@/lib/utils';
+import { saveBlobToDevice } from '@/lib/save-blob';
 
 type DetailLevel = 'brief' | 'full';
 
@@ -446,13 +447,10 @@ function DeliverablesSection({
       { headers: authToken ? { Authorization: `Bearer ${authToken}` } : {} },
     );
     if (!response.ok) return;
-    const blob = await response.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = effectiveDeliverableFile.split('/').pop() ?? 'download';
-    a.click();
-    URL.revokeObjectURL(url);
+    saveBlobToDevice(
+      await response.blob(),
+      effectiveDeliverableFile.split('/').pop() ?? 'download',
+    );
   }
 
   return (

--- a/packages/platform-ui/src/hooks/__tests__/use-run-output-files.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-run-output-files.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { RunOutputFileEntry } from '@mediforce/platform-api/contract';
+import { createQueryWrapper } from '@/test/react-query';
+
+function file(stepId: string, name: string): RunOutputFileEntry {
+  return { stepId, name, path: `.mediforce/output/${stepId}/${name}`, size: 42 };
+}
+
+const listOutputFilesMock = vi.fn<(...args: unknown[]) => Promise<{ files: RunOutputFileEntry[] }>>();
+class ApiError extends Error {
+  constructor(public status: number, message: string) { super(message); }
+}
+vi.mock('@/lib/mediforce', () => ({
+  mediforce: { runs: { listOutputFiles: listOutputFilesMock } },
+  ApiError,
+}));
+
+const { useRunOutputFiles } = await import('../use-run-output-files');
+
+describe('useRunOutputFiles', () => {
+  beforeEach(() => {
+    listOutputFilesMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('does not call the API when runId is null', () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRunOutputFiles(null, 'running'), { wrapper });
+    expect(result.current.data).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(listOutputFilesMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the file listing for a run', async () => {
+    const files = [file('intake', 'manifest.json'), file('report', 'summary.pdf')];
+    listOutputFilesMock.mockResolvedValue({ files });
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRunOutputFiles('run-a', 'running'), { wrapper });
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listOutputFilesMock).toHaveBeenCalledWith({ runId: 'run-a' });
+    expect(result.current.data).toEqual(files);
+  });
+
+  it('surfaces 4xx errors immediately and stops polling', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    listOutputFilesMock.mockRejectedValue(new ApiError(404, 'not found'));
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useRunOutputFiles('run-a', 'running'), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listOutputFilesMock).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(listOutputFilesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling when instanceStatus is terminal (completed)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    listOutputFilesMock.mockResolvedValue({ files: [] });
+    const { wrapper } = createQueryWrapper();
+    renderHook(() => useRunOutputFiles('run-a', 'completed'), { wrapper });
+
+    await waitFor(() => expect(listOutputFilesMock).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(listOutputFilesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps polling at STANDARD LIVE cadence while the run is non-terminal', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    listOutputFilesMock.mockResolvedValue({ files: [] });
+    const { wrapper } = createQueryWrapper();
+    renderHook(() => useRunOutputFiles('run-a', 'running'), { wrapper });
+
+    await waitFor(() => expect(listOutputFilesMock).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(5_500);
+    await waitFor(() => expect(listOutputFilesMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+});

--- a/packages/platform-ui/src/hooks/use-run-output-files.ts
+++ b/packages/platform-ui/src/hooks/use-run-output-files.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { InstanceStatus } from '@mediforce/platform-core';
+import type { RunOutputFileEntry } from '@mediforce/platform-api/contract';
+import { mediforce } from '@/lib/mediforce';
+import { queryKeys } from '@/lib/query-keys';
+import { STANDARD_LIVE_INTERVAL_MS, TERMINAL_STATUSES } from '@/lib/polling-cadence';
+import { stopRetryOn4xx } from '@/lib/retry';
+
+/**
+ * Output Files committed on the run branch, react-query backed
+ * (`mediforce.runs.listOutputFiles`).
+ *
+ * Polling: STANDARD LIVE (5 s) while the parent run is non-terminal — files
+ * appear as steps complete, not sub-second — stopped once `completed` /
+ * `failed` per ADR-0006 §4. Callers pass `instanceStatus` to gate the
+ * cadence; `undefined` means "not yet known" and is treated as non-terminal.
+ */
+export function useRunOutputFiles(
+  runId: string | null | undefined,
+  instanceStatus: InstanceStatus | undefined,
+): { data: RunOutputFileEntry[]; loading: boolean; error: Error | null } {
+  const enabled = runId !== null && runId !== undefined && runId.length > 0;
+  const isTerminal = instanceStatus !== undefined && TERMINAL_STATUSES.has(instanceStatus);
+
+  const query = useQuery({
+    queryKey: enabled
+      ? queryKeys.runOutputFiles(runId)
+      : queryKeys.runOutputFiles('__noop__'),
+    queryFn: async () => {
+      if (runId === null || runId === undefined) {
+        throw new Error('unreachable: enabled gates this');
+      }
+      const result = await mediforce.runs.listOutputFiles({ runId });
+      return result.files;
+    },
+    enabled,
+    refetchInterval: (q) => {
+      // PRD §9 rule 4: hooks must terminate on 4xx. A run deleted while the
+      // page is open (404) or a workspace membership change (403) would
+      // tight-loop forever at 5s otherwise.
+      if (q.state.error !== null) return false;
+      return isTerminal ? false : STANDARD_LIVE_INTERVAL_MS;
+    },
+    retry: stopRetryOn4xx,
+  });
+
+  return {
+    data: query.data ?? [],
+    loading: enabled && query.isPending,
+    error: (query.error as Error | null) ?? null,
+  };
+}

--- a/packages/platform-ui/src/lib/__tests__/format.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/format.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { buildStepExecution } from '@mediforce/platform-core/testing';
 import {
   formatDuration,
-  formatBytes,
   formatStepName,
   computeWallClockDuration,
   computeActiveProcessingTime,
@@ -38,27 +37,7 @@ describe('formatDuration', () => {
   });
 });
 
-describe('formatBytes', () => {
-  it('[DATA] formats zero bytes', () => {
-    expect(formatBytes(0)).toBe('0 B');
-  });
-
-  it('[DATA] formats bytes without a decimal', () => {
-    expect(formatBytes(512)).toBe('512 B');
-  });
-
-  it('[DATA] formats kilobytes with one decimal (1024-based)', () => {
-    expect(formatBytes(1536)).toBe('1.5 KB');
-  });
-
-  it('[DATA] formats megabytes', () => {
-    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
-  });
-
-  it('[DATA] caps the unit at GB', () => {
-    expect(formatBytes(3 * 1024 ** 4)).toBe('3072.0 GB');
-  });
-});
+// formatBytes tests live in @mediforce/platform-core (src/utils/__tests__/format.test.ts).
 
 describe('formatStepName', () => {
   it('[DATA] formats hyphenated step IDs', () => {

--- a/packages/platform-ui/src/lib/__tests__/format.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/format.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { buildStepExecution } from '@mediforce/platform-core/testing';
 import {
   formatDuration,
+  formatBytes,
   formatStepName,
   computeWallClockDuration,
   computeActiveProcessingTime,
@@ -34,6 +35,28 @@ describe('formatDuration', () => {
 
   it('[DATA] formats large durations', () => {
     expect(formatDuration(3661000)).toBe('61m 1s');
+  });
+});
+
+describe('formatBytes', () => {
+  it('[DATA] formats zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+  });
+
+  it('[DATA] formats bytes without a decimal', () => {
+    expect(formatBytes(512)).toBe('512 B');
+  });
+
+  it('[DATA] formats kilobytes with one decimal (1024-based)', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+
+  it('[DATA] formats megabytes', () => {
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+
+  it('[DATA] caps the unit at GB', () => {
+    expect(formatBytes(3 * 1024 ** 4)).toBe('3072.0 GB');
   });
 });
 

--- a/packages/platform-ui/src/lib/file-content-type.ts
+++ b/packages/platform-ui/src/lib/file-content-type.ts
@@ -1,0 +1,36 @@
+/**
+ * Content-Type + Content-Disposition helpers for file-serving routes.
+ * Single source for the extension → MIME map and the RFC 6266 attachment
+ * header, shared by `/api/agent-output-file` and `/api/runs/[runId]/files/[...path]`.
+ */
+
+const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  html: 'text/html; charset=utf-8',
+  htm: 'text/html; charset=utf-8',
+  pdf: 'application/pdf',
+  csv: 'text/csv; charset=utf-8',
+  md: 'text/markdown; charset=utf-8',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  json: 'application/json; charset=utf-8',
+  txt: 'text/plain; charset=utf-8',
+  zip: 'application/zip',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  svg: 'image/svg+xml',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+};
+
+export function contentTypeForFilePath(filePath: string): string {
+  const extension = filePath.split('.').pop()?.toLowerCase() ?? '';
+  return CONTENT_TYPE_BY_EXTENSION[extension] ?? 'application/octet-stream';
+}
+
+/**
+ * RFC 6266 `attachment` disposition: plain `filename` for legacy agents plus
+ * percent-encoded `filename*` for full Unicode and special-char safety.
+ */
+export function attachmentContentDisposition(fileName: string): string {
+  const encodedFileName = encodeURIComponent(fileName);
+  return `attachment; filename="${fileName.replace(/"/g, '\\"')}"; filename*=UTF-8''${encodedFileName}`;
+}

--- a/packages/platform-ui/src/lib/format.ts
+++ b/packages/platform-ui/src/lib/format.ts
@@ -16,6 +16,14 @@ export function formatCostUsd(cost: number): string {
   return `$${cost.toFixed(2)}`;
 }
 
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const size = bytes / Math.pow(1024, exponent);
+  return `${size.toFixed(exponent > 0 ? 1 : 0)} ${units[exponent]}`;
+}
+
 export function formatStepName(stepId: string): string {
   return stepId
     .replace(/[-_]/g, ' ')

--- a/packages/platform-ui/src/lib/format.ts
+++ b/packages/platform-ui/src/lib/format.ts
@@ -1,5 +1,7 @@
 import type { StepExecution } from '@mediforce/platform-core';
 
+export { formatBytes } from '@mediforce/platform-core';
+
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   const seconds = Math.round(ms / 1000);
@@ -14,14 +16,6 @@ export function formatCostUsd(cost: number): string {
   if (cost < 0.01) return `$${cost.toFixed(4)}`;
   if (cost < 1) return `$${cost.toFixed(3)}`;
   return `$${cost.toFixed(2)}`;
-}
-
-export function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B';
-  const units = ['B', 'KB', 'MB', 'GB'];
-  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
-  const size = bytes / Math.pow(1024, exponent);
-  return `${size.toFixed(exponent > 0 ? 1 : 0)} ${units[exponent]}`;
 }
 
 export function formatStepName(stepId: string): string {

--- a/packages/platform-ui/src/lib/query-keys.ts
+++ b/packages/platform-ui/src/lib/query-keys.ts
@@ -66,6 +66,9 @@ export const queryKeys = {
   /** Aggregate step-entry view for a process instance (processes.getSteps). */
   processSteps: (instanceId: string) => ['process-steps', instanceId] as const,
 
+  /** Output Files listing for a run (runs.listOutputFiles). */
+  runOutputFiles: (runId: string) => ['run-output-files', runId] as const,
+
   /** Agent event log slice. `stepId` undefined fetches every step's events
    *  on the instance. */
   agentEvents: (instanceId: string, stepId: string | null | undefined) =>

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -131,14 +131,17 @@ const prodRunKicker: RunKicker = createHttpSelfFetchRunKicker({
   apiKey: () => process.env.PLATFORM_API_KEY ?? '',
 });
 
-function defaultBuildScope(caller: CallerIdentity): CallerScope {
+// Exported for the rare non-JSON route (binary file download) that can't
+// compose through `createRouteAdapter` but MUST run the identical auth +
+// scope pipeline. Everything JSON goes through the adapter — see module doc.
+export function defaultBuildScope(caller: CallerIdentity): CallerScope {
   return createCallerScope(
     { ...getPlatformServices(), runKicker: prodRunKicker },
     caller,
   );
 }
 
-async function defaultResolveCaller(req: NextRequest): Promise<CallerIdentity | NextResponse> {
+export async function defaultResolveCaller(req: NextRequest): Promise<CallerIdentity | NextResponse> {
   const { namespaceRepo } = getPlatformServices();
   return resolveCallerIdentity(req, namespaceRepo);
 }

--- a/packages/platform-ui/src/lib/save-blob.ts
+++ b/packages/platform-ui/src/lib/save-blob.ts
@@ -1,0 +1,14 @@
+/**
+ * Trigger the browser's "save file" flow for an in-memory blob via a
+ * transient object URL. Shared by every authenticated download that fetches
+ * bytes with a Bearer token first (run-report deliverable, run Output Files)
+ * — a bare `<a href>` would not carry the Authorization header.
+ */
+export function saveBlobToDevice(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

Agents can now produce durable Output Files — artifacts left in the ephemeral `/output` directory are automatically preserved under `.mediforce/output/<stepId>/` on the run branch, making them listable and downloadable via the API and CLI.

Previously, everything except one whitelisted "deliverable" file was discarded after each step. This change captures the full output directory (minus internal runtime files) into the git workspace, committing it alongside the step result.

## Key Changes

**Runtime & Workspace**
- `copyOutputFilesIntoWorkspace()` copies step output into `.mediforce/output/<stepId>/`, filtering internal files (`auth.json`, `prompt.txt`, `result.json`, etc.) and dotfiles at the top level; nested directories are copied recursively
- `WorkspaceReader` provides read-only access to committed Output Files directly from the bare repo (no worktree needed), enabling listing and download after the worktree is swept
- `WorkspaceManager.commitStep()` now calls `copyOutputFilesIntoWorkspace()` to capture outputs before committing
- Container worker's `QueuedDockerSpawnStrategy` encodes/decodes output files as base64 JSON payloads for Redis transport, preserving binary content and directory structure

**API & Handlers**
- `GET /api/runs/<runId>/files` lists Output Files with step ID, name, repo-relative path, and size
- `GET /api/runs/<runId>/files/<path>` downloads individual files as binary (Content-Disposition attachment)
- `listRunOutputFiles` handler gates access by run workspace membership

**CLI**
- `mediforce run files <runId>` lists Output Files grouped by step
- `mediforce run download <runId> [path]` downloads single file or all files into a directory

**UI**
- `RunOutputFilesPanel` displays files grouped by step with file-type icons and download buttons
- `useRunOutputFiles` hook polls the API while the run is non-terminal
- Step detail view integrates Output Files inline with step execution info
- File download uses `saveBlobToDevice()` for authenticated binary downloads

**Shared Infrastructure**
- `formatBytes()` utility for human-readable file sizes (1024-based, B/KB/MB/GB)
- `file-content-type.ts` maps extensions to MIME types and RFC 6266 attachment headers
- Contract schemas for `ListRunOutputFilesInput/Output` and `DownloadRunOutputFileInput`

## Implementation Details

- **Filtering:** Internal files are filtered only at the top level of `/output`; nested files with the same names are preserved (e.g., `charts/result.json` is kept)
- **Size limits:** Configurable per-file max via `MEDIFORCE_OUTPUT_FILE_MAX_BYTES` (default 100 MB); oversized files are skipped with a warning
- **Binary safety:** Base64 encoding in the queued worker ensures all byte values (0–255) survive Redis serialization; git cat-file handles binary blobs natively
- **Presentation files:** `presentation.md` and `presentation.html` are copied as Output Files in addition to being surfaced via the result envelope
- **Path safety:** Download paths are validated to reject traversal (`..` segments) and enforce `.mediforce/output/` prefix before any git invocation

## Testing

- Unit tests for `copyOutputFilesIntoWorkspace`, `WorkspaceReader`, and file payload encoding/decoding
- E2E API test seeds Output Files into a bare repo and verifies listing and download
- CLI tests mock the API and verify command output formatting
- UI component tests verify grouping logic and file-type icon selection

https://claude.ai/code/session_01X1WiSVYW1QxoszhVU7jkYx