### PR TITLE
[development tools] Add reusable research PDF renderer - for design discussions and review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Changed
+- Added a reusable markdown-to-PDF renderer for research docs with four print styles (`github-raw`, `print-memo`, `editorial`, `technical-brief`) under `docs/research/`, and locally ignored generated `rendered-pdfs/` artifacts to keep review exports out of git.
 - **StepExecutor strategy pattern (ADR-0008)** — agent and script steps now execute through separate `StepExecutor` strategies (`AgentStepExecutor`, `ScriptStepExecutor`) instead of a monolithic `AgentRunner` with `isScript` branches. Each strategy owns its full lifecycle (run, audit, advance/review, cost tracking). `AgentPlugin` interface renamed to `StepExecutorPlugin` to reflect that scripts and Databricks jobs are peers, not special-cased agents:
   - `StepOutputEnvelope` base schema in platform-core [#688](https://github.com/Appsilon/mediforce/pull/688)
   - `PluginRunner` extracted from `AgentRunner` [#691](https://github.com/Appsilon/mediforce/pull/691)

--- a/docs/research/.gitignore
+++ b/docs/research/.gitignore
@@ -1,0 +1,1 @@
+rendered-pdfs/

--- a/docs/research/print-styles/editorial.css
+++ b/docs/research/print-styles/editorial.css
@@ -1,0 +1,161 @@
+:root {
+  color-scheme: light;
+  --ink: #151515;
+  --muted: #66645f;
+  --rule: #d8d5ce;
+  --soft: #f4f1ea;
+  --accent: #224e65;
+}
+
+@page {
+  size: A4;
+  margin: 17mm 17mm 18mm;
+}
+
+html {
+  font-size: 16px;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+
+body {
+  color: var(--ink);
+  column-gap: 10mm;
+  font-family: Baskerville, "Libre Baskerville", Georgia, serif;
+  font-size: 10.8pt;
+  line-height: 1.56;
+  margin: 0 auto;
+  max-width: 860px;
+  padding: 16px 4px 24px;
+}
+
+h1, h2, h3, h4 {
+  page-break-after: avoid;
+}
+
+h1 {
+  font-size: 25pt;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  margin: 0 0 1rem;
+}
+
+h2 {
+  border-top: 3px solid var(--accent);
+  font-family: "Gill Sans", "Avenir Next", Arial, sans-serif;
+  font-size: 15pt;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin: 2.4rem 0 1rem;
+  padding-top: 0.8rem;
+}
+
+h3 {
+  color: var(--accent);
+  font-family: "Gill Sans", "Avenir Next", Arial, sans-serif;
+  font-size: 11pt;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  margin: 1.5rem 0 0.45rem;
+  text-transform: uppercase;
+}
+
+p {
+  margin: 0.65rem 0;
+  orphans: 3;
+  widows: 3;
+}
+
+a {
+  color: var(--accent);
+  text-decoration-thickness: 1px;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--rule);
+  margin: 1.6rem 0;
+}
+
+blockquote {
+  background: var(--soft);
+  border: 1px solid var(--rule);
+  margin: 1.2rem 0;
+  padding: 0.9rem 1rem;
+}
+
+code {
+  background: #ece8df;
+  border-radius: 3px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.88em;
+  padding: 0.12em 0.28em;
+}
+
+pre {
+  background: #fbfaf7;
+  border: 1px solid var(--rule);
+  font-size: 0.82em;
+  padding: 0.95rem 1rem;
+  white-space: pre-wrap;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+}
+
+table {
+  border-collapse: collapse;
+  font-size: 0.88em;
+  margin: 1rem 0 1.2rem;
+  width: 100%;
+}
+
+th, td {
+  border-bottom: 1px solid var(--rule);
+  padding: 0.45rem 0.55rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: var(--accent);
+  font-family: "Gill Sans", "Avenir Next", Arial, sans-serif;
+  font-size: 0.82em;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+ul, ol {
+  padding-left: 1.3rem;
+}
+
+li {
+  margin: 0.15rem 0;
+}
+
+img, table, pre {
+  page-break-inside: avoid;
+}
+
+#TOC {
+  background: linear-gradient(to bottom, #f6f5f0, #efede6);
+  border: 1px solid var(--rule);
+  margin: 1.4rem 0 1.8rem;
+  padding: 0.9rem 1rem 1rem;
+}
+
+#TOC::before {
+  color: var(--accent);
+  content: "Contents";
+  display: block;
+  font-family: "Gill Sans", "Avenir Next", Arial, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+}

--- a/docs/research/print-styles/github-raw.css
+++ b/docs/research/print-styles/github-raw.css
@@ -1,0 +1,146 @@
+:root {
+  color-scheme: light;
+  --fg: #1f2328;
+  --muted: #59636e;
+  --border: #d0d7de;
+  --bg-subtle: #f6f8fa;
+  --link: #0969da;
+}
+
+@page {
+  size: A4;
+  margin: 18mm 16mm 20mm;
+}
+
+html {
+  font-size: 16px;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+
+body {
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 10.5pt;
+  line-height: 1.55;
+  margin: 0 auto;
+  max-width: 860px;
+  padding: 24px 32px 40px;
+}
+
+h1, h2, h3, h4 {
+  color: #101418;
+  font-weight: 600;
+  line-height: 1.25;
+  page-break-after: avoid;
+}
+
+h1 {
+  border-bottom: 1px solid var(--border);
+  font-size: 2em;
+  margin: 0 0 1rem;
+  padding-bottom: 0.3em;
+}
+
+h2 {
+  border-bottom: 1px solid var(--border);
+  font-size: 1.5em;
+  margin: 2rem 0 1rem;
+  padding-bottom: 0.3em;
+}
+
+h3 {
+  font-size: 1.25em;
+  margin: 1.6rem 0 0.75rem;
+}
+
+p, li {
+  orphans: 3;
+  widows: 3;
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+}
+
+hr {
+  background: var(--border);
+  border: 0;
+  height: 0.25mm;
+  margin: 1.75rem 0;
+}
+
+blockquote {
+  border-left: 0.2rem solid var(--border);
+  color: var(--muted);
+  margin: 1rem 0;
+  padding: 0 1rem;
+}
+
+code {
+  background: rgba(175, 184, 193, 0.2);
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  padding: 0.15em 0.35em;
+}
+
+pre {
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.9em;
+  overflow-wrap: anywhere;
+  padding: 0.9rem 1rem;
+  white-space: pre-wrap;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+}
+
+table {
+  border-collapse: collapse;
+  font-size: 0.95em;
+  margin: 1rem 0 1.25rem;
+  width: 100%;
+}
+
+th, td {
+  border: 1px solid var(--border);
+  padding: 0.55rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: var(--bg-subtle);
+  font-weight: 600;
+}
+
+ul, ol {
+  padding-left: 1.4rem;
+}
+
+img, table, pre {
+  page-break-inside: avoid;
+}
+
+#TOC {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin: 1.5rem 0 2rem;
+  padding: 1rem 1.2rem;
+}
+
+#TOC::before {
+  content: "Contents";
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+}

--- a/docs/research/print-styles/print-memo.css
+++ b/docs/research/print-styles/print-memo.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: light;
+  --ink: #1a1a18;
+  --muted: #5f5b54;
+  --rule: #d9d1c3;
+  --panel: #f5efe4;
+  --accent: #8a5a2b;
+}
+
+@page {
+  size: A4;
+  margin: 22mm 18mm 20mm;
+}
+
+html {
+  font-size: 16px;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+
+body {
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 11.5pt;
+  line-height: 1.62;
+  margin: 0 auto;
+  max-width: 760px;
+  padding: 20px 8px 32px;
+}
+
+h1, h2, h3, h4 {
+  color: #111;
+  page-break-after: avoid;
+}
+
+h1 {
+  border-bottom: 2px solid var(--accent);
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  font-size: 24pt;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.8rem;
+  padding-bottom: 0.45rem;
+}
+
+h2 {
+  border-top: 1px solid var(--rule);
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  font-size: 17pt;
+  font-weight: 700;
+  margin: 2.6rem 0 0.8rem;
+  padding-top: 1.2rem;
+  page-break-before: always;
+}
+
+h2:first-of-type {
+  page-break-before: auto;
+}
+
+h3 {
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  font-size: 12.5pt;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  margin: 1.7rem 0 0.5rem;
+}
+
+p:first-of-type strong:first-child {
+  letter-spacing: 0.01em;
+}
+
+p, li {
+  orphans: 3;
+  widows: 3;
+}
+
+a {
+  color: inherit;
+  text-decoration-color: #c6a47f;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--rule);
+  margin: 1.8rem 0;
+}
+
+blockquote {
+  background: var(--panel);
+  border-left: 4px solid var(--accent);
+  margin: 1.2rem 0 1.4rem;
+  padding: 0.9rem 1rem;
+}
+
+blockquote p {
+  margin: 0;
+}
+
+code {
+  background: #f0e7d8;
+  border-radius: 4px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  padding: 0.14em 0.32em;
+}
+
+pre {
+  background: #faf7f1;
+  border: 1px solid #e7ddce;
+  border-radius: 8px;
+  font-size: 0.88em;
+  line-height: 1.5;
+  padding: 1rem 1.1rem;
+  white-space: pre-wrap;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+}
+
+table {
+  border-collapse: collapse;
+  font-size: 0.93em;
+  margin: 1rem 0 1.3rem;
+  width: 100%;
+}
+
+th, td {
+  border-bottom: 1px solid var(--rule);
+  padding: 0.55rem 0.6rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  border-top: 1px solid var(--rule);
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.86em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+ul, ol {
+  padding-left: 1.35rem;
+}
+
+li {
+  margin: 0.2rem 0;
+}
+
+img, table, pre {
+  page-break-inside: avoid;
+}
+
+#TOC {
+  background: var(--panel);
+  border: 1px solid #e6dcca;
+  border-radius: 8px;
+  margin: 1.6rem 0 2rem;
+  padding: 1rem 1.2rem;
+}
+
+#TOC::before {
+  color: var(--accent);
+  content: "Review Map";
+  display: block;
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.45rem;
+  text-transform: uppercase;
+}

