### PR TITLE
feat: preflight validation for plugin-required env vars + secrets source visibility

### DIFF
--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -49,8 +49,8 @@ export type {
 } from './runner/step-executor';
 
 // Env validation
-export { validateWorkflowEnv, validateWorkflowModels, validateRetiredModels } from './plugins/resolve-env';
-export type { MissingEnvVar, UnknownModel, RetiredModelRef } from './plugins/resolve-env';
+export { validateWorkflowEnv, validateWorkflowModels, validateRetiredModels, validatePluginRequiredEnv } from './plugins/resolve-env';
+export type { MissingEnvVar, MissingPluginEnv, UnknownModel, RetiredModelRef } from './plugins/resolve-env';
 
 // MCP resolution helpers
 export { resolveMcpForStep, AgentDefinitionNotFoundError } from './mcp/resolve-mcp-for-step';

--- a/packages/agent-runtime/src/interfaces/step-executor-plugin.ts
+++ b/packages/agent-runtime/src/interfaces/step-executor-plugin.ts
@@ -80,6 +80,9 @@ export interface WorkflowAgentContext {
   getPreviousStepOutputs: () => Promise<Record<string, unknown>>;
   /** Pre-fetched workflow secrets for {{TEMPLATE}} resolution */
   workflowSecrets?: Record<string, string>;
+  /** Keys that came from namespace-level secrets (vs workflow-level).
+   *  Used by env resolution to tag source for audit visibility. */
+  namespaceSecretKeys?: ReadonlySet<string>;
   /** Pre-resolved MCP configuration for this step. Produced by
    *  resolveMcpForStep at handoff time: AgentDefinition + step
    *  restrictions + tool catalog collapsed into a flat map of server

--- a/packages/agent-runtime/src/plugins/__tests__/resolve-env.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/resolve-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveStepEnv, validateWorkflowEnv, validateWorkflowModels, validateRetiredModels, resolveValue } from '../resolve-env';
+import { resolveStepEnv, validateWorkflowEnv, validateWorkflowModels, validateRetiredModels, validatePluginRequiredEnv, resolveValue } from '../resolve-env';
 
 describe('resolve-env', () => {
   // ---------------------------------------------------------------------------
@@ -47,7 +47,7 @@ describe('resolve-env', () => {
 
     it('returns empty result when both config and step env are undefined', () => {
       const result = resolveStepEnv(undefined, undefined);
-      expect(result).toEqual({ vars: {}, injectedKeys: [] });
+      expect(result).toEqual({ vars: {}, injectedKeys: [], sources: {} });
     });
 
     it('injectedKeys contains all merged keys', () => {
@@ -56,6 +56,89 @@ describe('resolve-env', () => {
         { B: 'y', C: 'z' },
       );
       expect(result.injectedKeys).toEqual(['A', 'B', 'C']);
+    });
+
+    it('auto-injects plugin required env from secrets when absent from step env', () => {
+      const result = resolveStepEnv(
+        undefined,
+        undefined,
+        { ANTHROPIC_API_KEY: 'sk-ant-xxx' },
+        [['ANTHROPIC_API_KEY'], ['OPENROUTER_API_KEY', 'ANTHROPIC_BASE_URL']],
+      );
+      expect(result.vars).toEqual({ ANTHROPIC_API_KEY: 'sk-ant-xxx' });
+      expect(result.injectedKeys).toContain('ANTHROPIC_API_KEY');
+    });
+
+    it('auto-injection picks first fully-satisfiable group', () => {
+      const result = resolveStepEnv(
+        undefined,
+        undefined,
+        { OPENROUTER_API_KEY: 'sk-or-xxx', ANTHROPIC_BASE_URL: 'https://openrouter.ai' },
+        [['ANTHROPIC_API_KEY'], ['OPENROUTER_API_KEY', 'ANTHROPIC_BASE_URL']],
+      );
+      expect(result.vars.OPENROUTER_API_KEY).toBe('sk-or-xxx');
+      expect(result.vars.ANTHROPIC_BASE_URL).toBe('https://openrouter.ai');
+      expect(result.vars.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('explicit env overrides auto-injected values', () => {
+      const result = resolveStepEnv(
+        undefined,
+        { ANTHROPIC_API_KEY: 'explicit-value' },
+        { ANTHROPIC_API_KEY: 'from-secrets' },
+        [['ANTHROPIC_API_KEY']],
+      );
+      expect(result.vars.ANTHROPIC_API_KEY).toBe('explicit-value');
+    });
+
+    it('tracks source as namespace-secret when key is in namespaceSecretKeys', () => {
+      const result = resolveStepEnv(
+        undefined,
+        { API_KEY: '{{API_KEY}}' },
+        { API_KEY: 'value' },
+        undefined,
+        new Set(['API_KEY']),
+      );
+      expect(result.sources.API_KEY).toBe('namespace-secret');
+    });
+
+    it('tracks source as workflow-secret when key is NOT in namespaceSecretKeys', () => {
+      const result = resolveStepEnv(
+        undefined,
+        { API_KEY: '{{API_KEY}}' },
+        { API_KEY: 'value' },
+        undefined,
+        new Set(['OTHER_KEY']),
+      );
+      expect(result.sources.API_KEY).toBe('workflow-secret');
+    });
+
+    it('tracks source as literal for non-template values', () => {
+      const result = resolveStepEnv(
+        undefined,
+        { NODE_ENV: 'production' },
+      );
+      expect(result.sources.NODE_ENV).toBe('literal');
+    });
+
+    it('tracks source as auto-injected for plugin-required env', () => {
+      const result = resolveStepEnv(
+        undefined,
+        undefined,
+        { ANTHROPIC_API_KEY: 'sk-ant-xxx' },
+        [['ANTHROPIC_API_KEY']],
+      );
+      expect(result.sources.ANTHROPIC_API_KEY).toBe('auto-injected');
+    });
+
+    it('does not auto-inject when no group is satisfiable', () => {
+      const result = resolveStepEnv(
+        undefined,
+        undefined,
+        {},
+        [['ANTHROPIC_API_KEY'], ['OPENROUTER_API_KEY', 'ANTHROPIC_BASE_URL']],
+      );
+      expect(result.vars).toEqual({});
     });
   });
 
@@ -304,6 +387,126 @@ describe('resolveValue', () => {
       expect(result).toHaveLength(1);
       expect(result[0].model).toBe('openai/gpt-4');
       expect(result[0].retiredAt).toBe('2026-01-15T00:00:00Z');
+    });
+  });
+
+  describe('validatePluginRequiredEnv', () => {
+    const pluginMap = new Map<string, string[][]>([
+      ['claude-code-agent', [['ANTHROPIC_API_KEY'], ['OPENROUTER_API_KEY', 'ANTHROPIC_BASE_URL']]],
+      ['databricks-job', [['DATABRICKS_HOST', 'DATABRICKS_TOKEN']]],
+    ]);
+
+    it('returns empty when step env declares required key and secret exists', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Analyze', executor: 'agent', env: { ANTHROPIC_API_KEY: '{{ANTHROPIC_API_KEY}}' } }] },
+        pluginMap,
+        { ANTHROPIC_API_KEY: 'sk-ant-xxx' },
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty when alternative group is satisfied', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Analyze', executor: 'agent', env: { OPENROUTER_API_KEY: '{{OPENROUTER_API_KEY}}', ANTHROPIC_BASE_URL: 'https://openrouter.ai/api/v1' } }] },
+        pluginMap,
+        { OPENROUTER_API_KEY: 'sk-or-xxx' },
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('detects missing when no env mapping exists and no secrets', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Analyze', executor: 'agent' }] },
+        pluginMap,
+        {},
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].pluginName).toBe('claude-code-agent');
+      expect(result[0].steps).toEqual([{ stepId: 's1', stepName: 'Analyze' }]);
+    });
+
+    it('detects missing when env mapping exists but secret is absent', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Analyze', executor: 'agent', env: { ANTHROPIC_API_KEY: '{{ANTHROPIC_API_KEY}}' } }] },
+        pluginMap,
+        {},
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].groups.some((g) => g.missing.includes('ANTHROPIC_API_KEY'))).toBe(true);
+    });
+
+    it('defaults to claude-code-agent when step.plugin is unset', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Run', executor: 'agent' }] },
+        pluginMap,
+        {},
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].pluginName).toBe('claude-code-agent');
+    });
+
+    it('uses step.plugin when set', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Run', executor: 'script', plugin: 'databricks-job' }] },
+        pluginMap,
+        {},
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].pluginName).toBe('databricks-job');
+    });
+
+    it('skips plugins without requiredEnv in the map', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Run', executor: 'agent', plugin: 'custom-agent' }] },
+        pluginMap,
+        {},
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('skips non-agent/script steps', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Input', executor: 'human' }] },
+        pluginMap,
+        {},
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('groups same missing pattern across multiple steps', () => {
+      const result = validatePluginRequiredEnv(
+        {
+          steps: [
+            { id: 's1', name: 'Step A', executor: 'agent' },
+            { id: 's2', name: 'Step B', executor: 'agent' },
+          ],
+        },
+        pluginMap,
+        {},
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].steps).toHaveLength(2);
+    });
+
+    it('uses config-level env for resolution', () => {
+      const result = validatePluginRequiredEnv(
+        {
+          env: { ANTHROPIC_API_KEY: '{{ANTHROPIC_API_KEY}}' },
+          steps: [{ id: 's1', name: 'Run', executor: 'agent' }],
+        },
+        pluginMap,
+        { ANTHROPIC_API_KEY: 'sk-ant-xxx' },
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('literal env value satisfies requirement (no secret needed)', () => {
+      const result = validatePluginRequiredEnv(
+        { steps: [{ id: 's1', name: 'Run', executor: 'agent', env: { ANTHROPIC_API_KEY: 'sk-ant-hardcoded' } }] },
+        pluginMap,
+        {},
+      );
+      expect(result).toEqual([]);
     });
   });
 

--- a/packages/agent-runtime/src/plugins/__tests__/resolve-env.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/resolve-env.test.ts
@@ -131,6 +131,15 @@ describe('resolve-env', () => {
       expect(result.sources.ANTHROPIC_API_KEY).toBe('auto-injected');
     });
 
+    it('tracks source as secret (unspecified level) when namespaceSecretKeys not provided', () => {
+      const result = resolveStepEnv(
+        undefined,
+        { API_KEY: '{{API_KEY}}' },
+        { API_KEY: 'value' },
+      );
+      expect(result.sources.API_KEY).toBe('secret');
+    });
+
     it('does not auto-inject when no group is satisfiable', () => {
       const result = resolveStepEnv(
         undefined,

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -709,6 +709,8 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         this.context.workflowDefinition.env,
         this.context.step.env,
         this.context.workflowSecrets,
+        this.metadata.requiredEnv,
+        this.context.namespaceSecretKeys,
       );
     } else {
       const stepConfig = this.context.config.stepConfigs.find(
@@ -859,11 +861,16 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
         }
       }
 
-      // Log injected env vars for audit
+      // Log injected env vars with source info for audit
       if (spawnResult.injectedEnvVars.length > 0) {
+        const sources = this.resolvedEnv.sources;
+        const labeled = spawnResult.injectedEnvVars.map((key) => {
+          const src = sources[key];
+          return src && src !== 'literal' ? `${key} (${src})` : key;
+        });
         await emit({
           type: 'status',
-          payload: `injected env vars: ${spawnResult.injectedEnvVars.join(', ')}`,
+          payload: `injected env vars: ${labeled.join(', ')}`,
           timestamp: new Date().toISOString(),
         });
       } else {

--- a/packages/agent-runtime/src/plugins/claude-code-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/claude-code-agent-plugin.ts
@@ -137,7 +137,17 @@ export class ClaudeCodeAgentPlugin extends BaseContainerAgentPlugin {
       'Examples: extracted metadata, generated code, analysis reports.',
     roles: ['executor'],
     foundationModel: 'Claude Sonnet 4.6',
+    requiredEnv: [['ANTHROPIC_API_KEY'], ['OPENROUTER_API_KEY', 'ANTHROPIC_BASE_URL']],
   };
+
+  protected override getInternalEnvVars(): Record<string, string> {
+    const vars: Record<string, string> = {};
+    const resolved = this.resolvedEnv?.vars ?? {};
+    if (!resolved.ANTHROPIC_API_KEY && resolved.OPENROUTER_API_KEY) {
+      vars.ANTHROPIC_API_KEY = resolved.OPENROUTER_API_KEY;
+    }
+    return vars;
+  }
 
   getAgentCommand(_promptFilePath: string, options?: SpawnCliOptions): AgentCommandSpec {
     const args: string[] = [

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -246,7 +246,7 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
   abstract readonly metadata: PluginCapabilityMetadata;
 
   protected context!: AgentContext | WorkflowAgentContext;
-  protected resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [] };
+  protected resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [], sources: {} };
   protected imageBuild: ImageBuildMeta | undefined;
   /** Cached skills dir path fetched from git repo. */
   protected repoSkillsDir: string | null = null;
@@ -391,8 +391,9 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
     definitionEnv?: Record<string, string>,
     stepEnv?: Record<string, string>,
     workflowSecrets?: Record<string, string>,
+    namespaceSecretKeys?: ReadonlySet<string>,
   ): void {
-    this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv, workflowSecrets);
+    this.resolvedEnv = resolveStepEnv(definitionEnv, stepEnv, workflowSecrets, this.metadata.requiredEnv, namespaceSecretKeys);
   }
 
   /**

--- a/packages/agent-runtime/src/plugins/databricks/databricks-job-plugin.ts
+++ b/packages/agent-runtime/src/plugins/databricks/databricks-job-plugin.ts
@@ -40,6 +40,7 @@ export class DatabricksJobPlugin implements StepExecutorPlugin {
     inputDescription: 'step.databricks: jobId + optional notebookParams/jobParameters (values support ${steps.*} interpolation). Secrets: DATABRICKS_HOST, DATABRICKS_TOKEN.',
     outputDescription: 'JSON object the notebook exits with (dbutils.notebook.exit) as the step result; { raw } when the output is not a JSON object.',
     roles: ['executor'],
+    requiredEnv: [['DATABRICKS_HOST', 'DATABRICKS_TOKEN']],
   };
 
   private context!: WorkflowAgentContext;

--- a/packages/agent-runtime/src/plugins/mock-claude-code-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/mock-claude-code-agent-plugin.ts
@@ -3,7 +3,14 @@ import type { AgentContext, StepExecutorPlugin, EmitFn, WorkflowAgentContext } f
 import { ClaudeCodeAgentPlugin } from './claude-code-agent-plugin';
 
 export class MockClaudeCodeAgentPlugin implements StepExecutorPlugin {
-  readonly metadata: PluginCapabilityMetadata = new ClaudeCodeAgentPlugin().metadata;
+  // The mock emits a deterministic result without spawning a container, so it
+  // has none of the real plugin's implicit env requirements. Drop requiredEnv
+  // so the run preflight does not block MOCK_AGENT runs (e2e, local dev) that
+  // legitimately lack ANTHROPIC_API_KEY / OPENROUTER_API_KEY.
+  readonly metadata: PluginCapabilityMetadata = {
+    ...new ClaudeCodeAgentPlugin().metadata,
+    requiredEnv: undefined,
+  };
 
   private context: AgentContext | WorkflowAgentContext | null = null;
 

--- a/packages/agent-runtime/src/plugins/opencode-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/opencode-agent-plugin.ts
@@ -38,6 +38,7 @@ export class OpenCodeAgentPlugin extends BaseContainerAgentPlugin {
       'Examples: extracted metadata, generated code, analysis reports.',
     roles: ['executor'],
     foundationModel: 'DeepSeek Chat',
+    requiredEnv: [['OPENROUTER_API_KEY']],
   };
 
   protected override getInternalEnvVars(): Record<string, string> {

--- a/packages/agent-runtime/src/plugins/resolve-env.ts
+++ b/packages/agent-runtime/src/plugins/resolve-env.ts
@@ -16,7 +16,7 @@
  * Literal values (no `{{…}}` wrapper) are passed through as-is.
  */
 
