### PR TITLE
Fix preview deploys: Vercel CLI instead of empty-commit hack

### DIFF
--- a/.github/workflows/preview-on-comment.yml
+++ b/.github/workflows/preview-on-comment.yml
@@ -5,30 +5,24 @@ on:
     types: [created]
 
 permissions:
-  contents: write
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 jobs:
-  trigger:
+  deploy-preview:
     if: |
       github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/deploy-preview') &&
+      startsWith(github.event.comment.body, '/deploy') &&
       (
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'
       )
     runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
-      - name: Acknowledge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api -X POST \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-            -f content=rocket
-
       - name: Resolve PR branch
         id: pr
         env:
@@ -43,20 +37,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.pr.outputs.ref }}
-          fetch-depth: 2
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push empty commit with [preview] marker
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build
+        run: vercel build --token="$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy prebuilt artifact
+        id: deploy
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit --allow-empty -m "ci: trigger preview deploy [preview]"
-          git push origin HEAD:${{ steps.pr.outputs.ref }}
+          url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
-      - name: Post status comment
+      - name: Post preview URL
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr comment ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} \
-            --body "Preview deploy triggered via empty commit on \`${{ steps.pr.outputs.ref }}\`. Vercel build will start shortly."
+            --body "Preview deployed: ${{ steps.deploy.outputs.url }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ### Fixed
 - `scripts/sync-model-rankings.py` now uses OpenRouter's frontend rankings JSON endpoint instead of a brittle private server-action scrape, restoring local model ranking sync.
+- On-demand preview deploys now work: `/deploy` (or `/deploy-preview`) on a PR runs a real `vercel build` + `vercel deploy --prebuilt` via the Vercel CLI, replacing the empty-commit `[preview]`-marker hack that silently no-op'd.
 
 ## [2026-06-14]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ### Fixed
 - `scripts/sync-model-rankings.py` now uses OpenRouter's frontend rankings JSON endpoint instead of a brittle private server-action scrape, restoring local model ranking sync.
-- On-demand preview deploys now work: `/deploy` (or `/deploy-preview`) on a PR runs a real `vercel build` + `vercel deploy --prebuilt` via the Vercel CLI, replacing the empty-commit `[preview]`-marker hack that silently no-op'd.
+- On-demand preview deploys now work: `/deploy` on a PR runs a real `vercel build` + `vercel deploy --prebuilt` via the Vercel CLI, replacing the empty-commit `[preview]`-marker hack that silently no-op'd.
 
 ## [2026-06-14]
 

--- a/packages/platform-ui/scripts/vercel-ignore.sh
+++ b/packages/platform-ui/scripts/vercel-ignore.sh
@@ -2,14 +2,16 @@
 # Vercel ignoreCommand helper.
 # Exit 0 = skip build, exit 1 = build.
 #
-# Build only on main, or when latest commit message contains [preview].
+# Only main is auto-deployed via Git integration; skip every other branch
+# (on-demand previews go through the `/deploy` PR-comment workflow, which uses
+# the Vercel CLI and bypasses this ignoreCommand).
 # On main, additionally skip doc-only changes.
 set -euo pipefail
 
 ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
 
-if [ "${VERCEL_GIT_COMMIT_REF:-}" != "main" ] && ! git log -1 --pretty=%B | grep -q '\[preview\]'; then
+if [ "${VERCEL_GIT_COMMIT_REF:-}" != "main" ]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Why

`/deploy-preview` on PRs stopped working (see #699). Three stacked breakages:

1. **Wrong command skipped.** Workflow only matched `/deploy-preview`; `/deploy` and typos silently `skipped`.
2. **Org-capped `GITHUB_TOKEN` 403.** The 🚀-reaction "Acknowledge" step died with `Resource not accessible by integration (HTTP 403)` before pushing the marker commit.
3. **Empty commit self-skipped.** Even if pushed, `vercel-ignore.sh`'s diff gate exits 0 on an empty commit → Vercel `Ignored` (exactly the skipped deployment Vercel posted on #699).

## What

- New `preview-on-comment.yml`: on `/deploy` (also matches `/deploy-preview`) → `vercel pull` + `vercel build` + `vercel deploy --prebuilt`, posts the URL. Uses `VERCEL_TOKEN`, not `GITHUB_TOKEN`, for the deploy — no org-token wall. Reaction step removed.
- `vercel-ignore.sh` reverted to main-only doc-skip; the `[preview]`-marker branch is gone (CLI prebuilt deploys bypass `ignoreCommand` anyway).

## Required repo secrets (Settings → Secrets → Actions)

- `VERCEL_TOKEN` — minted by the Vercel project owner
- `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` — from `.vercel/project.json` after `npx vercel link`

Preview won't deploy until these three are set.