### PR TITLE
refactor(agent-runtime): extract PluginRunner from AgentRunner

### DIFF
--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -33,6 +33,8 @@ export type { DockerSpawnStrategy, DockerSpawnRequest, DockerSpawnResult } from 
 export type { AgentEventLog } from './runner/agent-event-log';
 export { PluginRegistry, PluginNotFoundError } from './runner/plugin-registry';
 export { OpenRouterLlmClient } from './runner/llm-client';
+export { PluginRunner } from './runner/plugin-runner';
+export type { PluginRunResult } from './runner/plugin-runner';
 export { AgentRunner } from './runner/agent-runner';
 export type { AgentRunResult } from './runner/agent-runner';
 export { FallbackHandler } from './runner/fallback-handler';

--- a/packages/agent-runtime/src/runner/agent-runner.ts
+++ b/packages/agent-runtime/src/runner/agent-runner.ts
@@ -10,7 +10,7 @@ import {
   type WorkflowStep,
 } from '@mediforce/platform-core';
 import { randomUUID } from 'crypto';
-import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitPayload } from '../interfaces/agent-plugin';
+import type { AgentPlugin, AgentContext, WorkflowAgentContext } from '../interfaces/agent-plugin';
 import type { AgentEventLog } from './agent-event-log';
 import { FallbackHandler } from './fallback-handler';
 import { PluginRunner } from './plugin-runner';
