### PR TITLE
Set up Node + pnpm in preview deploy workflow

### DIFF
--- a/.github/workflows/preview-on-comment.yml
+++ b/.github/workflows/preview-on-comment.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.ref }}
 
+      - name: Set up Node and pnpm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 


### PR DESCRIPTION
Follow-up to #729. `/deploy` now triggers and runs `vercel build`, but the GH runner has no pnpm:

```
Running "install" command: `pnpm install --frozen-lockfile`...
sh: 1: pnpm: not found
Error: Command exited with 127
```

`vercel build` runs on the runner (not Vercel infra), so it needs the toolchain. Adds `actions/setup-node@v4` + `corepack enable` (picks pnpm@10.34.1 from `package.json#packageManager`) before the build.

Merge to main to take effect (`issue_comment` workflows always run from the default branch).