### PR TITLE
fix: skip Docker image check for human-only workflows

### DIFF
--- a/packages/platform-api/src/handlers/workflows/register-workflow.ts
+++ b/packages/platform-api/src/handlers/workflows/register-workflow.ts
@@ -105,38 +105,44 @@ export async function registerWorkflow(
 
   const warnings: RegistrationWarning[] = [];
 
-  try {
-    const dockerInfo = isLocalAgentMode()
-      ? await fetchFromLocalDocker()
-      : await fetchFromContainerWorker();
-    if (dockerInfo.available) {
-      for (const step of definition.steps) {
-        if (step.executor !== 'agent' && step.executor !== 'script') continue;
-        const cfg = step.executor === 'script' ? step.script : step.agent;
-        const image = cfg?.image;
-        if (typeof image !== 'string' || image.length === 0) continue;
-        const hasBuildSource = typeof cfg?.repo === 'string' && cfg.repo.length > 0
-          && typeof cfg?.commit === 'string' && cfg.commit.length > 0;
-        if (hasBuildSource) continue;
-        const [repo, tag = 'latest'] = image.split(':');
-        const found = dockerInfo.images.some(
-          (img) => img.repository === repo && img.tag === tag,
-        );
-        if (!found) {
-          warnings.push({
-            code: 'image-not-found',
-            message: `Image '${image}' not found on platform (step '${step.name}'). The workflow will fail at runtime unless this image is built or pushed before starting a run.`,
-            stepName: step.name,
-          });
+  const hasDockerSteps = definition.steps.some(
+    (s) => s.executor === 'agent' || s.executor === 'script',
+  );
+
+  if (hasDockerSteps) {
+    try {
+      const dockerInfo = isLocalAgentMode()
+        ? await fetchFromLocalDocker()
+        : await fetchFromContainerWorker();
+      if (dockerInfo.available) {
+        for (const step of definition.steps) {
+          if (step.executor !== 'agent' && step.executor !== 'script') continue;
+          const cfg = step.executor === 'script' ? step.script : step.agent;
+          const image = cfg?.image;
+          if (typeof image !== 'string' || image.length === 0) continue;
+          const hasBuildSource = typeof cfg?.repo === 'string' && cfg.repo.length > 0
+            && typeof cfg?.commit === 'string' && cfg.commit.length > 0;
+          if (hasBuildSource) continue;
+          const [repo, tag = 'latest'] = image.split(':');
+          const found = dockerInfo.images.some(
+            (img) => img.repository === repo && img.tag === tag,
+          );
+          if (!found) {
+            warnings.push({
+              code: 'image-not-found',
+              message: `Image '${image}' not found on platform (step '${step.name}'). The workflow will fail at runtime unless this image is built or pushed before starting a run.`,
+              stepName: step.name,
+            });
+          }
         }
       }
+    } catch {
+      warnings.push({
+        code: 'image-check-unavailable',
+        message: 'Could not verify Docker images — the container runtime is unreachable. Image availability will be checked again at run start.',
+        stepName: '',
+      });
     }
-  } catch {
-    warnings.push({
-      code: 'image-check-unavailable',
-      message: 'Could not verify Docker images — the container runtime is unreachable. Image availability will be checked again at run start.',
-      stepName: '',
-    });
   }
 
   return {


### PR DESCRIPTION
## Summary

- Guard the Docker image availability check behind a `hasDockerSteps` predicate so it only runs when the workflow contains `agent` or `script` steps
- Fixes CI failure introduced in #756 — the check ran unconditionally, and when Docker was unreachable (CI, human-only workflows) it added a spurious `image-check-unavailable` warning that broke the `toEqual` assertion in the route test

## Test plan

- [x] `platform-ui` route test (`POST /api/workflow-definitions`) passes — human-only workflow returns clean `{ success, name, version }` with no warnings
- [x] `platform-api` handler test (`registerWorkflow`) passes — existing Docker mock tests unaffected
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYfWVurpxKvg4KxR7QmxeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYfWVurpxKvg4KxR7QmxeZ)_