### PR TITLE
refactor(agent-runtime): StepExecutor strategy pattern — AgentStepExecutor + ScriptStepExecutor

### DIFF
--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -38,6 +38,15 @@ export type { PluginRunResult } from './runner/plugin-runner';
 export { AgentRunner } from './runner/agent-runner';
 export type { AgentRunResult } from './runner/agent-runner';
 export { FallbackHandler } from './runner/fallback-handler';
+export { ScriptStepExecutor } from './runner/script-step-executor';
+export { AgentStepExecutor } from './runner/agent-step-executor';
+export type {
+  StepExecutor,
+  StepExecutionResult,
+  StepExecutionStatus,
+  StepExecutorServices,
+  StepExecutorMeta,
+} from './runner/step-executor';
 
 // Env validation
 export { validateWorkflowEnv, validateWorkflowModels, validateRetiredModels } from './plugins/resolve-env';

--- a/packages/agent-runtime/src/runner/__tests__/agent-step-executor.test.ts
+++ b/packages/agent-runtime/src/runner/__tests__/agent-step-executor.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AgentStepExecutor } from '../agent-step-executor';
-import type { AgentRunResult } from '../agent-runner';
 import type { StepExecutorServices, StepExecutorMeta } from '../step-executor';
 import type { AgentPlugin, WorkflowAgentContext } from '../../interfaces/agent-plugin';
 import { buildAgentOutputEnvelope, buildWorkflowDefinition } from '@mediforce/platform-core/testing';
 import type { WorkflowStep } from '@mediforce/platform-core';
 
 const mockAgentRunner = {
-  runWithWorkflowStep: vi.fn<[], Promise<AgentRunResult>>(),
+  runWithWorkflowStep: vi.fn(),
 };
 
 const mockAuditRepo = { append: vi.fn() };

--- a/packages/agent-runtime/src/runner/__tests__/agent-step-executor.test.ts
+++ b/packages/agent-runtime/src/runner/__tests__/agent-step-executor.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AgentStepExecutor } from '../agent-step-executor';
+import type { AgentRunResult } from '../agent-runner';
+import type { StepExecutorServices, StepExecutorMeta } from '../step-executor';
+import type { AgentPlugin, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import { buildAgentOutputEnvelope, buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+import type { WorkflowStep } from '@mediforce/platform-core';
+
+const mockAgentRunner = {
+  runWithWorkflowStep: vi.fn<[], Promise<AgentRunResult>>(),
+};
+
+const mockAuditRepo = { append: vi.fn() };
+const mockInstanceRepo = {
+  getById: vi.fn(),
+  update: vi.fn(),
+  updateStepExecution: vi.fn(),
+  getStepExecutions: vi.fn().mockResolvedValue([]),
+};
+const mockEngine = {
+  advanceStep: vi.fn(),
+  submitReviewVerdict: vi.fn(),
+};
+const mockHumanTaskRepo = { create: vi.fn() };
+const mockModelRegistryRepo = { getById: vi.fn().mockResolvedValue(null) };
+
+const services: StepExecutorServices = {
+  auditRepo: mockAuditRepo,
+  instanceRepo: mockInstanceRepo,
+  engine: mockEngine,
+  humanTaskRepo: mockHumanTaskRepo,
+  modelRegistryRepo: mockModelRegistryRepo,
+};
+
+const agentStep: WorkflowStep = {
+  id: 'analyze-data',
+  name: 'Analyze Data',
+  type: 'creation',
+  executor: 'agent',
+  autonomyLevel: 'L2',
+};
+
+const workflowDefinition = buildWorkflowDefinition({
+  name: 'analysis-pipeline',
+  version: 1,
+  steps: [agentStep, { id: 'done', name: 'Done', type: 'terminal', executor: 'human' }],
+  transitions: [{ from: 'analyze-data', to: 'done' }],
+});
+
+const defaultEnvelope = buildAgentOutputEnvelope({
+  result: { summary: 'analysis complete' },
+});
+
+const mockPlugin: AgentPlugin = {
+  initialize: vi.fn(),
+  run: vi.fn(),
+};
+
+function makeContext(overrides?: Partial<WorkflowAgentContext>): WorkflowAgentContext {
+  return {
+    stepId: 'analyze-data',
+    processInstanceId: 'inst-001',
+    runNamespace: 'acme',
+    definitionVersion: '1',
+    stepInput: {},
+    autonomyLevel: 'L2',
+    workflowDefinition,
+    step: agentStep,
+    llm: { complete: vi.fn() },
+    getPreviousStepOutputs: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+const meta: StepExecutorMeta = {
+  instanceId: 'inst-001',
+  stepId: 'analyze-data',
+  pluginId: 'claude-code-agent',
+  triggeredBy: 'auto-runner',
+  stepExecutionId: 'exec-001',
+  definitionVersion: '1',
+};
+
+describe('AgentStepExecutor', () => {
+  let executor: AgentStepExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new AgentStepExecutor(mockAgentRunner as never);
+    mockInstanceRepo.getById.mockResolvedValue({
+      status: 'running',
+      currentStepId: 'analyze-data',
+      definitionVersion: '1',
+      variables: {},
+    });
+    mockEngine.advanceStep.mockResolvedValue({
+      status: 'running',
+      currentStepId: 'done',
+    });
+  });
+
+  it('delegates to AgentRunner.runWithWorkflowStep', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'completed',
+      envelope: defaultEnvelope,
+      appliedToWorkflow: false,
+      fallbackReason: null,
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockAgentRunner.runWithWorkflowStep).toHaveBeenCalledWith(
+      mockPlugin,
+      expect.objectContaining({ stepId: 'analyze-data' }),
+    );
+  });
+
+  it('returns executorType=agent', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'completed',
+      envelope: defaultEnvelope,
+      appliedToWorkflow: false,
+      fallbackReason: null,
+    });
+
+    const result = await executor.execute(mockPlugin, makeContext(), services, meta);
+    expect(result.executorType).toBe('agent');
+  });
+
+  it('emits agent.step.started audit event', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'completed',
+      envelope: defaultEnvelope,
+      appliedToWorkflow: false,
+      fallbackReason: null,
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockAuditRepo.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'agent.step.started',
+        actorId: 'agent:claude-code-agent',
+        actorType: 'agent',
+        executorType: 'agent',
+      }),
+    );
+  });
+
+  it('L2 completed: calls advanceStep', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'completed',
+      envelope: defaultEnvelope,
+      appliedToWorkflow: false,
+      fallbackReason: null,
+    });
+
+    const result = await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockEngine.advanceStep).toHaveBeenCalledWith(
+      'inst-001',
+      { summary: 'analysis complete' },
+      { id: 'auto-runner', role: 'agent' },
+      undefined,
+    );
+    expect(result.instanceState?.currentStepId).toBe('done');
+  });
+
+  it('L4 appliedToWorkflow: calls advanceStep with runResult', async () => {
+    const runResult = {
+      status: 'completed' as const,
+      envelope: defaultEnvelope,
+      appliedToWorkflow: true,
+      fallbackReason: null,
+    };
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue(runResult);
+
+    const l4Context = makeContext({ autonomyLevel: 'L4', step: { ...agentStep, autonomyLevel: 'L4' } });
+    const result = await executor.execute(mockPlugin, l4Context, services, meta);
+
+    expect(mockEngine.advanceStep).toHaveBeenCalledWith(
+      'inst-001',
+      { summary: 'analysis complete' },
+      { id: 'auto-runner', role: 'agent' },
+      undefined,
+      runResult,
+    );
+    expect(result.appliedToWorkflow).toBe(true);
+  });
+
+  it('escalated: emits agent.escalated audit, does NOT call advanceStep', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'escalated',
+      envelope: null,
+      appliedToWorkflow: false,
+      fallbackReason: 'error',
+    });
+
+    const result = await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(result.status).toBe('escalated');
+    expect(mockEngine.advanceStep).not.toHaveBeenCalled();
+    expect(mockAuditRepo.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'agent.escalated',
+      }),
+    );
+  });
+
+  it('L3 paused: creates HumanTask for review', async () => {
+    const l3Step: WorkflowStep = { ...agentStep, autonomyLevel: 'L3', allowedRoles: ['reviewer'] };
+    const l3Context = makeContext({ autonomyLevel: 'L3', step: l3Step });
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'paused',
+      envelope: defaultEnvelope,
+      appliedToWorkflow: false,
+      fallbackReason: null,
+    });
+
+    const result = await executor.execute(mockPlugin, l3Context, services, meta);
+
+    expect(result.status).toBe('paused');
+    expect(mockHumanTaskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        processInstanceId: 'inst-001',
+        stepId: 'analyze-data',
+        assignedRole: 'reviewer',
+        creationReason: 'agent_review_l3',
+      }),
+    );
+  });
+
+  it('persists step execution on completion', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'completed',
+      envelope: defaultEnvelope,
+      appliedToWorkflow: false,
+      fallbackReason: null,
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockInstanceRepo.updateStepExecution).toHaveBeenCalledWith(
+      'inst-001',
+      'exec-001',
+      expect.objectContaining({
+        output: { summary: 'analysis complete' },
+        status: 'completed',
+      }),
+    );
+  });
+
+  it('marks step execution as failed on error fallback', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'escalated',
+      envelope: null,
+      appliedToWorkflow: false,
+      fallbackReason: 'error',
+      errorMessage: 'plugin crashed',
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockInstanceRepo.updateStepExecution).toHaveBeenCalledWith(
+      'inst-001',
+      'exec-001',
+      expect.objectContaining({
+        status: 'failed',
+        error: 'plugin crashed',
+      }),
+    );
+  });
+
+  it('persists output to instance.variables', async () => {
+    mockAgentRunner.runWithWorkflowStep.mockResolvedValue({
+      status: 'completed',
+      envelope: defaultEnvelope,
+      appliedToWorkflow: false,
+      fallbackReason: null,
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockInstanceRepo.update).toHaveBeenCalledWith('inst-001', expect.objectContaining({
+      variables: { 'analyze-data': { summary: 'analysis complete' } },
+    }));
+  });
+});

