### PR TITLE
fix: submission readiness demo — loop history, action steps, context panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ### Added
 - The "Before you start" pre-flight dialog now shows actionable resolution paths per warning instead of a static hint: missing-image warnings link to "Configure build source" (workflow editor), "Build manually" (Docker setup tutorial), and "Contact admin" (mailto: to the namespace owner); missing-secret warnings deep-link directly to the Secrets panel for the affected key. Backed by a new `GET /api/namespaces/:handle/admin-contact` endpoint that resolves the earliest owner's email [#312](https://github.com/Appsilon/mediforce/pull/312).
+- **Task view** — spreadsheet-style table replaces card grid; status column, clickable run links, bulk cancel via batch endpoint, hide-completed toggle
+- **Process card** — step-progress dots rendered against the run's actual definition version instead of the latest definition
 
 ### Changed
 - **StepExecutor strategy pattern (ADR-0008)** — agent and script steps now execute through separate `StepExecutor` strategies (`AgentStepExecutor`, `ScriptStepExecutor`) instead of a monolithic `AgentRunner` with `isScript` branches. Each strategy owns its full lifecycle (run, audit, advance/review, cost tracking). `AgentPlugin` interface renamed to `StepExecutorPlugin` to reflect that scripts and Databricks jobs are peers, not special-cased agents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ### Fixed
 - `scripts/sync-model-rankings.py` now uses OpenRouter's frontend rankings JSON endpoint instead of a brittle private server-action scrape, restoring local model ranking sync.
 - On-demand preview deploys now work: `/deploy` on a PR runs a real `vercel build` + `vercel deploy --prebuilt` via the Vercel CLI, replacing the empty-commit `[preview]`-marker hack that silently no-op'd.
+- Execution history panel now shows all iterations of looped steps — steps that completed before the current loop revisit (e.g. a timer-wait that ran between two visits to the same decision gate) were previously hidden or incorrectly marked pending due to the steps API returning only the latest execution per step and using a positional definition-order algorithm for status derivation.
 
 ## [2026-06-14]
 

--- a/packages/cli/src/__tests__/run-logs.test.ts
+++ b/packages/cli/src/__tests__/run-logs.test.ts
@@ -57,10 +57,10 @@ const SAMPLE_STEPS = {
       status: 'completed' as const,
       input: null,
       output: null,
-      execution: mkExecution('step-review', 'completed', {
+      executions: [mkExecution('step-review', 'completed', {
         startedAt: '2026-06-01T10:00:00.000Z',
         completedAt: '2026-06-01T10:00:05.000Z',
-      }),
+      })],
     },
     {
       stepId: 'step-approve',
@@ -70,12 +70,12 @@ const SAMPLE_STEPS = {
       status: 'completed' as const,
       input: null,
       output: null,
-      execution: mkExecution('step-approve', 'failed', {
+      executions: [mkExecution('step-approve', 'failed', {
         startedAt: '2026-06-01T10:00:06.000Z',
         completedAt: '2026-06-01T10:00:08.000Z',
         error: 'rejected by reviewer',
         verdict: 'reject',
-      }),
+      })],
     },
   ],
 };

--- a/packages/cli/src/__tests__/run-watch.test.ts
+++ b/packages/cli/src/__tests__/run-watch.test.ts
@@ -53,7 +53,7 @@ function mkSteps(steps: Array<{ stepId: string; status: string; error?: string }
       status: s.status,
       input: null,
       output: null,
-      execution: mkExecution(s.stepId, s.status, { error: s.error }),
+      executions: [mkExecution(s.stepId, s.status, { error: s.error })],
     })),
   };
 }

