### PR TITLE
fix(tests): guard against ALLOW_LOCAL_AGENTS leaking from .env.local

### DIFF
--- a/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.e2e.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.e2e.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'node:child_process';
+
+const originalAllowLocal = process.env.ALLOW_LOCAL_AGENTS;
+beforeEach(() => { delete process.env.ALLOW_LOCAL_AGENTS; });
+afterEach(() => {
+  if (originalAllowLocal === undefined) delete process.env.ALLOW_LOCAL_AGENTS;
+  else process.env.ALLOW_LOCAL_AGENTS = originalAllowLocal;
+});
 import type { AgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig } from '@mediforce/platform-core';
 import { ScriptContainerPlugin } from '../script-container-plugin';

--- a/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/script-container-plugin.test.ts
@@ -2,7 +2,14 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const originalAllowLocal = process.env.ALLOW_LOCAL_AGENTS;
+beforeEach(() => { delete process.env.ALLOW_LOCAL_AGENTS; });
+afterEach(() => {
+  if (originalAllowLocal === undefined) delete process.env.ALLOW_LOCAL_AGENTS;
+  else process.env.ALLOW_LOCAL_AGENTS = originalAllowLocal;
+});
 import type { ChildProcess } from 'node:child_process';
 import type { AgentContext, WorkflowAgentContext, EmitFn, EmitPayload } from '../../interfaces/step-executor-plugin';
 import type { ProcessConfig } from '@mediforce/platform-core';

--- a/packages/platform-api/src/handlers/workflows/__tests__/register-workflow.test.ts
+++ b/packages/platform-api/src/handlers/workflows/__tests__/register-workflow.test.ts
@@ -19,7 +19,9 @@ vi.mock('../../system/_docker', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../system/_docker')>();
   return {
     ...actual,
+    isLocalAgentMode: vi.fn().mockReturnValue(false),
     fetchFromContainerWorker: vi.fn().mockResolvedValue({ available: false }),
+    fetchFromLocalDocker: vi.fn().mockResolvedValue({ available: false }),
   };
 });
 


### PR DESCRIPTION
## Summary

- `ALLOW_LOCAL_AGENTS=true` in `packages/platform-ui/.env.local` was leaking into the test process, causing 7 test failures across two packages.
- `ScriptContainerPlugin` entered local-mode (no Docker) for inline scripts, so assertions on Docker args and env flags failed; E2E tests tried to spawn `Rscript` on the host.
- `registerWorkflow` skipped its missing-image validation (gated behind `!isLocalAgentMode()`) and called the unmocked `fetchFromLocalDocker` instead of the mocked `fetchFromContainerWorker`, producing unexpected `warnings` in results.

**Fix — three test files, no production code changed:**

- `script-container-plugin.test.ts` / `.e2e.test.ts`: `beforeEach` deletes `ALLOW_LOCAL_AGENTS`; `afterEach` restores it. Same pattern already used in `claude-code-agent-plugin.test.ts`.
- `register-workflow.test.ts`: extends the `vi.mock('../../system/_docker')` to also stub `isLocalAgentMode` (→ `false`) and `fetchFromLocalDocker` (→ `{ available: false }`), covering both execution paths.

## Test plan

- [ ] Run `pnpm vitest run` at repo root — all 7 previously-failing tests should pass
- [ ] Verify no other tests regress (the guards restore the original value after each test, so any test that explicitly sets `ALLOW_LOCAL_AGENTS=true` is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)