### PR TITLE
fix(agent-runtime): use python3 in script container runtime

### DIFF
--- a/packages/agent-runtime/container/Dockerfile.base
+++ b/packages/agent-runtime/container/Dockerfile.base
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     python3-requests \
+    python-is-python3 \
     curl \
     jq \
     ca-certificates \

--- a/packages/agent-runtime/src/plugins/script-container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/script-container-plugin.ts
@@ -13,7 +13,7 @@ const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 /** Runtime → Docker image, file extension, and run command (as array for spawn). */
 const RUNTIME_CONFIG: Record<string, { image: string; ext: string; cmd: (path: string) => string[] }> = {
   javascript: { image: 'mediforce-node:latest', ext: '.mjs', cmd: (p) => ['node', p] },
-  python: { image: 'python:3.12-slim', ext: '.py', cmd: (p) => ['python', p] },
+  python: { image: 'python:3.12-slim', ext: '.py', cmd: (p) => ['python3', p] },
   r: { image: 'rocker/r-ver:4', ext: '.R', cmd: (p) => ['Rscript', p] },
   bash: { image: 'alpine:3.19', ext: '.sh', cmd: (p) => ['sh', p] },
 };


### PR DESCRIPTION
## Summary
- `RUNTIME_CONFIG.python.cmd` now invokes `python3` instead of `python` — golden image (rocker/tidyverse) only has `python3`
- `Dockerfile.base` adds `python-is-python3` package as belt-and-suspenders symlink

Unblocks `markdown-to-pdf-generator` workflow (and any future `runtime: "python"` + golden image combo).

## Test plan
- [x] Verified `python:3.12-slim` has `python3` binary
- [ ] Deploy to staging → re-run markdown-to-pdf-generator workflow with Polish text

🤖 Generated with [Claude Code](https://claude.com/claude-code)