### PR TITLE
docs: fix stale references in GETTING-STARTED, running-workspace-locally, api-architecture

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -82,7 +82,7 @@ Most workflows under `apps/` use one or both of:
 - `mediforce-golden-image:latest` — Node + common tooling, the base for most
   inline `runtime: javascript` script steps
 - `mediforce-node:latest` — plain Node runtime, the fallback image when a
-  script step omits `agent.image`
+  script step omits `script.image`
 
 Build everything in one go:
 
@@ -240,7 +240,7 @@ curl -X POST http://localhost:9003/api/processes \
 
 Returns:
 ```json
-{ "instanceId": "proc-abc123", "status": "running" }
+{ "run": { "id": "proc-abc123", "status": "running", "definitionName": "my-first-workflow", ... } }
 ```
 
 ### Via UI

--- a/docs/api-architecture.md
+++ b/docs/api-architecture.md
@@ -82,8 +82,7 @@ Handler stays one file. New consumers wrap it from outside.
   — Mutation handler contract: error envelope, typed `ApiError`, HTTP
   status mapping, response shape, Server Action policy, audit-bridge.
 - [`docs/headless-migration.md`](./headless-migration.md)
-  — Living phased plan executing the separation. Gets deleted when the
-  migration completes; ADRs persist.
+  — Historical record; migration concluded in PR #534 (2026-05-31). ADRs persist.
 
 ## Adapter responsibilities, in detail
 

--- a/docs/running-workspace-locally.md
+++ b/docs/running-workspace-locally.md
@@ -16,7 +16,7 @@ End-to-end flow for clicking through the run-scoped git workspace in the UI, wit
 python3 packages/platform-ui/scripts/bootstrap_e2e.py
 ```
 
-Starts Firebase Auth (9099) + Firestore (8080), writes `.env.local` with demo creds, installs Playwright chromium and ffmpeg if missing. Idempotent — safe to re-run.
+Starts Firebase Auth (9099), writes `.env.local` with demo creds, installs Playwright chromium and ffmpeg if missing. Idempotent — safe to re-run.
 
 ### 2. Seed demo data
 
@@ -24,7 +24,7 @@ Starts Firebase Auth (9099) + Firestore (8080), writes `.env.local` with demo cr
 pnpm seed
 ```
 
-Seeds the test user + workflow definitions into the emulator Firestore. Includes the **Sales CSV Report** workflow — a two-step pipeline that exercises the workspace (generates `data/sales.csv`, summarises to `report/summary.md`).
+Seeds the test user into Firebase Auth emulator and workflow definitions into Postgres. Includes the **Sales CSV Report** workflow — a two-step pipeline that exercises the workspace (generates `data/sales.csv`, summarises to `report/summary.md`).
 
 Credentials: `test@mediforce.dev` / `test123456`
 
@@ -65,7 +65,7 @@ The bare repo holds one `run/<runId>` branch per trigger, each with three commit
 Emulator data + workspace state are independent.
 
 ```bash
-# Reset emulator Firestore + re-seed
+# Reset Auth emulator + re-seed
 cd packages/platform-ui && pnpm seed:dev
 
 # Wipe workspace state


### PR DESCRIPTION
## Summary

- **GETTING-STARTED.md**: script step fallback image field corrected from `agent.image` → `script.image` (`ScriptStepConfigSchema.image` lives at `step.script`, not `step.agent` — ADR-0023 breaking change)
- **GETTING-STARTED.md**: `POST /api/processes` response example updated from `{ instanceId, status }` to `{ run: { ... } }` (`StartRunOutputSchema` since PR #534)
- **docs/running-workspace-locally.md**: stale Firestore (8080) emulator reference removed — `bootstrap_e2e.py` only starts Auth; Firestore fully removed (ADR-0001); seed step description corrected to "Auth emulator + Postgres"
- **docs/api-architecture.md**: `headless-migration.md` description updated from "Living phased plan" to "Historical record" — migration concluded PR #534 (2026-05-31)

Found via `/sync-docs --audit` against the `[2026-06-07]` changelog section.

## Test plan

- [ ] No logic changes — documentation only
- [ ] Verify `ScriptStepConfigSchema` has `image` at `step.script` (`packages/platform-core/src/schemas/workflow-definition.ts`)
- [ ] Verify `StartRunOutputSchema = z.object({ run: ProcessInstanceSchema })` (`packages/platform-api/src/contract/runs.ts`)
- [ ] Verify `bootstrap_e2e.py` only starts auth emulator (not Firestore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)