--- a/packages/cli/src/commands/run-logs.ts
+++ b/packages/cli/src/commands/run-logs.ts
@@ -28,14 +28,21 @@ export const runLogsCommand = defineCommand({
     if (stepsResult.steps.length > 0) {
       output.stdout('Steps:');
       for (const step of stepsResult.steps) {
-        const exec = step.execution;
-        const status = exec?.status ?? step.status;
-        const duration = exec?.startedAt && exec?.completedAt
-          ? `${Math.round((new Date(exec.completedAt).getTime() - new Date(exec.startedAt).getTime()) / 1000)}s`
-          : '';
-        output.stdout(`  ${status.padEnd(12)} ${step.stepId}${duration ? `  (${duration})` : ''}`);
-        if (exec?.error) output.stdout(`             error: ${exec.error}`);
-        if (exec?.verdict) output.stdout(`             verdict: ${exec.verdict}`);
+        const execs = [...step.executions].sort(
+          (a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime(),
+        );
+        if (execs.length === 0) {
+          output.stdout(`  ${step.status.padEnd(12)} ${step.stepId}`);
+        } else {
+          for (const exec of execs) {
+            const duration = exec.startedAt && exec.completedAt
+              ? `${Math.round((new Date(exec.completedAt).getTime() - new Date(exec.startedAt).getTime()) / 1000)}s`
+              : '';
+            output.stdout(`  ${exec.status.padEnd(12)} ${step.stepId}${duration ? `  (${duration})` : ''}`);
+            if (exec.error) output.stdout(`             error: ${exec.error}`);
+            if (exec.verdict) output.stdout(`             verdict: ${exec.verdict}`);
+          }
+        }
       }
       output.stdout('');
     }

--- a/packages/cli/src/commands/run-watch.ts
+++ b/packages/cli/src/commands/run-watch.ts
@@ -32,21 +32,28 @@ export const runWatchCommand = defineCommand({
 
       const steps = await mediforce.processes.getSteps({ instanceId: args.runId });
       for (const step of steps.steps) {
-        const exec = step.execution;
-        const key = `${step.stepId}:${exec?.status ?? step.status}`;
-        if (seenSteps.has(key)) continue;
-        seenSteps.add(key);
+        for (const exec of step.executions) {
+          const key = `${step.stepId}:${exec.iterationNumber}:${exec.status}`;
+          if (seenSteps.has(key)) continue;
+          seenSteps.add(key);
 
-        const status = exec?.status ?? step.status;
-        const duration = exec?.startedAt && exec?.completedAt
-          ? ` (${Math.round((new Date(exec.completedAt).getTime() - new Date(exec.startedAt).getTime()) / 1000)}s)`
-          : '';
+          const duration = exec.startedAt && exec.completedAt
+            ? ` (${Math.round((new Date(exec.completedAt).getTime() - new Date(exec.startedAt).getTime()) / 1000)}s)`
+            : '';
 
-        if (jsonMode) {
-          printJson(output, { type: 'step', stepId: step.stepId, status, duration });
-        } else {
-          output.stdout(`  ${status.padEnd(12)} ${step.stepId}${duration}`);
-          if (exec?.error) output.stdout(`             error: ${exec.error}`);
+          if (jsonMode) {
+            printJson(output, { type: 'step', stepId: step.stepId, status: exec.status, duration });
+          } else {
+            output.stdout(`  ${exec.status.padEnd(12)} ${step.stepId}${duration}`);
+            if (exec.error) output.stdout(`             error: ${exec.error}`);
+          }
+        }
+        if (step.executions.length === 0) {
+          const key = `${step.stepId}::${step.status}`;
+          if (!seenSteps.has(key)) {
+            seenSteps.add(key);
+            if (!jsonMode) output.stdout(`  ${step.status.padEnd(12)} ${step.stepId}`);
+          }
         }
       }
 

--- a/packages/platform-api/src/contract/processes.ts
+++ b/packages/platform-api/src/contract/processes.ts
@@ -100,7 +100,7 @@ export const StepEntrySchema = z.object({
   status: StepEntryStatusSchema,
   input: z.record(z.string(), z.unknown()).nullable(),
   output: z.record(z.string(), z.unknown()).nullable(),
-  execution: StepExecutionSchema.nullable(),
+  executions: z.array(StepExecutionSchema),
 });
 
 export const GetProcessStepsInputSchema = z.object({

--- a/packages/platform-api/src/handlers/processes/__tests__/get-process-steps.test.ts
+++ b/packages/platform-api/src/handlers/processes/__tests__/get-process-steps.test.ts
@@ -193,7 +193,7 @@ describe('getProcessSteps handler', () => {
     expect(s1?.executorType).toBe('human');
     expect(s1?.status).toBe('completed');
     expect(s1?.output).toEqual({ decision: 'approve', notes: 'looks good' });
-    expect(s1?.execution).toBeNull();
+    expect(s1?.executions).toEqual([]);
   });
 
   it('marks all reachable steps completed when status=completed and currentStepId=null', async () => {
@@ -217,6 +217,83 @@ describe('getProcessSteps handler', () => {
 
     expect(result.steps.find((s) => s.stepId === 's1')?.status).toBe('completed');
     expect(result.steps.find((s) => s.stepId === 's2')?.status).toBe('completed');
+  });
+
+  it('returns all iterations for a step that ran multiple times in a loop', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({
+        id: 'inst-loop',
+        definitionName: 'demo',
+        definitionVersion: '1',
+        namespace: 'team-alpha',
+        currentStepId: 's1',
+      }),
+    );
+    const firstVisit = buildStepExecution({
+      instanceId: 'inst-loop',
+      stepId: 's2',
+      iterationNumber: 0,
+      startedAt: new Date('2024-01-01T10:00:00Z').toISOString(),
+      status: 'completed',
+      output: { ok: true },
+    });
+    const secondVisit = buildStepExecution({
+      instanceId: 'inst-loop',
+      stepId: 's2',
+      iterationNumber: 1,
+      startedAt: new Date('2024-01-01T11:00:00Z').toISOString(),
+      status: 'completed',
+      output: { ok: true },
+    });
+    await instanceRepo.addStepExecution('inst-loop', firstVisit);
+    await instanceRepo.addStepExecution('inst-loop', secondVisit);
+
+    const scope = createTestScope({ instanceRepo, processRepo });
+    const result = await getProcessSteps({ instanceId: 'inst-loop' }, scope);
+
+    const s2 = result.steps.find((s) => s.stepId === 's2');
+    expect(s2?.executions).toHaveLength(2);
+    expect(s2?.executions.map((e) => e.iterationNumber).sort()).toEqual([0, 1]);
+    expect(s2?.status).toBe('completed');
+  });
+
+  it('marks a step completed when it ran before currentStepId in a loop even if defined after it', async () => {
+    await processRepo.saveWorkflowDefinition(
+      buildWorkflowDefinition({
+        name: 'looping',
+        version: 1,
+        namespace: 'team-alpha',
+        steps: [
+          { id: 'gate', name: 'Gate', type: 'decision', executor: 'human' },
+          { id: 'wait', name: 'Wait', type: 'creation', executor: 'action' },
+        ],
+      }),
+    );
+    await instanceRepo.create(
+      buildProcessInstance({
+        id: 'inst-loop2',
+        definitionName: 'looping',
+        definitionVersion: '1',
+        namespace: 'team-alpha',
+        currentStepId: 'gate',
+      }),
+    );
+    await instanceRepo.addStepExecution(
+      'inst-loop2',
+      buildStepExecution({
+        instanceId: 'inst-loop2',
+        stepId: 'wait',
+        iterationNumber: 0,
+        status: 'completed',
+        output: { resumeReason: 'deadline_reached' },
+      }),
+    );
+
+    const scope = createTestScope({ instanceRepo, processRepo });
+    const result = await getProcessSteps({ instanceId: 'inst-loop2' }, scope);
+
+    expect(result.steps.find((s) => s.stepId === 'gate')?.status).toBe('running');
+    expect(result.steps.find((s) => s.stepId === 'wait')?.status).toBe('completed');
   });
 
   it('returns the steps for in-namespace user callers', async () => {

--- a/packages/platform-api/src/handlers/processes/get-process-steps.ts
+++ b/packages/platform-api/src/handlers/processes/get-process-steps.ts
@@ -39,13 +39,15 @@ export async function getProcessSteps(
     );
   }
 
-  const executions = await scope.runs.getStepExecutions(instanceId);
+  const allExecutions = await scope.runs.getStepExecutions(instanceId);
 
-  const executionsByStep = new Map<string, StepExecution>();
-  for (const exec of executions) {
-    const existing = executionsByStep.get(exec.stepId);
-    if (existing === undefined || exec.startedAt > existing.startedAt) {
-      executionsByStep.set(exec.stepId, exec);
+  const executionsByStep = new Map<string, StepExecution[]>();
+  for (const exec of allExecutions) {
+    const bucket = executionsByStep.get(exec.stepId);
+    if (bucket === undefined) {
+      executionsByStep.set(exec.stepId, [exec]);
+    } else {
+      bucket.push(exec);
     }
   }
 
@@ -53,38 +55,41 @@ export async function getProcessSteps(
   const variables = (instance.variables ?? {}) as Record<string, Record<string, unknown>>;
 
   const stepEntries: StepEntry[] = [];
-  let pastCurrentStep = false;
 
   for (const step of definition.steps) {
     if (step.type === 'terminal') continue;
 
     const executorType: StepEntry['executorType'] = step.executor ?? 'unknown';
-    const execution = executionsByStep.get(step.id) ?? null;
+    const stepExecs = executionsByStep.get(step.id) ?? [];
+    const latestExec = stepExecs.reduce<StepExecution | null>(
+      (best, e) => (best === null || e.startedAt > best.startedAt ? e : best),
+      null,
+    );
     const stepVariables = variables[step.id] ?? null;
 
     let status: StepEntry['status'];
-    if (pastCurrentStep) {
-      status = 'pending';
+    if (instance.status === 'completed') {
+      if (currentStepId === null) {
+        status = latestExec !== null || stepVariables !== null ? 'completed' : 'pending';
+      } else if (step.id === currentStepId) {
+        status = 'completed';
+      } else {
+        const hasOutput = latestExec?.output !== null || stepVariables !== null;
+        status = hasOutput ? 'completed' : 'pending';
+      }
     } else if (step.id === currentStepId) {
       status = 'running';
-      pastCurrentStep = true;
     } else {
-      const hasOutput = execution?.output !== null || stepVariables !== null;
-      status = hasOutput ? 'completed' : 'pending';
-    }
-    if (step.id === currentStepId && instance.status === 'completed') {
-      status = 'completed';
-    }
-    if (instance.status === 'completed' && currentStepId === null) {
-      const hasOutput = execution?.output !== null || stepVariables !== null;
-      status = hasOutput ? 'completed' : 'pending';
+      const hasCompleted =
+        stepExecs.some((e) => e.status === 'completed') || stepVariables !== null;
+      status = hasCompleted ? 'completed' : 'pending';
     }
 
     let stepInput: Record<string, unknown> | null = null;
     let stepOutput: Record<string, unknown> | null = null;
-    if (executorType === 'agent' && execution !== null) {
-      stepInput = execution.input;
-      stepOutput = execution.output;
+    if (executorType === 'agent' && latestExec !== null) {
+      stepInput = latestExec.input;
+      stepOutput = latestExec.output;
     } else if (executorType === 'human') {
       stepInput = step.ui !== undefined ? { ui: step.ui } : null;
       stepOutput = stepVariables;
@@ -98,7 +103,7 @@ export async function getProcessSteps(
       status,
       input: stepInput,
       output: stepOutput,
-      execution,
+      executions: stepExecs,
     });
   }
 

--- a/packages/platform-ui/e2e/api/script-plugins.journey.ts
+++ b/packages/platform-ui/e2e/api/script-plugins.journey.ts
@@ -40,11 +40,17 @@ async function pollUntil<T>(
   throw new Error(`Timed out waiting for ${description} (${timeoutMs}ms)`);
 }
 
+interface StepExecution {
+  status: string;
+  output?: Record<string, unknown>;
+  error?: string;
+}
+
 interface StepsResponse {
   steps: Array<{
     stepId: string;
     executorType?: string;
-    execution: { status: string; output?: Record<string, unknown>; error?: string } | null;
+    executions: StepExecution[];
   }>;
 }
 
@@ -67,7 +73,7 @@ async function waitForStepResult(
   request: APIRequestContext,
   instanceId: string,
   stepId: string,
-): Promise<NonNullable<StepsResponse['steps'][number]['execution']>> {
+): Promise<StepExecution> {
   return pollUntil(
     async () => {
       const res = await request.get(`/api/processes/${instanceId}/steps`, {
@@ -76,11 +82,12 @@ async function waitForStepResult(
       if (res.status() !== 200) return null;
       const body = (await res.json()) as StepsResponse;
       const entry = body.steps.find((step) => step.stepId === stepId);
-      if (entry?.execution == null) return null;
-      if (entry.execution.status === 'failed') {
-        throw new Error(`step '${stepId}' failed: ${entry.execution.error ?? 'no error detail'}`);
+      if (!entry || entry.executions.length === 0) return null;
+      const latest = entry.executions[entry.executions.length - 1]!;
+      if (latest.status === 'failed') {
+        throw new Error(`step '${stepId}' failed: ${latest.error ?? 'no error detail'}`);
       }
-      return entry.execution.status === 'completed' ? entry.execution : null;
+      return latest.status === 'completed' ? latest : null;
     },
     { description: `step '${stepId}' of ${instanceId} to complete` },
   );

--- a/packages/platform-ui/next-env.d.ts
+++ b/packages/platform-ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/runs/[runId]/steps/[stepId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { format } from 'date-fns';
@@ -38,6 +38,8 @@ function StatusIcon({ status }: { status: string }) {
 
 export default function StepDetailPage() {
   const { name, runId, stepId, handle } = useParams<{ name: string; runId: string; stepId: string; handle: string }>();
+  const searchParams = useSearchParams();
+  const executionId = searchParams.get('executionId') ?? undefined;
 
   const decodedName = name ? decodeURIComponent(name) : '';
   const decodedStepId = stepId ? decodeURIComponent(stepId) : '';
@@ -78,13 +80,16 @@ export default function StepDetailPage() {
     return prevStep?.name ?? formatStepName(incoming.from);
   }, [definition, decodedStepId]);
 
-  // Get the latest execution for this step
+  // Resolve the execution: pin to executionId from the URL when present (so
+  // each row in the history links to a different view), otherwise fall back
+  // to the latest execution for the step.
   const execution = useMemo((): StepExecution | null => {
-    const execs = stepExecutions
-      .filter((e) => e.stepId === decodedStepId)
-      .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
-    return execs[0] ?? null;
-  }, [stepExecutions, decodedStepId]);
+    const execs = stepExecutions.filter((e) => e.stepId === decodedStepId);
+    if (executionId !== undefined) {
+      return execs.find((e) => e.id === executionId) ?? null;
+    }
+    return execs.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())[0] ?? null;
+  }, [stepExecutions, decodedStepId, executionId]);
 
   // Agent prompt event for this step
   const promptEvent = useMemo(() => {

--- a/packages/platform-ui/src/components/processes/process-run-section.tsx
+++ b/packages/platform-ui/src/components/processes/process-run-section.tsx
@@ -12,7 +12,6 @@ import { routes } from '@/lib/routes';
 import { formatCostUsd, formatStepName } from '@/lib/format';
 import { STATUS_LABELS } from './process-status-badge';
 
-
 function StepDots({
   steps,
   currentStepId,

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { CheckCircle2, Clock, XCircle, Circle, Pause, User, Bot, Cog, ChevronDown, ChevronRight, FileText, FileCode, Paperclip, RotateCcw } from 'lucide-react';
+import { CheckCircle2, Clock, XCircle, Circle, Pause, User, Bot, Cog, ChevronDown, ChevronRight, FileText, FileCode, Paperclip } from 'lucide-react';
 import type { ProcessInstance, StepExecution, Step, HumanTask } from '@mediforce/platform-core';
 import type { RunOutputFileEntry } from '@mediforce/platform-api/contract';
 import { AutonomyBadge } from '../agents/autonomy-badge';
@@ -61,12 +61,7 @@ interface StepStatusPanelProps {
 type HistoryItem =
   | {
       kind: 'executed';
-      /** First attempt of this visit (iterationNumber === 0). */
-      anchor: StepExecution;
-      /** Subsequent retries within this visit (iterationNumber > 0). */
-      retries: StepExecution[];
-      /** Most recent execution in this visit — the one whose metadata we display. */
-      latestExec: StepExecution;
+      execution: StepExecution;
       step: Step | null;
       isCurrent: boolean;
     }
@@ -84,32 +79,15 @@ function buildHistory(
   instance: ProcessInstance,
   definitionSteps: Step[],
 ): HistoryItem[] {
-  // Chronological order — anchors (iterationNumber===0) establish visit order.
   const sorted = [...stepExecutions].sort(
     (a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime(),
   );
 
-  const anchors = sorted.filter((e) => e.iterationNumber === 0);
-
-  const items: HistoryItem[] = anchors.map((anchor, idx) => {
-    // Retries belong to this visit if they come after the anchor but before
-    // the next anchor for the same stepId (which would be a new loop visit).
-    const nextSameStep = anchors.slice(idx + 1).find((a) => a.stepId === anchor.stepId);
-    const retries = sorted.filter(
-      (e) =>
-        e.stepId === anchor.stepId &&
-        e.iterationNumber > 0 &&
-        new Date(e.startedAt) > new Date(anchor.startedAt) &&
-        (nextSameStep === undefined ||
-          new Date(e.startedAt) < new Date(nextSameStep.startedAt)),
-    );
-
-    const latestExec = retries.length > 0 ? retries[retries.length - 1]! : anchor;
-    const step = definitionSteps.find((s) => s.id === anchor.stepId) ?? null;
+  const items: HistoryItem[] = sorted.map((execution) => {
+    const step = definitionSteps.find((s) => s.id === execution.stepId) ?? null;
     const isCurrent =
-      anchor.stepId === instance.currentStepId && ACTIVE_STATUSES.has(latestExec.status);
-
-    return { kind: 'executed', anchor, retries, latestExec, step, isCurrent };
+      execution.stepId === instance.currentStepId && ACTIVE_STATUSES.has(execution.status);
+    return { kind: 'executed', execution, step, isCurrent };
   });
 
   // If the current step has no execution record yet (run just started or
@@ -528,10 +506,10 @@ export function StepStatusPanel({
             );
           }
 
-          const { anchor, retries, latestExec, step, isCurrent } = item;
-          const execId = anchor.id;
-          const stepId = anchor.stepId;
-          const status = getExecEffectiveStatus(latestExec, instance);
+          const { execution, step, isCurrent } = item;
+          const execId = execution.id;
+          const stepId = execution.stepId;
+          const status = getExecEffectiveStatus(execution, instance);
           const stepConfig = stepConfigMap?.get(stepId);
           const hasConfig = stepConfig?.executorType === 'agent';
           const isExpanded = expandedExecId === execId;
@@ -545,7 +523,7 @@ export function StepStatusPanel({
 
           // For review steps: show the verdict that was actually taken.
           const verdicts = step?.verdicts;
-          const takenVerdict = latestExec.status === 'completed' ? latestExec.verdict : undefined;
+          const takenVerdict = execution.status === 'completed' ? execution.verdict : undefined;
           const takenVerdictTarget = takenVerdict && verdicts
             ? Object.entries(verdicts).find(([k]) => k === takenVerdict)?.[1]?.target
             : undefined;
@@ -594,12 +572,6 @@ export function StepStatusPanel({
                   {stepConfig?.executorType === 'agent' && stepConfig.autonomyLevel && (
                     <AutonomyBadge level={stepConfig.autonomyLevel} />
                   )}
-                  {retries.length > 0 && (
-                    <span className="inline-flex items-center gap-0.5 text-xs bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 rounded-full px-1.5 py-0.5">
-                      <RotateCcw className="h-3 w-3" />
-                      Retried ×{retries.length}
-                    </span>
-                  )}
                   <StatusLabel status={status} />
                   {stepOutputFiles.length > 0 && (
                     <button
@@ -626,32 +598,32 @@ export function StepStatusPanel({
                 <div className="flex items-center gap-2 mt-1 flex-wrap">
                   <span className="text-xs text-muted-foreground">
                     <span className="text-muted-foreground/60 mr-1">Started</span>
-                    {format(new Date(latestExec.startedAt), 'MMM d, HH:mm')}
+                    {format(new Date(execution.startedAt), 'MMM d, HH:mm')}
                   </span>
-                  {!latestExec.completedAt && (
+                  {!execution.completedAt && (
                     <>
                       <span className="text-muted-foreground/40">·</span>
                       <span className="text-xs text-muted-foreground">
-                        <ElapsedTimer startedAt={latestExec.startedAt} />
+                        <ElapsedTimer startedAt={execution.startedAt} />
                       </span>
                     </>
                   )}
-                  {latestExec.completedAt && (
+                  {execution.completedAt && (
                     <>
                       <span className="text-muted-foreground/40">·</span>
                       <span className="text-xs text-muted-foreground">
                         <span className="text-muted-foreground/60 mr-1">Completed</span>
-                        {format(new Date(latestExec.completedAt), 'MMM d, HH:mm')}
+                        {format(new Date(execution.completedAt), 'MMM d, HH:mm')}
                       </span>
                       <span className="text-muted-foreground/40">·</span>
                       <span className="text-xs text-muted-foreground">
-                        {formatDuration(new Date(latestExec.completedAt).getTime() - new Date(latestExec.startedAt).getTime())}
+                        {formatDuration(new Date(execution.completedAt).getTime() - new Date(execution.startedAt).getTime())}
                       </span>
-                      {latestExec.agentOutput?.estimatedCostUsd != null && (
+                      {execution.agentOutput?.estimatedCostUsd != null && (
                         <>
                           <span className="text-muted-foreground/40">·</span>
                           <span className="text-xs text-muted-foreground">
-                            {formatCostUsd(latestExec.agentOutput.estimatedCostUsd)}
+                            {formatCostUsd(execution.agentOutput.estimatedCostUsd)}
                           </span>
                         </>
                       )}
@@ -659,7 +631,7 @@ export function StepStatusPanel({
                   )}
                   <span className="text-muted-foreground/40">·</span>
                   <ExecutedBy
-                    executedBy={latestExec.executedBy}
+                    executedBy={execution.executedBy}
                     executorType={stepConfig?.executorType}
                     plugin={stepConfig?.plugin}
                     autonomyLevel={stepConfig?.autonomyLevel}

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -554,7 +554,7 @@ export function StepStatusPanel({
                 <div className="flex flex-wrap items-center gap-2">
                   {stepDetailBaseHref && status !== 'pending' ? (
                     <Link
-                      href={`${stepDetailBaseHref}/steps/${encodeURIComponent(stepId)}`}
+                      href={`${stepDetailBaseHref}/steps/${encodeURIComponent(stepId)}?executionId=${encodeURIComponent(execId)}`}
                       className="text-sm font-medium text-primary hover:underline"
                       onClick={(e) => e.stopPropagation()}
                     >

--- a/packages/platform-ui/src/components/tasks/task-context-panel.tsx
+++ b/packages/platform-ui/src/components/tasks/task-context-panel.tsx
@@ -51,9 +51,19 @@ export function TaskContextPanel({
     const currentStepExecs = executions
       .filter((e) => e.stepId === stepId)
       .sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
-    const currentStepStart = currentStepExecs.length > 0
-      ? new Date(currentStepExecs[currentStepExecs.length - 1].startedAt).getTime()
-      : Infinity;
+
+    // In a loop revisit, the engine hasn't created an execution record for the
+    // new active visit yet. All known executions for this step are completed
+    // (they belong to past iterations). Use Infinity so the most recent
+    // preceding step from the current loop pass is found as context.
+    const isLoopRevisitWithNoRecord =
+      instance?.currentStepId === stepId &&
+      currentStepExecs.every((e) => e.status === 'completed');
+
+    const currentStepStart =
+      currentStepExecs.length === 0 || isLoopRevisitWithNoRecord
+        ? Infinity
+        : new Date(currentStepExecs[currentStepExecs.length - 1].startedAt).getTime();
 
     const completed = executions
       .filter((e) =>

--- a/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
@@ -70,6 +70,7 @@ const EXECUTOR_STYLES: Record<string, { icon: typeof User; color: string; bg: st
   agent: { icon: Bot, color: 'text-violet-600 dark:text-violet-400', bg: 'bg-violet-100 dark:bg-violet-900/30' },
   script: { icon: Terminal, color: 'text-amber-600 dark:text-amber-400', bg: 'bg-amber-100 dark:bg-amber-900/30' },
   cowork: { icon: Users, color: 'text-teal-600 dark:text-teal-400', bg: 'bg-teal-100 dark:bg-teal-900/30' },
+  action: { icon: Terminal, color: 'text-sky-600 dark:text-sky-400', bg: 'bg-sky-100 dark:bg-sky-900/30' },
 };
 
 // ---------------------------------------------------------------------------
@@ -212,7 +213,7 @@ function StepNode({ data, selected }: NodeProps<Node<StepNodeData>>) {
               <span className={cn('text-[10px] font-semibold', typeConfig.color)}>{typeConfig.label}</span>
               <span className="text-[10px] text-muted-foreground/30">·</span>
               <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
-                {{ human: 'Human', agent: 'Agent', script: 'Script', cowork: 'Cowork' }[data.executor] ?? data.executor}
+                {{ human: 'Human', agent: 'Agent', script: 'Script', cowork: 'Cowork', action: 'Action' }[data.executor] ?? data.executor}
               </span>
               {data.autonomyLevel && data.executor === 'agent' && (
                 <span className="text-[10px] font-mono text-muted-foreground/70">

--- a/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
@@ -86,6 +86,7 @@ const EXECUTOR_ICON: Record<string, { icon: React.ElementType; color: string; bg
   agent:  { icon: Bot,      color: 'text-violet-600 dark:text-violet-400', bg: 'bg-violet-100 dark:bg-violet-900/30', label: 'Agent' },
   script: { icon: Terminal, color: 'text-amber-600 dark:text-amber-400',   bg: 'bg-amber-100 dark:bg-amber-900/30',  label: 'Script' },
   cowork: { icon: Users,    color: 'text-teal-600 dark:text-teal-400',     bg: 'bg-teal-100 dark:bg-teal-900/30',    label: 'Cowork' },
+  action: { icon: Terminal, color: 'text-sky-600 dark:text-sky-400',       bg: 'bg-sky-100 dark:bg-sky-900/30',      label: 'Action' },
 };
 
 const STEP_TYPE_ICON: Record<string, { icon: React.ElementType; color: string; label: string }> = {

--- a/packages/platform-ui/src/hooks/__tests__/use-step-executions.test.ts
+++ b/packages/platform-ui/src/hooks/__tests__/use-step-executions.test.ts
@@ -12,7 +12,7 @@ type StepEntry = {
   status: 'completed' | 'running' | 'pending';
   input: Record<string, unknown> | null;
   output: Record<string, unknown> | null;
-  execution: StepExecution | null;
+  executions: StepExecution[];
 };
 
 type GetStepsResult = {
@@ -24,16 +24,16 @@ type GetStepsResult = {
   steps: StepEntry[];
 };
 
-function entry(stepId: string, execution: StepExecution | null): StepEntry {
+function entry(stepId: string, ...executions: StepExecution[]): StepEntry {
   return {
     stepId,
     name: stepId,
     type: 'review',
     executorType: 'agent',
-    status: execution !== null ? 'completed' : 'pending',
+    status: executions.length > 0 ? 'completed' : 'pending',
     input: null,
     output: null,
-    execution,
+    executions,
   };
 }
 
@@ -82,7 +82,7 @@ describe('useStepExecutions', () => {
     const ex2 = buildStepExecution({ id: 'ex-2', stepId: 's2' });
     getStepsMock.mockResolvedValue(result('inst-a', [
       entry('s1', ex1),
-      entry('s-pending', null),
+      entry('s-pending'),
       entry('s2', ex2),
     ]));
     const { wrapper } = createQueryWrapper();

--- a/packages/platform-ui/src/hooks/use-step-executions.ts
+++ b/packages/platform-ui/src/hooks/use-step-executions.ts
@@ -55,7 +55,7 @@ export function useStepExecutions(
     const entries = query.data ?? [];
     const out: StepExecution[] = [];
     for (const entry of entries) {
-      if (entry.execution !== null) out.push(entry.execution);
+      out.push(...entry.executions);
     }
     return out;
   }, [query.data]);


### PR DESCRIPTION
## Summary

- **Execution history shows all loop iterations**: `get-process-steps` now stores all executions per step in a `StepExecution[]` bucket (was only keeping the latest), so every pass through a looped step appears as its own row in chronological order
- **Steps completed before a loop revisit no longer stuck as pending**: status derivation now uses actual execution records rather than a positional `pastCurrentStep` flag, so `wait-for-recheck` and `verify-sftp` correctly show `completed` after the loop cycles back
- **Each history row links to its own iteration**: `?executionId=<uuid>` appended to step-detail links; the step detail page reads it to pin to that specific execution
- **TaskContextPanel shows correct previous-step output on loop revisit**: when the current step has no execution record yet for its active visit (all known executions are from past iterations), the boundary is set to `Infinity` so the most recent preceding step (e.g. verify-sftp second pass) is found as context
- **Action executor steps show Terminal icon and "Action" label**: workflow diagram and step details panel were incorrectly treating `executor: action` steps as human steps

## Test plan

- [ ] Run `pnpm --filter platform-api test` — all `get-process-steps` tests green, including two new loop-scenario tests
- [ ] Run `pnpm --filter platform-ui test` — `use-step-executions` hook tests green
- [ ] Open a workflow run that loops: execution history shows each iteration as a separate row (no "Retried ×N" grouping)
- [ ] Click a history row — URL gains `?executionId=<uuid>`; step detail shows that iteration's data
- [ ] At the second visit to `check-decision`, the TaskContextPanel shows the verify-sftp **second** run's PDF report, not the first run's "folder empty" message
- [ ] Action steps in the workflow diagram show the Terminal (cog) icon and "Action" label in the details panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)