### PR TITLE
fix(deploy): pin alpine to linux/arm64 in deploy script

### DIFF
--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -18,7 +18,7 @@ echo "==> Ensuring /var/lib/mediforce exists on host"
 # sudo, so we use a rootful alpine container as a permission-elevation
 # trick — the docker daemon the deploy already has access to (deploy
 # is in the docker group) lets us write outside the user's home tree.
-docker run --rm -v /var/lib:/host/var/lib alpine:latest \
+docker run --rm --platform linux/arm64 -v /var/lib:/host/var/lib alpine:latest \
   sh -c "mkdir -p /host/var/lib/mediforce && chmod 755 /host/var/lib/mediforce"
 
 # Only prune when the Docker data volume is actually filling up — unconditional


### PR DESCRIPTION
## Problem

The deploy script uses `docker run alpine:latest` without a `--platform` flag for the `/var/lib/mediforce` directory setup step. On the Hetzner ARM64 staging server, if an `amd64` alpine image ends up in the local Docker cache (e.g. from a `--platform linux/amd64` test run), subsequent deploys fail immediately with:

```
exec /bin/sh: exec format error
```

This is what caused the deploy failure in https://github.com/Appsilon/mediforce/actions/runs/27708504820.

## Fix

Add `--platform linux/arm64` to the alpine `docker run` call so it always uses the native ARM64 image regardless of local cache state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)