### PR TITLE
fix(entrypoint): add -type f to find so node_modules symlinks don't abort sed

### DIFF
--- a/packages/platform-ui/docker-entrypoint.sh
+++ b/packages/platform-ui/docker-entrypoint.sh
@@ -26,7 +26,9 @@ if [ "$needs_replacement" = true ]; then
     # Escape sed special chars in value
     escaped_value=$(printf '%s\n' "$value" | sed 's/[&/\|]/\\&/g')
     # Replace in client bundles (.next/static/) AND server chunks (.next/server/)
-    find "$NEXT_DIR" -name '*.js' -exec sed -i "s|${placeholder}|${escaped_value}|g" {} + 2>/dev/null || true
+    # -type f excludes symlinks (node_modules contains .js symlinks; sed -i on a
+    # symlink fails and aborts the rest of the batch, leaving later files untouched)
+    find "$NEXT_DIR" -name '*.js' -type f -exec sed -i "s|${placeholder}|${escaped_value}|g" {} + 2>/dev/null || true
     [ -f "$SERVER_JS" ] && sed -i "s|${placeholder}|${escaped_value}|g" "$SERVER_JS" 2>/dev/null || true
   done
 


### PR DESCRIPTION
## Root cause

`find "\$NEXT_DIR" -name '*.js' -exec sed -i ... {} +` matches **symlinks** in `node_modules` (e.g. `ipaddr.js`, `bignumber.js`). GNU `sed -i` with multiple files **aborts the rest of the list** when it hits a symlink:

```
sed: couldn't edit .../ipaddr.js: not a regular file
```

Static chunk files that sort after those symlinks in find's batch are never processed, leaving `__NEXT_PUBLIC_FIREBASE_API_KEY__` (and other vars) as literal placeholders in the client JS. Firebase Auth then fails because the Firebase project config is never injected — `sendPasswordResetEmail` returns a generic `"Error"`.

## Symptoms
- "Forgot password?" shows a red `Error` with no further detail
- `process.env.NEXT_PUBLIC_FIREBASE_API_KEY` resolves to the placeholder string `__NEXT_PUBLIC_FIREBASE_API_KEY__` in the browser

## Fix
Add `-type f` to the `find` call to exclude symlinks before handing the list to `sed`. One word change.

## Applied immediately
The fix was patched live onto the running container on staging; "Forgot password?" is working now. This PR bakes it into the image for all future deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)