### PR TITLE
Add user profile links to member and task displays

### DIFF
--- a/packages/platform-api/src/contract/namespaces.ts
+++ b/packages/platform-api/src/contract/namespaces.ts
@@ -9,6 +9,7 @@ export const GetNamespaceInputSchema = z.object({ handle: HandleSchema });
 export const GetNamespaceOutputSchema = z.object({
   namespace: NamespaceSchema,
   members: z.array(NamespaceMemberSchema),
+  personalHandles: z.record(z.string(), z.string()).optional(),
 });
 
 export type GetNamespaceInput = z.infer<typeof GetNamespaceInputSchema>;

--- a/packages/platform-api/src/handlers/namespaces/get-namespace.ts
+++ b/packages/platform-api/src/handlers/namespaces/get-namespace.ts
@@ -23,5 +23,22 @@ export async function getNamespace(
   }
 
   const members = await scope.workspaces.getMembers(input.handle);
-  return { namespace, members };
+
+  const settled = await Promise.allSettled(
+    members.map(async (m) => {
+      const namespaces = await scope.workspaces.getNamespacesByUser(m.uid);
+      const personal = namespaces.find((ns) => ns.type === 'personal');
+      return personal ? ([m.uid, personal.handle] as const) : null;
+    }),
+  );
+
+  const personalHandles: Record<string, string> = {};
+  for (const result of settled) {
+    if (result.status === 'fulfilled' && result.value) {
+      const [uid, handle] = result.value;
+      personalHandles[uid] = handle;
+    }
+  }
+
+  return { namespace, members, personalHandles };
 }

