### PR TITLE
fix(agent-runtime): guard prepareDeployKeyPath against EISDIR crash

### DIFF
--- a/packages/agent-runtime/src/plugins/__tests__/prepare-deploy-key-path.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/prepare-deploy-key-path.test.ts
@@ -55,6 +55,16 @@ describe('prepareDeployKeyPath', () => {
     expect(statSync(result).mode & 0o777).toBe(0o600);
   });
 
+  it('returns source path unchanged when source is a directory (EISDIR guard)', async () => {
+    const sourceDir = makeTmpDir();
+    process.env.DEPLOY_KEY_PATH = sourceDir;
+
+    const { prepareDeployKeyPath } = await importFresh();
+    const result = prepareDeployKeyPath();
+
+    expect(result).toBe(sourceDir);
+  });
+
   it('caches the prepared path across calls (does not re-copy)', async () => {
     const sourceDir = makeTmpDir();
     const source = join(sourceDir, 'deploy_key');

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -53,7 +53,7 @@
  * belongs in its own PR.
  */
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, cpSync, chmodSync, copyFileSync } from 'node:fs';
+import { existsSync, mkdirSync, cpSync, chmodSync, copyFileSync, statSync } from 'node:fs';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
@@ -79,7 +79,7 @@ let preparedDeployKeyPath: string | null = null;
  */
 export function prepareDeployKeyPath(): string {
   const source = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
-  if (!existsSync(source)) return source;
+  if (!existsSync(source) || !statSync(source).isFile()) return source;
   if (preparedDeployKeyPath && existsSync(preparedDeployKeyPath)) return preparedDeployKeyPath;
   const dir = mkdtempSync(join(tmpdir(), 'mediforce-ssh-'));
   const dest = join(dir, 'deploy_key');

--- a/packages/container-worker/src/docker-image-builder.ts
+++ b/packages/container-worker/src/docker-image-builder.ts
@@ -6,7 +6,7 @@
  */
 import { execSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { chmodSync, copyFileSync, existsSync, mkdtempSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdtempSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
 
@@ -21,7 +21,7 @@ let preparedDeployKeyPath: string | null = null;
  */
 function prepareDeployKeyPath(): string {
   const source = process.env.DEPLOY_KEY_PATH ?? join(homedir(), '.ssh', 'deploy_key');
-  if (!existsSync(source)) return source;
+  if (!existsSync(source) || !statSync(source).isFile()) return source;
   if (preparedDeployKeyPath && existsSync(preparedDeployKeyPath)) return preparedDeployKeyPath;
   const dir = mkdtempSync(join(tmpdir(), 'mediforce-ssh-'));
   const dest = join(dir, 'deploy_key');


### PR DESCRIPTION
## Root cause

When the platform starts a `script-container` or `claude-code-agent` step, `prepareDeployKeyPath()` is called to copy the SSH deploy key to a private `0600` temp file before injecting it into the container. The function resolves the key path from `DEPLOY_KEY_PATH` (or `~/.ssh/deploy_key` as default) and calls `copyFileSync(source, dest)`.

On Docker-based deployments, if the bind-mount source path doesn't exist on the host, Docker materialises it as an **empty directory** inside the container rather than a file. When `prepareDeployKeyPath()` encounters that directory, `existsSync()` returns `true` (the path exists), so the early-return guard is skipped — and `copyFileSync` throws:

```
Error: EISDIR: illegal operation on a directory,
  copyfile '/root/.ssh/deploy_key' -> '/tmp/mediforce-ssh-gJ0oXU/deploy_key'
```

This crashes the step immediately, before any container work begins.

## Fix

Add an `isFile()` check alongside the `existsSync()` guard:

```ts
// before
if (!existsSync(source)) return source;

// after
if (!existsSync(source) || !statSync(source).isFile()) return source;
```

A non-regular-file source (directory, symlink-to-dir, device node) is now treated the same as a missing path — the raw source path is returned without attempting a copy. Downstream behaviour:

- **HTTPS auth in use** (`remoteAuth` / `repoAuth` token resolved): `GIT_SSH_COMMAND` is set but git never invokes it for HTTPS URLs, so the bogus path is harmless.
- **SSH auth actually needed** (no token): git will fail at fetch time with a clear `ssh: not found` or `Bad configuration option` error — same as before, but without the premature EISDIR crash obscuring it.

The fix is applied to both the exported copy in `agent-runtime/container-plugin.ts` and the duplicate in `container-worker/docker-image-builder.ts` (kept separate to avoid pulling Firebase deps into container-worker).

## Test

Added a new case to the existing `prepareDeployKeyPath` test suite:

```
it('returns source path unchanged when source is a directory (EISDIR guard)')
```

All four cases in the suite pass.

## Verification

Confirmed end-to-end on a local `pnpm dev` instance running a `script-container` workflow step against a repo with `remoteAuth: GITHUB_TOKEN`. The step previously crashed immediately with EISDIR; after this fix it builds the Docker image and executes the container script successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)