### PR TITLE
feat: SMTP email provider as alternative to Mailgun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ complexity estimates because of medical vocabulary.
 packages/
   platform-core/    Zod schemas, repo interfaces, in-memory test doubles
   platform-api/     Contract + framework-free handlers
-  platform-infra/   Postgres, Firebase Auth, SendGrid
+  platform-infra/   Postgres, Firebase Auth, email (Mailgun/SMTP)
   platform-ui/      Next.js 15 App Router (dev :9003, e2e :9007)
   workflow-engine/  Engine, transitions, expression DSL
   agent-runtime/    PluginRegistry, AgentRunner, Docker spawn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Added
+- SMTP email provider as alternative to Mailgun — organisations can now use their own SMTP infrastructure instead of Mailgun by setting `SMTP_*` env vars; `EMAIL_PROVIDER` auto-detects or can be set explicitly; includes read-only admin status page, `mediforce email status` CLI command, and bootstrap script prompts for initial setup [#748](https://github.com/Appsilon/mediforce/issues/748).
 - **Run view UX** — execution history panel (renamed from "Step Status"), scrollable workflow diagram, active step info (started time, live elapsed timer, executor name/claimer for claimed human tasks)
 - **Task view** — spreadsheet-style table replaces card grid; status column, clickable run links, bulk cancel via batch endpoint, hide-completed toggle. Absolute dates replace relative timestamps in the table. `process × action` cross-grouping (sub-grouping within a process group by action type) is not carried forward in the table layout; each grouping mode renders a flat table.
 - **Process card** — step-progress dots rendered against the run's actual definition version instead of the latest definition

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -133,6 +133,7 @@ services:
       - SMTP_PASS=${SMTP_PASS:-}
       - SMTP_FROM_EMAIL=${SMTP_FROM_EMAIL:-}
       - SMTP_SECURE=${SMTP_SECURE:-true}
+      - SMTP_SENDER_NAME=${SMTP_SENDER_NAME:-Mediforce}
       # Firebase Admin SDK credentials for server-side Firestore/Auth access.
       # Mounted read-only from host ./secrets/firebase-admin-sa.json.
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-sa.json

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -122,10 +122,17 @@ services:
       # directory must exist before first launch:
       #   sudo mkdir -p /var/lib/mediforce
       - MEDIFORCE_DATA_DIR=/var/lib/mediforce
-      - MAILGUN_API_KEY=${MAILGUN_API_KEY}
-      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN}
-      - MAILGUN_FROM_EMAIL=${MAILGUN_FROM_EMAIL}
+      - EMAIL_PROVIDER=${EMAIL_PROVIDER:-}
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY:-}
+      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN:-}
+      - MAILGUN_FROM_EMAIL=${MAILGUN_FROM_EMAIL:-}
       - MAILGUN_SENDER_NAME=${MAILGUN_SENDER_NAME:-Mediforce}
+      - SMTP_HOST=${SMTP_HOST:-}
+      - SMTP_PORT=${SMTP_PORT:-587}
+      - SMTP_USER=${SMTP_USER:-}
+      - SMTP_PASS=${SMTP_PASS:-}
+      - SMTP_FROM_EMAIL=${SMTP_FROM_EMAIL:-}
+      - SMTP_SECURE=${SMTP_SECURE:-true}
       # Firebase Admin SDK credentials for server-side Firestore/Auth access.
       # Mounted read-only from host ./secrets/firebase-admin-sa.json.
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-sa.json

--- a/docs/knowledge-base/wiki/entities/packages/platform-infra.md
+++ b/docs/knowledge-base/wiki/entities/packages/platform-infra.md
@@ -10,12 +10,12 @@ tags: [package, platform-infra, firestore, firebase]
 
 ## Purpose
 
-Implements repo interfaces from `platform-core` against Firestore. Wraps Firebase Auth. Owns collection/doc shape, immutable version constraints, dual client-vs-admin SDK init, notification delivery (SendGrid + webhooks). Constructor-injected. No global singletons inside repos.
+Implements repo interfaces from `platform-core` against Firestore. Wraps Firebase Auth. Owns collection/doc shape, immutable version constraints, dual client-vs-admin SDK init, notification delivery (Mailgun/SMTP + webhooks). Constructor-injected. No global singletons inside repos.
 
 ## Dependencies
 
 - Internal: [`platform-core`](./platform-core.md).
-- External: `firebase`, `firebase-admin`, `@sendgrid/mail`.
+- External: `firebase`, `firebase-admin`, `nodemailer`.
 
 ## Key exports
 
@@ -31,7 +31,7 @@ Implements repo interfaces from `platform-core` against Firestore. Wraps Firebas
 - `src/auth/` — Firebase Auth wrappers, user directory, invites.
 - `src/config/firebase-init.ts` — client vs admin SDK init.
 - `src/crypto/secrets-cipher.ts` — HMAC validation.
-- `src/notifications/` — SendGrid + webhooks.
+- `src/notifications/` — email (Mailgun/SMTP) + webhooks.
 - `src/__tests__/` — repo CRUD, versioning, auth, cipher.
 
 ## Relationships

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,6 +36,7 @@ import {
   systemDiskCommand,
   systemRmiCommand,
 } from './commands/system-status';
+import { emailStatusCommand } from './commands/email-status';
 import { systemCreditsCommand } from './commands/system-credits';
 import { agentListCommand } from './commands/agent-list';
 import { agentGetCommand } from './commands/agent-get';