--- a/packages/agent-runtime/src/runner/__tests__/script-step-executor.test.ts
+++ b/packages/agent-runtime/src/runner/__tests__/script-step-executor.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ScriptStepExecutor } from '../script-step-executor';
-import type { PluginRunResult } from '../plugin-runner';
 import type { StepExecutorServices, StepExecutorMeta } from '../step-executor';
 import type { AgentPlugin, WorkflowAgentContext } from '../../interfaces/agent-plugin';
 import { buildStepOutputEnvelope, buildWorkflowDefinition } from '@mediforce/platform-core/testing';
 import type { WorkflowStep } from '@mediforce/platform-core';
 
 const mockPluginRunner = {
-  execute: vi.fn<[], Promise<PluginRunResult>>(),
+  execute: vi.fn(),
 };
 
 const mockAuditRepo = { append: vi.fn() };

--- a/packages/agent-runtime/src/runner/__tests__/script-step-executor.test.ts
+++ b/packages/agent-runtime/src/runner/__tests__/script-step-executor.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScriptStepExecutor } from '../script-step-executor';
+import type { PluginRunResult } from '../plugin-runner';
+import type { StepExecutorServices, StepExecutorMeta } from '../step-executor';
+import type { AgentPlugin, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import { buildStepOutputEnvelope, buildWorkflowDefinition } from '@mediforce/platform-core/testing';
+import type { WorkflowStep } from '@mediforce/platform-core';
+
+const mockPluginRunner = {
+  execute: vi.fn<[], Promise<PluginRunResult>>(),
+};
+
+const mockAuditRepo = { append: vi.fn() };
+const mockInstanceRepo = {
+  getById: vi.fn(),
+  update: vi.fn(),
+  updateStepExecution: vi.fn(),
+  getStepExecutions: vi.fn().mockResolvedValue([]),
+};
+const mockEngine = {
+  advanceStep: vi.fn(),
+  submitReviewVerdict: vi.fn(),
+};
+const mockHumanTaskRepo = { create: vi.fn() };
+const mockModelRegistryRepo = { getById: vi.fn().mockResolvedValue(null) };
+
+const services: StepExecutorServices = {
+  auditRepo: mockAuditRepo,
+  instanceRepo: mockInstanceRepo,
+  engine: mockEngine,
+  humanTaskRepo: mockHumanTaskRepo,
+  modelRegistryRepo: mockModelRegistryRepo,
+};
+
+const scriptStep: WorkflowStep = {
+  id: 'transform-data',
+  name: 'Transform Data',
+  type: 'creation',
+  executor: 'script',
+  script: { command: 'python transform.py', timeoutMinutes: 10 },
+};
+
+const workflowDefinition = buildWorkflowDefinition({
+  name: 'etl-pipeline',
+  version: 1,
+  steps: [scriptStep, { id: 'done', name: 'Done', type: 'terminal', executor: 'human' }],
+  transitions: [{ from: 'transform-data', to: 'done' }],
+});
+
+const mockPlugin: AgentPlugin = {
+  initialize: vi.fn(),
+  run: vi.fn(),
+};
+
+function makeContext(overrides?: Partial<WorkflowAgentContext>): WorkflowAgentContext {
+  return {
+    stepId: 'transform-data',
+    processInstanceId: 'inst-001',
+    runNamespace: 'acme',
+    definitionVersion: '1',
+    stepInput: { source: 'raw-data.csv' },
+    autonomyLevel: 'L4',
+    workflowDefinition,
+    step: scriptStep,
+    llm: { complete: vi.fn() },
+    getPreviousStepOutputs: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+const meta: StepExecutorMeta = {
+  instanceId: 'inst-001',
+  stepId: 'transform-data',
+  pluginId: 'script-container',
+  triggeredBy: 'auto-runner',
+  stepExecutionId: 'exec-001',
+  definitionVersion: '1',
+};
+
+describe('ScriptStepExecutor', () => {
+  let executor: ScriptStepExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new ScriptStepExecutor(mockPluginRunner as never);
+    mockInstanceRepo.getById.mockResolvedValue({
+      status: 'running',
+      currentStepId: 'transform-data',
+      definitionVersion: '1',
+      variables: {},
+    });
+    mockEngine.advanceStep.mockResolvedValue({
+      status: 'running',
+      currentStepId: 'done',
+    });
+  });
+
+  it('successful execution: validates with StepOutputEnvelopeSchema, advances step', async () => {
+    const envelope = buildStepOutputEnvelope({ result: { rows: 42 } });
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: envelope,
+      timedOut: false,
+      errorMessage: null,
+    });
+
+    const result = await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(result.executorType).toBe('script');
+    expect(result.status).toBe('completed');
+    expect(result.appliedToWorkflow).toBe(true);
+    expect(result.fallbackReason).toBeNull();
+    expect(result.envelope?.result).toEqual({ rows: 42 });
+
+    expect(mockEngine.advanceStep).toHaveBeenCalledWith(
+      'inst-001',
+      { rows: 42 },
+      { id: 'auto-runner', role: 'agent' },
+    );
+
+    expect(mockAuditRepo.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'script.step.started',
+        actorId: 'script:script-container',
+        actorType: 'system',
+        executorType: 'script',
+      }),
+    );
+  });
+
+  it('persists output to instance.variables on success', async () => {
+    const envelope = buildStepOutputEnvelope({ result: { rows: 42 } });
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: envelope,
+      timedOut: false,
+      errorMessage: null,
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockInstanceRepo.update).toHaveBeenCalledWith('inst-001', {
+      variables: { 'transform-data': { rows: 42 } },
+    });
+  });
+
+  it('persists step execution output on success', async () => {
+    const envelope = buildStepOutputEnvelope({ result: { rows: 42 } });
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: envelope,
+      timedOut: false,
+      errorMessage: null,
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockInstanceRepo.updateStepExecution).toHaveBeenCalledWith(
+      'inst-001',
+      'exec-001',
+      expect.objectContaining({
+        output: { rows: 42 },
+        status: 'completed',
+      }),
+    );
+  });
+
+  it('plugin error: returns escalated with error fallback', async () => {
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: null,
+      timedOut: false,
+      errorMessage: 'ENOENT: script not found',
+    });
+
+    const result = await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(result.status).toBe('escalated');
+    expect(result.fallbackReason).toBe('error');
+    expect(result.errorMessage).toBe('ENOENT: script not found');
+    expect(result.appliedToWorkflow).toBe(false);
+
+    expect(mockEngine.advanceStep).not.toHaveBeenCalled();
+
+    expect(mockInstanceRepo.update).toHaveBeenCalledWith('inst-001', expect.objectContaining({
+      error: expect.stringContaining('ENOENT: script not found'),
+    }));
+
+    expect(mockAuditRepo.append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'script.escalated',
+        actorType: 'system',
+      }),
+    );
+  });
+
+  it('plugin timeout: returns escalated with timeout fallback', async () => {
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: null,
+      timedOut: true,
+      errorMessage: null,
+    });
+
+    const result = await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(result.status).toBe('escalated');
+    expect(result.fallbackReason).toBe('timeout');
+    expect(result.appliedToWorkflow).toBe(false);
+
+    expect(mockInstanceRepo.update).toHaveBeenCalledWith('inst-001', expect.objectContaining({
+      error: expect.stringContaining('timed out'),
+    }));
+  });
+
+  it('marks step execution as failed on error', async () => {
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: null,
+      timedOut: false,
+      errorMessage: 'script crashed',
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockInstanceRepo.updateStepExecution).toHaveBeenCalledWith(
+      'inst-001',
+      'exec-001',
+      expect.objectContaining({
+        status: 'failed',
+        error: 'script crashed',
+      }),
+    );
+  });
+
+  it('invalid envelope: treats as error', async () => {
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: { not_a_valid_envelope: true },
+      timedOut: false,
+      errorMessage: null,
+    });
+
+    const result = await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(result.status).toBe('escalated');
+    expect(result.fallbackReason).toBe('error');
+  });
+
+  it('does not call humanTaskRepo or submitReviewVerdict (no autonomy/review)', async () => {
+    const envelope = buildStepOutputEnvelope({ result: { ok: true } });
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: envelope,
+      timedOut: false,
+      errorMessage: null,
+    });
+
+    await executor.execute(mockPlugin, makeContext(), services, meta);
+
+    expect(mockHumanTaskRepo.create).not.toHaveBeenCalled();
+    expect(mockEngine.submitReviewVerdict).not.toHaveBeenCalled();
+  });
+
+  it('throws when script completes with null result', async () => {
+    const envelope = buildStepOutputEnvelope({ result: null });
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: envelope,
+      timedOut: false,
+      errorMessage: null,
+    });
+
+    await expect(
+      executor.execute(mockPlugin, makeContext(), services, meta),
+    ).rejects.toThrow('completed with null result');
+  });
+
+  it('skips step execution persistence when no stepExecutionId', async () => {
+    const envelope = buildStepOutputEnvelope({ result: { ok: true } });
+    mockPluginRunner.execute.mockResolvedValue({
+      resultPayload: envelope,
+      timedOut: false,
+      errorMessage: null,
+    });
+
+    const metaNoExec = { ...meta, stepExecutionId: undefined };
+    await executor.execute(mockPlugin, makeContext(), services, metaNoExec);
+
+    expect(mockInstanceRepo.updateStepExecution).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-runtime/src/runner/agent-step-executor.ts
+++ b/packages/agent-runtime/src/runner/agent-step-executor.ts
@@ -1,0 +1,365 @@
+import {
+  calculateEstimatedCost,
+  type AgentOutputEnvelope,
+} from '@mediforce/platform-core';
+import type { AgentPlugin, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { AgentRunner, AgentRunResult } from './agent-runner';
+import type {
+  StepExecutor,
+  StepExecutorServices,
+  StepExecutorMeta,
+  StepExecutionResult,
+} from './step-executor';
+
+export class AgentStepExecutor implements StepExecutor {
+  constructor(private readonly agentRunner: AgentRunner) {}
+
+  async execute(
+    plugin: AgentPlugin,
+    context: WorkflowAgentContext,
+    services: StepExecutorServices,
+    meta: StepExecutorMeta,
+  ): Promise<StepExecutionResult> {
+    const { auditRepo, instanceRepo, engine, humanTaskRepo, modelRegistryRepo } = services;
+    const { instanceId, stepId, pluginId, triggeredBy, stepExecutionId, definitionVersion } = meta;
+    const autonomyLevel = context.autonomyLevel;
+    const workflowStep = context.step;
+
+    await auditRepo.append({
+      actorId: `agent:${pluginId}`,
+      actorType: 'agent',
+      actorRole: autonomyLevel,
+      action: 'agent.step.started',
+      description: `Workflow agent step '${stepId}' started (plugin: ${pluginId}, autonomy: ${autonomyLevel})`,
+      timestamp: new Date().toISOString(),
+      inputSnapshot: { stepId, pluginId, autonomyLevel, ...context.stepInput },
+      outputSnapshot: {},
+      basis: `Triggered by ${triggeredBy}`,
+      entityType: 'processInstance',
+      entityId: instanceId,
+      processInstanceId: instanceId,
+      stepId,
+      processDefinitionVersion: definitionVersion,
+      executorType: 'agent',
+      reviewerType: 'none',
+    });
+
+    const runResult = await this.agentRunner.runWithWorkflowStep(plugin, context);
+
+    const envelope = runResult.envelope;
+    const costResult = envelope ? await estimateCostField(envelope, modelRegistryRepo) : {};
+
+    if (stepExecutionId) {
+      const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
+      const isEscalatedToL3Review = autonomyLevel === 'L3' && runResult.status === 'escalated' && !isFailed;
+      await instanceRepo.updateStepExecution(instanceId, stepExecutionId, {
+        output: envelope?.result ?? null,
+        status: !isFailed && (runResult.status === 'completed' || runResult.status === 'paused' || isEscalatedToL3Review) ? 'completed' : 'failed',
+        completedAt: new Date().toISOString(),
+        ...(isFailed && runResult.errorMessage ? { error: runResult.errorMessage } : {}),
+        agentOutput: envelope
+          ? {
+              confidence: envelope.confidence ?? null,
+              confidence_rationale: envelope.confidence_rationale ?? null,
+              reasoning: envelope.reasoning_summary ?? null,
+              model: envelope.model ?? null,
+              duration_ms: envelope.duration_ms ?? null,
+              gitMetadata: envelope.gitMetadata ?? null,
+              deliverableFile: (envelope.deliverableFile as string | undefined) ?? null,
+              presentation: envelope.presentation ?? null,
+              ...(envelope.tokenUsage ? { tokenUsage: envelope.tokenUsage } : {}),
+              ...costResult,
+            }
+          : null,
+      });
+    }
+
+    const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
+    if (isFailed) {
+      const failLabel = runResult.fallbackReason === 'timeout' ? 'timed out' : 'failed';
+      const errorDetail = runResult.errorMessage ?? (runResult.fallbackReason === 'timeout' ? 'agent execution timed out' : null);
+      if (errorDetail !== null) {
+        await instanceRepo.update(instanceId, {
+          error: `Agent step '${stepId}' ${failLabel}: ${errorDetail}`,
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    }
+
+    // Persist output to instance.variables + accumulate cost
+    const agentOutput = envelope?.result ?? null;
+    const stepCost = costResult.estimatedCostUsd;
+    if (agentOutput !== null || stepCost !== undefined) {
+      const freshInstance = await instanceRepo.getById(instanceId);
+      if (freshInstance) {
+        await instanceRepo.update(instanceId, {
+          ...(agentOutput !== null ? {
+            variables: {
+              ...freshInstance.variables,
+              [stepId]: agentOutput,
+            },
+          } : {}),
+          ...(stepCost !== undefined ? {
+            totalCostUsd: (freshInstance.totalCostUsd ?? 0) + stepCost,
+          } : {}),
+        });
+      }
+    }
+
+    // Helper: create a human review task for L3 escalation
+    const createAgentReviewHumanTask = async (
+      escalationReason: 'low_confidence' | 'timeout' | 'error' | 'iterations_limit' | null,
+      auditBasis: string,
+    ): Promise<void> => {
+      const reviewTaskId = crypto.randomUUID();
+      const reviewTaskNow = new Date().toISOString();
+      const assignedRole = workflowStep.allowedRoles?.[0] ?? 'reviewer';
+
+      const priorReviewExecutions = (await instanceRepo.getStepExecutions(instanceId))
+        .filter((e) => e.stepId === stepId).length;
+
+      await humanTaskRepo.create({
+        id: reviewTaskId,
+        processInstanceId: instanceId,
+        stepId,
+        assignedRole,
+        assignedUserId: null,
+        status: 'pending',
+        deadline: null,
+        createdAt: reviewTaskNow,
+        updatedAt: reviewTaskNow,
+        completedAt: null,
+        completionData: {
+          reviewType: 'agent_output_review',
+          agentOutput: {
+            confidence: envelope?.confidence ?? null,
+            reasoning: envelope?.reasoning_summary ?? null,
+            result: envelope?.result ?? null,
+            model: envelope?.model ?? null,
+            annotations: envelope?.annotations ?? null,
+            duration_ms: envelope?.duration_ms ?? null,
+            gitMetadata: envelope?.gitMetadata ?? null,
+            presentation: envelope?.presentation ?? null,
+            escalationReason,
+          },
+          iterationNumber: priorReviewExecutions,
+        },
+        creationReason: 'agent_review_l3',
+      });
+
+      await auditRepo.append({
+        actorId: `agent:${pluginId}`,
+        actorType: 'agent',
+        actorRole: autonomyLevel,
+        action: 'task.created',
+        description: `Human task created for workflow step '${stepId}' (reason: agent_review_l3)`,
+        timestamp: reviewTaskNow,
+        inputSnapshot: { taskId: reviewTaskId, stepId, reason: 'agent_review_l3', assignedRole },
+        outputSnapshot: {},
+        basis: auditBasis,
+        entityType: 'humanTask',
+        entityId: reviewTaskId,
+        processInstanceId: instanceId,
+        stepId,
+        processDefinitionVersion: definitionVersion,
+        executorType: 'agent',
+        reviewerType: 'human',
+      });
+
+      await instanceRepo.update(instanceId, {
+        status: 'paused',
+        pauseReason: 'waiting_for_human',
+        updatedAt: new Date().toISOString(),
+      });
+    };
+
+    // ---- L3 Review Routing (skip when agent errored) ----
+    if ((runResult.status === 'paused' || runResult.status === 'escalated') && autonomyLevel === 'L3' && runResult.fallbackReason !== 'error') {
+      const reviewerType = workflowStep.review?.type ?? 'human';
+      const isEscalation = runResult.status === 'escalated';
+
+      if (reviewerType === 'human' || reviewerType === 'none' || isEscalation) {
+        await createAgentReviewHumanTask(
+          isEscalation ? runResult.fallbackReason : null,
+          'L3 workflow agent step paused — human reviewer task created',
+        );
+        return {
+          status: 'paused',
+          envelope,
+          appliedToWorkflow: false,
+          fallbackReason: runResult.fallbackReason,
+          executorType: 'agent',
+          instanceState: { status: 'paused', currentStepId: stepId },
+        };
+      }
+    }
+
+    // ---- L3 Agent-as-Reviewer: submit verdict ----
+    if (
+      autonomyLevel === 'L3' &&
+      workflowStep.review?.type === 'agent' &&
+      workflowStep.type === 'review' &&
+      runResult.status === 'completed' &&
+      runResult.appliedToWorkflow
+    ) {
+      const resultObj =
+        envelope?.result && typeof envelope.result === 'object' ? (envelope.result as Record<string, unknown>) : null;
+      const verdictValue = typeof resultObj?.verdict === 'string' ? resultObj.verdict : null;
+
+      if (verdictValue === null || verdictValue.length === 0) {
+        await createAgentReviewHumanTask(
+          'error',
+          `Agent reviewer for step '${stepId}' returned envelope without a verdict`,
+        );
+        return {
+          status: 'escalated',
+          envelope,
+          appliedToWorkflow: false,
+          fallbackReason: null,
+          executorType: 'agent',
+          instanceState: { status: 'paused', currentStepId: stepId },
+        };
+      }
+
+      const commentValue = typeof resultObj?.comment === 'string' ? resultObj.comment : null;
+      const reviewerId = `agent:${pluginId}`;
+
+      const updated = await engine.submitReviewVerdict(
+        instanceId,
+        stepId,
+        {
+          reviewerId,
+          reviewerRole: 'agent',
+          verdict: verdictValue,
+          comment: commentValue,
+          timestamp: new Date().toISOString(),
+        },
+        { id: reviewerId, role: 'agent' },
+      );
+
+      if (updated.status === 'paused' && updated.pauseReason === 'max_iterations_exceeded') {
+        await createAgentReviewHumanTask(
+          'iterations_limit',
+          `Agent reviewer for step '${stepId}' exhausted iteration limit`,
+        );
+        return {
+          status: 'escalated',
+          envelope,
+          appliedToWorkflow: false,
+          fallbackReason: null,
+          executorType: 'agent',
+          instanceState: { status: 'paused', currentStepId: stepId },
+        };
+      }
+
+      return {
+        status: 'completed' as const,
+        envelope,
+        appliedToWorkflow: true,
+        fallbackReason: null,
+        executorType: 'agent',
+        instanceState: { status: updated.status, currentStepId: updated.currentStepId },
+      };
+    }
+
+    // ---- Escalation/Pause (non-L3) ----
+    if (runResult.status === 'escalated' || runResult.status === 'paused') {
+      await auditRepo.append({
+        actorId: `agent:${pluginId}`,
+        actorType: 'agent',
+        actorRole: autonomyLevel,
+        action: 'agent.escalated',
+        description: `Workflow step '${stepId}' escalated — reason: ${runResult.fallbackReason ?? 'unknown'}`,
+        timestamp: new Date().toISOString(),
+        inputSnapshot: { stepId, fallbackReason: runResult.fallbackReason ?? null },
+        outputSnapshot: { status: runResult.status },
+        basis: 'FallbackHandler: agent could not complete step autonomously',
+        entityType: 'processInstance',
+        entityId: instanceId,
+        processInstanceId: instanceId,
+        stepId,
+        processDefinitionVersion: definitionVersion,
+        executorType: 'agent',
+        reviewerType: 'none',
+      });
+      return {
+        status: runResult.status as StepExecutionResult['status'],
+        envelope,
+        appliedToWorkflow: false,
+        fallbackReason: runResult.fallbackReason,
+        executorType: 'agent',
+      };
+    }
+
+    // L4: appliedToWorkflow=true — advance
+    if (runResult.appliedToWorkflow) {
+      const stepResult = runResult.envelope?.result;
+      if (stepResult === null || stepResult === undefined) {
+        throw new Error(
+          `Workflow step '${stepId}' completed with null result — cannot advance. ` +
+          `Reason: ${runResult.fallbackReason ?? runResult.envelope?.reasoning_summary ?? 'unknown'}`,
+        );
+      }
+
+      const updatedInstance = await engine.advanceStep(
+        instanceId,
+        stepResult,
+        { id: triggeredBy, role: 'agent' },
+        undefined,
+        runResult,
+      );
+
+      return {
+        status: 'completed' as const,
+        envelope,
+        appliedToWorkflow: true,
+        fallbackReason: null,
+        executorType: 'agent',
+        instanceState: { status: updatedInstance.status, currentStepId: updatedInstance.currentStepId },
+      };
+    }
+
+    // L0/L1/L2: agent completed but didn't auto-apply — advance to next step
+    if (runResult.status === 'completed') {
+      const stepResult = runResult.envelope?.result ?? {};
+      const updatedInstance = await engine.advanceStep(
+        instanceId,
+        stepResult,
+        { id: triggeredBy, role: 'agent' },
+        undefined,
+      );
+
+      return {
+        status: 'completed' as const,
+        envelope,
+        appliedToWorkflow: false,
+        fallbackReason: null,
+        executorType: 'agent',
+        instanceState: { status: updatedInstance.status, currentStepId: updatedInstance.currentStepId },
+      };
+    }
+
+    // Fallback: unknown status
+    const currentInstance = await instanceRepo.getById(instanceId);
+    return {
+      status: (currentInstance?.status ?? 'completed') as StepExecutionResult['status'],
+      envelope,
+      appliedToWorkflow: false,
+      fallbackReason: runResult.fallbackReason,
+      executorType: 'agent',
+    };
+  }
+}
+
+async function estimateCostField(
+  envelope: { model: string | null; tokenUsage?: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } },
+  modelRegistryRepo: { getById(id: string): Promise<{ pricing: { input: number; output: number; cacheRead?: number } } | null> },
+): Promise<{ estimatedCostUsd: number } | Record<string, never>> {
+  if (!envelope.tokenUsage || !envelope.model) return {};
+  const entry = await modelRegistryRepo.getById(envelope.model);
+  if (!entry) {
+    console.warn(`[cost] model "${envelope.model}" not found in registry — cost unavailable`);
+    return {};
+  }
+  return { estimatedCostUsd: calculateEstimatedCost(envelope.tokenUsage, entry.pricing) };
+}

--- a/packages/agent-runtime/src/runner/agent-step-executor.ts
+++ b/packages/agent-runtime/src/runner/agent-step-executor.ts
@@ -264,6 +264,7 @@ export class AgentStepExecutor implements StepExecutor {
 
     // ---- Escalation/Pause (non-L3) ----
     if (runResult.status === 'escalated' || runResult.status === 'paused') {
+      const escalationStatus = runResult.status;
       await auditRepo.append({
         actorId: `agent:${pluginId}`,
         actorType: 'agent',
@@ -272,7 +273,7 @@ export class AgentStepExecutor implements StepExecutor {
         description: `Workflow step '${stepId}' escalated — reason: ${runResult.fallbackReason ?? 'unknown'}`,
         timestamp: new Date().toISOString(),
         inputSnapshot: { stepId, fallbackReason: runResult.fallbackReason ?? null },
-        outputSnapshot: { status: runResult.status },
+        outputSnapshot: { status: escalationStatus },
         basis: 'FallbackHandler: agent could not complete step autonomously',
         entityType: 'processInstance',
         entityId: instanceId,
@@ -283,7 +284,7 @@ export class AgentStepExecutor implements StepExecutor {
         reviewerType: 'none',
       });
       return {
-        status: runResult.status as StepExecutionResult['status'],
+        status: escalationStatus,
         envelope,
         appliedToWorkflow: false,
         fallbackReason: runResult.fallbackReason,
@@ -339,10 +340,9 @@ export class AgentStepExecutor implements StepExecutor {
       };
     }
 
-    // Fallback: unknown status
-    const currentInstance = await instanceRepo.getById(instanceId);
+    // Fallback: unknown status — should not reach here
     return {
-      status: (currentInstance?.status ?? 'completed') as StepExecutionResult['status'],
+      status: 'completed',
       envelope,
       appliedToWorkflow: false,
       fallbackReason: runResult.fallbackReason,

--- a/packages/agent-runtime/src/runner/script-step-executor.ts
+++ b/packages/agent-runtime/src/runner/script-step-executor.ts
@@ -117,7 +117,6 @@ export class ScriptStepExecutor implements StepExecutor {
         reviewerType: 'none',
       });
 
-      const currentInstance = await instanceRepo.getById(instanceId);
       return {
         status: 'escalated',
         envelope,

--- a/packages/agent-runtime/src/runner/script-step-executor.ts
+++ b/packages/agent-runtime/src/runner/script-step-executor.ts
@@ -1,0 +1,167 @@
+import {
+  StepOutputEnvelopeSchema,
+  resolveStepTimeoutMinutes,
+  type StepOutputEnvelope,
+} from '@mediforce/platform-core';
+import type { AgentPlugin, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { PluginRunner } from './plugin-runner';
+import type {
+  StepExecutor,
+  StepExecutorServices,
+  StepExecutorMeta,
+  StepExecutionResult,
+} from './step-executor';
+
+export class ScriptStepExecutor implements StepExecutor {
+  constructor(private readonly pluginRunner: PluginRunner) {}
+
+  async execute(
+    plugin: AgentPlugin,
+    context: WorkflowAgentContext,
+    services: StepExecutorServices,
+    meta: StepExecutorMeta,
+  ): Promise<StepExecutionResult> {
+    const { auditRepo, instanceRepo, engine, modelRegistryRepo } = services;
+    const { instanceId, stepId, pluginId, triggeredBy, stepExecutionId, definitionVersion } = meta;
+
+    await auditRepo.append({
+      actorId: `script:${pluginId}`,
+      actorType: 'system',
+      actorRole: 'L4',
+      action: 'script.step.started',
+      description: `Script step '${stepId}' started (plugin: ${pluginId})`,
+      timestamp: new Date().toISOString(),
+      inputSnapshot: { stepId, pluginId, ...context.stepInput },
+      outputSnapshot: {},
+      basis: `Triggered by ${triggeredBy}`,
+      entityType: 'processInstance',
+      entityId: instanceId,
+      processInstanceId: instanceId,
+      stepId,
+      processDefinitionVersion: definitionVersion,
+      executorType: 'script',
+      reviewerType: 'none',
+    });
+
+    const timeoutMs = resolveStepTimeoutMinutes(context.step) * 60_000;
+    const { resultPayload, timedOut, errorMessage } = await this.pluginRunner.execute(
+      plugin, context, timeoutMs,
+    );
+
+    let envelope: StepOutputEnvelope | null = null;
+    let fallbackReason: 'timeout' | 'error' | null = null;
+
+    if (timedOut) {
+      fallbackReason = 'timeout';
+    } else if (errorMessage !== null) {
+      fallbackReason = 'error';
+    } else if (resultPayload === null) {
+      fallbackReason = 'error';
+    } else {
+      const parseResult = StepOutputEnvelopeSchema.safeParse(resultPayload);
+      if (!parseResult.success) {
+        fallbackReason = 'error';
+      } else {
+        envelope = parseResult.data;
+      }
+    }
+
+    if (stepExecutionId) {
+      const isFailed = fallbackReason !== null;
+      await instanceRepo.updateStepExecution(instanceId, stepExecutionId, {
+        output: envelope?.result ?? null,
+        status: isFailed ? 'failed' : 'completed',
+        completedAt: new Date().toISOString(),
+        ...(isFailed && errorMessage ? { error: errorMessage } : {}),
+        agentOutput: envelope
+          ? {
+              confidence: null,
+              confidence_rationale: null,
+              reasoning: null,
+              model: null,
+              duration_ms: envelope.duration_ms ?? null,
+              gitMetadata: envelope.gitMetadata ?? null,
+              deliverableFile: (envelope.deliverableFile as string | undefined) ?? null,
+              presentation: envelope.presentation ?? null,
+            }
+          : null,
+      });
+    }
+
+    if (fallbackReason !== null) {
+      const failLabel = fallbackReason === 'timeout' ? 'timed out' : 'failed';
+      const errorDetail = errorMessage ?? (fallbackReason === 'timeout' ? 'script execution timed out' : null);
+      if (errorDetail !== null) {
+        await instanceRepo.update(instanceId, {
+          error: `Script step '${stepId}' ${failLabel}: ${errorDetail}`,
+          updatedAt: new Date().toISOString(),
+        });
+      }
+
+      await auditRepo.append({
+        actorId: `script:${pluginId}`,
+        actorType: 'system',
+        actorRole: 'L4',
+        action: 'script.escalated',
+        description: `Script step '${stepId}' failed — reason: ${fallbackReason}`,
+        timestamp: new Date().toISOString(),
+        inputSnapshot: { stepId, fallbackReason },
+        outputSnapshot: { status: 'escalated' },
+        basis: 'Script step could not complete',
+        entityType: 'processInstance',
+        entityId: instanceId,
+        processInstanceId: instanceId,
+        stepId,
+        processDefinitionVersion: definitionVersion,
+        executorType: 'script',
+        reviewerType: 'none',
+      });
+
+      const currentInstance = await instanceRepo.getById(instanceId);
+      return {
+        status: 'escalated',
+        envelope,
+        appliedToWorkflow: false,
+        fallbackReason,
+        errorMessage,
+        executorType: 'script',
+      };
+    }
+
+    // Script always auto-applies: persist output to variables then advance
+    const scriptOutput = envelope?.result ?? null;
+    if (scriptOutput !== null) {
+      const freshInstance = await instanceRepo.getById(instanceId);
+      if (freshInstance) {
+        await instanceRepo.update(instanceId, {
+          variables: {
+            ...freshInstance.variables,
+            [stepId]: scriptOutput,
+          },
+        });
+      }
+    }
+
+    const stepResult = envelope?.result;
+    if (stepResult === null || stepResult === undefined) {
+      throw new Error(
+        `Script step '${stepId}' completed with null result — cannot advance.`,
+      );
+    }
+
+    const updatedInstance = await engine.advanceStep(
+      instanceId,
+      stepResult,
+      { id: triggeredBy, role: 'agent' },
+    );
+
+    return {
+      status: 'completed' as const,
+      envelope,
+      appliedToWorkflow: true,
+      fallbackReason: null,
+      executorType: 'script',
+      instanceState: { status: updatedInstance.status, currentStepId: updatedInstance.currentStepId },
+    };
+  }
+}

--- a/packages/agent-runtime/src/runner/step-executor.ts
+++ b/packages/agent-runtime/src/runner/step-executor.ts
@@ -1,0 +1,80 @@
+import type { StepOutputEnvelope, AgentOutputEnvelope } from '@mediforce/platform-core';
+import type { AgentPlugin, WorkflowAgentContext } from '../interfaces/agent-plugin';
+
+export type StepExecutionStatus = 'completed' | 'paused' | 'escalated' | 'failed';
+
+export interface StepExecutionResult {
+  /** The run status (completed, paused, escalated, failed) — reflects the
+   *  agent/script run outcome, not the workflow instance state. */
+  status: StepExecutionStatus;
+  envelope: StepOutputEnvelope | AgentOutputEnvelope | null;
+  appliedToWorkflow: boolean;
+  fallbackReason: 'timeout' | 'low_confidence' | 'error' | null;
+  errorMessage?: string | null;
+  executorType: 'agent' | 'script';
+  /** Instance status + currentStepId as known by the executor at return time.
+   *  Avoids a redundant getById in the caller. Null when unknown (caller
+   *  should re-fetch). */
+  instanceState?: { status: string; currentStepId: string | null };
+}
+
+export interface StepExecutorServices {
+  auditRepo: StepExecutorAuditRepo;
+  instanceRepo: StepExecutorInstanceRepo;
+  engine: StepExecutorEngine;
+  humanTaskRepo: StepExecutorHumanTaskRepo;
+  modelRegistryRepo: StepExecutorModelRegistryRepo;
+}
+
+export interface StepExecutorAuditRepo {
+  append(event: Record<string, unknown>): Promise<void>;
+}
+
+export interface StepExecutorInstanceRepo {
+  getById(id: string): Promise<{ status: string; currentStepId: string | null; definitionVersion: string; variables: Record<string, unknown>; totalCostUsd?: number } | null>;
+  update(id: string, data: Record<string, unknown>): Promise<void>;
+  updateStepExecution(instanceId: string, executionId: string, data: Record<string, unknown>): Promise<void>;
+  getStepExecutions(instanceId: string): Promise<Array<{ stepId: string; output: unknown }>>;
+}
+
+export interface StepExecutorEngine {
+  advanceStep(
+    instanceId: string,
+    stepResult: unknown,
+    actor: { id: string; role: string },
+    options?: unknown,
+    agentRunResult?: unknown,
+  ): Promise<{ status: string; currentStepId: string | null }>;
+  submitReviewVerdict(
+    instanceId: string,
+    stepId: string,
+    verdict: Record<string, unknown>,
+    actor: { id: string; role: string },
+  ): Promise<{ status: string; currentStepId: string | null; pauseReason?: string }>;
+}
+
+export interface StepExecutorHumanTaskRepo {
+  create(task: Record<string, unknown>): Promise<void>;
+}
+
+export interface StepExecutorModelRegistryRepo {
+  getById(id: string): Promise<{ pricing: { input: number; output: number; cacheRead?: number } } | null>;
+}
+
+export interface StepExecutor {
+  execute(
+    plugin: AgentPlugin,
+    context: WorkflowAgentContext,
+    services: StepExecutorServices,
+    meta: StepExecutorMeta,
+  ): Promise<StepExecutionResult>;
+}
+
+export interface StepExecutorMeta {
+  instanceId: string;
+  stepId: string;
+  pluginId: string;
+  triggeredBy: string;
+  stepExecutionId?: string;
+  definitionVersion: string;
+}

--- a/packages/agent-runtime/src/runner/step-executor.ts
+++ b/packages/agent-runtime/src/runner/step-executor.ts
@@ -27,13 +27,13 @@ export interface StepExecutorServices {
 }
 
 export interface StepExecutorAuditRepo {
-  append(event: Record<string, unknown>): Promise<void>;
+  append(event: Record<string, unknown>): Promise<unknown>;
 }
 
 export interface StepExecutorInstanceRepo {
   getById(id: string): Promise<{ status: string; currentStepId: string | null; definitionVersion: string; variables: Record<string, unknown>; totalCostUsd?: number } | null>;
-  update(id: string, data: Record<string, unknown>): Promise<void>;
-  updateStepExecution(instanceId: string, executionId: string, data: Record<string, unknown>): Promise<void>;
+  update(id: string, data: Record<string, unknown>): Promise<unknown>;
+  updateStepExecution(instanceId: string, executionId: string, data: Record<string, unknown>): Promise<unknown>;
   getStepExecutions(instanceId: string): Promise<Array<{ stepId: string; output: unknown }>>;
 }
 
@@ -50,11 +50,11 @@ export interface StepExecutorEngine {
     stepId: string,
     verdict: Record<string, unknown>,
     actor: { id: string; role: string },
-  ): Promise<{ status: string; currentStepId: string | null; pauseReason?: string }>;
+  ): Promise<{ status: string; currentStepId: string | null; pauseReason?: string | null }>;
 }
 
 export interface StepExecutorHumanTaskRepo {
-  create(task: Record<string, unknown>): Promise<void>;
+  create(task: Record<string, unknown>): Promise<unknown>;
 }
 
 export interface StepExecutorModelRegistryRepo {

--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -71,6 +71,7 @@ import {
 } from '@mediforce/workflow-engine';
 import {
   AgentRunner,
+  PluginRunner,
   PluginRegistry,
   OpenRouterLlmClient,
   ClaudeCodeAgentPlugin,
@@ -78,6 +79,8 @@ import {
   OpenCodeAgentPlugin,
   ScriptContainerPlugin,
   DatabricksJobPlugin,
+  ScriptStepExecutor,
+  AgentStepExecutor,
 } from '@mediforce/agent-runtime';
 import {
   ActionRegistry,
@@ -103,6 +106,8 @@ export interface PlatformServices {
   webhookRouter: WebhookRouter;
   actionRegistry: ActionRegistry;
   agentRunner: AgentRunner;
+  scriptStepExecutor: ScriptStepExecutor;
+  agentStepExecutor: AgentStepExecutor;
   pluginRegistry: PluginRegistry;
   llmClient: OpenRouterLlmClient;
   processRepo: ProcessRepository;
@@ -341,12 +346,17 @@ export function getPlatformServices(): PlatformServices {
     userDirectoryService,
   );
 
+  const pluginRunner = new PluginRunner(eventLog);
+
   const agentRunner = new AgentRunner(
     instanceRepo,
     auditRepo,
     eventLog,
     agentRunRepo,
   );
+
+  const scriptStepExecutor = new ScriptStepExecutor(pluginRunner);
+  const agentStepExecutor = new AgentStepExecutor(agentRunner);
 
   const manualTrigger = new ManualTrigger(engine, processRepo);
 
@@ -393,6 +403,8 @@ export function getPlatformServices(): PlatformServices {
     webhookRouter,
     actionRegistry,
     agentRunner,
+    scriptStepExecutor,
+    agentStepExecutor,
     pluginRegistry,
     llmClient,
     processRepo,

--- a/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/execute-agent-step.test.ts
@@ -18,7 +18,13 @@ import {
   InMemoryAgentOAuthTokenRepository,
   InMemoryOAuthProviderRepository,
 } from '@mediforce/platform-core/testing';
-import { PluginNotFoundError } from '@mediforce/agent-runtime';
+import {
+  PluginNotFoundError,
+  AgentStepExecutor,
+  ScriptStepExecutor,
+  InMemoryAgentEventLog,
+  PluginRunner,
+} from '@mediforce/agent-runtime';
 
 // Mock platform-services module
 const mockProcessRepo = {
@@ -90,13 +96,23 @@ const mockToolCatalogRepo = {
 // them (see the OAuth suite below). The module-scoped defaults only have
 // to exist — executeAgentStep never hits them unless step.agentId + oauth
 // binding are both present, which our non-OAuth tests don't exercise.
+const mockModelRegistryRepo = {
+  getById: vi.fn().mockResolvedValue(null),
+};
 const oauthProviderRepo = new InMemoryOAuthProviderRepository();
 const agentOAuthTokenRepo = new InMemoryAgentOAuthTokenRepository();
+
+const eventLog = new InMemoryAgentEventLog();
+const pluginRunner = new PluginRunner(eventLog);
+const agentStepExecutor = new AgentStepExecutor(mockAgentRunner as never);
+const scriptStepExecutor = new ScriptStepExecutor(pluginRunner);
 
 vi.mock('@/lib/platform-services', () => ({
   getPlatformServices: () => ({
     engine: mockEngine,
     agentRunner: mockAgentRunner,
+    scriptStepExecutor,
+    agentStepExecutor,
     pluginRegistry: mockPluginRegistry,
     instanceRepo: mockInstanceRepo,
     processRepo: mockProcessRepo,
@@ -107,6 +123,7 @@ vi.mock('@/lib/platform-services', () => ({
     toolCatalogRepo: mockToolCatalogRepo,
     oauthProviderRepo,
     agentOAuthTokenRepo,
+    modelRegistryRepo: mockModelRegistryRepo,
   }),
 }));
 
@@ -280,15 +297,16 @@ describe('executeAgentStep', () => {
     expect(contextArg.autonomyLevel).toBe('L2');
   });
 
-  it('[DATA] script executor always uses L4 autonomy', async () => {
+  it('[DATA] script executor uses ScriptStepExecutor (not AgentRunner)', async () => {
     const scriptStep: WorkflowStep = {
       id: 'gather-data', name: 'Gather Data', type: 'creation', executor: 'script', autonomyLevel: 'L1',
     };
 
     await executeAgentStep('inst-wf-001', 'gather-data', scriptStep, {}, 'user-1');
 
-    const contextArg = mockAgentRunner.runWithWorkflowStep.mock.calls[0][1];
-    expect(contextArg.autonomyLevel).toBe('L4');
+    // Script steps now bypass AgentRunner entirely — they go through
+    // ScriptStepExecutor → PluginRunner directly.
+    expect(mockAgentRunner.runWithWorkflowStep).not.toHaveBeenCalled();
   });
 
   // ---- L0/L1/L2 step advancement (THE FIX for "stuck on first step") ----

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -1,9 +1,7 @@
-// Workflow-native agent step executor.
-// Reads executor type, plugin, autonomy level, and all step settings directly
-// from WorkflowStep — no separate ProcessConfig required.
-//
-// This is the WorkflowDefinition counterpart to execute-agent-step.ts (legacy ProcessConfig path).
-// Called by the auto-runner loop when the instance was created via fireWorkflow (no configName).
+// Workflow-native agent step orchestrator.
+// Builds the execution context (plugin, MCP, OAuth, secrets, identity) from the
+// WorkflowStep, then dispatches to the right StepExecutor strategy:
+// AgentStepExecutor (autonomy, review, escalation) or ScriptStepExecutor (direct).
 
 import { getPlatformServices } from './platform-services';
 import {

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -14,9 +14,9 @@ import {
   type AgentPlugin,
   type ResolvedOAuthBinding,
   type WorkflowAgentContext,
+  type StepExecutorServices,
 } from '@mediforce/agent-runtime';
 import {
-  calculateEstimatedCost,
   type AgentOAuthTokenRepository,
   type OAuthProviderRepository,
   type ResolvedMcpConfig,
@@ -51,6 +51,8 @@ export async function executeAgentStep(
   const {
     engine,
     agentRunner,
+    scriptStepExecutor,
+    agentStepExecutor,
     pluginRegistry,
     instanceRepo,
     processRepo,
@@ -105,35 +107,11 @@ export async function executeAgentStep(
     ? 'L4'
     : (workflowStep.autonomyLevel ?? 'L2');
 
-  const executorType = workflowStep.executor === 'script' ? ('script' as const) : ('agent' as const);
-
   // Merge step params into context — stepParams take lower priority than appContext
   const mergedInput: Record<string, unknown> = {
     ...(workflowStep.stepParams ?? {}),
     ...appContext,
   };
-
-  const isScript = executorType === 'script';
-  await auditRepo.append({
-    actorId: `${isScript ? 'script' : 'agent'}:${pluginId}`,
-    actorType: isScript ? 'system' : 'agent',
-    actorRole: autonomyLevel,
-    action: isScript ? 'script.step.started' : 'agent.step.started',
-    description: isScript
-      ? `Script step '${stepId}' started (plugin: ${pluginId})`
-      : `Workflow agent step '${stepId}' started (plugin: ${pluginId}, autonomy: ${autonomyLevel})`,
-    timestamp: new Date().toISOString(),
-    inputSnapshot: { stepId, pluginId, ...(isScript ? {} : { autonomyLevel }), ...appContext },
-    outputSnapshot: {},
-    basis: `Triggered by ${triggeredBy}`,
-    entityType: 'processInstance',
-    entityId: instanceId,
-    processInstanceId: instanceId,
-    stepId,
-    processDefinitionVersion: instance.definitionVersion,
-    executorType,
-    reviewerType: 'none',
-  });
 
   // Pre-fetch secrets for {{TEMPLATE}} resolution.
   // Namespace secrets provide org-wide defaults; workflow secrets override per-workflow.
@@ -208,324 +186,50 @@ export async function executeAgentStep(
     },
   };
 
-  const runResult = await agentRunner.runWithWorkflowStep(plugin, workflowAgentContext);
-
-  // Persist agent output to step execution
-  const envelope = runResult.envelope;
-  const costResult = envelope ? await estimateCostField(envelope, modelRegistryRepo) : {};
-  if (stepExecutionId) {
-    const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
-    // L3 + escalated (non-error) routes to human review below, so the execution
-    // is not a failure — the run produced a usable envelope, just flagged for review.
-    const isEscalatedToL3Review = autonomyLevel === 'L3' && runResult.status === 'escalated' && !isFailed;
-    await instanceRepo.updateStepExecution(instanceId, stepExecutionId, {
-      output: envelope?.result ?? null,
-      status: !isFailed && (runResult.status === 'completed' || runResult.status === 'paused' || isEscalatedToL3Review) ? 'completed' : 'failed',
-      completedAt: new Date().toISOString(),
-      ...(isFailed && runResult.errorMessage ? { error: runResult.errorMessage } : {}),
-      agentOutput: envelope
-        ? {
-            confidence: envelope.confidence ?? null,
-            confidence_rationale: envelope.confidence_rationale ?? null,
-            reasoning: envelope.reasoning_summary ?? null,
-            model: envelope.model ?? null,
-            duration_ms: envelope.duration_ms ?? null,
-            gitMetadata: envelope.gitMetadata ?? null,
-            deliverableFile: (envelope.deliverableFile as string | undefined) ?? null,
-            presentation: envelope.presentation ?? null,
-            ...(envelope.tokenUsage ? { tokenUsage: envelope.tokenUsage } : {}),
-            ...costResult,
-          }
-        : null,
-    });
-  }
-
-  // When the agent/script crashes (fallbackReason='error'), surface the error on the
-  // run overview by writing it to processInstance.error. Without this the error
-  // is only visible on the step detail page.
-  const isFailed = runResult.fallbackReason === 'error' || runResult.fallbackReason === 'timeout';
-  if (isFailed) {
-    const failLabel = runResult.fallbackReason === 'timeout' ? 'timed out' : 'failed';
-    const stepKind = isScript ? 'Script' : 'Agent';
-    const errorDetail = runResult.errorMessage ?? (runResult.fallbackReason === 'timeout' ? `${stepKind.toLowerCase()} execution timed out` : null);
-    if (errorDetail !== null) {
-      await instanceRepo.update(instanceId, {
-        error: `${stepKind} step '${stepId}' ${failLabel}: ${errorDetail}`,
-        updatedAt: new Date().toISOString(),
-      });
-    }
-  }
-
-  // Persist output to instance.variables so subsequent steps can read it.
-  // Also accumulate totalCostUsd on the instance for list views.
-  // Note: read-then-increment is not atomic, but steps execute sequentially
-  // per instance (auto-runner loop is serial). If parallel branches are
-  // added, switch to Firestore FieldValue.increment().
-  const agentOutput = envelope?.result ?? null;
-  const stepCost = costResult.estimatedCostUsd;
-  if (agentOutput !== null || stepCost !== undefined) {
-    const freshInstance = await instanceRepo.getById(instanceId);
-    if (freshInstance) {
-      await instanceRepo.update(instanceId, {
-        ...(agentOutput !== null ? {
-          variables: {
-            ...freshInstance.variables,
-            [stepId]: agentOutput,
-          },
-        } : {}),
-        ...(stepCost !== undefined ? {
-          totalCostUsd: (freshInstance.totalCostUsd ?? 0) + stepCost,
-        } : {}),
-      });
-    }
-  }
-
-  // Create a human review task for an L3 step, append audit, pause instance.
-  // Used for: (a) paused/escalated agent run, (b) agent reviewer returned no
-  // verdict, (c) agent reviewer exhausted the iteration limit.
-  const createAgentReviewHumanTask = async (
-    escalationReason: 'low_confidence' | 'timeout' | 'error' | 'iterations_limit' | null,
-    auditBasis: string,
-  ): Promise<void> => {
-    const reviewTaskId = crypto.randomUUID();
-    const reviewTaskNow = new Date().toISOString();
-    const assignedRole = workflowStep.allowedRoles?.[0] ?? 'reviewer';
-
-    // Iteration count = number of prior executions of this step on this
-    // instance. Lets the UI/audit show "Iter N of M" instead of every L3
-    // review task showing as iteration 0.
-    const priorReviewExecutions = (await instanceRepo.getStepExecutions(instanceId))
-      .filter((e) => e.stepId === stepId).length;
-
-    await humanTaskRepo.create({
-      id: reviewTaskId,
-      processInstanceId: instanceId,
-      stepId,
-      assignedRole,
-      assignedUserId: null,
-      status: 'pending',
-      deadline: null,
-      createdAt: reviewTaskNow,
-      updatedAt: reviewTaskNow,
-      completedAt: null,
-      completionData: {
-        reviewType: 'agent_output_review',
-        agentOutput: {
-          confidence: envelope?.confidence ?? null,
-          reasoning: envelope?.reasoning_summary ?? null,
-          result: envelope?.result ?? null,
-          model: envelope?.model ?? null,
-          annotations: envelope?.annotations ?? null,
-          duration_ms: envelope?.duration_ms ?? null,
-          gitMetadata: envelope?.gitMetadata ?? null,
-          presentation: envelope?.presentation ?? null,
-          escalationReason,
-        },
-        iterationNumber: priorReviewExecutions,
-      },
-      creationReason: 'agent_review_l3',
-    });
-
-    await auditRepo.append({
-      actorId: `agent:${pluginId}`,
-      actorType: 'agent',
-      actorRole: autonomyLevel,
-      action: 'task.created',
-      description: `Human task created for workflow step '${stepId}' (reason: agent_review_l3)`,
-      timestamp: reviewTaskNow,
-      inputSnapshot: { taskId: reviewTaskId, stepId, reason: 'agent_review_l3', assignedRole },
-      outputSnapshot: {},
-      basis: auditBasis,
-      entityType: 'humanTask',
-      entityId: reviewTaskId,
-      processInstanceId: instanceId,
-      stepId,
-      processDefinitionVersion: instance.definitionVersion,
-      executorType,
-      reviewerType: 'human',
-    });
-
-    await instanceRepo.update(instanceId, {
-      status: 'paused',
-      pauseReason: 'waiting_for_human',
-      updatedAt: new Date().toISOString(),
-    });
+  const services: StepExecutorServices = {
+    auditRepo,
+    instanceRepo,
+    engine,
+    humanTaskRepo,
+    modelRegistryRepo,
   };
 
-  // ---- L3 Review Routing (skip when agent errored — nothing to review) ----
-  // Escalation from fallback handler (status='escalated') always needs a human,
-  // even when review.type='agent' — the whole point of escalate_to_human is that
-  // the agent couldn't self-resolve.
-  if ((runResult.status === 'paused' || runResult.status === 'escalated') && autonomyLevel === 'L3' && runResult.fallbackReason !== 'error') {
-    const reviewerType = workflowStep.review?.type ?? 'human';
-    const isEscalation = runResult.status === 'escalated';
+  const meta = {
+    instanceId,
+    stepId,
+    pluginId,
+    triggeredBy,
+    stepExecutionId,
+    definitionVersion: instance.definitionVersion,
+  };
 
-    if (reviewerType === 'human' || reviewerType === 'none' || isEscalation) {
-      await createAgentReviewHumanTask(
-        isEscalation ? runResult.fallbackReason : null,
-        'L3 workflow agent step paused — human reviewer task created',
-      );
-      return {
-        instanceId,
-        status: 'paused',
-        currentStepId: stepId,
-        agentRunStatus: runResult.status,
-      };
-    }
-  }
+  // Dispatch to the right executor based on step type
+  const executor = workflowStep.executor === 'script'
+    ? scriptStepExecutor
+    : agentStepExecutor;
 
-  // ---- L3 Agent-as-Reviewer: submit verdict via engine.submitReviewVerdict ----
-  // review.type='agent' on a review step: the agent's verdict flows through
-  // ReviewTracker so iteration counting and maxIterations enforcement fire.
-  // On verdict='revise' the step routes back to a prior creation step; when
-  // iterations are exhausted, the engine pauses with max_iterations_exceeded
-  // and we create a human escalation task so the process stays actionable.
-  if (
-    autonomyLevel === 'L3' &&
-    workflowStep.review?.type === 'agent' &&
-    workflowStep.type === 'review' &&
-    runResult.status === 'completed' &&
-    runResult.appliedToWorkflow
-  ) {
-    const resultObj =
-      envelope?.result && typeof envelope.result === 'object' ? (envelope.result as Record<string, unknown>) : null;
-    const verdictValue = typeof resultObj?.verdict === 'string' ? resultObj.verdict : null;
+  const executionResult = await executor.execute(plugin, workflowAgentContext, services, meta);
 
-    if (verdictValue === null || verdictValue.length === 0) {
-      await createAgentReviewHumanTask(
-        'error',
-        `Agent reviewer for step '${stepId}' returned envelope without a verdict`,
-      );
-      return {
-        instanceId,
-        status: 'paused',
-        currentStepId: stepId,
-        agentRunStatus: 'escalated',
-      };
-    }
-
-    const commentValue = typeof resultObj?.comment === 'string' ? resultObj.comment : null;
-    const reviewerId = `agent:${pluginId}`;
-
-    const updated = await engine.submitReviewVerdict(
-      instanceId,
-      stepId,
-      {
-        reviewerId,
-        reviewerRole: 'agent',
-        verdict: verdictValue,
-        comment: commentValue,
-        timestamp: new Date().toISOString(),
-      },
-      { id: reviewerId, role: 'agent' },
-    );
-
-    if (updated.status === 'paused' && updated.pauseReason === 'max_iterations_exceeded') {
-      await createAgentReviewHumanTask(
-        'iterations_limit',
-        `Agent reviewer for step '${stepId}' exhausted iteration limit`,
-      );
-      return {
-        instanceId,
-        status: 'paused',
-        currentStepId: stepId,
-        agentRunStatus: 'escalated',
-      };
-    }
-
+  // Use the executor's authoritative instance state when available (avoids a
+  // redundant getById — the executor already updated the instance and knows
+  // its final state from engine responses). Fall back to a fresh read when
+  // the executor didn't track the instance state (e.g. fallback/unknown paths).
+  const instState = executionResult.instanceState;
+  if (instState) {
     return {
       instanceId,
-      status: updated.status,
-      currentStepId: updated.currentStepId,
-      agentRunStatus: 'completed',
+      status: instState.status,
+      currentStepId: instState.currentStepId,
+      agentRunStatus: executionResult.status,
     };
   }
 
-  // ---- Escalation/Pause (non-L3) ----
-  if (runResult.status === 'escalated' || runResult.status === 'paused') {
-    await auditRepo.append({
-      actorId: `${isScript ? 'script' : 'agent'}:${pluginId}`,
-      actorType: isScript ? 'system' : 'agent',
-      actorRole: autonomyLevel,
-      action: isScript ? 'script.escalated' : 'agent.escalated',
-      description: isScript
-        ? `Script step '${stepId}' failed — reason: ${runResult.fallbackReason ?? 'unknown'}`
-        : `Workflow step '${stepId}' escalated — reason: ${runResult.fallbackReason ?? 'unknown'}`,
-      timestamp: new Date().toISOString(),
-      inputSnapshot: { stepId, fallbackReason: runResult.fallbackReason ?? null },
-      outputSnapshot: { status: runResult.status },
-      basis: isScript
-        ? 'Script step could not complete'
-        : 'FallbackHandler: agent could not complete step autonomously',
-      entityType: 'processInstance',
-      entityId: instanceId,
-      processInstanceId: instanceId,
-      stepId,
-      processDefinitionVersion: instance.definitionVersion,
-      executorType,
-      reviewerType: 'none',
-    });
-    const currentInstance = await instanceRepo.getById(instanceId);
-    return {
-      instanceId,
-      status: currentInstance?.status ?? 'paused',
-      currentStepId: currentInstance?.currentStepId ?? null,
-      agentRunStatus: runResult.status,
-    };
-  }
-
-  // L4: appliedToWorkflow=true — advance the step using WorkflowEngine
-  if (runResult.appliedToWorkflow) {
-    const stepResult = runResult.envelope?.result;
-    if (stepResult === null || stepResult === undefined) {
-      throw new Error(
-        `Workflow step '${stepId}' completed with null result — cannot advance. ` +
-        `Reason: ${runResult.fallbackReason ?? runResult.envelope?.reasoning_summary ?? 'unknown'}`,
-      );
-    }
-
-    const updatedInstance = await engine.advanceStep(
-      instanceId,
-      stepResult,
-      { id: triggeredBy, role: 'agent' },
-      undefined,
-      runResult,
-    );
-
-    return {
-      instanceId,
-      status: updatedInstance.status,
-      currentStepId: updatedInstance.currentStepId,
-      agentRunStatus: runResult.status,
-    };
-  }
-
-  // L0/L1/L2: agent completed but didn't auto-apply — advance to next step.
-  // If the next step is human, advanceStep creates a HumanTask and pauses.
-  if (runResult.status === 'completed') {
-    const stepResult = runResult.envelope?.result ?? {};
-    const updatedInstance = await engine.advanceStep(
-      instanceId,
-      stepResult,
-      { id: triggeredBy, role: 'agent' },
-      undefined,
-    );
-
-    return {
-      instanceId,
-      status: updatedInstance.status,
-      currentStepId: updatedInstance.currentStepId,
-      agentRunStatus: runResult.status,
-    };
-  }
-
-  // Fallback: unknown status — return current state (should not reach here)
   const currentInstance = await instanceRepo.getById(instanceId);
   return {
     instanceId,
-    status: currentInstance?.status ?? instance.status,
-    currentStepId: currentInstance?.currentStepId ?? instance.currentStepId,
-    agentRunStatus: runResult.status,
+    status: currentInstance?.status ?? executionResult.status,
+    currentStepId: currentInstance?.currentStepId ?? null,
+    agentRunStatus: executionResult.status,
   };
 }
 
@@ -584,17 +288,4 @@ async function loadOAuthTokens(
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
-}
-
-async function estimateCostField(
-  envelope: { model: string | null; tokenUsage?: { inputTokens: number; outputTokens: number; cachedInputTokens?: number } },
-  modelRegistryRepo: { getById(id: string): Promise<{ pricing: { input: number; output: number; cacheRead?: number } } | null> },
-): Promise<{ estimatedCostUsd: number } | Record<string, never>> {
-  if (!envelope.tokenUsage || !envelope.model) return {};
-  const entry = await modelRegistryRepo.getById(envelope.model);
-  if (!entry) {
-    console.warn(`[cost] model "${envelope.model}" not found in registry — cost unavailable`);
-    return {};
-  }
-  return { estimatedCostUsd: calculateEstimatedCost(envelope.tokenUsage, entry.pricing) };
 }


### PR DESCRIPTION
Replace the monolithic executeAgentStep() dispatch with a StepExecutor
strategy pattern (ADR-0008 PR 3/4). Script steps now bypass AgentRunner
entirely and use PluginRunner directly via ScriptStepExecutor, while
agent steps flow through AgentStepExecutor which wraps AgentRunner.

- StepExecutor interface with StepExecutionResult in agent-runtime
- ScriptStepExecutor: PluginRunner → StepOutputEnvelopeSchema → auto-advance
- AgentStepExecutor: AgentRunner → L3 review/escalation/verdict routing
- executeAgentStep() becomes thin orchestrator: context setup + dispatch
- 20 new L1 tests (10 script, 10 agent); all 44 existing tests pass

https://claude.ai/code/session_012eRALAYDp4kTnqzNgVdX48