-export type EnvVarSource = 'literal' | 'namespace-secret' | 'workflow-secret' | 'auto-injected';
+export type EnvVarSource = 'literal' | 'namespace-secret' | 'workflow-secret' | 'auto-injected' | 'secret';
 
 export interface ResolvedEnv {
   /** Resolved env vars to inject into the agent process */
@@ -334,7 +334,7 @@ export function resolveStepEnv(
       } else if (namespaceSecretKeys) {
         sources[key] = 'namespace-secret';
       } else {
-        sources[key] = 'workflow-secret';
+        sources[key] = 'secret';
       }
     }
   }

--- a/packages/agent-runtime/src/plugins/resolve-env.ts
+++ b/packages/agent-runtime/src/plugins/resolve-env.ts
@@ -157,7 +157,12 @@ export function validatePluginRequiredEnv(
     const groupResults = groups.map((group) => {
       const missing = group.filter((key) => {
         const value = mergedEnv[key];
-        if (value === undefined) return true;
+        if (value === undefined) {
+          // Key not in env — auto-injection will add it at runtime if
+          // the secret exists, so only report missing when the secret
+          // is also absent.
+          return !(workflowSecrets && key in workflowSecrets && workflowSecrets[key] !== '');
+        }
         const parsed = parseTemplate(value);
         if (parsed === null) return false;
         if (parsed.namespace === 'OAUTH') return false;

--- a/packages/agent-runtime/src/plugins/resolve-env.ts
+++ b/packages/agent-runtime/src/plugins/resolve-env.ts
@@ -16,11 +16,15 @@
  * Literal values (no `{{…}}` wrapper) are passed through as-is.
  */
 
+export type EnvVarSource = 'literal' | 'namespace-secret' | 'workflow-secret' | 'auto-injected';
+
 export interface ResolvedEnv {
   /** Resolved env vars to inject into the agent process */
   vars: Record<string, string>;
   /** Env var names that were injected (for audit logging — no values) */
   injectedKeys: string[];
+  /** Source of each resolved env var (for visibility in run UI) */
+  sources: Record<string, EnvVarSource>;
 }
 
 // Accepts `{{KEY}}` (legacy) or `{{NS:key}}` (namespaced, e.g. SECRET/OAUTH).
@@ -100,6 +104,79 @@ export function validateWorkflowEnv(
   }
 
   return Array.from(missingMap.values());
+}
+
+// ---------------------------------------------------------------------------
+// Pre-flight validation — plugin-required env vars present in step env + secrets
+// ---------------------------------------------------------------------------
+
+export interface MissingPluginEnv {
+  pluginName: string;
+  /** All alternative groups and which keys each group is missing. */
+  groups: Array<{ keys: string[]; missing: string[] }>;
+  steps: Array<{ stepId: string; stepName: string }>;
+}
+
+/**
+ * Validate that every agent/script step's plugin-required env vars are
+ * (a) declared in the step's merged env and (b) resolvable from secrets.
+ *
+ * A plugin declares `requiredEnv: string[][]` — an array of alternative
+ * groups. At least one group must be fully satisfied: every key in the
+ * group must appear in the step's merged env as a resolvable template.
+ *
+ * Keys that are absent from the step env entirely are the primary gap
+ * this catches — `validateWorkflowEnv` already covers templates that
+ * are present but whose secret is missing.
+ */
+export function validatePluginRequiredEnv(
+  definition: {
+    env?: Record<string, string>;
+    steps: Array<{
+      id: string;
+      name: string;
+      executor: string;
+      plugin?: string;
+      env?: Record<string, string>;
+    }>;
+  },
+  pluginRequiredEnv: Map<string, string[][]>,
+  workflowSecrets?: Record<string, string>,
+): MissingPluginEnv[] {
+  const resultMap = new Map<string, MissingPluginEnv>();
+
+  for (const step of definition.steps) {
+    if (step.executor !== 'agent' && step.executor !== 'script') continue;
+
+    const pluginName = step.plugin ?? 'claude-code-agent';
+    const groups = pluginRequiredEnv.get(pluginName);
+    if (!groups || groups.length === 0) continue;
+
+    const mergedEnv = { ...definition.env, ...step.env };
+
+    const groupResults = groups.map((group) => {
+      const missing = group.filter((key) => {
+        const value = mergedEnv[key];
+        if (value === undefined) return true;
+        const parsed = parseTemplate(value);
+        if (parsed === null) return false;
+        if (parsed.namespace === 'OAUTH') return false;
+        return !(workflowSecrets && parsed.key in workflowSecrets && workflowSecrets[parsed.key] !== '');
+      });
+      return { keys: group, missing };
+    });
+
+    const satisfied = groupResults.some((g) => g.missing.length === 0);
+    if (satisfied) continue;
+
+    const mapKey = `${pluginName}:${groupResults.map((g) => g.missing.sort().join(',')).join('|')}`;
+    if (!resultMap.has(mapKey)) {
+      resultMap.set(mapKey, { pluginName, groups: groupResults, steps: [] });
+    }
+    resultMap.get(mapKey)!.steps.push({ stepId: step.id, stepName: step.name });
+  }
+
+  return Array.from(resultMap.values());
 }
 
 // ---------------------------------------------------------------------------
@@ -198,19 +275,69 @@ export function validateRetiredModels(
   return Array.from(retiredRefMap.values());
 }
 
+/**
+ * Auto-inject plugin-required env vars that are absent from the merged env
+ * but available in secrets. For alternative groups, picks the first group
+ * whose keys are ALL available. Returns env entries to add (lowest priority).
+ */
+function autoInjectPluginEnv(
+  merged: Record<string, string>,
+  pluginRequiredEnv: string[][] | undefined,
+  workflowSecrets: Record<string, string> | undefined,
+): Record<string, string> {
+  if (!pluginRequiredEnv || pluginRequiredEnv.length === 0) return {};
+
+  for (const group of pluginRequiredEnv) {
+    const allKeysAvailable = group.every((key) => {
+      if (key in merged) return true;
+      return workflowSecrets !== undefined && key in workflowSecrets && workflowSecrets[key] !== '';
+    });
+    if (!allKeysAvailable) continue;
+
+    const injections: Record<string, string> = {};
+    for (const key of group) {
+      if (!(key in merged)) {
+        injections[key] = `{{${key}}}`;
+      }
+    }
+    return injections;
+  }
+  return {};
+}
+
 export function resolveStepEnv(
   configEnv: Record<string, string> | undefined,
   stepEnv: Record<string, string> | undefined,
   workflowSecrets?: Record<string, string>,
+  pluginRequiredEnv?: string[][],
+  namespaceSecretKeys?: ReadonlySet<string>,
 ): ResolvedEnv {
-  const merged = { ...configEnv, ...stepEnv };
+  const explicit = { ...configEnv, ...stepEnv };
+  const autoInjected = autoInjectPluginEnv(explicit, pluginRequiredEnv, workflowSecrets);
+  const merged = { ...autoInjected, ...explicit };
   const vars: Record<string, string> = {};
   const injectedKeys: string[] = [];
+  const sources: Record<string, EnvVarSource> = {};
 
   for (const [key, value] of Object.entries(merged)) {
     vars[key] = resolveValue(value, workflowSecrets);
     injectedKeys.push(key);
+
+    if (key in autoInjected && !(key in explicit)) {
+      sources[key] = 'auto-injected';
+    } else {
+      const parsed = parseTemplate(value);
+      if (parsed === null) {
+        sources[key] = 'literal';
+      } else if (namespaceSecretKeys && !namespaceSecretKeys.has(parsed.key)) {
+        sources[key] = 'workflow-secret';
+      } else if (namespaceSecretKeys) {
+        sources[key] = 'namespace-secret';
+      } else {
+        sources[key] = 'workflow-secret';
+      }
+    }
   }
 
-  return { vars, injectedKeys };
+  return { vars, injectedKeys, sources };
 }

--- a/packages/agent-runtime/src/plugins/script-container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/script-container-plugin.ts
@@ -164,7 +164,8 @@ export class ScriptContainerPlugin extends ContainerPlugin {
 
     // Resolve env vars from definition-level + step-level env + workflow secrets
     const workflowSecrets = isWorkflowAgentContext(context) ? context.workflowSecrets : undefined;
-    this.resolveEnvironment(definitionEnv, stepEnv, workflowSecrets);
+    const nsKeys = isWorkflowAgentContext(context) ? context.namespaceSecretKeys : undefined;
+    this.resolveEnvironment(definitionEnv, stepEnv, workflowSecrets, nsKeys);
     this.imageBuild = resolveImageBuild(this.image, scriptConfig, context, this.resolvedEnv.vars);
   }
 

--- a/packages/platform-core/src/schemas/plugin-capability-metadata.ts
+++ b/packages/platform-core/src/schemas/plugin-capability-metadata.ts
@@ -9,6 +9,13 @@ export const PluginCapabilityMetadataSchema = z.object({
   outputDescription: z.string(),
   roles: z.array(PluginRoleSchema).min(1),
   foundationModel: z.string().optional(),
+  /** Env vars the plugin implicitly needs inside the container.
+   *  Each inner array is one alternative group — ALL keys in a group
+   *  must be present. At least ONE group must be fully satisfied.
+   *  Example: `[['ANTHROPIC_API_KEY'], ['OPENROUTER_API_KEY', 'ANTHROPIC_BASE_URL']]`
+   *  means the plugin needs ANTHROPIC_API_KEY *or* both OPENROUTER_API_KEY and
+   *  ANTHROPIC_BASE_URL. */
+  requiredEnv: z.array(z.array(z.string())).optional(),
 });
 
 export type PluginCapabilityMetadata = z.infer<typeof PluginCapabilityMetadataSchema>;

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/__tests__/route.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/lib/platform-services', () => ({
       getByInstanceId: mockHumanTaskGetByInstanceId,
     },
     namespaceRepo: {},
+    pluginRegistry: { list: vi.fn().mockReturnValue([]) },
     modelRegistryRepo: { list: vi.fn().mockResolvedValue([]) },
     actionRegistry: { dispatch: mockActionDispatch },
     engine: { advanceStep: (...args: unknown[]) => mockAdvanceStep(...args) },

--- a/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
+++ b/packages/platform-ui/src/app/api/processes/[instanceId]/run/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 import { getPlatformServices } from '@/lib/platform-services';
 import { resolveCallerIdentity, requireNamespaceAccess } from '@/lib/api-auth';
 import { executeAgentStep } from '@/lib/execute-agent-step';
-import { flattenResolvedMcpToLegacy, resolveMcpForStep, validateWorkflowEnv, validateWorkflowModels } from '@mediforce/agent-runtime';
+import { flattenResolvedMcpToLegacy, resolveMcpForStep, validateWorkflowEnv, validateWorkflowModels, validatePluginRequiredEnv } from '@mediforce/agent-runtime';
 import { checkRetiredModels } from '@mediforce/platform-api/handlers';
 import { validateActionSecrets, isWaitSentinel, interpolate } from '@mediforce/core-actions';
 import { getWorkflowSecretsForRuntime } from '@/app/actions/workflow-secrets';
@@ -118,9 +118,35 @@ export async function POST(
         workflowDefinition.steps,
         workflowSecrets,
       );
+
+      // Check plugin-required env vars (implicit agent needs like ANTHROPIC_API_KEY)
+      const { pluginRegistry } = getPlatformServices();
+      const pluginRequiredEnvMap = new Map<string, string[][]>();
+      for (const { name, metadata } of pluginRegistry.list()) {
+        if (metadata?.requiredEnv) {
+          pluginRequiredEnvMap.set(name, metadata.requiredEnv);
+        }
+      }
+      const missingPluginEnv = validatePluginRequiredEnv(
+        workflowDefinition, pluginRequiredEnvMap, workflowSecrets,
+      );
+      const pluginEnvAsMissing = missingPluginEnv.flatMap((m) => {
+        const bestGroup = m.groups.reduce((a, b) => a.missing.length <= b.missing.length ? a : b);
+        return bestGroup.missing.map((key) => ({
+          secretName: key,
+          template: `{{${key}}}`,
+          steps: m.steps,
+          hint: `Required by ${m.pluginName}` +
+            (m.groups.length > 1
+              ? `. Alternatives: ${m.groups.map((g) => g.keys.join(' + ')).join(' or ')}`
+              : ''),
+        }));
+      });
+
       const allMissing = [
         ...missingEnv,
         ...missingActionSecrets.map((m) => ({ ...m, template: `\${secrets.${m.secretName}}` })),
+        ...pluginEnvAsMissing,
       ];
       if (allMissing.length > 0) {
         const names = allMissing.map((m) => m.secretName);

--- a/packages/platform-ui/src/components/processes/missing-env-banner.tsx
+++ b/packages/platform-ui/src/components/processes/missing-env-banner.tsx
@@ -9,6 +9,7 @@ interface MissingEnvVar {
   secretName: string;
   template: string;
   steps: Array<{ stepId: string; stepName: string }>;
+  hint?: string;
 }
 
 export function MissingEnvBanner({
@@ -98,6 +99,7 @@ export function MissingEnvBanner({
             </div>
             <p className="text-xs text-amber-600 dark:text-amber-500 pl-[13.5rem]">
               Used by: {m.steps.map((s) => s.stepName).join(', ')}
+              {m.hint && <span className="ml-1">({m.hint})</span>}
             </p>
           </div>
         ))}

--- a/packages/platform-ui/src/lib/execute-agent-step.ts
+++ b/packages/platform-ui/src/lib/execute-agent-step.ts
@@ -161,6 +161,7 @@ export async function executeAgentStep(
     step: workflowStep,
     llm: llmClient,
     workflowSecrets,
+    namespaceSecretKeys: new Set(Object.keys(namespaceSecrets)),
     resolvedMcpConfig,
     ...(instance.previousRun !== undefined
       ? { previousRun: instance.previousRun }


### PR DESCRIPTION
## Summary

- Plugins now declare `requiredEnv` (alternative groups of env vars they implicitly need inside the container). The preflight validates these before the run starts — no more cryptic Docker failures 30s in.
- Auto-injection: if the plugin needs `ANTHROPIC_API_KEY` and the secret exists but the workflow env section doesn't declare the mapping, `resolveStepEnv` injects it automatically.
- Claude Code agent bridges `OPENROUTER_API_KEY` → `ANTHROPIC_API_KEY` when the direct key is absent (the CLI reads `ANTHROPIC_API_KEY`).
- Env resolution tracks source per key (`literal` / `namespace-secret` / `workflow-secret` / `auto-injected` / `secret`) and emits it in the status event so users can see where each secret came from.
- MissingEnvBanner shows plugin name + alternatives hint.

## Context

Debugging `linkedin-posts-filter` workflow on staging — agent step failed with "Not logged in · Please run /login" because:
1. Preflight only checked explicit `{{TEMPLATE}}` refs in workflow env — didn't know claude-code-agent implicitly needs `ANTHROPIC_API_KEY`
2. Workflow had `OPENROUTER_API_KEY` + `ANTHROPIC_BASE_URL` in env (valid OpenRouter setup) but Claude CLI reads `ANTHROPIC_API_KEY`, not `OPENROUTER_API_KEY`

## Test plan

- [x] 63 unit tests in `resolve-env.test.ts` (19 new: auto-injection, source tracking, validatePluginRequiredEnv)
- [x] 424/425 agent-runtime tests pass (1 pre-existing skip)
- [x] TypeCheck passes (agent-runtime, platform-ui — pre-existing nodemailer error only)
- [x] Local verification: started `linkedin-posts-filter` with no secrets → preflight paused with `missing_env` + hint about alternatives
- [x] Local verification: set `OPENROUTER_API_KEY` + `ANTHROPIC_BASE_URL` + `HARVEST_API_KEY` → preflight passed, run started

🤖 Generated with [Claude Code](https://claude.com/claude-code)