### PR TITLE
fix(ci): build native arm64 images so staging picks up every deploy

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,7 +16,15 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -32,50 +40,89 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU (for arm64 cross-compilation on release)
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build & push platform-ui
+      - name: Sanitise platform slug
+        run: echo "PLATFORM_SLUG=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> $GITHUB_ENV
+
+      - name: Build & push platform-ui (${{ matrix.platform }})
         uses: docker/build-push-action@v6
         with:
           context: .
           file: packages/platform-ui/Dockerfile
           target: runner
-          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            ${{ env.IMAGE_PREFIX }}-platform-ui:latest
-            ${{ env.IMAGE_PREFIX }}-platform-ui:${{ github.sha }}
-          cache-from: type=gha,scope=platform-ui
-          cache-to: type=gha,mode=max,scope=platform-ui
+            ${{ env.IMAGE_PREFIX }}-platform-ui:${{ env.PLATFORM_SLUG }}
+          cache-from: type=gha,scope=platform-ui-${{ env.PLATFORM_SLUG }}
+          cache-to: type=gha,mode=max,scope=platform-ui-${{ env.PLATFORM_SLUG }}
 
-      - name: Build & push migrate
+      - name: Build & push migrate (${{ matrix.platform }})
         uses: docker/build-push-action@v6
         with:
           context: .
           file: packages/platform-ui/Dockerfile
           target: migrate
-          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            ${{ env.IMAGE_PREFIX }}-migrate:latest
-            ${{ env.IMAGE_PREFIX }}-migrate:${{ github.sha }}
-          cache-from: type=gha,scope=migrate
-          cache-to: type=gha,mode=max,scope=migrate
+            ${{ env.IMAGE_PREFIX }}-migrate:${{ env.PLATFORM_SLUG }}
+          cache-from: type=gha,scope=migrate-${{ env.PLATFORM_SLUG }}
+          cache-to: type=gha,mode=max,scope=migrate-${{ env.PLATFORM_SLUG }}
 
-      - name: Build & push container-worker
+      - name: Build & push container-worker (${{ matrix.platform }})
         uses: docker/build-push-action@v6
         with:
           context: .
           file: packages/container-worker/Dockerfile.worker
-          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            ${{ env.IMAGE_PREFIX }}-container-worker:latest
-            ${{ env.IMAGE_PREFIX }}-container-worker:${{ github.sha }}
-          cache-from: type=gha,scope=container-worker
-          cache-to: type=gha,mode=max,scope=container-worker
+            ${{ env.IMAGE_PREFIX }}-container-worker:${{ env.PLATFORM_SLUG }}
+          cache-from: type=gha,scope=container-worker-${{ env.PLATFORM_SLUG }}
+          cache-to: type=gha,mode=max,scope=container-worker-${{ env.PLATFORM_SLUG }}
+
+  merge-manifests:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create multi-arch manifest — platform-ui
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE_PREFIX }}-platform-ui:latest \
+            --tag ${{ env.IMAGE_PREFIX }}-platform-ui:${{ github.sha }} \
+            ${{ env.IMAGE_PREFIX }}-platform-ui:linux-amd64 \
+            ${{ env.IMAGE_PREFIX }}-platform-ui:linux-arm64
+
+      - name: Create multi-arch manifest — migrate
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE_PREFIX }}-migrate:latest \
+            --tag ${{ env.IMAGE_PREFIX }}-migrate:${{ github.sha }} \
+            ${{ env.IMAGE_PREFIX }}-migrate:linux-amd64 \
+            ${{ env.IMAGE_PREFIX }}-migrate:linux-arm64
+
+      - name: Create multi-arch manifest — container-worker
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE_PREFIX }}-container-worker:latest \
+            --tag ${{ env.IMAGE_PREFIX }}-container-worker:${{ github.sha }} \
+            ${{ env.IMAGE_PREFIX }}-container-worker:linux-amd64 \
+            ${{ env.IMAGE_PREFIX }}-container-worker:linux-arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Codex now mirrors Claude's repo-local skill and agent discovery layout via `.codex/skills/*` and `.codex/agents` symlinks, with `AGENTS.md` documenting how Codex should translate Claude-specific skill tool syntax.
 
 ### Fixed
+- Staging deploys now pick up each push to main — `build-images.yml` now builds native `linux/amd64 + linux/arm64` images via a matrix job on GitHub-hosted ARM64 runners; the Hetzner ARM64 staging server was silently falling back to a stale local `be65eae4` build because the amd64-only CI images had no matching manifest for `arm64/v8`; deploy script pull errors are now visible instead of swallowed [#740](https://github.com/Appsilon/mediforce/pull/740).
 - `scripts/sync-model-rankings.py` now uses OpenRouter's frontend rankings JSON endpoint instead of a brittle private server-action scrape, restoring local model ranking sync.
 - On-demand preview deploys now work: `/deploy` on a PR runs a real `vercel build` + `vercel deploy --prebuilt` via the Vercel CLI, replacing the empty-commit `[preview]`-marker hack that silently no-op'd.
 - Execution history panel now shows all iterations of looped steps — steps that completed before the current loop revisit (e.g. a timer-wait that ran between two visits to the same decision gate) were previously hidden or incorrectly marked pending due to the steps API returning only the latest execution per step and using a positional definition-order algorithm for status derivation.

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -37,7 +37,7 @@ fi
 export NEXT_PUBLIC_GIT_SHA=$(git rev-parse --short HEAD)
 
 echo "==> Pulling pre-built platform images from registry"
-$COMPOSE pull --ignore-pull-failures 2>/dev/null || true
+$COMPOSE pull --ignore-pull-failures 2>&1 || true
 
 if [ "${2:-}" = "--no-cache" ]; then
   echo "==> Rebuilding platform-ui (no-cache, SHA: $NEXT_PUBLIC_GIT_SHA)"


### PR DESCRIPTION
## Root cause

Staging server is Hetzner **ARM64** (`linux/arm64/v8`). Every `docker compose pull` since `be65eae4` failed silently with:

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

The `build-images.yml` only produced `linux/amd64` images (arm64 was added in #741 but only for `v*` tags, not main branch pushes). The `--ignore-pull-failures 2>/dev/null` in `deploy-staging.sh` swallowed the error, so the staging server kept running the original locally-built `be65eae4` image indefinitely.

## Fix

**`build-images.yml`** — matrix strategy with native runners:
- `ubuntu-latest` (amd64) for `linux/amd64`
- `ubuntu-24.04-arm` (ARM64) for `linux/arm64`
- `merge-manifests` job combines both into a multi-arch manifest for `:latest` and `:<sha>` tags

Each platform builds natively (no QEMU emulation), keeping per-platform build time the same as before. Cache scopes are split per-platform (`scope=platform-ui-linux-amd64`, `scope=platform-ui-linux-arm64`).

**`deploy-staging.sh`** — changed `2>/dev/null` to `2>&1` so pull errors appear in the deploy log instead of being silently discarded.

## Test plan

- [ ] After this merges, trigger a deploy to staging and confirm the displayed git SHA matches the latest commit
- [ ] Verify `docker pull ghcr.io/appsilon/mediforce-platform-ui:latest` on the staging server succeeds and shows `arm64` in the manifest
- [ ] Check both `linux/amd64` and `linux/arm64` matrix jobs complete in GHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)