### PR TITLE
fix: entrypoint server chunks + bootstrap git ownership

### DIFF
--- a/docs/setup/index.html
+++ b/docs/setup/index.html
@@ -1383,7 +1383,7 @@ function generateScript() {
   s += 'echo "▸ Starting platform — pulling pre-built images..."\n';
   s += 'echo ""\n';
   s += 'cd "$DEPLOY_DIR"\n';
-  s += 'export NEXT_PUBLIC_GIT_SHA=$(git rev-parse --short HEAD)\n';
+  s += 'export NEXT_PUBLIC_GIT_SHA=$(sudo -u deploy git -C "$DEPLOY_DIR" rev-parse --short HEAD)\n';
   s += '# Pull pre-built images from registry (fast). Falls back to local build.\n';
   s += 'sudo -u deploy docker compose -f docker-compose.prod.yml pull --ignore-pull-failures 2>/dev/null || true\n';
   s += 'sudo -u deploy docker compose -f docker-compose.prod.yml up -d --remove-orphans\n';

--- a/packages/platform-ui/docker-entrypoint.sh
+++ b/packages/platform-ui/docker-entrypoint.sh
@@ -9,11 +9,11 @@ set -euo pipefail
 # Only runs when placeholders are detected (i.e. image was built without
 # real values). Local `docker compose build` with real build args skips this.
 
-STATIC_DIR="/app/packages/platform-ui/.next/static"
+NEXT_DIR="/app/packages/platform-ui/.next"
 SERVER_JS="/app/packages/platform-ui/server.js"
 
 needs_replacement=false
-if grep -rq '__NEXT_PUBLIC_' "$STATIC_DIR" 2>/dev/null || \
+if grep -rq '__NEXT_PUBLIC_' "$NEXT_DIR" 2>/dev/null || \
    grep -q '__NEXT_PUBLIC_' "$SERVER_JS" 2>/dev/null; then
   needs_replacement=true
 fi
@@ -25,7 +25,8 @@ if [ "$needs_replacement" = true ]; then
     placeholder="__${name}__"
     # Escape sed special chars in value
     escaped_value=$(printf '%s\n' "$value" | sed 's/[&/\|]/\\&/g')
-    find "$STATIC_DIR" -name '*.js' -exec sed -i "s|${placeholder}|${escaped_value}|g" {} + 2>/dev/null || true
+    # Replace in client bundles (.next/static/) AND server chunks (.next/server/)
+    find "$NEXT_DIR" -name '*.js' -exec sed -i "s|${placeholder}|${escaped_value}|g" {} + 2>/dev/null || true
     [ -f "$SERVER_JS" ] && sed -i "s|${placeholder}|${escaped_value}|g" "$SERVER_JS" 2>/dev/null || true
   done
 


### PR DESCRIPTION
## Summary

Two fixes found during live self-host testing on fresh Hetzner server:

- **Entrypoint: replace placeholders in `.next/server/` too** — Turbopack inlines `NEXT_PUBLIC_*` in server chunks, not just client bundles. Entrypoint only replaced in `.next/static/` + `server.js`, causing Firebase Admin SDK to init with `projectId: undefined` → 401 on all API calls.
- **Bootstrap: run `git rev-parse` as deploy user** — repo is owned by deploy, script runs as root → "dubious ownership" error.

## Test plan

- [x] Verified on live server: sed replacement in `.next/server/` fixes 401
- [x] Firebase Admin SDK initializes with correct project ID after fix
- [x] Login + workspace-selection works after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)