### PR TITLE
docs: ADR-0008 step executor model + CONTEXT.md glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,11 +70,51 @@ One attempt to execute one Workflow Step inside a Workflow Run. Captures
 input, output, verdict, gate result, iteration number, error. Optionally has
 0..1 Agent Run, 0..1 Cowork Session, 0..N Human Tasks attached.
 
+### Step execution model
+
+**Step Executor** *(dispatch strategy)*:
+The abstraction that dispatches a Workflow Step to its runtime and collects
+the result. Two concrete strategies today: `AgentStepExecutor` (LLM-driven,
+with autonomy levels, review/escalation) and `ScriptStepExecutor`
+(deterministic, auto-applied, no autonomy concept). Each delegates to a
+`PluginRunner` which calls the `StepExecutorPlugin`.
+_Code:_ `StepExecutor` interface with `execute()`. Replaces the monolithic
+`executeAgentStep()` function.
+_Avoid_: "AgentRunner" for script steps — AgentRunner is agent-only.
+
+**Step Executor Plugin** *(runtime implementation)*:
+Interface a plugin implements to be runnable by the `PluginRunner`:
+`initialize()` + `run()`. Implementations: `claude-code`, `opencode`,
+`script-container`, `databricks-job`, plus mocks. Registered in
+PluginRegistry.
+_Code:_ `StepExecutorPlugin` (rename from `AgentPlugin`).
+_Avoid_: conflating with Plugin (the glossary entry below is the
+domain-level concept; StepExecutorPlugin is the code interface).
+
+**Plugin Runner** *(shared infrastructure)*:
+Runs a `StepExecutorPlugin` — dispatch, collect output, report status.
+Shared by both `AgentStepExecutor` and `ScriptStepExecutor`. Does not
+know about autonomy levels, review, or escalation.
+_Code:_ `PluginRunner` (extracted from `AgentRunner`).
+
+**Step Output Envelope** *(base result shape)*:
+What every Step Execution produces: `result`, `duration_ms`, `annotations`,
+`gitMetadata`, `outputFiles`. Executor-agnostic.
+_Code:_ `StepOutputEnvelope` schema.
+
+**Agent Output Envelope** *(agent-specific extension)*:
+Extends Step Output Envelope with LLM-specific fields: `confidence`,
+`confidence_rationale`, `model`, `reasoning_summary`, `reasoning_chain`,
+`tokenUsage`. Only populated by agent-type steps.
+_Code:_ `AgentOutputEnvelope extends StepOutputEnvelope`.
+_Avoid_: using Agent Output Envelope for script steps — scripts produce
+Step Output Envelope (no confidence, no model).
+
 ### What an agent / human / cowork produces
 
 **Output** (`StepExecution.output`):
 Immediate result of one Step Execution. Polymorphic — shape depends on
-executor (form submission, agent envelope, gate decision).
+executor (form submission, agent envelope, script envelope, gate decision).
 
 **Variables** (`ProcessInstance.variables`):
 Accumulated outputs across all completed Step Executions of one Process