@@ -346,6 +346,7 @@ export class AgentRunner {
 
     switch (level) {
       case 'L0':
+        // Silent Observer — run completes but output not surfaced
         return {
           status: 'completed',
           envelope,
@@ -354,6 +355,7 @@ export class AgentRunner {
         };
 
       case 'L1':
+        // Shadow — emit shadow_result event to event log
         await this.eventLog.write(processInstanceId, stepId, {
           type: 'shadow_result',
           payload: envelope,
@@ -367,6 +369,7 @@ export class AgentRunner {
         };
 
       case 'L2':
+        // Annotator — annotations already in event log from plugin emissions
         return {
           status: 'completed',
           envelope,
@@ -375,6 +378,7 @@ export class AgentRunner {
         };
 
       case 'L3':
+        // Advisor — pause instance awaiting approval
         await this.instanceRepository.update(context.processInstanceId, {
           status: 'paused',
           pauseReason: 'awaiting_agent_approval',
@@ -387,6 +391,7 @@ export class AgentRunner {
         };
 
       case 'L4':
+        // Autopilot — result applied directly to workflow
         return {
           status: 'completed',
           envelope,
@@ -395,6 +400,7 @@ export class AgentRunner {
         };
 
       default:
+        // Unknown autonomy level — treat as L0 (safe default)
         return {
           status: 'completed',
           envelope,

--- a/packages/agent-runtime/src/runner/agent-runner.ts
+++ b/packages/agent-runtime/src/runner/agent-runner.ts
@@ -13,6 +13,7 @@ import { randomUUID } from 'crypto';
 import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitPayload } from '../interfaces/agent-plugin';
 import type { AgentEventLog } from './agent-event-log';
 import { FallbackHandler } from './fallback-handler';
+import { PluginRunner } from './plugin-runner';
 
 export interface AgentRunResult {
   status: AgentRunStatus;
@@ -22,15 +23,9 @@ export interface AgentRunResult {
   errorMessage?: string | null;
 }
 
-class AgentTimeoutError extends Error {
-  override name = 'AgentTimeoutError';
-  constructor() {
-    super('Agent execution timed out');
-  }
-}
-
 export class AgentRunner {
   private readonly fallbackHandler: FallbackHandler;
+  private readonly pluginRunner: PluginRunner;
 
   constructor(
     private readonly instanceRepository: ProcessInstanceRepository,
@@ -39,6 +34,7 @@ export class AgentRunner {
     private readonly agentRunRepository?: AgentRunRepository,
   ) {
     this.fallbackHandler = new FallbackHandler(instanceRepository);
+    this.pluginRunner = new PluginRunner(eventLog);
   }
 
   /**
@@ -71,104 +67,63 @@ export class AgentRunner {
       });
     }
 
-    const emit = async (event: EmitPayload): Promise<void> => {
-      await this.eventLog.write(processInstanceId, stepId, event);
-    };
-
-    await plugin.initialize(context);
-
     const timeoutMs = resolveStepTimeoutMinutes(context.step) * 60_000;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new AgentTimeoutError()), timeoutMs);
-    });
+    const { resultPayload, timedOut, errorMessage } = await this.pluginRunner.execute(
+      plugin, context, timeoutMs,
+    );
 
     let fallbackReason: 'timeout' | 'low_confidence' | 'error' | null = null;
-    let caughtErrorMessage: string | null = null;
+    let envelope: AgentOutputEnvelope | null = null;
 
-    try {
-      await Promise.race([plugin.run(emit), timeoutPromise]);
-
-      const events = this.eventLog.getEvents(processInstanceId, stepId);
-      const resultEvent = [...events].reverse().find((e) => e.type === 'result');
-
-      if (!resultEvent) {
+    if (timedOut) {
+      fallbackReason = 'timeout';
+    } else if (errorMessage !== null) {
+      fallbackReason = 'error';
+    } else if (resultPayload === null) {
+      fallbackReason = 'error';
+    } else {
+      const parseResult = AgentOutputEnvelopeSchema.safeParse(resultPayload);
+      if (!parseResult.success) {
         fallbackReason = 'error';
       } else {
-        const parseResult = AgentOutputEnvelopeSchema.safeParse(resultEvent.payload);
-        if (!parseResult.success) {
-          fallbackReason = 'error';
-        } else {
-          const envelope = parseResult.data;
-
-          const threshold = context.step.agent?.confidenceThreshold ?? 0;
-          if (envelope.confidence < threshold) {
-            fallbackReason = 'low_confidence';
-          }
-
-          if (fallbackReason) {
-            const partialWork = this.eventLog.getPartialWork(processInstanceId, stepId);
-            const fallbackResult = await this.fallbackHandler.handleWithWorkflowStep(
-              fallbackReason,
-              context,
-              partialWork,
-              envelope,
-            );
-            const duration_ms = Date.now() - startedAt;
-            await this.appendAuditEventFromWorkflowStep(context, envelope, fallbackResult.status, duration_ms);
-            if (this.agentRunRepository) {
-              await this.agentRunRepository.create({
-                id: runId,
-                processInstanceId,
-                stepId,
-                pluginId,
-                autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
-                status: fallbackResult.status,
-                envelope: fallbackResult.envelope,
-                fallbackReason: fallbackResult.fallbackReason,
-                startedAt: new Date(startedAt).toISOString(),
-                completedAt: new Date().toISOString(),
-              });
-            }
-            return fallbackResult;
-          }
-
-          const result = await this.applyAutonomyBehaviorForWorkflowStep(autonomyLevel, envelope, context);
-          const duration_ms = Date.now() - startedAt;
-          await this.appendAuditEventFromWorkflowStep(context, envelope, result.status, duration_ms);
-          if (this.agentRunRepository) {
-            await this.agentRunRepository.create({
-              id: runId,
-              processInstanceId,
-              stepId,
-              pluginId,
-              autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
-              status: result.status,
-              envelope: result.envelope,
-              fallbackReason: result.fallbackReason,
-              startedAt: new Date(startedAt).toISOString(),
-              completedAt: new Date().toISOString(),
-            });
-          }
-          return result;
+        envelope = parseResult.data;
+        const threshold = context.step.agent?.confidenceThreshold ?? 0;
+        if (envelope.confidence < threshold) {
+          fallbackReason = 'low_confidence';
         }
-      }
-    } catch (err) {
-      if (err instanceof AgentTimeoutError) {
-        fallbackReason = 'timeout';
-      } else {
-        fallbackReason = 'error';
-        caughtErrorMessage = err instanceof Error ? err.message : String(err);
       }
     }
 
-    const partialWork = this.eventLog.getPartialWork(processInstanceId, stepId);
-    const fallbackResult = await this.fallbackHandler.handleWithWorkflowStep(
-      fallbackReason!,
-      context,
-      partialWork,
-    );
+    if (fallbackReason) {
+      const partialWork = this.eventLog.getPartialWork(processInstanceId, stepId);
+      const fallbackResult = await this.fallbackHandler.handleWithWorkflowStep(
+        fallbackReason,
+        context,
+        partialWork,
+        envelope,
+      );
+      const duration_ms = Date.now() - startedAt;
+      await this.appendAuditEventFromWorkflowStep(context, envelope, fallbackResult.status, duration_ms, errorMessage);
+      if (this.agentRunRepository) {
+        await this.agentRunRepository.create({
+          id: runId,
+          processInstanceId,
+          stepId,
+          pluginId,
+          autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
+          status: fallbackResult.status,
+          envelope: fallbackResult.envelope,
+          fallbackReason: fallbackResult.fallbackReason,
+          startedAt: new Date(startedAt).toISOString(),
+          completedAt: new Date().toISOString(),
+        });
+      }
+      return { ...fallbackResult, errorMessage };
+    }
+
+    const result = await this.applyAutonomyBehaviorForWorkflowStep(autonomyLevel, envelope!, context);
     const duration_ms = Date.now() - startedAt;
-    await this.appendAuditEventFromWorkflowStep(context, null, fallbackResult.status, duration_ms, caughtErrorMessage);
+    await this.appendAuditEventFromWorkflowStep(context, envelope!, result.status, duration_ms);
     if (this.agentRunRepository) {
       await this.agentRunRepository.create({
         id: runId,
@@ -176,14 +131,14 @@ export class AgentRunner {
         stepId,
         pluginId,
         autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
-        status: fallbackResult.status,
-        envelope: fallbackResult.envelope,
-        fallbackReason: fallbackResult.fallbackReason,
+        status: result.status,
+        envelope: result.envelope,
+        fallbackReason: result.fallbackReason,
         startedAt: new Date(startedAt).toISOString(),
         completedAt: new Date().toISOString(),
       });
     }
-    return { ...fallbackResult, errorMessage: caughtErrorMessage };
+    return result;
   }
 
   /**
@@ -200,7 +155,6 @@ export class AgentRunner {
     const runId = randomUUID();
     const pluginId = stepConfig.plugin ?? context.stepId;
 
-    // Persist initial 'running' state if repository is provided
     if (this.agentRunRepository) {
       await this.agentRunRepository.create({
         id: runId,
@@ -216,118 +170,64 @@ export class AgentRunner {
       });
     }
 
-    // Build emit function wired to event log
-    const emit = async (event: EmitPayload): Promise<void> => {
-      await this.eventLog.write(processInstanceId, stepId, event);
-    };
-
-    // Initialize plugin
-    await plugin.initialize(context);
-
-    // Set up timeout
     const timeoutMs = (stepConfig.timeoutMinutes ?? 30) * 60_000;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new AgentTimeoutError()), timeoutMs);
-    });
+    const { resultPayload, timedOut, errorMessage } = await this.pluginRunner.execute(
+      plugin, context, timeoutMs,
+    );
 
     let fallbackReason: 'timeout' | 'low_confidence' | 'error' | null = null;
-    let caughtErrorMessage: string | null = null;
+    let envelope: AgentOutputEnvelope | null = null;
 
-    try {
-      // Race plugin run against timeout
-      await Promise.race([plugin.run(emit), timeoutPromise]);
-
-      // Find result event (last event with type === 'result')
-      const events = this.eventLog.getEvents(processInstanceId, stepId);
-      const resultEvent = [...events].reverse().find((e) => e.type === 'result');
-
-      if (!resultEvent) {
-        // No result event emitted — treat as error
+    if (timedOut) {
+      fallbackReason = 'timeout';
+    } else if (errorMessage !== null) {
+      fallbackReason = 'error';
+    } else if (resultPayload === null) {
+      fallbackReason = 'error';
+    } else {
+      const parseResult = AgentOutputEnvelopeSchema.safeParse(resultPayload);
+      if (!parseResult.success) {
         fallbackReason = 'error';
       } else {
-        // Validate against AgentOutputEnvelopeSchema
-        const parseResult = AgentOutputEnvelopeSchema.safeParse(resultEvent.payload);
-        if (!parseResult.success) {
-          fallbackReason = 'error';
-        } else {
-          const envelope = parseResult.data;
-
-          // Check confidence threshold
-          const threshold = stepConfig.confidenceThreshold ?? 0;
-          if (envelope.confidence < threshold) {
-            fallbackReason = 'low_confidence';
-          }
-
-          if (fallbackReason) {
-            // Delegate to fallback handler for low_confidence
-            const partialWork = this.eventLog.getPartialWork(processInstanceId, stepId);
-            const fallbackResult = await this.fallbackHandler.handle(
-              fallbackReason,
-              context,
-              stepConfig,
-              partialWork,
-              envelope,
-            );
-            const duration_ms = Date.now() - startedAt;
-            await this.appendAuditEvent(context, stepConfig, envelope, fallbackResult.status, duration_ms);
-            if (this.agentRunRepository) {
-              await this.agentRunRepository.create({
-                id: runId,
-                processInstanceId,
-                stepId,
-                pluginId,
-                autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
-                status: fallbackResult.status,
-                envelope: fallbackResult.envelope,
-                fallbackReason: fallbackResult.fallbackReason,
-                startedAt: new Date(startedAt).toISOString(),
-                completedAt: new Date().toISOString(),
-              });
-            }
-            return fallbackResult;
-          }
-
-          // Success path — apply autonomy behavior
-          const result = await this.applyAutonomyBehavior(autonomyLevel, envelope, context);
-          const duration_ms = Date.now() - startedAt;
-          await this.appendAuditEvent(context, stepConfig, envelope, result.status, duration_ms);
-          if (this.agentRunRepository) {
-            await this.agentRunRepository.create({
-              id: runId,
-              processInstanceId,
-              stepId,
-              pluginId,
-              autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
-              status: result.status,
-              envelope: result.envelope,
-              fallbackReason: result.fallbackReason,
-              startedAt: new Date(startedAt).toISOString(),
-              completedAt: new Date().toISOString(),
-            });
-          }
-          return result;
+        envelope = parseResult.data;
+        const threshold = stepConfig.confidenceThreshold ?? 0;
+        if (envelope.confidence < threshold) {
+          fallbackReason = 'low_confidence';
         }
-      }
-    } catch (err) {
-      if (err instanceof AgentTimeoutError) {
-        fallbackReason = 'timeout';
-      } else {
-        // Unexpected error — treat as error fallback, preserve message for audit
-        fallbackReason = 'error';
-        caughtErrorMessage = err instanceof Error ? err.message : String(err);
       }
     }
 
-    // Fallback path (timeout or error with no envelope)
-    const partialWork = this.eventLog.getPartialWork(processInstanceId, stepId);
-    const fallbackResult = await this.fallbackHandler.handle(
-      fallbackReason!,
-      context,
-      stepConfig,
-      partialWork,
-    );
+    if (fallbackReason) {
+      const partialWork = this.eventLog.getPartialWork(processInstanceId, stepId);
+      const fallbackResult = await this.fallbackHandler.handle(
+        fallbackReason,
+        context,
+        stepConfig,
+        partialWork,
+        envelope,
+      );
+      const duration_ms = Date.now() - startedAt;
+      await this.appendAuditEvent(context, stepConfig, envelope, fallbackResult.status, duration_ms, errorMessage);
+      if (this.agentRunRepository) {
+        await this.agentRunRepository.create({
+          id: runId,
+          processInstanceId,
+          stepId,
+          pluginId,
+          autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
+          status: fallbackResult.status,
+          envelope: fallbackResult.envelope,
+          fallbackReason: fallbackResult.fallbackReason,
+          startedAt: new Date(startedAt).toISOString(),
+          completedAt: new Date().toISOString(),
+        });
+      }
+      return { ...fallbackResult, errorMessage };
+    }
+
+    const result = await this.applyAutonomyBehavior(autonomyLevel, envelope!, context);
     const duration_ms = Date.now() - startedAt;
-    await this.appendAuditEvent(context, stepConfig, null, fallbackResult.status, duration_ms, caughtErrorMessage);
+    await this.appendAuditEvent(context, stepConfig, envelope!, result.status, duration_ms);
     if (this.agentRunRepository) {
       await this.agentRunRepository.create({
         id: runId,
@@ -335,14 +235,14 @@ export class AgentRunner {
         stepId,
         pluginId,
         autonomyLevel: autonomyLevel as 'L0' | 'L1' | 'L2' | 'L3' | 'L4',
-        status: fallbackResult.status,
-        envelope: fallbackResult.envelope,
-        fallbackReason: fallbackResult.fallbackReason,
+        status: result.status,
+        envelope: result.envelope,
+        fallbackReason: result.fallbackReason,
         startedAt: new Date(startedAt).toISOString(),
         completedAt: new Date().toISOString(),
       });
     }
-    return fallbackResult;
+    return result;
   }
 
   private async applyAutonomyBehaviorForWorkflowStep(
@@ -446,7 +346,6 @@ export class AgentRunner {
 
     switch (level) {
       case 'L0':
-        // Silent Observer — run completes but output not surfaced
         return {
           status: 'completed',
           envelope,
@@ -455,7 +354,6 @@ export class AgentRunner {
         };
 
       case 'L1':
-        // Shadow — emit shadow_result event to event log
         await this.eventLog.write(processInstanceId, stepId, {
           type: 'shadow_result',
           payload: envelope,
@@ -469,7 +367,6 @@ export class AgentRunner {
         };
 
       case 'L2':
-        // Annotator — annotations already in event log from plugin emissions
         return {
           status: 'completed',
           envelope,
@@ -478,7 +375,6 @@ export class AgentRunner {
         };
 
       case 'L3':
-        // Advisor — pause instance awaiting approval
         await this.instanceRepository.update(context.processInstanceId, {
           status: 'paused',
           pauseReason: 'awaiting_agent_approval',
@@ -491,7 +387,6 @@ export class AgentRunner {
         };
 
       case 'L4':
-        // Autopilot — result returned as step output for workflow
         return {
           status: 'completed',
           envelope,
@@ -500,7 +395,6 @@ export class AgentRunner {
         };
 
       default:
-        // Unknown autonomy level — treat as L0 (safe default)
         return {
           status: 'completed',
           envelope,
@@ -518,7 +412,6 @@ export class AgentRunner {
     duration_ms: number,
     errorMessage: string | null = null,
   ): Promise<void> {
-    // Derive reviewerType from autonomy level and stepConfig
     const reviewerType = context.autonomyLevel === 'L4'
       ? 'none'
       : context.autonomyLevel === 'L3'

--- a/packages/agent-runtime/src/runner/plugin-runner.test.ts
+++ b/packages/agent-runtime/src/runner/plugin-runner.test.ts
@@ -3,7 +3,7 @@ import { PluginRunner } from './plugin-runner';
 import { InMemoryAgentEventLog } from '../testing/index';
 import type { AgentPlugin, AgentContext, EmitFn } from '../interfaces/agent-plugin';
 import { NoopLlmClient } from '../testing/index';
-import type { StepConfig, ProcessConfig, AgentOutputEnvelope } from '@mediforce/platform-core';
+import type { ProcessConfig, AgentOutputEnvelope } from '@mediforce/platform-core';
 
 function makeProcessConfig(): ProcessConfig {
   return {
@@ -142,6 +142,21 @@ describe('PluginRunner', () => {
     const events = eventLog.getEvents('instance-1', 'step-1');
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe('status');
+  });
+
+  it('captures error when initialize() throws', async () => {
+    const eventLog = new InMemoryAgentEventLog();
+    const runner = new PluginRunner(eventLog);
+    const plugin: AgentPlugin = {
+      initialize: async () => { throw new Error('MCP server unreachable'); },
+      run: async () => {},
+    };
+
+    const result = await runner.execute(plugin, makeContext(), 30_000);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.errorMessage).toBe('MCP server unreachable');
+    expect(result.resultPayload).toBeNull();
   });
 
   it('returns last result event when multiple result events emitted', async () => {

--- a/packages/agent-runtime/src/runner/plugin-runner.test.ts
+++ b/packages/agent-runtime/src/runner/plugin-runner.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { PluginRunner } from './plugin-runner';
+import { InMemoryAgentEventLog } from '../testing/index';
+import type { AgentPlugin, AgentContext, EmitFn } from '../interfaces/agent-plugin';
+import { NoopLlmClient } from '../testing/index';
+import type { StepConfig, ProcessConfig, AgentOutputEnvelope } from '@mediforce/platform-core';
+
+function makeProcessConfig(): ProcessConfig {
+  return {
+    processName: 'test-process',
+    configName: 'all-human',
+    configVersion: '1',
+    stepConfigs: [],
+  };
+}
+
+function makeContext(overrides: Partial<AgentContext> = {}): AgentContext {
+  return {
+    stepId: 'step-1',
+    processInstanceId: 'instance-1',
+    definitionVersion: '1.0.0',
+    stepInput: { patientId: 'P001' },
+    autonomyLevel: 'L4',
+    config: makeProcessConfig(),
+    llm: new NoopLlmClient(),
+    getPreviousStepOutputs: async () => ({}),
+    ...overrides,
+  };
+}
+
+function makeValidEnvelope(overrides: Partial<AgentOutputEnvelope> = {}): AgentOutputEnvelope {
+  return {
+    confidence: 0.9,
+    reasoning_summary: 'Analysis complete.',
+    reasoning_chain: ['loaded', 'analyzed', 'concluded'],
+    annotations: [],
+    model: 'anthropic/claude-sonnet-4',
+    duration_ms: 500,
+    result: { recommendation: 'continue' },
+    ...overrides,
+  };
+}
+
+function makeSuccessPlugin(envelope: AgentOutputEnvelope): AgentPlugin {
+  return {
+    initialize: async () => {},
+    run: async (emit: EmitFn) => {
+      await emit({
+        type: 'status',
+        payload: { message: 'Starting' },
+        timestamp: new Date().toISOString(),
+      });
+      await emit({
+        type: 'result',
+        payload: envelope,
+        timestamp: new Date().toISOString(),
+      });
+    },
+  };
+}
+
+describe('PluginRunner', () => {
+  it('returns result payload on successful execution', async () => {
+    const eventLog = new InMemoryAgentEventLog();
+    const runner = new PluginRunner(eventLog);
+    const envelope = makeValidEnvelope();
+    const plugin = makeSuccessPlugin(envelope);
+
+    const result = await runner.execute(plugin, makeContext(), 30_000);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.errorMessage).toBeNull();
+    expect(result.resultPayload).toMatchObject({ confidence: 0.9 });
+  });
+
+  it('returns null resultPayload when no result event emitted', async () => {
+    const eventLog = new InMemoryAgentEventLog();
+    const runner = new PluginRunner(eventLog);
+    const plugin: AgentPlugin = {
+      initialize: async () => {},
+      run: async (emit: EmitFn) => {
+        await emit({
+          type: 'status',
+          payload: { message: 'Working...' },
+          timestamp: new Date().toISOString(),
+        });
+      },
+    };
+
+    const result = await runner.execute(plugin, makeContext(), 30_000);
+
+    expect(result.resultPayload).toBeNull();
+    expect(result.timedOut).toBe(false);
+    expect(result.errorMessage).toBeNull();
+  });
+
+  it('returns timedOut: true when plugin exceeds timeout', async () => {
+    const eventLog = new InMemoryAgentEventLog();
+    const runner = new PluginRunner(eventLog);
+    const plugin: AgentPlugin = {
+      initialize: async () => {},
+      run: async () => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 200));
+      },
+    };
+
+    const result = await runner.execute(plugin, makeContext(), 5);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.resultPayload).toBeNull();
+    expect(result.errorMessage).toBeNull();
+  }, 5000);
+
+  it('captures error message when plugin throws', async () => {
+    const eventLog = new InMemoryAgentEventLog();
+    const runner = new PluginRunner(eventLog);
+    const plugin: AgentPlugin = {
+      initialize: async () => {},
+      run: async () => { throw new Error('API key invalid'); },
+    };
+
+    const result = await runner.execute(plugin, makeContext(), 30_000);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.errorMessage).toBe('API key invalid');
+    expect(result.resultPayload).toBeNull();
+  });
+
+  it('preserves partial events in event log after plugin throw', async () => {
+    const eventLog = new InMemoryAgentEventLog();
+    const runner = new PluginRunner(eventLog);
+    const plugin: AgentPlugin = {
+      initialize: async () => {},
+      run: async (emit: EmitFn) => {
+        await emit({ type: 'status', payload: 'partial', timestamp: new Date().toISOString() });
+        throw new Error('crash');
+      },
+    };
+
+    await runner.execute(plugin, makeContext(), 30_000);
+
+    const events = eventLog.getEvents('instance-1', 'step-1');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('status');
+  });
+
+  it('returns last result event when multiple result events emitted', async () => {
+    const eventLog = new InMemoryAgentEventLog();
+    const runner = new PluginRunner(eventLog);
+    const plugin: AgentPlugin = {
+      initialize: async () => {},
+      run: async (emit: EmitFn) => {
+        await emit({
+          type: 'result',
+          payload: { confidence: 0.5, first: true },
+          timestamp: new Date().toISOString(),
+        });
+        await emit({
+          type: 'result',
+          payload: { confidence: 0.9, last: true },
+          timestamp: new Date().toISOString(),
+        });
+      },
+    };
+
+    const result = await runner.execute(plugin, makeContext(), 30_000);
+
+    expect(result.resultPayload).toMatchObject({ confidence: 0.9, last: true });
+  });
+});

--- a/packages/agent-runtime/src/runner/plugin-runner.ts
+++ b/packages/agent-runtime/src/runner/plugin-runner.ts
@@ -28,13 +28,13 @@ export class PluginRunner {
       await this.eventLog.write(processInstanceId, stepId, event);
     };
 
-    await plugin.initialize(context);
-
+    let timerId: ReturnType<typeof setTimeout>;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new PluginTimeoutError()), timeoutMs);
+      timerId = setTimeout(() => reject(new PluginTimeoutError()), timeoutMs);
     });
 
     try {
+      await plugin.initialize(context);
       await Promise.race([plugin.run(emit), timeoutPromise]);
 
       const events = this.eventLog.getEvents(processInstanceId, stepId);
@@ -54,6 +54,8 @@ export class PluginRunner {
         timedOut: false,
         errorMessage: err instanceof Error ? err.message : String(err),
       };
+    } finally {
+      clearTimeout(timerId!);
     }
   }
 }

--- a/packages/agent-runtime/src/runner/plugin-runner.ts
+++ b/packages/agent-runtime/src/runner/plugin-runner.ts
@@ -1,0 +1,59 @@
+import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitPayload } from '../interfaces/agent-plugin';
+import type { AgentEventLog } from './agent-event-log';
+
+export interface PluginRunResult {
+  resultPayload: unknown | null;
+  timedOut: boolean;
+  errorMessage: string | null;
+}
+
+class PluginTimeoutError extends Error {
+  override name = 'PluginTimeoutError';
+  constructor() {
+    super('Plugin execution timed out');
+  }
+}
+
+export class PluginRunner {
+  constructor(private readonly eventLog: AgentEventLog) {}
+
+  async execute(
+    plugin: AgentPlugin,
+    context: AgentContext | WorkflowAgentContext,
+    timeoutMs: number,
+  ): Promise<PluginRunResult> {
+    const { processInstanceId, stepId } = context;
+
+    const emit = async (event: EmitPayload): Promise<void> => {
+      await this.eventLog.write(processInstanceId, stepId, event);
+    };
+
+    await plugin.initialize(context);
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new PluginTimeoutError()), timeoutMs);
+    });
+
+    try {
+      await Promise.race([plugin.run(emit), timeoutPromise]);
+
+      const events = this.eventLog.getEvents(processInstanceId, stepId);
+      const resultEvent = [...events].reverse().find((e) => e.type === 'result');
+
+      return {
+        resultPayload: resultEvent?.payload ?? null,
+        timedOut: false,
+        errorMessage: null,
+      };
+    } catch (err) {
+      if (err instanceof PluginTimeoutError) {
+        return { resultPayload: null, timedOut: true, errorMessage: null };
+      }
+      return {
+        resultPayload: null,
+        timedOut: false,
+        errorMessage: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- PR 2/4 of ADR-0008 (Step Executor Model)
- Extracts plugin lifecycle (`initialize` → `run` with timeout → extract result event) into standalone `PluginRunner` class
- `AgentRunner` delegates to `PluginRunner`, keeps agent-only concerns (validation, confidence, fallback, autonomy, audit, run persistence)
- `PluginRunner.execute()` returns raw `resultPayload: unknown | null` — caller validates with appropriate schema
- `AgentRunner.runWithWorkflowStep()` flattened from nested try/catch to sequential early-return style (-105 lines)

## Test plan

- [x] 6 new `PluginRunner` tests (success, no result, timeout, throw, partial events, multiple results)
- [x] All 19 existing `AgentRunner` tests pass unchanged
- [x] Full agent-runtime suite: 375/375 pass
- [x] Typecheck clean: agent-runtime, platform-api, platform-ui

## ADR-0008 delivery sequence

1. ~~`StepOutputEnvelope` base schema~~ (#688, merged)
2. **Extract `PluginRunner` from `AgentRunner`** ← this PR
3. `StepExecutor` strategy + both executors
4. Rename `AgentPlugin` → `StepExecutorPlugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)