### PR TITLE
feat(verdict-form): per-verdict param requirements via requiredForVerdicts

### DIFF
--- a/packages/platform-core/src/schemas/process-definition.ts
+++ b/packages/platform-core/src/schemas/process-definition.ts
@@ -23,6 +23,11 @@ export const StepParamSchema = z.object({
   // still fails parsing loudly.
   type: z.string().min(1).default('string'),
   required: z.boolean().default(false),
+  // When set, the param is only required when the user chooses one of these
+  // verdict keys — all other verdicts can be submitted without filling it.
+  // Takes precedence over `required` for the named verdicts; `required: true`
+  // still blocks every verdict unconditionally.
+  requiredForVerdicts: z.array(z.string()).optional(),
   description: z.string().optional(),
   default: z.unknown().optional(),
   options: z.array(z.string()).optional(),

--- a/packages/platform-ui/src/components/tasks/param-verdict-view.tsx
+++ b/packages/platform-ui/src/components/tasks/param-verdict-view.tsx
@@ -36,6 +36,19 @@ export function ParamVerdictView({ task, remainingTaskCount }: TaskBodyProps) {
   return null;
 }
 
+function isParamBlockedForVerdict(
+  verdictKey: string,
+  params: StepParam[],
+  values: Record<string, unknown>,
+): boolean {
+  return params.some((p) => {
+    const val = values[p.name];
+    const missing = val === undefined || val === '';
+    if (!missing) return false;
+    return p.required || p.requiredForVerdicts?.includes(verdictKey) === true;
+  });
+}
+
 function ParamVerdictForm({
   taskId,
   params,
@@ -47,7 +60,7 @@ function ParamVerdictForm({
   verdicts: TaskVerdict[];
   remainingTaskCount?: number;
 }) {
-  const { values, setValue, requiredMissing, coerce } = useParamValues(params);
+  const { values, setValue, coerce } = useParamValues(params);
   const [comment, setComment] = React.useState('');
   const [submitting, setSubmitting] = React.useState<string | null>(null);
   const [submitted, setSubmitted] = React.useState(false);
@@ -56,7 +69,7 @@ function ParamVerdictForm({
   const trimmedComment = comment.trim();
 
   async function handleVerdict(cfg: TaskVerdict) {
-    if (requiredMissing) return;
+    if (isParamBlockedForVerdict(cfg.key, params, values)) return;
     if (cfg.requiresComment && !trimmedComment) return;
     if (submitting !== null) return;
 
@@ -118,7 +131,7 @@ function ParamVerdictForm({
         verdicts={verdicts}
         submitting={submitting}
         trimmedComment={trimmedComment}
-        outerBlocked={requiredMissing}
+        isVerdictBlocked={(key) => isParamBlockedForVerdict(key, params, values)}
         outerBlockedHint="Fill required fields first"
         onVerdict={handleVerdict}
       />

--- a/packages/platform-ui/src/components/tasks/verdict-form.tsx
+++ b/packages/platform-ui/src/components/tasks/verdict-form.tsx
@@ -60,6 +60,7 @@ export function VerdictButtons({
   trimmedComment,
   outerBlocked,
   outerBlockedHint,
+  isVerdictBlocked,
   onVerdict,
 }: {
   verdicts: TaskVerdict[];
@@ -67,6 +68,8 @@ export function VerdictButtons({
   trimmedComment: string;
   outerBlocked?: boolean;
   outerBlockedHint?: string;
+  /** Per-verdict param block — overrides `outerBlocked` when provided. */
+  isVerdictBlocked?: (key: string) => boolean;
   onVerdict: (cfg: TaskVerdict) => void;
 }) {
   const sorted = [...verdicts].sort((a, b) =>
@@ -76,9 +79,10 @@ export function VerdictButtons({
   return (
     <div className="flex flex-col gap-2">
       {sorted.map((cfg) => {
+        const paramBlocked = isVerdictBlocked ? isVerdictBlocked(cfg.key) : !!outerBlocked;
         const commentBlocked = cfg.requiresComment && !trimmedComment;
         const isSubmittingThis = submitting === cfg.key;
-        const isDisabled = submitting !== null || !!outerBlocked || commentBlocked;
+        const isDisabled = submitting !== null || paramBlocked || commentBlocked;
         return (
           <div key={cfg.key} className="flex flex-col items-start gap-1">
             <button
@@ -96,10 +100,10 @@ export function VerdictButtons({
                 : <IntentIcon intent={cfg.intent} className="h-4 w-4" />}
               {cfg.label}
             </button>
-            {outerBlocked && outerBlockedHint && (
+            {paramBlocked && outerBlockedHint && (
               <span className="text-xs text-muted-foreground/70 pl-1">{outerBlockedHint}</span>
             )}
-            {!outerBlocked && commentBlocked && (
+            {!paramBlocked && commentBlocked && (
               <span className="text-xs text-muted-foreground/70 pl-1">Comment required</span>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Adds `StepParam.requiredForVerdicts: string[]` — a param can now be required only for specific verdicts instead of blocking all buttons equally.
- A verdict button is blocked when: any `required: true` param is empty (unchanged), **or** any param listing that verdict key in `requiredForVerdicts` is empty.
- Registered `collecting-submission-documents` **v3** on staging: `scheduled_action_date` now only blocks the three "wait/remind/request-fixes" buttons — the "Finalize — collection complete" button is no longer gated on it.

## How it works

In the workflow definition:
```json
{
  "name": "scheduled_action_date",
  "type": "datetime",
  "required": false,
  "requiredForVerdicts": ["wait", "remind", "request-fixes"]
}
```

`VerdictButtons` accepts a new `isVerdictBlocked?: (key: string) => boolean` prop that overrides `outerBlocked` for per-verdict control. Existing callers using `outerBlocked` are unchanged.

## Test plan

- [ ] All 121 existing task component tests pass
- [ ] On staging: open a `collecting-submission-documents` run at the `check-decision` step — "Finalize — collection complete" button is clickable without a date; the three wait/remind buttons show "Fill required fields first" hint when date is empty
- [ ] Existing workflows using `required: true` params still block all verdict buttons as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)