### PR TITLE
fix: self-review fixes + multi-arch Docker images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -3,6 +3,7 @@ name: Build & Push Docker Images
 on:
   push:
     branches: [main]
+    tags: ['v*']
   workflow_dispatch:
 
 concurrency:
@@ -31,6 +32,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU (for arm64 cross-compilation on release)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -40,6 +45,7 @@ jobs:
           context: .
           file: packages/platform-ui/Dockerfile
           target: runner
+          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}-platform-ui:latest
@@ -53,6 +59,7 @@ jobs:
           context: .
           file: packages/platform-ui/Dockerfile
           target: migrate
+          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}-migrate:latest
@@ -65,6 +72,7 @@ jobs:
         with:
           context: .
           file: packages/container-worker/Dockerfile.worker
+          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}-container-worker:latest


### PR DESCRIPTION
## Summary

Follow-up to #739. Fixes from self-review + multi-arch support.

- Mobile nav click-outside-to-close handler (regression fix)
- Active link background tint restored
- Dead `.header` CSS removed from fda-principles, security, validated-ai
- Sed pipe delimiter escape in docker-entrypoint.sh
- Multi-arch Docker images: amd64 on every push, amd64+arm64 on release tags (Hetzner offers Arm64 Ampere servers)

## Test plan

- [x] Self-review passed on all items
- [x] Images confirmed on ghcr.io
- [ ] Verify multi-arch build on next `v*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)