--- a/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
@@ -18,6 +18,7 @@ import {
 import { ApiError, mediforce } from '@/lib/mediforce';
 import { useAuth } from '@/contexts/auth-context';
 import { useNamespace } from '@/hooks/use-namespace';
+import { UserProfileLink } from '@/components/user-profile-link';
 import {
   useDeleteNamespace,
   useLeaveNamespace,
@@ -161,7 +162,7 @@ export default function WorkspaceConfigPage() {
   const qc = useQueryClient();
 
   const { firebaseUser } = useAuth();
-  const { namespace, loading: namespaceLoading } = useNamespace(handle);
+  const { namespace, personalHandles, loading: namespaceLoading } = useNamespace(handle);
 
   // Polled members list via the headless contract — replaces the previous
   // `onSnapshot(namespaces/{handle}/members)` subscription. Realtime updates
@@ -716,17 +717,23 @@ export default function WorkspaceConfigPage() {
                       <tr key={member.id} className="hover:bg-muted/30 transition-colors">
                         {/* User */}
                         <td className="px-4 py-3 whitespace-nowrap">
-                          <div className="flex items-center gap-2.5">
-                            {avatar !== undefined ? (
-                              // eslint-disable-next-line @next/next/no-img-element
-                              <img src={avatar} alt={name} className="h-7 w-7 shrink-0 rounded-full object-cover" />
-                            ) : (
-                              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-[11px] font-semibold">
-                                {initials}
-                              </div>
-                            )}
-                            <span className="font-medium">{name}</span>
-                          </div>
+                          <UserProfileLink
+                            displayName={name}
+                            personalHandle={personalHandles.get(member.uid)}
+                            className="flex items-center gap-2.5 hover:opacity-80 transition-opacity"
+                          >
+                            <div className="flex items-center gap-2.5">
+                              {avatar !== undefined ? (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img src={avatar} alt={name} className="h-7 w-7 shrink-0 rounded-full object-cover" />
+                              ) : (
+                                <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary text-[11px] font-semibold">
+                                  {initials}
+                                </div>
+                              )}
+                              <span className="font-medium">{name}</span>
+                            </div>
+                          </UserProfileLink>
                         </td>
 
                         {/* Email */}

--- a/packages/platform-ui/src/components/processes/runs-table.tsx
+++ b/packages/platform-ui/src/components/processes/runs-table.tsx
@@ -6,8 +6,9 @@ import { ChevronRight, ExternalLink, Archive, ArchiveRestore, XCircle } from 'lu
 import { formatDistanceToNow } from 'date-fns';
 import type { ProcessInstance } from '@mediforce/platform-core';
 import { ProcessStatusBadge } from './process-status-badge';
-import { useUserDisplayNames } from '@/hooks/use-users';
+import { useUserProfiles } from '@/hooks/use-users';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
+import { UserProfileLink } from '@/components/user-profile-link';
 import { routes } from '@/lib/routes';
 import { ApiError } from '@/lib/mediforce';
 import type { BulkRunOutput } from '@mediforce/platform-api/contract';
@@ -52,7 +53,7 @@ export function RunsTable({
 }: RunsTableProps) {
   const handle = useHandleFromPath();
   const { toast } = useToast();
-  const userNames = useUserDisplayNames(handle);
+  const userProfiles = useUserProfiles(handle);
   const archiveMutation = useArchiveRun();
   const bulkCancelMutation = useBulkCancelRuns();
   const bulkArchiveMutation = useBulkArchiveRuns();
@@ -311,7 +312,12 @@ export function RunsTable({
                     >
                       {run.parentDefinitionName}
                     </Link>
-                  ) : run.createdBy ? (userNames.get(run.createdBy) ?? run.createdBy) : '—'}
+                  ) : run.createdBy ? (
+                    <UserProfileLink
+                      displayName={userProfiles.get(run.createdBy)?.displayName ?? run.createdBy}
+                      personalHandle={userProfiles.get(run.createdBy)?.personalHandle}
+                    />
+                  ) : '—'}
                 </td>
                 <td className="px-4 py-3 text-xs">
                   {run.currentStepId ? (

--- a/packages/platform-ui/src/components/tasks/human-step-view.tsx
+++ b/packages/platform-ui/src/components/tasks/human-step-view.tsx
@@ -12,7 +12,8 @@ import { resolveTaskBody } from './task-body-registry';
 import { getTaskDisplayTitle, isAgentReviewTask, type AgentOutputData } from './task-utils';
 import type { HumanStepAccess } from './resolve-step-view';
 import { useMyActionableTasksByRole } from '@/hooks/use-tasks';
-import { useUserDisplayNames } from '@/hooks/use-users';
+import { useUserDisplayNames, usePersonalHandles } from '@/hooks/use-users';
+import { UserProfileLink } from '@/components/user-profile-link';
 import { cn } from '@/lib/utils';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
 import { routes } from '@/lib/routes';
@@ -53,6 +54,7 @@ export function HumanStepView({
 }: HumanStepViewProps) {
   const handle = useHandleFromPath();
   const userNames = useUserDisplayNames(handle);
+  const personalHandles = usePersonalHandles(handle);
 
   const { data: remainingTasks } = useMyActionableTasksByRole(task.assignedRole);
   const remainingTaskCount = remainingTasks.filter((t) => t.id !== task.id).length;
@@ -89,9 +91,9 @@ export function HumanStepView({
           </span>
         </div>
 
-        {readOnly && <AccessBanner access={access} userNames={userNames} />}
+        {readOnly && <AccessBanner access={access} userNames={userNames} personalHandles={personalHandles} />}
 
-        <TaskMetadataCard task={task} processInstance={processInstance} handle={handle} userNames={userNames} />
+        <TaskMetadataCard task={task} processInstance={processInstance} handle={handle} userNames={userNames} personalHandles={personalHandles} />
 
         {!bodyIsWide && body}
 
@@ -126,9 +128,11 @@ export function HumanStepView({
 function AccessBanner({
   access,
   userNames,
+  personalHandles,
 }: {
   access: HumanStepAccess;
   userNames: Map<string, string>;
+  personalHandles: Map<string, string>;
 }) {
   if (access.kind === 'claimed-by-other') {
     return (
@@ -136,7 +140,11 @@ function AccessBanner({
         <Lock className="h-4 w-4 mt-0.5 shrink-0" />
         <div>
           <p className="font-medium">
-            Claimed by {userNames.get(access.claimedBy) ?? access.claimedBy}
+            Claimed by{' '}
+            <UserProfileLink
+              displayName={userNames.get(access.claimedBy) ?? access.claimedBy}
+              personalHandle={personalHandles.get(access.claimedBy)}
+            />
           </p>
           <p className="text-xs mt-0.5 opacity-80">Only the claimant can act on this task.</p>
         </div>
@@ -162,11 +170,13 @@ function TaskMetadataCard({
   processInstance,
   handle,
   userNames,
+  personalHandles,
 }: {
   task: HumanTask;
   processInstance: ProcessInstance | null;
   handle: string;
   userNames: Map<string, string>;
+  personalHandles: Map<string, string>;
 }) {
   return (
     <div className="rounded-lg border p-4 grid grid-cols-2 gap-4 text-sm">
@@ -206,7 +216,12 @@ function TaskMetadataCard({
           <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">
             Assigned To
           </div>
-          <div>{userNames.get(task.assignedUserId) ?? task.assignedUserId}</div>
+          <div>
+            <UserProfileLink
+              displayName={userNames.get(task.assignedUserId) ?? task.assignedUserId}
+              personalHandle={personalHandles.get(task.assignedUserId)}
+            />
+          </div>
         </div>
       )}
       {task.completedAt && (

--- a/packages/platform-ui/src/components/user-profile-link.tsx
+++ b/packages/platform-ui/src/components/user-profile-link.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Link from 'next/link';
+
+interface UserProfileLinkProps {
+  displayName: string;
+  personalHandle?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function UserProfileLink({
+  displayName,
+  personalHandle,
+  className,
+  children,
+}: UserProfileLinkProps) {
+  const content = children ?? displayName;
+
+  if (personalHandle === undefined) {
+    return <span className={className}>{content}</span>;
+  }
+
+  return (
+    <Link
+      href={`/${personalHandle}`}
+      className={className ?? 'hover:underline hover:text-foreground transition-colors'}
+    >
+      {content}
+    </Link>
+  );
+}

--- a/packages/platform-ui/src/hooks/__tests__/use-users.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-users.test.ts
@@ -11,11 +11,12 @@ const { useUserProfiles, useUserDisplayNames } = await import('../use-users');
 
 function namespaceResult(members: Partial<NamespaceMember>[] | null) {
   if (members === null) {
-    return { namespace: null, members: [], loading: false, error: null };
+    return { namespace: null, members: [], personalHandles: new Map<string, string>(), loading: false, error: null };
   }
   return {
     namespace: { handle: 'ns1' },
     members,
+    personalHandles: new Map<string, string>(),
     loading: false,
     error: null,
   };
@@ -45,8 +46,8 @@ describe('useUserProfiles', () => {
       ]),
     );
     const { result } = renderHook(() => useUserProfiles('ns1'));
-    expect(result.current.get('u1')).toEqual({ displayName: 'Alice', photoURL: 'https://x/a.png' });
-    expect(result.current.get('u2')).toEqual({ displayName: 'Bob', photoURL: undefined });
+    expect(result.current.get('u1')).toEqual({ displayName: 'Alice', photoURL: 'https://x/a.png', personalHandle: undefined });
+    expect(result.current.get('u2')).toEqual({ displayName: 'Bob', photoURL: undefined, personalHandle: undefined });
   });
 
   it('falls back to uid when displayName is missing', () => {

--- a/packages/platform-ui/src/hooks/use-namespace.ts
+++ b/packages/platform-ui/src/hooks/use-namespace.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { Namespace, NamespaceMember } from '@mediforce/platform-core';
 import { ApiError, mediforce } from '@/lib/mediforce';
@@ -9,6 +10,7 @@ import { stopRetryOn4xx } from '@/lib/retry';
 export interface UseNamespaceResult {
   namespace: Namespace | null;
   members: NamespaceMember[];
+  personalHandles: Map<string, string>;
   loading: boolean;
   error: Error | null;
 }
@@ -31,9 +33,16 @@ export function useNamespace(handle: string | undefined | null): UseNamespaceRes
   const err = enabled ? (query.error as Error | null) ?? null : null;
   const notFound = err instanceof ApiError && err.status === 404;
 
+  const rawHandles = query.data?.personalHandles;
+  const personalHandles = useMemo(() => {
+    if (rawHandles === undefined || rawHandles === null) return new Map<string, string>();
+    return new Map(Object.entries(rawHandles));
+  }, [rawHandles]);
+
   return {
     namespace: enabled ? query.data?.namespace ?? null : null,
     members: enabled ? query.data?.members ?? [] : [],
+    personalHandles,
     loading: query.isLoading && enabled,
     error: notFound ? null : err,
   };

--- a/packages/platform-ui/src/hooks/use-users.ts
+++ b/packages/platform-ui/src/hooks/use-users.ts
@@ -6,21 +6,23 @@ import { useNamespace } from './use-namespace';
 export type UserInfo = {
   displayName: string;
   photoURL: string | undefined;
+  personalHandle: string | undefined;
 };
 
 export function useUserProfiles(handle: string | null | undefined): Map<string, UserInfo> {
-  const { members } = useNamespace(handle ?? '');
+  const { members, personalHandles } = useNamespace(handle ?? '');
   return useMemo(() => {
     const map = new Map<string, UserInfo>();
     for (const member of members) {
       const info: UserInfo = {
         displayName: member.displayName ?? member.uid,
         photoURL: typeof member.avatarUrl === 'string' && member.avatarUrl !== '' ? member.avatarUrl : undefined,
+        personalHandle: personalHandles.get(member.uid),
       };
       map.set(member.uid, info);
     }
     return map;
-  }, [members]);
+  }, [members, personalHandles]);
 }
 
 export function useUserDisplayNames(handle: string | null | undefined): Map<string, string> {
@@ -32,4 +34,9 @@ export function useUserDisplayNames(handle: string | null | undefined): Map<stri
     }
     return map;
   }, [profiles]);
+}
+
+export function usePersonalHandles(handle: string | null | undefined): Map<string, string> {
+  const { personalHandles } = useNamespace(handle ?? '');
+  return personalHandles;
 }


### PR DESCRIPTION
## Summary
This PR adds clickable user profile links throughout the application, allowing users to navigate to other users' personal profiles. A new `UserProfileLink` component handles the conditional rendering of links based on whether a personal handle is available.

## Key Changes
- **New Component**: Created `UserProfileLink` component that renders either a link to a user's profile or a plain span, depending on whether a personal handle is available
- **Backend Enhancement**: Modified `getNamespace` handler to fetch and return personal handles for all namespace members
- **Hook Updates**: 
  - Extended `useNamespace` hook to return `personalHandles` map
  - Added new `usePersonalHandles` hook for direct access to personal handles
  - Updated `useUserProfiles` hook to include `personalHandle` in `UserInfo` type
- **UI Integration**: Applied `UserProfileLink` component to:
  - Member list in workspace settings page
  - Task assignment display in human step view
  - Access banner showing who claimed a task
  - Process runs table showing who created a run
- **Contract Update**: Extended `GetNamespaceOutput` schema to include optional `personalHandles` field

## Implementation Details
- Personal handles are fetched via `getNamespacesByUser` for each member and filtered to find their personal namespace
- Uses `Promise.allSettled` to safely handle potential failures when fetching personal handles
- The `UserProfileLink` component gracefully degrades to a span when no personal handle is available
- Maintains consistent styling with hover effects and transitions across all usages

https://claude.ai/code/session_012zhzet689o2ertfZZG8SwE