### PR TITLE
fix: deploy staging after images are built

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,7 +1,9 @@
 name: Deploy to Staging
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build & Push Docker Images"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -13,6 +15,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Deploy via SSH
@@ -20,4 +23,5 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key deploy@${{ secrets.STAGING_SERVER_IP }} "/opt/mediforce/scripts/deploy-staging.sh ${{ github.sha }}"
+          SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key deploy@${{ secrets.STAGING_SERVER_IP }} "/opt/mediforce/scripts/deploy-staging.sh $SHA"


### PR DESCRIPTION
## Summary

Fix race condition: deploy-staging and build-images both triggered on push to main. Deploy finished in ~30s pulling the OLD `:latest`; build-images took ~6min to push the new one.

Deploy now triggers via `workflow_run` after build-images completes. Skips deploy if build failed.

## Test plan

- [ ] Push to main triggers build-images → on success triggers deploy-staging
- [ ] `workflow_dispatch` still works for manual deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)