### PR TITLE
Add Docker image and repository configuration fields to agent steps

### DIFF
--- a/packages/platform-ui/src/components/workflows/workflow-editor-canvas.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-editor-canvas.tsx
@@ -605,6 +605,7 @@ export function WorkflowEditorCanvas({
                   onChange={(patch) => updateStep(selectedStep.id, patch)}
                   errors={stepErrors?.[selectedStep.id]}
                   imageWarning={warningStepIds?.get(selectedStep.id)}
+                  dockerImages={dockerImages}
                 />
               </div>
             </>

--- a/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
@@ -496,16 +496,14 @@ export function StepEditor({
                 <input
                   value={step.agent?.image ?? ''}
                   onChange={(e) => updateAgent({ image: e.target.value || undefined })}
-                  placeholder="or type custom…"
-                  className={cn(riMono, 'w-36 shrink-0 placeholder:italic placeholder:text-muted-foreground/40')}
+                  className={cn(riMono, 'w-36 shrink-0')}
                 />
               </div>
             ) : (
               <input
                 value={step.agent?.image ?? ''}
                 onChange={(e) => updateAgent({ image: e.target.value || undefined })}
-                placeholder="e.g. python:3.11-slim"
-                className={cn(riMono, 'placeholder:italic placeholder:text-muted-foreground/40')}
+                className={riMono}
               />
             )}
           </FieldRow>

--- a/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
@@ -73,6 +73,10 @@ const riMono = inputBaseMono;
 const rs = selectBase;
 const rt = textareaBase;
 
+function imageRef(img: DockerImageInfo): string {
+  return img.tag && img.tag !== '<none>' ? `${img.repository}:${img.tag}` : img.repository;
+}
+
 // ---------------------------------------------------------------------------
 // Executor / step-type icon maps (mirrors workflow-diagram.tsx)
 // ---------------------------------------------------------------------------
@@ -350,7 +354,7 @@ export function StepEditor({
       </FieldGroup>
 
       {/* ── Agent config ─────────────────────────────────────────── */}
-      {isAgent && (
+      {isAgent && (<>
         <FieldGroup>
           <FieldRow label="autonomyLevel" tooltip={TIP.autonomyLevel}>
             <select
@@ -482,13 +486,10 @@ export function StepEditor({
                 >
                   <option value="">Select image…</option>
                   {dockerImages.map((img) => {
-                    const ref = img.tag && img.tag !== '<none>' ? `${img.repository}:${img.tag}` : img.repository;
+                    const ref = imageRef(img);
                     return <option key={img.id} value={ref}>{ref}</option>;
                   })}
-                  {step.agent?.image && !dockerImages.some((img) => {
-                    const ref = img.tag && img.tag !== '<none>' ? `${img.repository}:${img.tag}` : img.repository;
-                    return ref === step.agent?.image;
-                  }) && (
+                  {step.agent?.image && !dockerImages.some((img) => imageRef(img) === step.agent?.image) && (
                     <option value={step.agent.image}>{step.agent.image}</option>
                   )}
                 </select>
@@ -547,7 +548,7 @@ export function StepEditor({
             />
           </FieldRow>
         </FieldGroup>
-      )}
+      </>)}
 
       {/* ── Script config ────────────────────────────────────────── */}
       {isScript && (

--- a/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/auth-context';
 import { mediforce } from '@/lib/mediforce';
 import { cn } from '@/lib/utils';
 import type { WorkflowStep, HttpMethod, ActionConfig } from '@mediforce/platform-core';
+import type { DockerImageInfo } from '@mediforce/platform-api/contract';
 import { ModelPicker } from './model-picker';
 import {
   AUTONOMY_LEVELS,
@@ -114,6 +115,11 @@ const TIP = {
   agentFallback:           'What to do if the agent fails or is below the confidence threshold: escalate to human, retry, or skip.',
   agentAllowedTools:       'Tools the agent may call, comma-separated. Leave empty to allow all available tools.',
   agentPrompt:             'Additional instructions appended to the agent\'s system prompt for this step only.',
+  agentImage:              'Docker image for the agent container (e.g. python:3.11-slim). Required for deployed execution.',
+  agentDockerfile:         'Path to a Dockerfile in agent.repo. When set, the container is built from this file instead of agent.image.',
+  agentRepo:               'Git repository URL to clone into the container before running the agent.',
+  agentCommit:             'Commit SHA or branch to check out from agent.repo. Defaults to the repo\'s default branch.',
+  agentRepoAuth:           'Name of a workflow secret holding the auth token for cloning a private repository.',
 
   scriptRuntime:           'Language runtime for the inline script: javascript, python, r, or bash.',
   scriptCommand:           'Shell command to run in the container, typically to invoke a file from script.repo.',
@@ -203,6 +209,7 @@ export function StepEditor({
   onChange,
   errors,
   imageWarning,
+  dockerImages,
 }: {
   step: WorkflowStep;
   allSteps: WorkflowStep[];
@@ -210,6 +217,7 @@ export function StepEditor({
   onChange: (patch: Partial<WorkflowStep>) => void;
   errors?: Record<string, string>;
   imageWarning?: string;
+  dockerImages?: DockerImageInfo[];
 }) {
   const isNewStep = step.id.startsWith('new-step-');
   const { plugins } = usePlugins();
@@ -459,6 +467,83 @@ export function StepEditor({
               rows={3}
               placeholder="Instructions for the agent…"
               className={cn(rt, 'placeholder:italic placeholder:text-muted-foreground/40')}
+            />
+          </FieldRow>
+        </FieldGroup>
+
+        <FieldGroup>
+          <FieldRow label="agent.image" tooltip={TIP.agentImage}>
+            {dockerImages && dockerImages.length > 0 ? (
+              <div className="flex items-center gap-1.5">
+                <select
+                  value={step.agent?.image ?? ''}
+                  onChange={(e) => updateAgent({ image: e.target.value || undefined })}
+                  className={cn(rs, 'flex-1')}
+                >
+                  <option value="">Select image…</option>
+                  {dockerImages.map((img) => {
+                    const ref = img.tag && img.tag !== '<none>' ? `${img.repository}:${img.tag}` : img.repository;
+                    return <option key={img.id} value={ref}>{ref}</option>;
+                  })}
+                  {step.agent?.image && !dockerImages.some((img) => {
+                    const ref = img.tag && img.tag !== '<none>' ? `${img.repository}:${img.tag}` : img.repository;
+                    return ref === step.agent?.image;
+                  }) && (
+                    <option value={step.agent.image}>{step.agent.image}</option>
+                  )}
+                </select>
+                <input
+                  value={step.agent?.image ?? ''}
+                  onChange={(e) => updateAgent({ image: e.target.value || undefined })}
+                  placeholder="or type custom…"
+                  className={cn(riMono, 'w-36 shrink-0 placeholder:italic placeholder:text-muted-foreground/40')}
+                />
+              </div>
+            ) : (
+              <input
+                value={step.agent?.image ?? ''}
+                onChange={(e) => updateAgent({ image: e.target.value || undefined })}
+                placeholder="e.g. python:3.11-slim"
+                className={cn(riMono, 'placeholder:italic placeholder:text-muted-foreground/40')}
+              />
+            )}
+          </FieldRow>
+          {imageWarning && (
+            <div className="flex items-center gap-1.5 px-3 -mt-1">
+              <AlertTriangle className="h-3 w-3 text-amber-500 shrink-0" strokeWidth={2} />
+              <span className="text-[11px] text-amber-600 dark:text-amber-400">{imageWarning}</span>
+            </div>
+          )}
+
+          <FieldRow label="agent.dockerfile" tooltip={TIP.agentDockerfile}>
+            <input
+              value={step.agent?.dockerfile ?? ''}
+              onChange={(e) => updateAgent({ dockerfile: e.target.value || undefined })}
+              className={riMono}
+            />
+          </FieldRow>
+
+          <FieldRow label="agent.repo" tooltip={TIP.agentRepo}>
+            <input
+              value={step.agent?.repo ?? ''}
+              onChange={(e) => updateAgent({ repo: e.target.value || undefined })}
+              className={riMono}
+            />
+          </FieldRow>
+
+          <FieldRow label="agent.commit" tooltip={TIP.agentCommit}>
+            <input
+              value={step.agent?.commit ?? ''}
+              onChange={(e) => updateAgent({ commit: e.target.value || undefined })}
+              className={riMono}
+            />
+          </FieldRow>
+
+          <FieldRow label="agent.repoAuth" tooltip={TIP.agentRepoAuth}>
+            <input
+              value={step.agent?.repoAuth ?? ''}
+              onChange={(e) => updateAgent({ repoAuth: e.target.value || undefined })}
+              className={riMono}
             />
           </FieldRow>
         </FieldGroup>


### PR DESCRIPTION
## Summary
Adds UI support for configuring Docker container execution parameters in agent workflow steps, including image selection, custom Dockerfile paths, and Git repository cloning options.

## Key Changes
- Added new form fields to the step editor for agent container configuration:
  - `agent.image`: Docker image selection with dropdown (when images available) or manual text input
  - `agent.dockerfile`: Path to custom Dockerfile in the agent repository
  - `agent.repo`: Git repository URL to clone into the container
  - `agent.commit`: Commit SHA or branch to check out from the repository
  - `agent.repoAuth`: Workflow secret name for private repository authentication
- Imported `DockerImageInfo` type from platform-api contract
- Added tooltip descriptions for all new fields in the TIP configuration
- Implemented smart image picker UI that shows available Docker images in a dropdown when available, with fallback to text input
- Displays existing custom image values even if not in the available images list
- Passes `dockerImages` prop from canvas to step editor component
- Added image warning display below the image field

## Implementation Details
- The `agent.image` field uses a dual-input pattern: a select dropdown for predefined images and a text input for custom values, allowing both convenience and flexibility
- The dropdown gracefully handles the `<none>` tag case by using only the repository name
- All new fields use monospace font styling (`riMono` class) for consistency with other technical configuration fields
- The component maintains backward compatibility by using optional chaining and undefined checks

https://claude.ai/code/session_01SgpevN1Pwx1a7MUKNPfsvL