@@ -218,6 +219,12 @@ export const TREE: Record<string, BranchEntry> = {
       rmi: { description: 'Remove a Docker image by ID or name:tag', fn: systemRmiCommand },
       disk: { description: 'Docker disk usage breakdown', fn: systemDiskCommand },
       credits: { description: 'OpenRouter credit balance for a workspace', fn: systemCreditsCommand },
+    },
+  },
+  email: {
+    description: 'Email provider status',
+    leaves: {
+      status: { description: 'Show configured email provider', fn: emailStatusCommand },
     },
   },
   config: {

--- a/packages/cli/src/commands/email-status.ts
+++ b/packages/cli/src/commands/email-status.ts
@@ -1,0 +1,23 @@
+import { defineCommand } from '../define-command';
+import { printJson } from '../output';
+
+export const emailStatusCommand = defineCommand({
+  name: 'mediforce email status',
+  description: 'Show the configured email provider and its status.',
+  args: {},
+  async run({ output, mediforce, jsonMode }) {
+    const data = await mediforce.system.emailStatus();
+    if (jsonMode) {
+      printJson(output, data);
+      return 0;
+    }
+    if (data.provider === null) {
+      output.stdout('Email: not configured');
+      return 0;
+    }
+    output.stdout(`Email provider: ${data.provider}`);
+    output.stdout(`From address:   ${data.from ?? '(not set)'}`);
+    output.stdout(`Status:         ${data.configured ? 'configured' : 'not configured'}`);
+    return 0;
+  },
+});

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -368,6 +368,10 @@ import {
   type GetConfigByPrefixOutput,
   type SetConfigOutput,
   type TestWebhookOutput,
+  GetEmailStatusInputSchema,
+  GetEmailStatusOutputSchema,
+  type GetEmailStatusInput,
+  type GetEmailStatusOutput,
 } from '../contract/index';
 // SDK consumers reach for one path:
 //   import { Mediforce, ApiError, type ApiErrorCode } from '@mediforce/platform-api/client';
@@ -571,6 +575,7 @@ export class Mediforce {
   readonly system: {
     dockerInfo: () => Promise<DockerInfoResponse>;
     credits: (input: OpenRouterCreditsInput) => Promise<OpenRouterCreditsOutput>;
+    emailStatus: () => Promise<GetEmailStatusOutput>;
   };
 
   readonly cron: {
@@ -1347,6 +1352,11 @@ export class Mediforce {
         const res = await this.request(`/api/system/openrouter-credits${qs}`);
         const body = await parseJsonOrThrow(res, 'mediforce.system.credits');
         return OpenRouterCreditsOutputSchema.parse(body);
+      },
+      emailStatus: async () => {
+        const res = await this.request('/api/admin/email-status');
+        const body = await parseJsonOrThrow(res, 'mediforce.system.emailStatus');
+        return GetEmailStatusOutputSchema.parse(body);
       },
     };
 

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -368,9 +368,7 @@ import {
   type GetConfigByPrefixOutput,
   type SetConfigOutput,
   type TestWebhookOutput,
-  GetEmailStatusInputSchema,
   GetEmailStatusOutputSchema,
-  type GetEmailStatusInput,
   type GetEmailStatusOutput,
 } from '../contract/index';
 // SDK consumers reach for one path:

--- a/packages/platform-api/src/contract/email-status.ts
+++ b/packages/platform-api/src/contract/email-status.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const GetEmailStatusInputSchema = z.object({});
+export type GetEmailStatusInput = z.infer<typeof GetEmailStatusInputSchema>;
+
+export const GetEmailStatusOutputSchema = z.object({
+  provider: z.enum(['mailgun', 'smtp']).nullable(),
+  configured: z.boolean(),
+  from: z.string().nullable(),
+});
+export type GetEmailStatusOutput = z.infer<typeof GetEmailStatusOutputSchema>;

--- a/packages/platform-api/src/contract/index.ts
+++ b/packages/platform-api/src/contract/index.ts
@@ -103,6 +103,13 @@ export {
 } from './system';
 
 export {
+  GetEmailStatusInputSchema,
+  GetEmailStatusOutputSchema,
+  type GetEmailStatusInput,
+  type GetEmailStatusOutput,
+} from './email-status';
+
+export {
   ListAgentsInputSchema,
   ListAgentsOutputSchema,
   GetAgentInputSchema,

--- a/packages/platform-api/src/handlers/admin/__tests__/email-status.test.ts
+++ b/packages/platform-api/src/handlers/admin/__tests__/email-status.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getEmailStatus } from '../email-status';
+import { createTestScope, userCaller } from '../../../repositories/__tests__/create-test-scope';
+
+describe('getEmailStatus handler', () => {
+  it('returns null provider when emailProviderInfo is not configured', async () => {
+    const scope = createTestScope();
+    const result = await getEmailStatus({}, scope);
+
+    expect(result).toEqual({ provider: null, configured: false, from: null });
+  });
+
+  it('returns provider info when configured', async () => {
+    const scope = createTestScope({
+      emailProviderInfo: { provider: 'smtp', configured: true, from: 'test@example.com' },
+    });
+    const result = await getEmailStatus({}, scope);
+
+    expect(result).toEqual({ provider: 'smtp', configured: true, from: 'test@example.com' });
+  });
+
+  it('rejects non-admin callers', async () => {
+    const scope = createTestScope({ caller: userCaller('u1', ['ns1']) });
+    await expect(getEmailStatus({}, scope)).rejects.toThrow();
+  });
+});

--- a/packages/platform-api/src/handlers/admin/email-status.ts
+++ b/packages/platform-api/src/handlers/admin/email-status.ts
@@ -1,0 +1,16 @@
+import type { GetEmailStatusInput, GetEmailStatusOutput } from '../../contract/email-status';
+import type { CallerScope } from '../../repositories/caller-scope';
+import { assertCallerCanAdminDockerImages } from '../../auth';
+
+export async function getEmailStatus(
+  _input: GetEmailStatusInput,
+  scope: CallerScope,
+): Promise<GetEmailStatusOutput> {
+  assertCallerCanAdminDockerImages(scope.caller);
+  const info = scope.system.emailProviderInfo;
+  return {
+    provider: info?.provider ?? null,
+    configured: info?.configured ?? false,
+    from: info?.from ?? null,
+  };
+}

--- a/packages/platform-api/src/handlers/index.ts
+++ b/packages/platform-api/src/handlers/index.ts
@@ -75,6 +75,7 @@ export { saveWorkflowSecrets } from './secrets/save-workflow-secrets';
 
 export { getDockerInfo } from './system/get-docker-info';
 export { getOpenRouterCredits } from './system/get-openrouter-credits';
+export { getEmailStatus } from './admin/email-status';
 
 export { deleteDockerImage } from './docker-images/delete-image';
 

--- a/packages/platform-api/src/repositories/__tests__/create-test-scope.ts
+++ b/packages/platform-api/src/repositories/__tests__/create-test-scope.ts
@@ -22,6 +22,7 @@ import {
 } from '@mediforce/platform-core/testing';
 import type {
   AgentRunRepository,
+  EmailProviderInfo,
   ModelRegistryRepository,
   NamespaceRepository,
   NamespaceSecretsRepository,
@@ -183,6 +184,7 @@ export interface TestScopeOverrides {
   readonly userProfileRepo?: UserProfileRepository;
   readonly userDirectory?: UserDirectoryService | null;
   readonly platformSettingsRepo?: PlatformSettingsRepository;
+  readonly emailProviderInfo?: EmailProviderInfo | null;
 }
 
 const apiKeyCaller: CallerIdentity = { kind: 'apiKey', isSystemActor: true };
@@ -236,6 +238,7 @@ export function createTestScope(overrides: TestScopeOverrides = {}): CallerScope
     inviteNotificationService: overrides.inviteNotificationService ?? null,
     dockerImages: overrides.dockerImages ?? null,
     userDirectory: overrides.userDirectory ?? null,
+    emailProviderInfo: overrides.emailProviderInfo ?? null,
   };
   return createCallerScope(services, caller);
 }

--- a/packages/platform-api/src/repositories/caller-scope.ts
+++ b/packages/platform-api/src/repositories/caller-scope.ts
@@ -2,6 +2,7 @@ import type { AgentRunner, PluginRegistry } from '@mediforce/agent-runtime';
 import type {
   AuditRepository,
   CronTriggerStateRepository,
+  EmailProviderInfo,
   ModelRegistryRepository,
   NamespaceRepository,
   PlatformSettingsRepository,
@@ -138,4 +139,5 @@ export interface SystemServices {
    */
   readonly userDirectory: UserDirectoryService | null;
   readonly platformSettings: PlatformSettingsRepository;
+  readonly emailProviderInfo: EmailProviderInfo | null;
 }

--- a/packages/platform-api/src/repositories/create-caller-scope.ts
+++ b/packages/platform-api/src/repositories/create-caller-scope.ts
@@ -7,6 +7,7 @@ import type {
   AuditRepository,
   CoworkSessionRepository,
   CronTriggerStateRepository,
+  EmailProviderInfo,
   HandoffRepository,
   HumanTaskRepository,
   ModelRegistryRepository,
@@ -83,6 +84,7 @@ export interface CallerScopeServices {
   readonly dockerImages: DockerImagesService | null;
   readonly userDirectory: UserDirectoryService | null;
   readonly platformSettingsRepo: PlatformSettingsRepository;
+  readonly emailProviderInfo: EmailProviderInfo | null;
 }
 
 /**
@@ -150,6 +152,7 @@ export function createCallerScope(
       dockerImages: services.dockerImages,
       userDirectory: services.userDirectory,
       platformSettings: services.platformSettingsRepo,
+      emailProviderInfo: services.emailProviderInfo,
     },
   };
 }

--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -23,6 +23,7 @@ import {
   FirebaseInviteService,
   validateSecretsKey,
   createMailgunSender,
+  createSmtpSender,
   MailgunNotificationService,
   FirebaseUserDirectoryService,
   getAdminAuth,
@@ -35,6 +36,7 @@ import type {
   AuditRepository,
   CoworkSessionRepository,
   CronTriggerStateRepository,
+  EmailProviderInfo,
   HandoffRepository,
   HumanTaskRepository,
   ModelRegistryRepository,
@@ -130,8 +132,9 @@ export interface PlatformServices {
   secretsRepo: WorkflowSecretsRepository;
   namespaceSecretsRepo: NamespaceSecretsRepository;
   inviteService: InviteService;
-  /** `null` when Mailgun env vars are unset (email disabled). */
+  /** `null` when email env vars are unset (email disabled). */
   inviteNotificationService: InviteNotificationService | null;
+  emailProviderInfo: EmailProviderInfo | null;
   dockerImages: DockerImagesService;
   /**
    * Firebase Auth metadata lookup (uid → email, lastSignInTime). Always wired
@@ -303,34 +306,71 @@ export function getPlatformServices(): PlatformServices {
   const mailgunDomain = process.env.MAILGUN_DOMAIN ?? '';
   const mailgunFrom = process.env.MAILGUN_FROM_EMAIL ?? '';
   const mailgunSenderName = process.env.MAILGUN_SENDER_NAME ?? 'Mediforce';
-
   const mailgunConfigured = mailgunApiKey !== '' && mailgunDomain !== '' && mailgunFrom !== '';
-  if (!emailDisabled && !mailgunConfigured) {
-    const missing = [
-      !mailgunApiKey && 'MAILGUN_API_KEY',
-      !mailgunDomain && 'MAILGUN_DOMAIN',
-      !mailgunFrom && 'MAILGUN_FROM_EMAIL',
-    ].filter(Boolean).join(', ');
-    throw new Error(
-      `Email is enabled but Mailgun config incomplete (missing: ${missing}). ` +
-      `Set the env vars or set MEDIFORCE_DISABLE_EMAIL=true to start without email.`,
-    );
-  }
+
+  const smtpHost = process.env.SMTP_HOST ?? '';
+  const smtpPort = process.env.SMTP_PORT ?? '';
+  const smtpUser = process.env.SMTP_USER ?? '';
+  const smtpPass = process.env.SMTP_PASS ?? '';
+  const smtpSecure = process.env.SMTP_SECURE !== 'false';
+  const smtpFrom = process.env.SMTP_FROM_EMAIL ?? '';
+  const smtpConfigured = smtpHost !== '' && smtpFrom !== '';
+
+  const explicitProvider = process.env.EMAIL_PROVIDER as 'mailgun' | 'smtp' | undefined;
+  const resolvedProvider = resolveEmailProvider(explicitProvider, mailgunConfigured, smtpConfigured);
+
   if (emailDisabled) {
     console.log('[platform-services] MEDIFORCE_DISABLE_EMAIL=true — email handler and notifications disabled');
   }
 
-  const mailgunSender = mailgunConfigured
-    ? createMailgunSender({
-        apiKey: mailgunApiKey,
-        domain: mailgunDomain,
-        defaultFrom: mailgunFrom,
-        defaultSenderName: mailgunSenderName,
-      })
-    : undefined;
+  let emailSender: SendEmailFn | undefined;
+  let emailProviderInfo: EmailProviderInfo | null = null;
 
-  const notificationService = mailgunSender
-    ? new MailgunNotificationService(mailgunSender)
+  if (!emailDisabled && resolvedProvider === 'mailgun') {
+    if (!mailgunConfigured) {
+      const missing = [
+        !mailgunApiKey && 'MAILGUN_API_KEY',
+        !mailgunDomain && 'MAILGUN_DOMAIN',
+        !mailgunFrom && 'MAILGUN_FROM_EMAIL',
+      ].filter(Boolean).join(', ');
+      throw new Error(
+        `EMAIL_PROVIDER=mailgun but config incomplete (missing: ${missing}). ` +
+        `Set the env vars or set MEDIFORCE_DISABLE_EMAIL=true to start without email.`,
+      );
+    }
+    emailSender = createMailgunSender({
+      apiKey: mailgunApiKey,
+      domain: mailgunDomain,
+      defaultFrom: mailgunFrom,
+      defaultSenderName: mailgunSenderName,
+    });
+    emailProviderInfo = { provider: 'mailgun', configured: true, from: mailgunFrom };
+    console.log('[platform-services] Email provider: Mailgun');
+  } else if (!emailDisabled && resolvedProvider === 'smtp') {
+    if (!smtpConfigured) {
+      const missing = [
+        !smtpHost && 'SMTP_HOST',
+        !smtpFrom && 'SMTP_FROM_EMAIL',
+      ].filter(Boolean).join(', ');
+      throw new Error(
+        `EMAIL_PROVIDER=smtp but config incomplete (missing: ${missing}). ` +
+        `Set the env vars or set MEDIFORCE_DISABLE_EMAIL=true to start without email.`,
+      );
+    }
+    emailSender = createSmtpSender({
+      host: smtpHost,
+      port: smtpPort !== '' ? Number(smtpPort) : 587,
+      secure: smtpSecure,
+      user: smtpUser,
+      pass: smtpPass,
+      defaultFrom: smtpFrom,
+    });
+    emailProviderInfo = { provider: 'smtp', configured: true, from: smtpFrom };
+    console.log('[platform-services] Email provider: SMTP');
+  }
+
+  const notificationService = emailSender
+    ? new MailgunNotificationService(emailSender)
     : undefined;
   // Wired whenever Firebase Auth is available — independent of Mailgun.
   // Email-disabled deployments still need uid → email/lastSignInTime lookups
@@ -375,8 +415,8 @@ export function getPlatformServices(): PlatformServices {
   });
   actionRegistry.register('spawn', createSpawnActionHandler(manualTrigger, processRepo, spawnRunKicker));
   actionRegistry.register('wait', waitActionHandler);
-  if (mailgunSender) {
-    actionRegistry.register('email', createEmailActionHandler(mailgunSender));
+  if (emailSender) {
+    actionRegistry.register('email', createEmailActionHandler(emailSender));
   }
 
   const webhookRouter = new WebhookRouter(engine, processRepo);
@@ -391,8 +431,9 @@ export function getPlatformServices(): PlatformServices {
   // NEXT_PUBLIC_PLATFORM_URL still renders sensible links.
   const inviteAppUrl =
     process.env.NEXT_PUBLIC_PLATFORM_URL ?? `http://localhost:${process.env.PORT ?? '3000'}`;
-  const inviteNotificationService = mailgunSender
-    ? new MailgunInviteNotificationService(mailgunSender, inviteAppUrl, mailgunSenderName)
+  const senderName = resolvedProvider === 'mailgun' ? mailgunSenderName : 'Mediforce';
+  const inviteNotificationService = emailSender
+    ? new MailgunInviteNotificationService(emailSender, inviteAppUrl, senderName)
     : null;
 
   const dockerImages: DockerImagesService = isLocalAgentMode()
@@ -434,6 +475,7 @@ export function getPlatformServices(): PlatformServices {
     namespaceSecretsRepo,
     inviteService,
     inviteNotificationService,
+    emailProviderInfo,
     dockerImages,
     userDirectory: userDirectoryService,
   };
@@ -452,4 +494,20 @@ export function getPlatformServices(): PlatformServices {
   }
 
   return services;
+}
+
+function resolveEmailProvider(
+  explicit: 'mailgun' | 'smtp' | undefined,
+  mailgunConfigured: boolean,
+  smtpConfigured: boolean,
+): 'mailgun' | 'smtp' | null {
+  if (explicit !== undefined) return explicit;
+  if (mailgunConfigured && smtpConfigured) {
+    throw new Error(
+      'Both Mailgun and SMTP env vars are set. Set EMAIL_PROVIDER=mailgun or EMAIL_PROVIDER=smtp to disambiguate.',
+    );
+  }
+  if (mailgunConfigured) return 'mailgun';
+  if (smtpConfigured) return 'smtp';
+  return null;
 }

--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -24,7 +24,7 @@ import {
   validateSecretsKey,
   createMailgunSender,
   createSmtpSender,
-  MailgunNotificationService,
+  EmailNotificationService,
   FirebaseUserDirectoryService,
   getAdminAuth,
 } from '@mediforce/platform-infra';
@@ -205,11 +205,11 @@ class FirebaseInviteServiceAdapter implements InviteService {
 }
 
 /**
- * Adapts the Mailgun `SendEmailFn` into the `InviteNotificationService`
+ * Adapts a `SendEmailFn` into the `InviteNotificationService`
  * interface — delegates to the existing pure email-body helpers and supplies
  * deployment config (app URL, sender name) so handlers never see env vars.
  */
-class MailgunInviteNotificationService implements InviteNotificationService {
+class EmailInviteNotificationService implements InviteNotificationService {
   constructor(
     private readonly sendEmail: SendEmailFn,
     private readonly appUrl: string,
@@ -314,9 +314,16 @@ export function getPlatformServices(): PlatformServices {
   const smtpPass = process.env.SMTP_PASS ?? '';
   const smtpSecure = process.env.SMTP_SECURE !== 'false';
   const smtpFrom = process.env.SMTP_FROM_EMAIL ?? '';
+  const smtpSenderName = process.env.SMTP_SENDER_NAME ?? 'Mediforce';
   const smtpConfigured = smtpHost !== '' && smtpFrom !== '';
 
-  const explicitProvider = process.env.EMAIL_PROVIDER as 'mailgun' | 'smtp' | undefined;
+  const rawEmailProvider = process.env.EMAIL_PROVIDER || undefined;
+  if (rawEmailProvider !== undefined && rawEmailProvider !== 'mailgun' && rawEmailProvider !== 'smtp') {
+    throw new Error(
+      `EMAIL_PROVIDER="${rawEmailProvider}" is not valid. Use "mailgun" or "smtp".`,
+    );
+  }
+  const explicitProvider = rawEmailProvider as 'mailgun' | 'smtp' | undefined;
   const resolvedProvider = resolveEmailProvider(explicitProvider, mailgunConfigured, smtpConfigured);
 
   if (emailDisabled) {
@@ -364,15 +371,21 @@ export function getPlatformServices(): PlatformServices {
       user: smtpUser,
       pass: smtpPass,
       defaultFrom: smtpFrom,
+      defaultSenderName: smtpSenderName,
     });
     emailProviderInfo = { provider: 'smtp', configured: true, from: smtpFrom };
     console.log('[platform-services] Email provider: SMTP');
+  } else if (!emailDisabled && resolvedProvider === null) {
+    throw new Error(
+      'Email is enabled but no email provider is configured. ' +
+      'Set MAILGUN_* or SMTP_* env vars, or set MEDIFORCE_DISABLE_EMAIL=true to start without email.',
+    );
   }
 
   const notificationService = emailSender
-    ? new MailgunNotificationService(emailSender)
+    ? new EmailNotificationService(emailSender)
     : undefined;
-  // Wired whenever Firebase Auth is available — independent of Mailgun.
+  // Wired whenever Firebase Auth is available — independent of email provider.
   // Email-disabled deployments still need uid → email/lastSignInTime lookups
   // for the namespace-members endpoint.
   const userDirectoryService: UserDirectoryService = new FirebaseUserDirectoryService(
@@ -431,9 +444,9 @@ export function getPlatformServices(): PlatformServices {
   // NEXT_PUBLIC_PLATFORM_URL still renders sensible links.
   const inviteAppUrl =
     process.env.NEXT_PUBLIC_PLATFORM_URL ?? `http://localhost:${process.env.PORT ?? '3000'}`;
-  const senderName = resolvedProvider === 'mailgun' ? mailgunSenderName : 'Mediforce';
+  const senderName = resolvedProvider === 'mailgun' ? mailgunSenderName : smtpSenderName;
   const inviteNotificationService = emailSender
-    ? new MailgunInviteNotificationService(emailSender, inviteAppUrl, senderName)
+    ? new EmailInviteNotificationService(emailSender, inviteAppUrl, senderName)
     : null;
 
   const dockerImages: DockerImagesService = isLocalAgentMode()

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -245,6 +245,7 @@ export type {
   SendEmailParams,
   SendEmailResult,
   SendEmailFn,
+  EmailProviderInfo,
 } from './interfaces/index';
 
 export { encodeCursor, decodeCursor } from './cursors/cursor';

--- a/packages/platform-core/src/interfaces/email-service.ts
+++ b/packages/platform-core/src/interfaces/email-service.ts
@@ -14,3 +14,9 @@ export interface SendEmailResult {
 }
 
 export type SendEmailFn = (params: SendEmailParams) => Promise<SendEmailResult>;
+
+export interface EmailProviderInfo {
+  provider: 'mailgun' | 'smtp' | null;
+  configured: boolean;
+  from: string | null;
+}

--- a/packages/platform-core/src/interfaces/index.ts
+++ b/packages/platform-core/src/interfaces/index.ts
@@ -10,7 +10,7 @@ export type {
 export type { HumanTaskRepository } from './human-task-repository';
 export type { HandoffRepository } from './handoff-repository';
 export type { NotificationService, NotificationEvent, NotificationTarget } from './notification-service';
-export type { SendEmailParams, SendEmailResult, SendEmailFn } from './email-service';
+export type { SendEmailParams, SendEmailResult, SendEmailFn, EmailProviderInfo } from './email-service';
 export type { UserDirectoryService, DirectoryUser, UserAuthMetadata } from './user-directory-service';
 export type {
   AgentRunRepository,

--- a/packages/platform-infra/package.json
+++ b/packages/platform-infra/package.json
@@ -11,11 +11,13 @@
     "drizzle-orm": "^0.45.2",
     "firebase": "^12.0.0",
     "firebase-admin": "^13.6.1",
+    "nodemailer": "^8.0.11",
     "postgres": "^3.4.9",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
+    "@types/nodemailer": "^8.0.1",
     "drizzle-kit": "^0.31.10"
   },
   "scripts": {

--- a/packages/platform-infra/src/email/index.ts
+++ b/packages/platform-infra/src/email/index.ts
@@ -1,2 +1,4 @@
 export { createMailgunSender } from './mailgun-client';
 export type { MailgunConfig } from './mailgun-client';
+export { createSmtpSender } from './smtp-client';
+export type { SmtpConfig } from './smtp-client';

--- a/packages/platform-infra/src/email/smtp-client.ts
+++ b/packages/platform-infra/src/email/smtp-client.ts
@@ -4,10 +4,11 @@ import { createTransport } from 'nodemailer';
 export interface SmtpConfig {
   host: string;
   port: number;
-  secure: boolean; // true for port 465 (implicit TLS), false for STARTTLS on 587
+  secure: boolean;
   user: string;
   pass: string;
   defaultFrom: string;
+  defaultSenderName: string;
 }
 
 export function createSmtpSender(
@@ -21,7 +22,7 @@ export function createSmtpSender(
   });
 
   return async (params) => {
-    const from = params.from ?? config.defaultFrom;
+    const from = params.from ?? `${config.defaultSenderName} <${config.defaultFrom}>`;
     const info = await transport.sendMail({
       from,
       to: params.to.join(', '),

--- a/packages/platform-infra/src/email/smtp-client.ts
+++ b/packages/platform-infra/src/email/smtp-client.ts
@@ -1,0 +1,37 @@
+import type { SendEmailParams, SendEmailResult } from '@mediforce/platform-core';
+import { createTransport } from 'nodemailer';
+
+export interface SmtpConfig {
+  host: string;
+  port: number;
+  secure: boolean; // true for port 465 (implicit TLS), false for STARTTLS on 587
+  user: string;
+  pass: string;
+  defaultFrom: string;
+}
+
+export function createSmtpSender(
+  config: SmtpConfig,
+): (params: SendEmailParams) => Promise<SendEmailResult> {
+  const transport = createTransport({
+    host: config.host,
+    port: config.port,
+    secure: config.secure,
+    auth: { user: config.user, pass: config.pass },
+  });
+
+  return async (params) => {
+    const from = params.from ?? config.defaultFrom;
+    const info = await transport.sendMail({
+      from,
+      to: params.to.join(', '),
+      cc: params.cc?.join(', '),
+      bcc: params.bcc?.join(', '),
+      replyTo: params.replyTo,
+      subject: params.subject,
+      text: params.text,
+      html: params.html ?? undefined,
+    });
+    return { messageId: info.messageId ?? '' };
+  };
+}

--- a/packages/platform-infra/src/index.ts
+++ b/packages/platform-infra/src/index.ts
@@ -11,7 +11,7 @@ export {
 export type { FirebaseConfig } from './config/firebase-init';
 
 // Notifications + email
-export { MailgunNotificationService } from './notifications/mailgun-notification-service';
+export { EmailNotificationService } from './notifications/mailgun-notification-service';
 export { WebhookNotificationService } from './notifications/webhook-notification-service';
 export { createMailgunSender } from './email/mailgun-client';
 export type { MailgunConfig } from './email/mailgun-client';

--- a/packages/platform-infra/src/index.ts
+++ b/packages/platform-infra/src/index.ts
@@ -15,6 +15,8 @@ export { MailgunNotificationService } from './notifications/mailgun-notification
 export { WebhookNotificationService } from './notifications/webhook-notification-service';
 export { createMailgunSender } from './email/mailgun-client';
 export type { MailgunConfig } from './email/mailgun-client';
+export { createSmtpSender } from './email/smtp-client';
+export type { SmtpConfig } from './email/smtp-client';
 
 // Postgres repositories — the only data backend (ADR-0001).
 export { PostgresToolCatalogRepository } from './postgres/repositories/tool-catalog-repository';

--- a/packages/platform-infra/src/notifications/mailgun-notification-service.ts
+++ b/packages/platform-infra/src/notifications/mailgun-notification-service.ts
@@ -1,6 +1,6 @@
 import type { NotificationService, NotificationEvent, NotificationTarget, SendEmailFn } from '@mediforce/platform-core';
 
-export class MailgunNotificationService implements NotificationService {
+export class EmailNotificationService implements NotificationService {
   constructor(private readonly sendEmail: SendEmailFn) {}
 
   async send(event: NotificationEvent, targets: NotificationTarget[]): Promise<void> {

--- a/packages/platform-ui/.env.example
+++ b/packages/platform-ui/.env.example
@@ -53,6 +53,7 @@ MEDIFORCE_DISABLE_EMAIL=true
 # SMTP_PASS=
 # SMTP_FROM_EMAIL=
 # SMTP_SECURE=true             # true for port 465 (implicit TLS), false for STARTTLS on 587
+# SMTP_SENDER_NAME=Mediforce
 
 # --- Tracing (OTel, ADR-0007) ---
 # Opt-in: when unset, agent-run spans are no-ops. Point at any OTLP-HTTP

--- a/packages/platform-ui/.env.example
+++ b/packages/platform-ui/.env.example
@@ -40,13 +40,19 @@ GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/firebase-sa.json
 # Without a real key, agent steps will fail with 401.
 # OPENROUTER_API_KEY=
 
-# --- Email (Mailgun) ---
-# Set to "true" to skip email sends. Useful in dev where you don't want to
-# configure Mailgun.
+# --- Email ---
+# Set to "true" to skip email sends entirely.
 MEDIFORCE_DISABLE_EMAIL=true
+# EMAIL_PROVIDER=              # "mailgun" or "smtp". Auto-detected if only one is configured.
 # MAILGUN_API_KEY=
 # MAILGUN_DOMAIN=
 # MAILGUN_FROM_EMAIL=
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASS=
+# SMTP_FROM_EMAIL=
+# SMTP_SECURE=true             # true for port 465 (implicit TLS), false for STARTTLS on 587
 
 # --- Tracing (OTel, ADR-0007) ---
 # Opt-in: when unset, agent-run spans are no-ops. Point at any OTLP-HTTP

--- a/packages/platform-ui/src/app/(app)/[handle]/admin/email-status/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/admin/email-status/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, Mail, Loader2, CheckCircle2, XCircle } from 'lucide-react';
+import { mediforce } from '@/lib/mediforce';
+import { useNamespaceRole } from '@/hooks/use-namespace-role';
+import type { GetEmailStatusOutput } from '@mediforce/platform-api/contract';
+
+export default function AdminEmailStatusPage() {
+  const params = useParams();
+  const rawHandle = params.handle;
+  const handle = Array.isArray(rawHandle) ? rawHandle[0] : (rawHandle ?? '');
+  const { canAdmin, loading: roleLoading } = useNamespaceRole(handle);
+  const [data, setData] = useState<GetEmailStatusOutput | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (roleLoading || !canAdmin) return;
+    setLoading(true);
+    mediforce.system
+      .emailStatus()
+      .then(setData)
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setLoading(false));
+  }, [canAdmin, roleLoading]);
+
+  if (roleLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!canAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-10">
+        <p className="text-sm text-muted-foreground">You need admin access to view this page.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10">
+      <Link
+        href={`/${handle}/settings`}
+        className="mb-6 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        Settings
+      </Link>
+
+      <div className="mb-8">
+        <h1 className="text-lg font-semibold">Email provider</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Email is used for user invitations, workflow notifications, and alerts.
+        </p>
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {error !== null && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {data !== null && !loading && (
+        <div className="rounded-lg border bg-card">
+          <div className="px-5 py-4 flex items-start gap-4">
+            <div className="mt-0.5 rounded-md bg-muted p-2">
+              <Mail className="h-5 w-5 text-muted-foreground" />
+            </div>
+            <div className="flex-1 space-y-3">
+              <div className="flex items-center gap-2">
+                {data.configured ? (
+                  <CheckCircle2 className="h-4 w-4 text-green-500" />
+                ) : (
+                  <XCircle className="h-4 w-4 text-muted-foreground" />
+                )}
+                <span className="text-sm font-medium">
+                  {data.provider !== null
+                    ? data.provider.charAt(0).toUpperCase() + data.provider.slice(1)
+                    : 'Not configured'}
+                </span>
+              </div>
+
+              {data.configured && (
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+                  <dt className="text-muted-foreground">Provider</dt>
+                  <dd>{data.provider}</dd>
+                  <dt className="text-muted-foreground">From address</dt>
+                  <dd className="font-mono text-xs">{data.from ?? '—'}</dd>
+                </dl>
+              )}
+
+              {!data.configured && (
+                <p className="text-xs text-muted-foreground">
+                  Set <code className="rounded bg-muted px-1 py-0.5">EMAIL_PROVIDER</code> and
+                  the corresponding provider env vars to enable email.
+                  See the deployment guide for details.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
@@ -930,6 +930,17 @@ export default function WorkspaceConfigPage() {
                 </div>
                 <ArrowLeft className="h-4 w-4 text-muted-foreground rotate-180 group-hover:text-primary transition-colors" />
               </Link>
+              <div className="border-t" />
+              <Link
+                href={`/${handle}/admin/email-status`}
+                className="flex items-center justify-between group"
+              >
+                <div>
+                  <p className="text-sm font-medium group-hover:text-primary transition-colors">Email</p>
+                  <p className="text-xs text-muted-foreground">Email provider configuration status</p>
+                </div>
+                <ArrowLeft className="h-4 w-4 text-muted-foreground rotate-180 group-hover:text-primary transition-colors" />
+              </Link>
             </div>
           </div>
         )}

--- a/packages/platform-ui/src/app/api/admin/email-status/route.ts
+++ b/packages/platform-ui/src/app/api/admin/email-status/route.ts
@@ -1,0 +1,12 @@
+import { createRouteAdapter } from '@/lib/route-adapter';
+import { getEmailStatus } from '@mediforce/platform-api/handlers';
+import {
+  GetEmailStatusInputSchema,
+  type GetEmailStatusInput,
+} from '@mediforce/platform-api/contract';
+
+export const GET = createRouteAdapter<typeof GetEmailStatusInputSchema, GetEmailStatusInput>(
+  GetEmailStatusInputSchema,
+  () => ({}),
+  getEmailStatus,
+);

--- a/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-editor/step-editor.tsx
@@ -158,7 +158,7 @@ const TIP = {
   actionTo:                'Recipient email address(es), comma-separated.',
   actionCc:                'CC recipients, comma-separated.',
   actionBcc:               'BCC recipients, comma-separated. Not visible to other recipients.',
-  actionFrom:              'Sender address. Must be an authorised SendGrid verified sender.',
+  actionFrom:              'Sender address. Must be authorised by the configured email provider.',
   actionReplyTo:           'Reply-to address. Replies from recipients go here instead of action.from.',
   actionSubject:           'Email subject line. Supports ${variables.field} interpolation.',
   actionEmailBody:         'Plain-text email body. Displayed by clients that do not support HTML.',

--- a/packages/platform-ui/src/instrumentation-node.ts
+++ b/packages/platform-ui/src/instrumentation-node.ts
@@ -60,16 +60,20 @@ export function validateEnv(existsSync: (path: string) => boolean): void {
     );
   }
 
-  // --- MAILGUN EMAIL CONFIG ---
+  // --- EMAIL PROVIDER CONFIG ---
   if (process.env.MEDIFORCE_DISABLE_EMAIL !== 'true') {
     const mailgunVars = ['MAILGUN_API_KEY', 'MAILGUN_DOMAIN', 'MAILGUN_FROM_EMAIL'] as const;
-    const missingMailgun = mailgunVars.filter(
-      (v) => typeof process.env[v] !== 'string' || process.env[v] === '',
+    const smtpVars = ['SMTP_HOST', 'SMTP_FROM_EMAIL'] as const;
+    const hasMailgun = mailgunVars.every(
+      (v) => typeof process.env[v] === 'string' && process.env[v] !== '',
     );
-    if (missingMailgun.length > 0) {
+    const hasSmtp = smtpVars.every(
+      (v) => typeof process.env[v] === 'string' && process.env[v] !== '',
+    );
+    if (!hasMailgun && !hasSmtp) {
       errors.push(
-        `Email is enabled but Mailgun config incomplete (missing: ${missingMailgun.join(', ')}). `
-        + 'Set the env vars or set MEDIFORCE_DISABLE_EMAIL=true to start without email.',
+        'Email is enabled but no email provider is configured. '
+        + 'Set MAILGUN_* or SMTP_* env vars, or set MEDIFORCE_DISABLE_EMAIL=true to start without email.',
       );
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       firebase-admin:
         specifier: ^13.6.1
         version: 13.10.0
+      nodemailer:
+        specifier: ^8.0.11
+        version: 8.0.11
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -315,6 +318,9 @@ importers:
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.4
+      '@types/nodemailer':
+        specifier: ^8.0.1
+        version: 8.0.1
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -2696,6 +2702,9 @@ packages:
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
+  '@types/nodemailer@8.0.1':
+    resolution: {integrity: sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -4059,6 +4068,10 @@ packages:
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
+
+  nodemailer@8.0.11:
+    resolution: {integrity: sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==}
+    engines: {node: '>=6.0.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -6773,6 +6786,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/nodemailer@8.0.1':
+    dependencies:
+      '@types/node': 24.12.4
+
   '@types/react-dom@19.2.3(@types/react@19.2.15)':
     dependencies:
       '@types/react': 19.2.15
@@ -8460,6 +8477,8 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
     optional: true
+
+  nodemailer@8.0.11: {}
 
   object-assign@4.1.1: {}
 

--- a/scripts/bootstrap-server.py
+++ b/scripts/bootstrap-server.py
@@ -1424,11 +1424,18 @@ def _render_compose_env(ctx: Context) -> str:
         "# Caddy — site block matcher (real domain → Let's Encrypt cert, IP → self-signed)",
         f"DOMAIN={_caddy_site(ctx)}",
         "",
-        "# Mailgun — email notifications (invite emails, alerts)",
+        "# Email — provider + credentials (Mailgun or SMTP)",
+        f"EMAIL_PROVIDER={ctx.collected.get('EMAIL_PROVIDER', '')}",
         f"MAILGUN_API_KEY={ctx.collected.get('MAILGUN_API_KEY', '')}",
         f"MAILGUN_DOMAIN={ctx.collected.get('MAILGUN_DOMAIN', '')}",
         f"MAILGUN_FROM_EMAIL={ctx.collected.get('MAILGUN_FROM_EMAIL', '')}",
         f"MAILGUN_SENDER_NAME={ctx.collected.get('MAILGUN_SENDER_NAME', 'Mediforce')}",
+        f"SMTP_HOST={ctx.collected.get('SMTP_HOST', '')}",
+        f"SMTP_PORT={ctx.collected.get('SMTP_PORT', '587')}",
+        f"SMTP_USER={ctx.collected.get('SMTP_USER', '')}",
+        f"SMTP_PASS={ctx.collected.get('SMTP_PASS', '')}",
+        f"SMTP_FROM_EMAIL={ctx.collected.get('SMTP_FROM_EMAIL', '')}",
+        f"SMTP_SECURE={ctx.collected.get('SMTP_SECURE', 'true')}",
         "",
     ]
     return "\n".join(lines)
@@ -1523,28 +1530,29 @@ def _ensure_api_keys(ctx: Context) -> None:
         ctx.collected["POSTGRES_PASSWORD"] = secrets.token_urlsafe(32)
         ok("POSTGRES_PASSWORD auto-generated (32 bytes url-safe) — back this up; losing it locks you out of the Postgres data volume")
 
-    if "MAILGUN_API_KEY" not in ctx.collected:
-        if confirm("Configure Mailgun for email notifications (invite emails, alerts)?", default=False):
-            ctx.collected["MAILGUN_API_KEY"] = ask(
-                "Mailgun API key",
-                secret=True,
+    if "EMAIL_PROVIDER" not in ctx.collected:
+        if confirm("Configure email notifications (invite emails, alerts)?", default=False):
+            provider = ask(
+                "Email provider — 'mailgun' or 'smtp'",
+                validate=lambda v: v in ("mailgun", "smtp"),
             )
-            ctx.collected["MAILGUN_DOMAIN"] = ask(
-                "Mailgun domain (e.g. mg.mediforce.ai)",
-            )
-            ctx.collected["MAILGUN_FROM_EMAIL"] = ask(
-                "From email address (e.g. noreply@mediforce.ai)",
-            )
-            ctx.collected["MAILGUN_SENDER_NAME"] = ask(
-                "Sender name",
-                default="Mediforce",
-            )
-            ok("Mailgun config accepted")
+            ctx.collected["EMAIL_PROVIDER"] = provider
+            if provider == "mailgun":
+                ctx.collected["MAILGUN_API_KEY"] = ask("Mailgun API key", secret=True)
+                ctx.collected["MAILGUN_DOMAIN"] = ask("Mailgun domain (e.g. mg.mediforce.ai)")
+                ctx.collected["MAILGUN_FROM_EMAIL"] = ask("From email address (e.g. noreply@mediforce.ai)")
+                ctx.collected["MAILGUN_SENDER_NAME"] = ask("Sender name", default="Mediforce")
+                ok("Mailgun config accepted")
+            else:
+                ctx.collected["SMTP_HOST"] = ask("SMTP host (e.g. smtp.gmail.com)")
+                ctx.collected["SMTP_PORT"] = ask("SMTP port", default="587")
+                ctx.collected["SMTP_USER"] = ask("SMTP username (leave empty if none)", default="")
+                ctx.collected["SMTP_PASS"] = ask("SMTP password", secret=True, default="")
+                ctx.collected["SMTP_FROM_EMAIL"] = ask("From email address (e.g. noreply@example.com)")
+                ctx.collected["SMTP_SECURE"] = ask("Use implicit TLS? (true for port 465, false for STARTTLS on 587)", default="false")
+                ok("SMTP config accepted")
         else:
-            ctx.collected["MAILGUN_API_KEY"] = ""
-            ctx.collected["MAILGUN_DOMAIN"] = ""
-            ctx.collected["MAILGUN_FROM_EMAIL"] = ""
-            ctx.collected["MAILGUN_SENDER_NAME"] = ""
+            ctx.collected["EMAIL_PROVIDER"] = ""
 
 
 def step_env_local(ctx: Context) -> None:


### PR DESCRIPTION
## Summary

Closes #748. Adds SMTP as an alternative email provider to Mailgun, letting organisations use their existing SMTP infrastructure without setting up another email service.

- **SMTP sender** (`platform-infra/src/email/smtp-client.ts`) — `createSmtpSender(SmtpConfig) → SendEmailFn` via nodemailer, matching the Mailgun client's shape and `"SenderName <email>"` from-header pattern
- **Provider resolution** — `EMAIL_PROVIDER` env var (`mailgun` | `smtp`) with auto-detect fallback: if only one set of vars is present, that provider is used; if both are set without explicit choice, startup throws; if neither is set and email is enabled, startup throws (preserving pre-existing fail-fast behaviour)
- **Email status endpoint** — `GET /api/admin/email-status` returns `{ provider, configured, from }` (read-only, no secrets exposed); wired through `CallerScope.system.emailProviderInfo`
- **CLI** — `mediforce email status` command
- **Admin UI** — `/{handle}/admin/email-status` page showing current provider and from address
- **Bootstrap script** — `scripts/bootstrap-server.py` now prompts for Mailgun or SMTP at setup
- **Housekeeping** — renamed `MailgunNotificationService` → `EmailNotificationService` and `MailgunInviteNotificationService` → `EmailInviteNotificationService` (both were already provider-agnostic via `SendEmailFn`); cleaned stale SendGrid references from docs and UI; fixed `instrumentation-node.ts` boot validation to accept either provider

### New env vars

| Variable | Default | Notes |
|----------|---------|-------|
| `EMAIL_PROVIDER` | auto-detect | `mailgun` or `smtp`; optional when only one provider's vars are set |
| `SMTP_HOST` | — | SMTP server hostname |
| `SMTP_PORT` | `587` | |
| `SMTP_USER` | — | |
| `SMTP_PASS` | — | |
| `SMTP_FROM_EMAIL` | — | Sender address |
| `SMTP_SECURE` | `true` | `true` for implicit TLS (465), `false` for STARTTLS (587) |
| `SMTP_SENDER_NAME` | `Mediforce` | Display name in from header |

## Test plan

- [ ] Existing Mailgun deployments with no `EMAIL_PROVIDER` set continue to work (auto-detect)
- [ ] SMTP-only deployment (`SMTP_HOST` + `SMTP_FROM_EMAIL` set, no Mailgun vars) starts and sends email
- [ ] `EMAIL_PROVIDER=smtp` with missing `SMTP_HOST` crashes at startup with clear error
- [ ] Invalid `EMAIL_PROVIDER` value (e.g. `sendgrid`) crashes at startup with clear error
- [ ] `MEDIFORCE_DISABLE_EMAIL=true` still disables all email regardless of provider vars
- [ ] `mediforce email status` CLI shows provider info
- [ ] Admin UI at `/{handle}/admin/email-status` displays current provider
- [ ] Invite emails send correctly via SMTP (from header shows `"SenderName <email>"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsGo3ZzgNUfdQCygQtaFnt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsGo3ZzgNUfdQCygQtaFnt)_