### PR TITLE
fix(infra): move postgres command from volumes to services in staging compose

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -54,11 +54,6 @@ services:
   #   sudo mkdir -p /var/lib/mediforce/postgres-data
   #   sudo chown -R 999:999 /var/lib/mediforce/postgres-data   # postgres-alpine UID
   postgres:
-    volumes:
-      - /var/lib/mediforce/postgres-data:/var/lib/postgresql/data
-
-volumes:
-  phoenix-data:
     # ADR-0001 — staging-only planner tuning. The staging host has only
     # ~3.7GB total RAM shared across postgres + platform-ui +
     # container-worker + agent-worker + caddy + redis + stunnel. Postgres
@@ -75,3 +70,8 @@ volumes:
       - postgres
       - -c
       - effective_cache_size=1536MB
+    volumes:
+      - /var/lib/mediforce/postgres-data:/var/lib/postgresql/data
+
+volumes:
+  phoenix-data:


### PR DESCRIPTION
## Summary
- `command` block with `effective_cache_size=1536MB` tuning was incorrectly placed under `volumes.phoenix-data` instead of `services.postgres`
- Docker Compose schema validation rejected it — broke staging deploy CI
- Moved `command` + ADR-0001 comment to `services.postgres` where it belongs

## Test plan
- [x] `docker compose -f docker-compose.prod.yml -f docker-compose.staging.yml config --quiet` passes (no schema errors)
- [ ] CI staging deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)