@@ -101,6 +141,8 @@ The execution of one `agent`-type Step inside a Workflow Run. An autonomous
 (L0–L4) attempt by one Agent (the template the Step's `agentId` resolves to)
 to produce the Step's Output. Belongs to the workflow domain — not an
 agent-side concept. Result: an Agent Output Envelope. Immutable once created.
+_Note_: Autonomy levels (L0–L4) are an agent-only concept. Script steps
+have no autonomy level — they are deterministic and auto-applied.
 
 **Cowork Session**:
 A real-time, human-in-the-loop session attached to a Step Execution where
@@ -133,9 +175,13 @@ question, resolution. Lifecycle: `created → acknowledged → resolved`.
 ### Plugin / Skill / MCP
 
 **Plugin** *(runtime strategy)*:
-A pluggable agent runtime implementation. Today: `claude-code`, `opencode`,
-`script-container`, plus mocks. Each implements `BaseContainerAgentPlugin` and
-declares roles (`executor`, `reviewer`). Registered in PluginRegistry.
+A pluggable step executor implementation. Today: `claude-code`, `opencode`,
+`script-container`, `databricks-job`, plus mocks. Each implements
+`StepExecutorPlugin` and is registered in PluginRegistry. Two families:
+agent plugins (LLM-driven, container-based) and script plugins
+(deterministic, container or remote API).
+_Code:_ `StepExecutorPlugin` interface (rename from `AgentPlugin`).
+_Avoid_: conflating with Skill — Plugin is the runtime; Skill is data.
 
 **Skill** *(code payload)*:
 A code artifact (script or git repo) consumed by an agent at spawn time

--- a/docs/adr/0008-step-executor-model.md
+++ b/docs/adr/0008-step-executor-model.md
@@ -1,0 +1,102 @@
+# ADR-0008: Step Executor Model — Separating Agent from Script Execution
+
+**Status:** Accepted  
+**Date:** 2026-06-11  
+**Deciders:** Filip Stachura  
+
+## Context
+
+The platform supports two fundamentally different executor types for workflow
+steps: **agent** (LLM-driven, with autonomy levels L0–L4, review/escalation,
+confidence scoring) and **script** (deterministic jobs — `script-container`,
+`databricks-job`). Both were forced through the same code path:
+
+- `AgentRunner` dispatched both types
+- `AgentOutputEnvelope` wrapped both outputs (script steps emitted meaningless
+  `confidence: 1.0`, `model: 'databricks'`)
+- `executeAgentStep()` — one 500-line function — used `isScript` guards to
+  skip autonomy routing for scripts
+- Audit events emitted `agent.*` for script steps
+- UI needed `executorType === 'script'` checks to hide LLM metadata
+
+The databricks-job plugin (#681) made this technical debt visible: a
+deterministic API call was presented as an "agent" everywhere in the system.
+
+## Decision
+
+Introduce a **Step Executor** strategy pattern that cleanly separates the
+shared execution concern from executor-specific behavior.
+
+### Architecture
+
+```
+StepExecutor (interface)
+├── AgentStepExecutor   — autonomy routing, review/escalation, confidence
+└── ScriptStepExecutor  — auto-apply, no autonomy concept
+
+PluginRunner (shared)    — dispatch StepExecutorPlugin, collect output
+├── used by AgentStepExecutor (wraps with AgentRunner for autonomy)
+└── used by ScriptStepExecutor (directly)
+
+StepOutputEnvelope (base) — result, duration_ms, annotations, git, files
+└── AgentOutputEnvelope   — + confidence, model, reasoning, tokenUsage
+```
+
+### Key decisions
+
+1. **StepExecutor** is the shared abstraction (strategy pattern, not
+   base-wraps-extension). Each executor implements `execute()` with a
+   clean contract.
+
+2. **StepOutputEnvelope** is the base result shape. AgentOutputEnvelope
+   extends it with LLM-specific fields. Script steps produce the base —
+   no fake confidence, no meaningless model field.
+
+3. **Autonomy levels are agent-only.** Script steps have no autonomy level
+   (not "L4 by convention"). The script executor flow has no review,
+   escalation, or pause paths.
+
+4. **PluginRunner** extracted from AgentRunner — shared by both executors.
+   Handles plugin dispatch + output collection. AgentRunner becomes
+   agent-only, wrapping PluginRunner with autonomy/audit behavior.
+
+5. **StepExecutorPlugin** replaces `AgentPlugin` as the interface name.
+   Same shape (`initialize()` + `run()`), accurate name.
+
+6. **Audit events keep `agent.*` / `script.*` prefixes.** Users filter by
+   executor type at the top level — payload-level filtering is less
+   discoverable. New executor types get their own prefix.
+
+### Delivery plan (incremental, 4 PRs)
+
+1. `StepOutputEnvelope` base + `AgentOutputEnvelope extends` (platform-core)
+2. Extract `PluginRunner` from `AgentRunner` (agent-runtime)
+3. `StepExecutor` strategy + `ScriptStepExecutor` / `AgentStepExecutor`
+   (platform-ui, replaces `executeAgentStep`)
+4. Rename `AgentPlugin` → `StepExecutorPlugin` + remove `isScript` guards
+
+Each PR is shippable independently with no behavior change until PR 3.
+
+## Alternatives considered
+
+- **Single function with `isScript` guards** (status quo): works but
+  accumulates guards with every new script plugin. Autonomy concepts leak
+  into script paths. Already 4+ sites checking `executorType === 'script'`.
+
+- **Base function + agent wrapper** (extract `executeStep()` called by
+  `executeAgentStep()`): fuzzy boundary — hard to define what's "base" vs
+  "agent" in a 500-line function. Boundary drifts with each PR.
+
+- **Unified `step.*` audit events**: cleaner namespace but loses the
+  instant visual distinction between agent and script in the audit log.
+  Users see executor type as a top-level concern.
+
+## Consequences
+
+- Script plugins no longer carry agent baggage (autonomy, confidence, model)
+- New executor types (future) implement `StepExecutor` without touching
+  agent code
+- UI renders what's in the envelope — no executor-type guards needed
+- AgentRunner scope shrinks to agent-only concerns
+- Migration: existing `AgentOutputEnvelope` records in DB remain valid
+  (superset of `StepOutputEnvelope`)


### PR DESCRIPTION
## Summary

- **ADR-0008**: Documents the StepExecutor strategy pattern decision — why separate agent/script execution, alternatives considered, delivery plan
- **CONTEXT.md**: New glossary entries for Step Executor, Step Executor Plugin, Plugin Runner, Step Output Envelope; updated Agent Output Envelope and Plugin definitions

Cherry-picked docs-only commit from #687. Code changes from that branch already landed in #692 and #696.

## Test plan

- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)