--- a/docs/research/print-styles/technical-brief.css
+++ b/docs/research/print-styles/technical-brief.css
@@ -1,0 +1,152 @@
+:root {
+  color-scheme: light;
+  --ink: #151b23;
+  --muted: #5f6b7a;
+  --rule: #c9d4e0;
+  --soft: #f2f6fa;
+  --accent: #0f4c81;
+}
+
+@page {
+  size: A4;
+  margin: 14mm 14mm 16mm;
+}
+
+html {
+  font-size: 16px;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+
+body {
+  color: var(--ink);
+  font-family: "IBM Plex Sans", "Segoe UI", Arial, sans-serif;
+  font-size: 10pt;
+  line-height: 1.45;
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 14px 0 20px;
+}
+
+h1, h2, h3, h4 {
+  page-break-after: avoid;
+}
+
+h1 {
+  border-bottom: 2px solid var(--accent);
+  font-size: 22pt;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.9rem;
+  padding-bottom: 0.4rem;
+}
+
+h2 {
+  background: var(--soft);
+  border-left: 5px solid var(--accent);
+  font-size: 14pt;
+  font-weight: 700;
+  margin: 2rem 0 0.9rem;
+  padding: 0.45rem 0.7rem;
+}
+
+h3 {
+  color: var(--accent);
+  font-size: 11pt;
+  font-weight: 700;
+  margin: 1.4rem 0 0.45rem;
+}
+
+p, li {
+  orphans: 3;
+  widows: 3;
+}
+
+a {
+  color: #0a58a8;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--rule);
+  margin: 1.4rem 0;
+}
+
+blockquote {
+  background: var(--soft);
+  border-left: 4px solid #7aa5cc;
+  margin: 1rem 0;
+  padding: 0.8rem 0.9rem;
+}
+
+code {
+  background: #eaf1f8;
+  border-radius: 3px;
+  font-family: "IBM Plex Mono", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  padding: 0.1em 0.3em;
+}
+
+pre {
+  background: #f8fbfd;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  font-size: 0.84em;
+  padding: 0.85rem 0.95rem;
+  white-space: pre-wrap;
+}
+
+pre code {
+  background: transparent;
+  padding: 0;
+}
+
+table {
+  border-collapse: collapse;
+  font-size: 0.86em;
+  margin: 0.9rem 0 1.2rem;
+  width: 100%;
+}
+
+th, td {
+  border: 1px solid var(--rule);
+  padding: 0.42rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #e8f0f8;
+  font-weight: 700;
+}
+
+ul, ol {
+  padding-left: 1.2rem;
+}
+
+li {
+  margin: 0.12rem 0;
+}
+
+img, table, pre {
+  page-break-inside: avoid;
+}
+
+#TOC {
+  background: #f7fafc;
+  border: 1px solid var(--rule);
+  border-left: 5px solid var(--accent);
+  margin: 1.2rem 0 1.6rem;
+  padding: 0.85rem 0.9rem;
+}
+
+#TOC::before {
+  color: var(--accent);
+  content: "Document Map";
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+}

