### PR TITLE
refactor(agent-runtime): rename AgentPlugin → StepExecutorPlugin (ADR-0008 4/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Changed
+- **StepExecutor strategy pattern (ADR-0008)** — agent and script steps now execute through separate `StepExecutor` strategies (`AgentStepExecutor`, `ScriptStepExecutor`) instead of a monolithic `AgentRunner` with `isScript` branches. Each strategy owns its full lifecycle (run, audit, advance/review, cost tracking). `AgentPlugin` interface renamed to `StepExecutorPlugin` to reflect that scripts and Databricks jobs are peers, not special-cased agents:
+  - `StepOutputEnvelope` base schema in platform-core [#688](https://github.com/Appsilon/mediforce/pull/688)
+  - `PluginRunner` extracted from `AgentRunner` [#691](https://github.com/Appsilon/mediforce/pull/691)
+  - `StepExecutor` interface + `AgentStepExecutor` + `ScriptStepExecutor` [#692](https://github.com/Appsilon/mediforce/pull/692)
+  - `AgentPlugin` → `StepExecutorPlugin` rename [#694](https://github.com/Appsilon/mediforce/pull/694)
+
 ## [2026-06-07]
 
 ### Added

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -9,7 +9,7 @@ export type {
   ResolvedOAuthBinding,
   EmitPayload,
   EmitFn,
-  AgentPlugin,
+  StepExecutorPlugin,
   ReviewPlugin,
   ReviewPluginContext,
   ReviewPluginResult,

--- a/packages/agent-runtime/src/interfaces/index.ts
+++ b/packages/agent-runtime/src/interfaces/index.ts
@@ -8,8 +8,8 @@ export type {
   ResolvedOAuthBinding,
   EmitPayload,
   EmitFn,
-  AgentPlugin,
-} from './agent-plugin';
+  StepExecutorPlugin,
+} from './step-executor-plugin';
 
 export type {
   ReviewPlugin,

--- a/packages/agent-runtime/src/interfaces/review-plugin.ts
+++ b/packages/agent-runtime/src/interfaces/review-plugin.ts
@@ -1,5 +1,5 @@
 import type { AgentOutputEnvelope } from '@mediforce/platform-core';
-import type { LlmClient } from './agent-plugin';
+import type { LlmClient } from './step-executor-plugin';
 
 export interface ReviewPluginContext {
   stepId: string;

--- a/packages/agent-runtime/src/interfaces/step-executor-plugin.ts
+++ b/packages/agent-runtime/src/interfaces/step-executor-plugin.ts
@@ -108,7 +108,7 @@ export interface WorkflowAgentContext {
 export type EmitPayload = Omit<AgentEvent, 'id' | 'sequence' | 'processInstanceId' | 'stepId'>;
 export type EmitFn = (event: EmitPayload) => Promise<void>;
 
-export interface AgentPlugin {
+export interface StepExecutorPlugin {
   metadata?: PluginCapabilityMetadata;
   initialize(context: AgentContext | WorkflowAgentContext): Promise<void>;
   run(emit: EmitFn): Promise<void>;

--- a/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.e2e.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.e2e.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest
 import { resolve } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { execSync } from 'node:child_process';
-import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/agent-plugin';
+import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig } from '@mediforce/platform-core';
 import { ClaudeCodeAgentPlugin } from '../claude-code-agent-plugin';
 import { createFakeWorkspaceManager } from './helpers/fake-workspace-manager';

--- a/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/agent-plugin';
+import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig } from '@mediforce/platform-core';
 import { ClaudeCodeAgentPlugin } from '../claude-code-agent-plugin';
 import { createFakeWorkspaceManager } from './helpers/fake-workspace-manager';

--- a/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.workspace.integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.workspace.integration.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { WorkflowDefinition, WorkflowStep } from '@mediforce/platform-core';
 import { ClaudeCodeAgentPlugin } from '../claude-code-agent-plugin';
-import type { EmitPayload, EmitFn, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import type { EmitPayload, EmitFn, WorkflowAgentContext } from '../../interfaces/step-executor-plugin';
 import type { AgentCommandSpec } from '../base-container-agent-plugin';
 
 type GetAgentCommandTarget = { getAgentCommand: (promptPath: string, options?: unknown) => AgentCommandSpec };

--- a/packages/agent-runtime/src/plugins/__tests__/databricks-job-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/databricks-job-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { AgentContext, WorkflowAgentContext, EmitFn, EmitPayload } from '../../interfaces/agent-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig, WorkflowStep } from '@mediforce/platform-core';
 import { AgentOutputEnvelopeSchema } from '@mediforce/platform-core';
 import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';

--- a/packages/agent-runtime/src/plugins/__tests__/mcp-config-integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/mcp-config-integration.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { AgentContext, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import type { AgentContext, WorkflowAgentContext } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig, WorkflowDefinition, WorkflowStep } from '@mediforce/platform-core';
 import { ClaudeCodeAgentPlugin } from '../claude-code-agent-plugin';
 

--- a/packages/agent-runtime/src/plugins/__tests__/mock-claude-code-agent-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/mock-claude-code-agent-plugin.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
 import { MockClaudeCodeAgentPlugin } from '../mock-claude-code-agent-plugin';
-import type { EmitPayload, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import type { EmitPayload, WorkflowAgentContext } from '../../interfaces/step-executor-plugin';
 
 describe('MockClaudeCodeAgentPlugin', () => {
   it('[DATA] emits deterministic output without step.agent config', async () => {

--- a/packages/agent-runtime/src/plugins/__tests__/opencode-agent-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/opencode-agent-plugin.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/agent-plugin';
+import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig } from '@mediforce/platform-core';
 import { OpenCodeAgentPlugin, normaliseModelId } from '../opencode-agent-plugin';
 import { createFakeWorkspaceManager } from './helpers/fake-workspace-manager';

--- a/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.e2e.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.e2e.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { execSync } from 'node:child_process';
-import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/agent-plugin';
+import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig } from '@mediforce/platform-core';
 import { ScriptContainerPlugin } from '../script-container-plugin';
 

--- a/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ChildProcess } from 'node:child_process';
-import type { AgentContext, WorkflowAgentContext, EmitFn, EmitPayload } from '../../interfaces/agent-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig } from '@mediforce/platform-core';
 import { buildWorkflowDefinition } from '@mediforce/platform-core/testing';
 import { ScriptContainerPlugin } from '../script-container-plugin';

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -3,7 +3,7 @@ import { readFile, readdir, mkdtemp, writeFile, rm, mkdir, appendFile, realpath,
 import { join, dirname, isAbsolute, resolve } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/step-executor-plugin';
 import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata, McpServerConfig, ResolvedMcpConfig, Presentation, OutputSchemaShape } from '@mediforce/platform-core';
 import { resolveStepEnv, resolveValue, type ResolvedEnv } from './resolve-env';
 import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy';

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -58,7 +58,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
-import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/step-executor-plugin';
 import type { AgentConfig, PluginCapabilityMetadata } from '@mediforce/platform-core';
 import { writeFile } from 'node:fs/promises';
 import type { GitMetadata } from '@mediforce/platform-core';
@@ -242,7 +242,7 @@ export interface ContainerPluginInit {
   workspaceManager?: WorkspaceManagerLike;
 }
 
-export abstract class ContainerPlugin implements AgentPlugin {
+export abstract class ContainerPlugin implements StepExecutorPlugin {
   abstract readonly metadata: PluginCapabilityMetadata;
 
   protected context!: AgentContext | WorkflowAgentContext;

--- a/packages/agent-runtime/src/plugins/databricks/databricks-job-plugin.ts
+++ b/packages/agent-runtime/src/plugins/databricks/databricks-job-plugin.ts
@@ -6,7 +6,7 @@ import {
   type InterpolationSources,
   type PluginCapabilityMetadata,
 } from '@mediforce/platform-core';
-import type { AgentContext, AgentPlugin, EmitFn, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import type { AgentContext, StepExecutorPlugin, EmitFn, WorkflowAgentContext } from '../../interfaces/step-executor-plugin';
 import { isWorkflowAgentContext } from '../container-plugin';
 import { DatabricksClient, isTerminalLifecycle } from './databricks-client';
 
@@ -33,7 +33,7 @@ export interface DatabricksJobPluginInit {
  * Errors fail the step (never a low-confidence result) — same rule as
  * ScriptContainerPlugin.
  */
-export class DatabricksJobPlugin implements AgentPlugin {
+export class DatabricksJobPlugin implements StepExecutorPlugin {
   readonly metadata: PluginCapabilityMetadata = {
     name: 'Databricks Job',
     description: 'Triggers an existing Databricks job via REST and waits for its result — no LLM involved.',

--- a/packages/agent-runtime/src/plugins/mock-claude-code-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/mock-claude-code-agent-plugin.ts
@@ -1,8 +1,8 @@
 import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
-import type { AgentContext, AgentPlugin, EmitFn, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { AgentContext, StepExecutorPlugin, EmitFn, WorkflowAgentContext } from '../interfaces/step-executor-plugin';
 import { ClaudeCodeAgentPlugin } from './claude-code-agent-plugin';
 
-export class MockClaudeCodeAgentPlugin implements AgentPlugin {
+export class MockClaudeCodeAgentPlugin implements StepExecutorPlugin {
   readonly metadata: PluginCapabilityMetadata = new ClaudeCodeAgentPlugin().metadata;
 
   private context: AgentContext | WorkflowAgentContext | null = null;

--- a/packages/agent-runtime/src/plugins/script-container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/script-container-plugin.ts
@@ -2,7 +2,7 @@ import { readFile, mkdtemp, writeFile, rm, realpath, mkdir, appendFile, stat } f
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/agent-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/step-executor-plugin';
 import type { AgentConfig, ScriptStepConfig, StepConfig, PluginCapabilityMetadata, Presentation } from '@mediforce/platform-core';
 import { getDockerSpawnStrategy } from './docker-spawn-strategy';
 import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, formatExitInfo, type ContainerPluginInit } from './container-plugin';

--- a/packages/agent-runtime/src/runner/__tests__/agent-step-executor.test.ts
+++ b/packages/agent-runtime/src/runner/__tests__/agent-step-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AgentStepExecutor } from '../agent-step-executor';
 import type { StepExecutorServices, StepExecutorMeta } from '../step-executor';
-import type { AgentPlugin, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import type { StepExecutorPlugin, WorkflowAgentContext } from '../../interfaces/step-executor-plugin';
 import { buildAgentOutputEnvelope, buildWorkflowDefinition } from '@mediforce/platform-core/testing';
 import type { WorkflowStep } from '@mediforce/platform-core';
 
@@ -50,7 +50,7 @@ const defaultEnvelope = buildAgentOutputEnvelope({
   result: { summary: 'analysis complete' },
 });
 
-const mockPlugin: AgentPlugin = {
+const mockPlugin: StepExecutorPlugin = {
   initialize: vi.fn(),
   run: vi.fn(),
 };

--- a/packages/agent-runtime/src/runner/__tests__/script-step-executor.test.ts
+++ b/packages/agent-runtime/src/runner/__tests__/script-step-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ScriptStepExecutor } from '../script-step-executor';
 import type { StepExecutorServices, StepExecutorMeta } from '../step-executor';
-import type { AgentPlugin, WorkflowAgentContext } from '../../interfaces/agent-plugin';
+import type { StepExecutorPlugin, WorkflowAgentContext } from '../../interfaces/step-executor-plugin';
 import { buildStepOutputEnvelope, buildWorkflowDefinition } from '@mediforce/platform-core/testing';
 import type { WorkflowStep } from '@mediforce/platform-core';
 
@@ -46,7 +46,7 @@ const workflowDefinition = buildWorkflowDefinition({
   transitions: [{ from: 'transform-data', to: 'done' }],
 });
 
-const mockPlugin: AgentPlugin = {
+const mockPlugin: StepExecutorPlugin = {
   initialize: vi.fn(),
   run: vi.fn(),
 };

--- a/packages/agent-runtime/src/runner/agent-event-log.ts
+++ b/packages/agent-runtime/src/runner/agent-event-log.ts
@@ -1,5 +1,5 @@
 import type { AgentEvent } from '@mediforce/platform-core';
-import type { EmitPayload } from '../interfaces/agent-plugin';
+import type { EmitPayload } from '../interfaces/step-executor-plugin';
 
 export interface AgentEventLog {
   write(instanceId: string, stepId: string, event: EmitPayload): Promise<void>;

--- a/packages/agent-runtime/src/runner/agent-runner.test.ts
+++ b/packages/agent-runtime/src/runner/agent-runner.test.ts
@@ -7,10 +7,10 @@ import {
 import { InMemoryAgentEventLog } from '../testing/index';
 import { NoopLlmClient } from '../testing/index';
 import type {
-  AgentPlugin,
+  StepExecutorPlugin,
   AgentContext,
   EmitFn,
-} from '../interfaces/agent-plugin';
+} from '../interfaces/step-executor-plugin';
 import type {
   StepConfig,
   ProcessConfig,
@@ -66,7 +66,7 @@ function makeValidEnvelope(overrides: Partial<AgentOutputEnvelope> = {}): AgentO
 }
 
 /** Simple plugin that emits events synchronously then resolves */
-function makeSuccessPlugin(envelope: AgentOutputEnvelope): AgentPlugin {
+function makeSuccessPlugin(envelope: AgentOutputEnvelope): StepExecutorPlugin {
   return {
     initialize: async (_context: AgentContext) => {},
     run: async (emit: EmitFn) => {
@@ -85,7 +85,7 @@ function makeSuccessPlugin(envelope: AgentOutputEnvelope): AgentPlugin {
 }
 
 /** Plugin that emits status events before a slow result (for timeout test) */
-function makeSlowPlugin(delayMs: number, envelope: AgentOutputEnvelope): AgentPlugin {
+function makeSlowPlugin(delayMs: number, envelope: AgentOutputEnvelope): StepExecutorPlugin {
   return {
     initialize: async (_context: AgentContext) => {},
     run: async (emit: EmitFn) => {
@@ -105,7 +105,7 @@ function makeSlowPlugin(delayMs: number, envelope: AgentOutputEnvelope): AgentPl
 }
 
 /** Plugin that emits an invalid result payload */
-function makeInvalidEnvelopePlugin(): AgentPlugin {
+function makeInvalidEnvelopePlugin(): StepExecutorPlugin {
   return {
     initialize: async (_context: AgentContext) => {},
     run: async (emit: EmitFn) => {
@@ -119,7 +119,7 @@ function makeInvalidEnvelopePlugin(): AgentPlugin {
 }
 
 /** Plugin that emits multiple events before result */
-function makeMultiEventPlugin(envelope: AgentOutputEnvelope): AgentPlugin {
+function makeMultiEventPlugin(envelope: AgentOutputEnvelope): StepExecutorPlugin {
   return {
     initialize: async (_context: AgentContext) => {},
     run: async (emit: EmitFn) => {
@@ -383,7 +383,7 @@ describe('AgentRunner', () => {
   // --- Plugin throws a raw Error ---
 
   it('plugin throw: fallbackReason is error, instance paused with agent_escalated', async () => {
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async () => { throw new Error('LLM API key invalid'); },
     };
@@ -402,7 +402,7 @@ describe('AgentRunner', () => {
   });
 
   it('plugin throw: error message is captured in audit outputSnapshot', async () => {
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async () => { throw new Error('OpenRouter 401 Unauthorized'); },
     };
@@ -420,7 +420,7 @@ describe('AgentRunner', () => {
   });
 
   it('plugin throw after partial work: partial events preserved in event log', async () => {
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async (emit: EmitFn) => {
         await emit({ type: 'status', payload: 'Starting...', timestamp: new Date().toISOString() });
@@ -438,7 +438,7 @@ describe('AgentRunner', () => {
   });
 
   it('plugin throw: audit event written even when no result emitted', async () => {
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async () => { throw new TypeError('Cannot read properties of undefined'); },
     };

--- a/packages/agent-runtime/src/runner/agent-runner.ts
+++ b/packages/agent-runtime/src/runner/agent-runner.ts
@@ -10,7 +10,7 @@ import {
   type WorkflowStep,
 } from '@mediforce/platform-core';
 import { randomUUID } from 'crypto';
-import type { AgentPlugin, AgentContext, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, AgentContext, WorkflowAgentContext } from '../interfaces/step-executor-plugin';
 import type { AgentEventLog } from './agent-event-log';
 import { FallbackHandler } from './fallback-handler';
 import { PluginRunner } from './plugin-runner';
@@ -44,7 +44,7 @@ export class AgentRunner {
    * step.autonomyLevel / step.plugin; timeout via resolveStepTimeoutMinutes.
    */
   async runWithWorkflowStep(
-    plugin: AgentPlugin,
+    plugin: StepExecutorPlugin,
     context: WorkflowAgentContext,
   ): Promise<AgentRunResult> {
     const startedAt = Date.now();
@@ -146,7 +146,7 @@ export class AgentRunner {
    * StepConfig model which is being replaced by WorkflowStep.
    */
   async run(
-    plugin: AgentPlugin,
+    plugin: StepExecutorPlugin,
     context: AgentContext,
     stepConfig: StepConfig,
   ): Promise<AgentRunResult> {

--- a/packages/agent-runtime/src/runner/agent-step-executor.ts
+++ b/packages/agent-runtime/src/runner/agent-step-executor.ts
@@ -2,7 +2,7 @@ import {
   calculateEstimatedCost,
   type AgentOutputEnvelope,
 } from '@mediforce/platform-core';
-import type { AgentPlugin, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, WorkflowAgentContext } from '../interfaces/step-executor-plugin';
 import type { AgentRunner, AgentRunResult } from './agent-runner';
 import type {
   StepExecutor,
@@ -15,7 +15,7 @@ export class AgentStepExecutor implements StepExecutor {
   constructor(private readonly agentRunner: AgentRunner) {}
 
   async execute(
-    plugin: AgentPlugin,
+    plugin: StepExecutorPlugin,
     context: WorkflowAgentContext,
     services: StepExecutorServices,
     meta: StepExecutorMeta,

--- a/packages/agent-runtime/src/runner/fallback-handler.test.ts
+++ b/packages/agent-runtime/src/runner/fallback-handler.test.ts
@@ -3,7 +3,7 @@ import { FallbackHandler } from './fallback-handler';
 import {
   InMemoryProcessInstanceRepository,
 } from '@mediforce/platform-core';
-import type { AgentContext } from '../interfaces/agent-plugin';
+import type { AgentContext } from '../interfaces/step-executor-plugin';
 import type { StepConfig, AgentEvent, ProcessConfig } from '@mediforce/platform-core';
 import { NoopLlmClient } from '../testing/index';
 

--- a/packages/agent-runtime/src/runner/fallback-handler.ts
+++ b/packages/agent-runtime/src/runner/fallback-handler.ts
@@ -4,7 +4,7 @@ import type {
   AgentEvent,
   AgentOutputEnvelope,
 } from '@mediforce/platform-core';
-import type { AgentContext, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { AgentContext, WorkflowAgentContext } from '../interfaces/step-executor-plugin';
 import type { AgentRunResult } from './agent-runner';
 
 export class FallbackHandler {

--- a/packages/agent-runtime/src/runner/llm-client.ts
+++ b/packages/agent-runtime/src/runner/llm-client.ts
@@ -1,7 +1,7 @@
-import type { LlmMessage, LlmResponse } from '../interfaces/agent-plugin';
+import type { LlmMessage, LlmResponse } from '../interfaces/step-executor-plugin';
 
 // Re-export the interface defined in interfaces/ for barrel convenience
-export type { LlmClient, LlmMessage, LlmResponse } from '../interfaces/agent-plugin';
+export type { LlmClient, LlmMessage, LlmResponse } from '../interfaces/step-executor-plugin';
 
 // OpenRouterLlmClient: wraps the OpenRouter API for LLM access.
 // Platform provides this to agents — agents never call OpenRouter directly.

--- a/packages/agent-runtime/src/runner/plugin-registry.test.ts
+++ b/packages/agent-runtime/src/runner/plugin-registry.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { PluginRegistry } from './plugin-registry';
-import type { AgentPlugin, AgentContext, EmitFn } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, AgentContext, EmitFn } from '../interfaces/step-executor-plugin';
 import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
 
 // Minimal mock plugin without metadata
-function makeMockPlugin(): AgentPlugin {
+function makeMockPlugin(): StepExecutorPlugin {
   return {
     initialize: async (_ctx: AgentContext) => {},
     run: async (_emit: EmitFn) => {},
@@ -12,7 +12,7 @@ function makeMockPlugin(): AgentPlugin {
 }
 
 // Mock plugin with metadata
-function makeMockPluginWithMetadata(metadata: PluginCapabilityMetadata): AgentPlugin & { metadata: PluginCapabilityMetadata } {
+function makeMockPluginWithMetadata(metadata: PluginCapabilityMetadata): StepExecutorPlugin & { metadata: PluginCapabilityMetadata } {
   return {
     initialize: async (_ctx: AgentContext) => {},
     run: async (_emit: EmitFn) => {},

--- a/packages/agent-runtime/src/runner/plugin-registry.ts
+++ b/packages/agent-runtime/src/runner/plugin-registry.ts
@@ -1,5 +1,5 @@
 import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
-import type { AgentPlugin } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin } from '../interfaces/step-executor-plugin';
 
 export class PluginNotFoundError extends Error {
   override name = 'PluginNotFoundError';
@@ -10,16 +10,16 @@ export class PluginNotFoundError extends Error {
 }
 
 export class PluginRegistry {
-  private plugins = new Map<string, AgentPlugin>();
+  private plugins = new Map<string, StepExecutorPlugin>();
 
-  register(name: string, plugin: AgentPlugin): void {
+  register(name: string, plugin: StepExecutorPlugin): void {
     if (this.plugins.has(name)) {
       throw new Error(`Plugin "${name}" is already registered. Duplicate registration is not allowed.`);
     }
     this.plugins.set(name, plugin);
   }
 
-  get(name: string): AgentPlugin {
+  get(name: string): StepExecutorPlugin {
     const plugin = this.plugins.get(name);
     if (!plugin) throw new PluginNotFoundError(name);
     return plugin;

--- a/packages/agent-runtime/src/runner/plugin-runner.test.ts
+++ b/packages/agent-runtime/src/runner/plugin-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { PluginRunner } from './plugin-runner';
 import { InMemoryAgentEventLog } from '../testing/index';
-import type { AgentPlugin, AgentContext, EmitFn } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, AgentContext, EmitFn } from '../interfaces/step-executor-plugin';
 import { NoopLlmClient } from '../testing/index';
 import type { ProcessConfig, AgentOutputEnvelope } from '@mediforce/platform-core';
 
@@ -41,7 +41,7 @@ function makeValidEnvelope(overrides: Partial<AgentOutputEnvelope> = {}): AgentO
   };
 }
 
-function makeSuccessPlugin(envelope: AgentOutputEnvelope): AgentPlugin {
+function makeSuccessPlugin(envelope: AgentOutputEnvelope): StepExecutorPlugin {
   return {
     initialize: async () => {},
     run: async (emit: EmitFn) => {
@@ -76,7 +76,7 @@ describe('PluginRunner', () => {
   it('returns null resultPayload when no result event emitted', async () => {
     const eventLog = new InMemoryAgentEventLog();
     const runner = new PluginRunner(eventLog);
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async (emit: EmitFn) => {
         await emit({
@@ -97,7 +97,7 @@ describe('PluginRunner', () => {
   it('returns timedOut: true when plugin exceeds timeout', async () => {
     const eventLog = new InMemoryAgentEventLog();
     const runner = new PluginRunner(eventLog);
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async () => {
         await new Promise<void>((resolve) => setTimeout(resolve, 200));
@@ -114,7 +114,7 @@ describe('PluginRunner', () => {
   it('captures error message when plugin throws', async () => {
     const eventLog = new InMemoryAgentEventLog();
     const runner = new PluginRunner(eventLog);
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async () => { throw new Error('API key invalid'); },
     };
@@ -129,7 +129,7 @@ describe('PluginRunner', () => {
   it('preserves partial events in event log after plugin throw', async () => {
     const eventLog = new InMemoryAgentEventLog();
     const runner = new PluginRunner(eventLog);
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async (emit: EmitFn) => {
         await emit({ type: 'status', payload: 'partial', timestamp: new Date().toISOString() });
@@ -147,7 +147,7 @@ describe('PluginRunner', () => {
   it('captures error when initialize() throws', async () => {
     const eventLog = new InMemoryAgentEventLog();
     const runner = new PluginRunner(eventLog);
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => { throw new Error('MCP server unreachable'); },
       run: async () => {},
     };
@@ -162,7 +162,7 @@ describe('PluginRunner', () => {
   it('returns last result event when multiple result events emitted', async () => {
     const eventLog = new InMemoryAgentEventLog();
     const runner = new PluginRunner(eventLog);
-    const plugin: AgentPlugin = {
+    const plugin: StepExecutorPlugin = {
       initialize: async () => {},
       run: async (emit: EmitFn) => {
         await emit({

--- a/packages/agent-runtime/src/runner/plugin-runner.ts
+++ b/packages/agent-runtime/src/runner/plugin-runner.ts
@@ -1,4 +1,4 @@
-import type { AgentPlugin, AgentContext, WorkflowAgentContext, EmitPayload } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, AgentContext, WorkflowAgentContext, EmitPayload } from '../interfaces/step-executor-plugin';
 import type { AgentEventLog } from './agent-event-log';
 
 export interface PluginRunResult {
@@ -18,7 +18,7 @@ export class PluginRunner {
   constructor(private readonly eventLog: AgentEventLog) {}
 
   async execute(
-    plugin: AgentPlugin,
+    plugin: StepExecutorPlugin,
     context: AgentContext | WorkflowAgentContext,
     timeoutMs: number,
   ): Promise<PluginRunResult> {

--- a/packages/agent-runtime/src/runner/script-step-executor.ts
+++ b/packages/agent-runtime/src/runner/script-step-executor.ts
@@ -3,7 +3,7 @@ import {
   resolveStepTimeoutMinutes,
   type StepOutputEnvelope,
 } from '@mediforce/platform-core';
-import type { AgentPlugin, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, WorkflowAgentContext } from '../interfaces/step-executor-plugin';
 import type { PluginRunner } from './plugin-runner';
 import type {
   StepExecutor,
@@ -16,7 +16,7 @@ export class ScriptStepExecutor implements StepExecutor {
   constructor(private readonly pluginRunner: PluginRunner) {}
 
   async execute(
-    plugin: AgentPlugin,
+    plugin: StepExecutorPlugin,
     context: WorkflowAgentContext,
     services: StepExecutorServices,
     meta: StepExecutorMeta,

--- a/packages/agent-runtime/src/runner/step-executor.ts
+++ b/packages/agent-runtime/src/runner/step-executor.ts
@@ -1,5 +1,5 @@
 import type { StepOutputEnvelope, AgentOutputEnvelope } from '@mediforce/platform-core';
-import type { AgentPlugin, WorkflowAgentContext } from '../interfaces/agent-plugin';
+import type { StepExecutorPlugin, WorkflowAgentContext } from '../interfaces/step-executor-plugin';
 
 export type StepExecutionStatus = 'completed' | 'paused' | 'escalated' | 'failed';
 
@@ -63,7 +63,7 @@ export interface StepExecutorModelRegistryRepo {
 
 export interface StepExecutor {
   execute(
-    plugin: AgentPlugin,
+    plugin: StepExecutorPlugin,
     context: WorkflowAgentContext,
     services: StepExecutorServices,
     meta: StepExecutorMeta,

--- a/packages/agent-runtime/src/testing/in-memory-agent-event-log.ts
+++ b/packages/agent-runtime/src/testing/in-memory-agent-event-log.ts
@@ -1,6 +1,6 @@
 import type { AgentEvent } from '@mediforce/platform-core';
 import type { AgentEventLog } from '../runner/agent-event-log';
-import type { EmitPayload } from '../interfaces/agent-plugin';
+import type { EmitPayload } from '../interfaces/step-executor-plugin';
 
 export class InMemoryAgentEventLog implements AgentEventLog {
   private events: AgentEvent[] = [];

--- a/packages/agent-runtime/src/testing/noop-llm-client.ts
+++ b/packages/agent-runtime/src/testing/noop-llm-client.ts
@@ -1,4 +1,4 @@
-import type { LlmClient, LlmMessage, LlmResponse } from '../interfaces/agent-plugin';
+import type { LlmClient, LlmMessage, LlmResponse } from '../interfaces/step-executor-plugin';
 
 export class NoopLlmClient implements LlmClient {
   private responses: LlmResponse[] = [];

--- a/packages/agent-runtime/src/workspace/__tests__/output-files.test.ts
+++ b/packages/agent-runtime/src/workspace/__tests__/output-files.test.ts
@@ -12,7 +12,7 @@ import type { PluginCapabilityMetadata, WorkflowDefinition, WorkflowStep, Workfl
 import { WorkspaceManager, type RunWorkspaceHandle } from '../workspace-manager';
 import { copyOutputFilesIntoWorkspace } from '../output-files';
 import { ContainerPlugin, type CommitRunWorkspaceOptions, type WorkspaceManagerLike } from '../../plugins/container-plugin';
-import type { AgentContext, WorkflowAgentContext, EmitFn } from '../../interfaces/agent-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../../interfaces/step-executor-plugin';
 import type { GitMetadata } from '@mediforce/platform-core';
 
 const MAX_BYTES_ENV = 'MEDIFORCE_OUTPUT_FILE_MAX_BYTES';

--- a/packages/agent-runtime/src/workspace/__tests__/workspace-docker.integration.test.ts
+++ b/packages/agent-runtime/src/workspace/__tests__/workspace-docker.integration.test.ts
@@ -28,7 +28,7 @@ import type {
   EmitFn,
   EmitPayload,
   WorkflowAgentContext,
-} from '../../interfaces/agent-plugin';
+} from '../../interfaces/step-executor-plugin';
 
 function dockerAvailable(): boolean {
   try {

--- a/packages/example-agent/src/example-agent.ts
+++ b/packages/example-agent/src/example-agent.ts
@@ -1,7 +1,7 @@
-import type { AgentPlugin, AgentContext, EmitFn } from '@mediforce/agent-runtime';
+import type { StepExecutorPlugin, AgentContext, EmitFn } from '@mediforce/agent-runtime';
 
 /**
- * ExampleAgent: Reference implementation of AgentPlugin.
+ * ExampleAgent: Reference implementation of StepExecutorPlugin.
  *
  * Plugin pattern:
  * 1. initialize(): receive and store context (step input, config, LLM client)
@@ -13,7 +13,7 @@ import type { AgentPlugin, AgentContext, EmitFn } from '@mediforce/agent-runtime
  * Autonomy behavior is applied by AgentRunner AFTER run() completes.
  * Plugins are autonomy-agnostic — never check context.autonomyLevel.
  */
-export class ExampleAgent implements AgentPlugin {
+export class ExampleAgent implements StepExecutorPlugin {
   private context!: AgentContext;
 
   async initialize(context: AgentContext): Promise<void> {

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -9,7 +9,7 @@ import {
   resolveOAuthToken,
   OAuthTokenUnavailableError,
   PluginNotFoundError,
-  type AgentPlugin,
+  type StepExecutorPlugin,
   type ResolvedOAuthBinding,
   type WorkflowAgentContext,
   type StepExecutorServices,
@@ -83,7 +83,7 @@ export async function executeAgentStep(
 
   // Resolve plugin: use workflowStep.plugin when set, fall back to stepId
   const pluginId = workflowStep.plugin ?? stepId;
-  let plugin: AgentPlugin;
+  let plugin: StepExecutorPlugin;
   try {
     plugin = pluginRegistry.get(pluginId);
   } catch (err) {


### PR DESCRIPTION
## Summary

Final PR of the ADR-0008 StepExecutor strategy delivery. Mechanical rename:

- `AgentPlugin` interface → `StepExecutorPlugin` — scripts, Databricks jobs, and LLM agents all implement the same plugin contract; calling it "AgentPlugin" was a naming mismatch
- File renamed `agent-plugin.ts` → `step-executor-plugin.ts`
- 39 files touched, 76 lines changed (all 1:1 substitutions)
- `AgentContext` (deprecated) left as-is — `WorkflowAgentContext` replaces it, rename would be high churn for a dying type
- No behavioral changes

### ADR-0008 series
1. `StepOutputEnvelope` base schema #688 ✅
2. `PluginRunner` extraction #691 ✅
3. `StepExecutor` strategy + `AgentStepExecutor` + `ScriptStepExecutor` #692 ✅
4. **`AgentPlugin` → `StepExecutorPlugin` rename** ← this PR
5. ADR-0008 docs #687 (ready to merge)

## Test plan

- [x] `pnpm tsc --noEmit` passes for agent-runtime, platform-api, platform-ui, example-agent
- [x] `pnpm vitest run` in agent-runtime: 399 passed, 0 failed
- [x] No remaining `\bAgentPlugin\b` references (only compound class names like `ClaudeCodeAgentPlugin`)
- [x] `git diff --stat` confirms 1:1 line changes (76→76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)