### PR TITLE
fix(ui+audit): script executor UX — hide agent metadata, emit script.* events

### DIFF
--- a/packages/agent-runtime/src/runner/agent-runner.ts
+++ b/packages/agent-runtime/src/runner/agent-runner.ts
@@ -399,6 +399,7 @@ export class AgentRunner {
     errorMessage: string | null = null,
   ): Promise<void> {
     const pluginId = context.step.plugin ?? context.stepId;
+    const isScript = context.step.executor === 'script';
     const reviewerType = context.autonomyLevel === 'L4'
       ? 'none'
       : context.autonomyLevel === 'L3'
@@ -406,15 +407,17 @@ export class AgentRunner {
         : 'none';
 
     await this.auditRepository.append({
-      actorId: `agent:${pluginId}`,
-      actorType: 'agent',
+      actorId: `${isScript ? 'script' : 'agent'}:${pluginId}`,
+      actorType: isScript ? 'system' : 'agent',
       actorRole: context.autonomyLevel,
-      action: 'agent.run',
-      description: `Agent run completed with status '${runStatus}' at autonomy level ${context.autonomyLevel}`,
+      action: isScript ? 'script.run' : 'agent.run',
+      description: isScript
+        ? `Script completed with status '${runStatus}'`
+        : `Agent run completed with status '${runStatus}' at autonomy level ${context.autonomyLevel}`,
       timestamp: new Date().toISOString(),
       inputSnapshot: {
         stepInput: context.stepInput,
-        autonomyLevel: context.autonomyLevel,
+        ...(isScript ? {} : { autonomyLevel: context.autonomyLevel }),
         model: context.step.agent?.model ?? envelope?.model ?? null,
       },
       outputSnapshot: {
@@ -426,13 +429,15 @@ export class AgentRunner {
         result: envelope?.result ?? null,
         ...(errorMessage !== null ? { error: errorMessage } : {}),
       },
-      basis: `Autonomy level ${context.autonomyLevel} — ${this.getBasisDescription(context.autonomyLevel)}`,
+      basis: isScript
+        ? 'Deterministic script execution'
+        : `Autonomy level ${context.autonomyLevel} — ${this.getBasisDescription(context.autonomyLevel)}`,
       entityType: 'process_instance',
       entityId: context.processInstanceId,
       processInstanceId: context.processInstanceId,
       stepId: context.stepId,
       processDefinitionVersion: context.definitionVersion,
-      executorType: context.step.executor === 'script' ? 'script' : 'agent',
+      executorType: isScript ? 'script' : 'agent',
       reviewerType,
     });
   }

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { format } from 'date-fns';
 import { CheckCircle2, Clock, XCircle, Circle, Pause, Bot, User, ExternalLink, FileText, GitBranch, Gauge, ChevronDown, ChevronRight, MessageSquare, DollarSign } from 'lucide-react';
-import type { StepExecution, Step, AgentEvent, HumanTask } from '@mediforce/platform-core';
+import type { StepExecution, Step, AgentEvent, HumanTask, WorkflowStep } from '@mediforce/platform-core';
 import { useProcessInstance } from '@/hooks/use-process-instances';
 import { useStepExecutions } from '@/hooks/use-step-executions';
 import { useAgentEvents } from '@/hooks/use-agent-events';
@@ -63,6 +63,11 @@ export default function StepDetailPage() {
   const definitionStep = useMemo((): Step | null => {
     return definition?.steps?.find((s) => s.id === decodedStepId) ?? null;
   }, [definition, decodedStepId]);
+
+  const executorType = useMemo(() => {
+    if (!definitionStep) return undefined;
+    return (definitionStep as unknown as WorkflowStep).executor;
+  }, [definitionStep]);
 
   // Find previous step name for the "From:" label
   const previousStepName = useMemo(() => {
@@ -233,7 +238,7 @@ export default function StepDetailPage() {
                   previousStepName={previousStepName}
                   promptEvent={promptEvent}
                 />
-                <OutputColumn execution={execution} />
+                <OutputColumn execution={execution} executorType={executorType} />
               </div>
             </Collapsible.Content>
           </Collapsible.Root>
@@ -244,7 +249,7 @@ export default function StepDetailPage() {
               previousStepName={previousStepName}
               promptEvent={promptEvent}
             />
-            <OutputColumn execution={execution} />
+            <OutputColumn execution={execution} executorType={executorType} />
           </div>
         )
       ) : (
@@ -331,7 +336,7 @@ function CollapsiblePrompt({ prompt }: { prompt: unknown }) {
 
 // ── Output Column ───────────────────────────────────────────────────────────
 
-function OutputColumn({ execution }: { execution: StepExecution }) {
+function OutputColumn({ execution, executorType }: { execution: StepExecution; executorType?: string }) {
   const agentOutput = execution.agentOutput;
   const hasAgent = agentOutput !== undefined;
   const output = execution.output;
@@ -348,7 +353,7 @@ function OutputColumn({ execution }: { execution: StepExecution }) {
         ) : (
           <div className="divide-y">
             {hasAgent && agentOutput && (
-              <AgentMetadataSection agentOutput={agentOutput} />
+              <AgentMetadataSection agentOutput={agentOutput} executorType={executorType} />
             )}
 
             {hasAgent && agentOutput?.gitMetadata && (
@@ -367,8 +372,9 @@ function OutputColumn({ execution }: { execution: StepExecution }) {
 
 // ── Agent Metadata ──────────────────────────────────────────────────────────
 
-function AgentMetadataSection({ agentOutput }: { agentOutput: NonNullable<StepExecution['agentOutput']> }) {
-  const confidencePct = agentOutput.confidence !== null
+function AgentMetadataSection({ agentOutput, executorType }: { agentOutput: NonNullable<StepExecution['agentOutput']>; executorType?: string }) {
+  const isScript = executorType === 'script';
+  const confidencePct = !isScript && agentOutput.confidence !== null
     ? Math.round(agentOutput.confidence * 100)
     : null;
 
@@ -391,7 +397,7 @@ function AgentMetadataSection({ agentOutput }: { agentOutput: NonNullable<StepEx
             )}>{confidencePct}%</span>
           </div>
         )}
-        {agentOutput.model && (
+        {!isScript && agentOutput.model && (
           <div className="flex items-center gap-1.5">
             <span className="text-muted-foreground">Model:</span>
             <span className="font-mono text-xs">{agentOutput.model}</span>
@@ -418,7 +424,7 @@ function AgentMetadataSection({ agentOutput }: { agentOutput: NonNullable<StepEx
           </div>
         )}
       </div>
-      {agentOutput.confidence_rationale && (
+      {!isScript && agentOutput.confidence_rationale && (
         <p className="text-xs text-muted-foreground italic">{agentOutput.confidence_rationale}</p>
       )}
       {agentOutput.reasoning && (

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -199,14 +199,23 @@ export async function POST(
       let lastActiveStepId: string | null = null;
       try {
         const agentStepCount = workflowDefinition.steps.filter(
-          (s) => s.executor === 'agent' || s.executor === 'script',
+          (s) => s.executor === 'agent',
         ).length;
+        const scriptStepCount = workflowDefinition.steps.filter(
+          (s) => s.executor === 'script',
+        ).length;
+        const stepCountParts: string[] = [];
+        if (agentStepCount > 0) stepCountParts.push(`${agentStepCount} agent step(s)`);
+        if (scriptStepCount > 0) stepCountParts.push(`${scriptStepCount} script step(s)`);
+        const stepCountDescription = stepCountParts.length > 0
+          ? stepCountParts.join(', ')
+          : '0 step(s)';
         await auditRepo.append({
           actorId: 'auto-runner',
           actorType: 'system',
           actorRole: 'orchestrator',
           action: 'process.run.started',
-          description: `Auto-runner started for '${initialInstance.definitionName}' (workflow) — ${agentStepCount} agent step(s) to execute`,
+          description: `Auto-runner started for '${initialInstance.definitionName}' (workflow) — ${stepCountDescription} to execute`,
           timestamp: new Date().toISOString(),
           inputSnapshot: { definitionName: initialInstance.definitionName, definitionVersion: initialInstance.definitionVersion, appContext, triggeredBy: triggeredBy ?? 'auto-runner' },
           outputSnapshot: {},

--- a/packages/platform-ui/src/components/processes/process-detail.tsx
+++ b/packages/platform-ui/src/components/processes/process-detail.tsx
@@ -362,7 +362,7 @@ export function ProcessDetail({
 
         {/* Results */}
         {instance.status === 'completed' && (
-          <RunResultsPanel stepExecutions={stepExecutions} />
+          <RunResultsPanel stepExecutions={stepExecutions} stepConfigMap={stepConfigMap} />
         )}
 
         {/* Output Files — hidden until the run has at least one */}

--- a/packages/platform-ui/src/components/processes/run-results-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-results-panel.tsx
@@ -7,8 +7,14 @@ import { cn, isBrowsableRepoUrl } from '@/lib/utils';
 import { formatDuration, formatStepName, formatCostUsd } from '@/lib/format';
 import { SandboxedHtmlIframe } from '@/components/tasks/sandboxed-html-iframe';
 
+interface StepConfigInfo {
+  executorType?: string;
+  [key: string]: unknown;
+}
+
 interface RunResultsPanelProps {
   stepExecutions: StepExecution[];
+  stepConfigMap?: Map<string, StepConfigInfo>;
 }
 
 const RESULT_KEY_LABELS: Record<string, string> = {
@@ -167,7 +173,7 @@ function findFinalAgentOutput(stepExecutions: StepExecution[]): {
   };
 }
 
-export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
+export function RunResultsPanel({ stepExecutions, stepConfigMap }: RunResultsPanelProps) {
   const finalOutput = React.useMemo(
     () => findFinalAgentOutput(stepExecutions),
     [stepExecutions],
@@ -176,7 +182,8 @@ export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
   if (!finalOutput) return null;
 
   const { stepId, output, result } = finalOutput;
-  const confidencePct = output.confidence !== null
+  const isScript = stepConfigMap?.get(stepId)?.executorType === 'script';
+  const confidencePct = !isScript && output.confidence !== null
     ? Math.round(output.confidence * 100)
     : null;
   const git = output.gitMetadata;
@@ -209,10 +216,10 @@ export function RunResultsPanel({ stepExecutions }: RunResultsPanelProps) {
               )}>{confidencePct}%</span>
             </div>
           )}
-          {output.confidence_rationale && (
+          {!isScript && output.confidence_rationale && (
             <p className="text-xs text-muted-foreground italic">{output.confidence_rationale}</p>
           )}
-          {output.model && (
+          {!isScript && output.model && (
             <div className="flex items-center gap-1.5">
               <span className="text-muted-foreground">Model:</span>
               <span className="font-mono text-xs">{output.model}</span>

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -285,10 +285,12 @@ function StepConfigDetail({
   const entries: Array<{ label: string; value: string }> = [];
 
   if (config.plugin) entries.push({ label: 'Plugin', value: config.plugin });
-  const model = config.agentConfig?.model ?? config.model;
-  if (model) entries.push({ label: 'Model', value: model });
+  if (config.executorType !== 'script') {
+    const model = config.agentConfig?.model ?? config.model;
+    if (model) entries.push({ label: 'Model', value: model });
+  }
   if (config.agentConfig?.skill) entries.push({ label: 'Skill', value: config.agentConfig.skill });
-  if (config.confidenceThreshold !== undefined) entries.push({ label: 'Confidence threshold', value: `${config.confidenceThreshold}` });
+  if (config.executorType !== 'script' && config.confidenceThreshold !== undefined) entries.push({ label: 'Confidence threshold', value: `${config.confidenceThreshold}` });
   if (config.fallbackBehavior) entries.push({ label: 'Fallback', value: config.fallbackBehavior.replace(/_/g, ' ') });
   if (config.timeoutMinutes) entries.push({ label: 'Timeout', value: `${config.timeoutMinutes} min` });
   if (config.reviewerType && config.reviewerType !== 'none') entries.push({ label: 'Reviewer', value: config.reviewerType });

--- a/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
@@ -925,6 +925,34 @@ describe('executeAgentStep', () => {
     );
   });
 
+  it('[DATA] emits script.step.started audit event for script executor', async () => {
+    const scriptStep: WorkflowStep = {
+      id: 'gather-data', name: 'Gather Data', type: 'creation', executor: 'script',
+    };
+    const updatedInstance = buildProcessInstance({ id: 'inst-wf-001', status: 'running' });
+    mockEngine.advanceStep.mockResolvedValue(updatedInstance);
+
+    await executeAgentStep('inst-wf-001', 'gather-data', scriptStep, { topic: 'test' }, 'user-1');
+
+    expect(mockAuditRepo.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'script.step.started',
+        actorId: 'script:gather-data',
+        actorType: 'system',
+        entityId: 'inst-wf-001',
+        processInstanceId: 'inst-wf-001',
+        executorType: 'script',
+      }),
+    );
+
+    // Description must NOT contain autonomy level for scripts
+    const scriptStartedCall = mockAuditRepo.append.mock.calls.find(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).action === 'script.step.started',
+    );
+    expect(scriptStartedCall).toBeDefined();
+    expect((scriptStartedCall![0] as Record<string, unknown>).description).not.toContain('autonomy');
+  });
+
   // ---- OAuth token loading + refresh pass-through ----
   //
   // Verifies execute-agent-step wires the binding → token repo → refresh →

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -113,14 +113,17 @@ export async function executeAgentStep(
     ...appContext,
   };
 
+  const isScript = executorType === 'script';
   await auditRepo.append({
-    actorId: `agent:${pluginId}`,
-    actorType: 'agent',
+    actorId: `${isScript ? 'script' : 'agent'}:${pluginId}`,
+    actorType: isScript ? 'system' : 'agent',
     actorRole: autonomyLevel,
-    action: 'agent.step.started',
-    description: `Workflow agent step '${stepId}' started (plugin: ${pluginId}, autonomy: ${autonomyLevel})`,
+    action: isScript ? 'script.step.started' : 'agent.step.started',
+    description: isScript
+      ? `Script step '${stepId}' started (plugin: ${pluginId})`
+      : `Workflow agent step '${stepId}' started (plugin: ${pluginId}, autonomy: ${autonomyLevel})`,
     timestamp: new Date().toISOString(),
-    inputSnapshot: { stepId, pluginId, autonomyLevel, ...appContext },
+    inputSnapshot: { stepId, pluginId, ...(isScript ? {} : { autonomyLevel }), ...appContext },
     outputSnapshot: {},
     basis: `Triggered by ${triggeredBy}`,
     entityType: 'processInstance',
@@ -237,16 +240,17 @@ export async function executeAgentStep(
     });
   }
 
-  // When the agent crashes (fallbackReason='error'), surface the error on the
+  // When the agent/script crashes (fallbackReason='error'), surface the error on the
   // run overview by writing it to processInstance.error. Without this the error
   // is only visible on the step detail page.
   const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
   if (isFailed) {
     const failLabel = runResult.fallbackReason === 'timeout' ? 'timed out' : 'failed';
-    const errorDetail = runResult.errorMessage ?? (runResult.fallbackReason === 'timeout' ? 'agent execution timed out' : null);
+    const stepKind = isScript ? 'Script' : 'Agent';
+    const errorDetail = runResult.errorMessage ?? (runResult.fallbackReason === 'timeout' ? `${stepKind.toLowerCase()} execution timed out` : null);
     if (errorDetail !== null) {
       await instanceRepo.update(instanceId, {
-        error: `Agent step '${stepId}' ${failLabel}: ${errorDetail}`,
+        error: `${stepKind} step '${stepId}' ${failLabel}: ${errorDetail}`,
         updatedAt: new Date().toISOString(),
       });
     }
@@ -440,15 +444,19 @@ export async function executeAgentStep(
   // ---- Escalation/Pause (non-L3) ----
   if (runResult.status === 'escalated' || runResult.status === 'paused') {
     await auditRepo.append({
-      actorId: `agent:${pluginId}`,
-      actorType: 'agent',
+      actorId: `${isScript ? 'script' : 'agent'}:${pluginId}`,
+      actorType: isScript ? 'system' : 'agent',
       actorRole: autonomyLevel,
-      action: 'agent.escalated',
-      description: `Workflow step '${stepId}' escalated — reason: ${runResult.fallbackReason ?? 'unknown'}`,
+      action: isScript ? 'script.escalated' : 'agent.escalated',
+      description: isScript
+        ? `Script step '${stepId}' failed — reason: ${runResult.fallbackReason ?? 'unknown'}`
+        : `Workflow step '${stepId}' escalated — reason: ${runResult.fallbackReason ?? 'unknown'}`,
       timestamp: new Date().toISOString(),
       inputSnapshot: { stepId, fallbackReason: runResult.fallbackReason ?? null },
       outputSnapshot: { status: runResult.status },
-      basis: 'FallbackHandler: agent could not complete step autonomously',
+      basis: isScript
+        ? 'Script step could not complete'
+        : 'FallbackHandler: agent could not complete step autonomously',
       entityType: 'processInstance',
       entityId: instanceId,
       processInstanceId: instanceId,


### PR DESCRIPTION
## Summary

Follow-up to #681 (databricks-job plugin). Script executor steps were displaying LLM agent metadata and emitting agent audit events — both misleading for deterministic executors.

- **UI**: Hide Model and Confidence display when `executorType === 'script'` in step-status-panel, run-results-panel, and step detail page
- **Audit events**: Script steps now emit `script.step.started`, `script.run`, `script.escalated` instead of `agent.*`. Autonomy level omitted (meaningless for scripts). Auto-runner counts agent and script steps separately in `process.run.started`.

## Test plan

- [x] TypeScript type check passes
- [x] New test: script executor emits `script.step.started` with correct actorId/actorType
- [ ] Verify audit log shows `script.*` events for databricks-job steps on staging
- [ ] Verify UI hides Model/Confidence for script executor steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)