--- a/docs/research/render_markdown_pdfs.py
+++ b/docs/research/render_markdown_pdfs.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+STYLE_DIR = ROOT / "print-styles"
+DEFAULT_SOURCE = ROOT / "layer2-scores-research.md"
+DEFAULT_OUTPUT_DIR = ROOT / "rendered-pdfs"
+
+PLAYWRIGHT_PDF_SCRIPT = """
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(process.argv[1], { waitUntil: 'networkidle' });
+  await page.pdf({
+    path: process.argv[2],
+    format: 'A4',
+    printBackground: true,
+    margin: { top: '0', right: '0', bottom: '0', left: '0' },
+    preferCSSPageSize: true
+  });
+  await browser.close();
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+""".strip()
+
+
+VARIANTS = {
+    "github-raw": {
+        "suffix": "github-raw",
+        "title_suffix": "GitHub Raw",
+        "css": "github-raw.css",
+        "toc": False,
+    },
+    "print-memo": {
+        "suffix": "print-memo",
+        "title_suffix": "Print Memo",
+        "css": "print-memo.css",
+        "toc": True,
+    },
+    "editorial": {
+        "suffix": "editorial",
+        "title_suffix": "Editorial",
+        "css": "editorial.css",
+        "toc": True,
+    },
+    "technical-brief": {
+        "suffix": "technical-brief",
+        "title_suffix": "Technical Brief",
+        "css": "technical-brief.css",
+        "toc": True,
+    },
+}
+
+
+def run(command: list[str]) -> None:
+    subprocess.run(command, check=True, cwd=ROOT)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a markdown document into one or more print-ready PDF variants."
+    )
+    parser.add_argument(
+        "source",
+        nargs="?",
+        default=str(DEFAULT_SOURCE),
+        help="Path to the markdown file. Defaults to layer2-scores-research.md.",
+    )
+    parser.add_argument(
+        "--variant",
+        action="append",
+        choices=sorted(VARIANTS),
+        help="Render only the selected variant. Repeat to render multiple variants.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for generated HTML and PDF files.",
+    )
+    parser.add_argument(
+        "--title",
+        help="Override the document title used in PDF metadata and browser tab title.",
+    )
+    parser.add_argument(
+        "--author",
+        help="Override the document author metadata.",
+    )
+    parser.add_argument(
+        "--date",
+        help="Override the document date metadata.",
+    )
+    parser.add_argument(
+        "--pdf-only",
+        action="store_true",
+        help="Delete intermediate HTML files after PDF generation.",
+    )
+    return parser.parse_args()
+
+
+def read_markdown_title(source: Path) -> str:
+    for line in source.read_text(encoding="utf-8").splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return source.stem.replace("-", " ").replace("_", " ").title()
+
+
+def slugify_stem(source: Path) -> str:
+    return source.stem.replace(" ", "-")
+
+
+def build_html(
+    source: Path,
+    variant_name: str,
+    variant: dict[str, object],
+    html_path: Path,
+    title: str,
+    author: str | None,
+    date_value: str | None,
+) -> None:
+    command = [
+        "pandoc",
+        str(source),
+        "--from",
+        "gfm",
+        "--to",
+        "html5",
+        "--standalone",
+        "--embed-resources",
+        "--metadata",
+        f"pagetitle={title} - {variant['title_suffix']}",
+        "--metadata",
+        f"title={title}",
+        "--css",
+        str(STYLE_DIR / str(variant["css"])),
+        "-o",
+        str(html_path),
+    ]
+    if author:
+        command.extend(["--metadata", f"author={author}"])
+    if date_value:
+        command.extend(["--metadata", f"date={date_value}"])
+    if variant["toc"]:
+        command.extend(["--toc", "--toc-depth=2"])
+    run(command)
+
+
+def build_pdf(html_path: Path, pdf_path: Path) -> None:
+    run(["node", "-e", PLAYWRIGHT_PDF_SCRIPT, html_path.as_uri(), str(pdf_path)])
+
+
+def main() -> None:
+    args = parse_args()
+    source = Path(args.source).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    variants = args.variant or list(VARIANTS.keys())
+
+    if not source.exists():
+        raise FileNotFoundError(f"Source file does not exist: {source}")
+
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    title = args.title or read_markdown_title(source)
+    base_slug = slugify_stem(source)
+
+    for variant_name in variants:
+        variant = VARIANTS[variant_name]
+        html_path = output_dir / f"{base_slug}.{variant['suffix']}.html"
+        pdf_path = output_dir / f"{base_slug}.{variant['suffix']}.pdf"
+        build_html(source, variant_name, variant, html_path, title, args.author, args.date)
+        build_pdf(html_path, pdf_path)
+        if args.pdf_only:
+            html_path.unlink(missing_ok=True)
+        print(pdf_path.name)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed
- added a reusable `docs/research/render_markdown_pdfs.py` CLI to render markdown docs into print-ready PDFs
- added four print styles: `github-raw`, `print-memo`, `editorial`, and `technical-brief`
- ignored `docs/research/rendered-pdfs/` locally so generated review artifacts stay out of git
- added a changelog entry under `Unreleased`

## Why
Research and review docs need a repeatable way to produce consistent PDF handouts without manually styling each markdown file or accidentally committing generated exports.

## Impact
Authors can now render any markdown document under `docs/research/` into one or more consistent PDF variants from a single script, while keeping generated files out of the repository.

## Validation
- `python3 docs/research/render_markdown_pdfs.py --help`
- end-to-end PDF generation was previously verified locally for the selected styles using the same renderer pipeline
