### PR TITLE
fix(credits): show effective spendable OpenRouter balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Pre-flight model validation: agent steps with unknown model IDs show an "Unknown model" warning (with Levenshtein-based "did you mean?" suggestions) in the start-run dialog before the run begins.
 - Start-run dialog: selecting a different workflow version from the dropdown no longer skips pre-flight checks — the dialog now waits for the new version's definition and validation to load before allowing start.
 - Extracted `normaliseModelId` to `platform-core` — was duplicated 5 times across 3 packages.
-- OpenRouter credits indicator now shows the effective spendable balance `min(key limit, account credits)` with a `(key limit / credits)` breakdown, instead of the key-limit ceiling alone which overstated available funds.
+- OpenRouter credits indicator and the start-run low-credit warning now use the effective spendable balance `min(key limit, account credits)` (indicator shows a `(key limit / credits)` breakdown), instead of the key-limit ceiling alone which overstated available funds.
 - Codex now mirrors Claude's repo-local skill and agent discovery layout via `.codex/skills/*` and `.codex/agents` symlinks, with `AGENTS.md` documenting how Codex should translate Claude-specific skill tool syntax.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Pre-flight model validation: agent steps with unknown model IDs show an "Unknown model" warning (with Levenshtein-based "did you mean?" suggestions) in the start-run dialog before the run begins.
 - Start-run dialog: selecting a different workflow version from the dropdown no longer skips pre-flight checks — the dialog now waits for the new version's definition and validation to load before allowing start.
 - Extracted `normaliseModelId` to `platform-core` — was duplicated 5 times across 3 packages.
+- OpenRouter credits indicator now shows the effective spendable balance `min(key limit, account credits)` with a `(key limit / credits)` breakdown, instead of the key-limit ceiling alone which overstated available funds.
 - Codex now mirrors Claude's repo-local skill and agent discovery layout via `.codex/skills/*` and `.codex/agents` symlinks, with `AGENTS.md` documenting how Codex should translate Claude-specific skill tool syntax.
 
 ### Removed

--- a/packages/cli/src/__tests__/system-credits.test.ts
+++ b/packages/cli/src/__tests__/system-credits.test.ts
@@ -7,6 +7,8 @@ const CREDITS_RESPONSE = {
   limit: 30,
   usage: 19.85,
   remaining: 10.15,
+  accountRemaining: 4.5,
+  effectiveRemaining: 4.5,
 };
 
 beforeEach(() => {
@@ -24,9 +26,10 @@ describe('system credits', () => {
     });
     expect(code).toBe(0);
     const text = output.stdoutLines.join('\n');
-    expect(text).toContain('$10.15');
-    expect(text).toContain('$19.85');
-    expect(text).toContain('$30.00');
+    expect(text).toContain('$4.50'); // effective + account credits
+    expect(text).toContain('$10.15'); // key limit remaining
+    expect(text).toContain('$19.85'); // key used
+    expect(text).toContain('$30.00'); // key limit
   });
 
   it('emits JSON when --json', async () => {
@@ -45,7 +48,14 @@ describe('system credits', () => {
 
   it('returns exit 1 when unavailable', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      jsonResponse({ available: false, limit: 0, usage: 0, remaining: 0, error: 'Not configured' }),
+      jsonResponse({
+        available: false,
+        limit: 0,
+        usage: 0,
+        remaining: 0,
+        effectiveRemaining: 0,
+        error: 'Not configured',
+      }),
     );
     const output = captureOutput();
     const code = await systemCreditsCommand({

--- a/packages/cli/src/commands/system-credits.ts
+++ b/packages/cli/src/commands/system-credits.ts
@@ -23,9 +23,16 @@ export const systemCreditsCommand = defineCommand({
 
     output.stdout(`OpenRouter credits for namespace "${args.namespace}":\n`);
     printKv(output, [
-      ['Remaining', `$${data.remaining.toFixed(2)}`],
-      ['Used', `$${data.usage.toFixed(2)}`],
-      ['Limit', `$${data.limit.toFixed(2)}`],
+      ['Effective remaining', `$${data.effectiveRemaining.toFixed(2)}`],
+      ['Key limit remaining', `$${data.remaining.toFixed(2)}`],
+      [
+        'Account credits remaining',
+        data.accountRemaining === undefined
+          ? 'unavailable'
+          : `$${data.accountRemaining.toFixed(2)}`,
+      ],
+      ['Key used', `$${data.usage.toFixed(2)}`],
+      ['Key limit', `$${data.limit.toFixed(2)}`],
     ]);
     return 0;
   },

--- a/packages/platform-api/src/contract/__tests__/system.test.ts
+++ b/packages/platform-api/src/contract/__tests__/system.test.ts
@@ -28,6 +28,19 @@ describe('OpenRouterCreditsOutputSchema', () => {
       limit: 30,
       usage: 19.85,
       remaining: 10.15,
+      accountRemaining: 0.13,
+      effectiveRemaining: 0.13,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts available response without the optional account balance', () => {
+    const result = OpenRouterCreditsOutputSchema.safeParse({
+      available: true,
+      limit: 30,
+      usage: 19.85,
+      remaining: 10.15,
+      effectiveRemaining: 10.15,
     });
     expect(result.success).toBe(true);
   });
@@ -38,6 +51,7 @@ describe('OpenRouterCreditsOutputSchema', () => {
       limit: 0,
       usage: 0,
       remaining: 0,
+      effectiveRemaining: 0,
       error: 'OPENROUTER_API_KEY not configured',
     });
     expect(result.success).toBe(true);

--- a/packages/platform-api/src/contract/system.ts
+++ b/packages/platform-api/src/contract/system.ts
@@ -34,9 +34,24 @@ export const OpenRouterCreditsInputSchema = z.object({
 
 export const OpenRouterCreditsOutputSchema = z.object({
   available: z.boolean(),
+  /** Key-level spend cap (OpenRouter `GET /auth/key` `limit`). */
   limit: z.number(),
+  /** Key-level usage so far. */
   usage: z.number(),
+  /** Key-level headroom under the cap (`limit_remaining`). */
   remaining: z.number(),
+  /**
+   * Account prepaid credit remaining (`total_credits - total_usage` from
+   * `GET /credits`). Omitted when the credits call fails but the key call
+   * succeeds.
+   */
+  accountRemaining: z.number().optional(),
+  /**
+   * Real spendable budget the runtime enforces per request:
+   * `min(remaining, accountRemaining)`. Falls back to `remaining` when the
+   * account balance is unknown.
+   */
+  effectiveRemaining: z.number(),
   error: z.string().optional(),
 });
 

--- a/packages/platform-api/src/handlers/system/__tests__/get-openrouter-credits.test.ts
+++ b/packages/platform-api/src/handlers/system/__tests__/get-openrouter-credits.test.ts
@@ -11,6 +11,28 @@ function makeJsonResponse(body: unknown, ok = true): Response {
   });
 }
 
+/**
+ * Route fetches by URL: `/auth/key` returns key-level numbers, `/credits`
+ * returns the account balance. Pass `null` for either to simulate that call
+ * failing (non-OK 500).
+ */
+function routedFetch(opts: {
+  key?: { limit?: number; usage?: number; limit_remaining?: number } | null;
+  credits?: { total_credits?: number; total_usage?: number } | null;
+}) {
+  return vi.fn(async (url: string) => {
+    if (url.includes('/auth/key')) {
+      if (opts.key === null) return makeJsonResponse({}, false);
+      return makeJsonResponse({ data: opts.key });
+    }
+    if (url.includes('/credits')) {
+      if (opts.credits === null) return makeJsonResponse({}, false);
+      return makeJsonResponse({ data: opts.credits });
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+}
+
 describe('getOpenRouterCredits handler', () => {
   let secretsRepo: NamespaceSecretsRepository;
 
@@ -21,10 +43,13 @@ describe('getOpenRouterCredits handler', () => {
     });
   });
 
-  it('fetches credits when the api key is present (apiKey caller)', async () => {
-    const fetchSpy = vi.fn(async () =>
-      makeJsonResponse({ data: { limit: 100, usage: 10, limit_remaining: 90 } }),
-    );
+  it('fetches key + account credits and reports the effective minimum', async () => {
+    // Account balance ($0.5) is far below the key cap ($90) — the binding
+    // constraint is the account, so effectiveRemaining must be $0.5.
+    const fetchSpy = routedFetch({
+      key: { limit: 100, usage: 10, limit_remaining: 90 },
+      credits: { total_credits: 10, total_usage: 9.5 },
+    });
 
     const scope = createTestScope({ namespaceSecretsRepo: secretsRepo });
     const result = await getOpenRouterCredits(
@@ -33,8 +58,68 @@ describe('getOpenRouterCredits handler', () => {
       { fetch: fetchSpy as unknown as typeof globalThis.fetch },
     );
 
-    expect(result).toEqual({ available: true, limit: 100, usage: 10, remaining: 90 });
-    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      available: true,
+      limit: 100,
+      usage: 10,
+      remaining: 90,
+      accountRemaining: 0.5,
+      effectiveRemaining: 0.5,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the key remaining when it is the binding constraint', async () => {
+    const fetchSpy = routedFetch({
+      key: { limit: 20, usage: 18, limit_remaining: 2 },
+      credits: { total_credits: 100, total_usage: 10 },
+    });
+
+    const scope = createTestScope({ namespaceSecretsRepo: secretsRepo });
+    const result = await getOpenRouterCredits(
+      { namespace: 'alpha' },
+      scope,
+      { fetch: fetchSpy as unknown as typeof globalThis.fetch },
+    );
+
+    expect(result.accountRemaining).toBe(90);
+    expect(result.effectiveRemaining).toBe(2);
+  });
+
+  it('degrades to key-level numbers when the credits call fails', async () => {
+    const fetchSpy = routedFetch({
+      key: { limit: 100, usage: 10, limit_remaining: 90 },
+      credits: null,
+    });
+
+    const scope = createTestScope({ namespaceSecretsRepo: secretsRepo });
+    const result = await getOpenRouterCredits(
+      { namespace: 'alpha' },
+      scope,
+      { fetch: fetchSpy as unknown as typeof globalThis.fetch },
+    );
+
+    expect(result.available).toBe(true);
+    expect(result.accountRemaining).toBeUndefined();
+    expect(result.effectiveRemaining).toBe(90);
+  });
+
+  it('degrades to key-level numbers when the credits payload shape is unexpected', async () => {
+    const fetchSpy = routedFetch({
+      key: { limit: 100, usage: 10, limit_remaining: 90 },
+      credits: { total_credits: 5 },
+    });
+
+    const scope = createTestScope({ namespaceSecretsRepo: secretsRepo });
+    const result = await getOpenRouterCredits(
+      { namespace: 'alpha' },
+      scope,
+      { fetch: fetchSpy as unknown as typeof globalThis.fetch },
+    );
+
+    expect(result.available).toBe(true);
+    expect(result.accountRemaining).toBeUndefined();
+    expect(result.effectiveRemaining).toBe(90);
   });
 
   it('returns "not configured" when the workspace has no OPENROUTER_API_KEY', async () => {

--- a/packages/platform-api/src/handlers/system/get-openrouter-credits.ts
+++ b/packages/platform-api/src/handlers/system/get-openrouter-credits.ts
@@ -9,6 +9,7 @@ const EMPTY: OpenRouterCreditsOutput = {
   limit: 0,
   usage: 0,
   remaining: 0,
+  effectiveRemaining: 0,
 };
 
 export interface GetOpenRouterCreditsOptions {
@@ -57,13 +58,53 @@ async function fetchCredits(
     if (!data || typeof data.limit_remaining !== 'number') {
       return { ...EMPTY, error: 'Unexpected response shape from OpenRouter' };
     }
+    const remaining = data.limit_remaining;
+    const accountRemaining = await fetchAccountRemaining(apiKey, fetchImpl);
+    const effectiveRemaining =
+      accountRemaining === undefined ? remaining : Math.min(remaining, accountRemaining);
     return {
       available: true,
       limit: data.limit ?? 0,
       usage: data.usage ?? 0,
-      remaining: data.limit_remaining,
+      remaining,
+      accountRemaining,
+      effectiveRemaining,
     };
   } catch (err) {
     return { ...EMPTY, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}
+
+/**
+ * Account prepaid credit remaining from `GET /credits`. This is the balance the
+ * runtime actually charges against, separate from the per-key cap. Returns
+ * `undefined` on any failure so the caller degrades to key-level numbers
+ * instead of dropping the whole response.
+ */
+async function fetchAccountRemaining(
+  apiKey: string,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<number | undefined> {
+  try {
+    const res = await fetchImpl('https://openrouter.ai/api/v1/credits', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) {
+      return undefined;
+    }
+    const body = (await res.json()) as {
+      data?: { total_credits?: number; total_usage?: number };
+    };
+    const data = body?.data;
+    if (
+      !data ||
+      typeof data.total_credits !== 'number' ||
+      typeof data.total_usage !== 'number'
+    ) {
+      return undefined;
+    }
+    return data.total_credits - data.total_usage;
+  } catch {
+    return undefined;
   }
 }

--- a/packages/platform-ui/src/components/namespace/openrouter-credits-indicator.tsx
+++ b/packages/platform-ui/src/components/namespace/openrouter-credits-indicator.tsx
@@ -56,8 +56,12 @@ export function OpenRouterCreditsIndicator({ handle }: OpenRouterCreditsIndicato
 
   if (loading || !credits?.available) return null;
 
-  const isLow = !hidden && credits.remaining <= LOW_CREDITS_THRESHOLD;
-  const isExhausted = !hidden && credits.remaining <= 0;
+  const isLow = !hidden && credits.effectiveRemaining <= LOW_CREDITS_THRESHOLD;
+  const isExhausted = !hidden && credits.effectiveRemaining <= 0;
+  const accountPart =
+    credits.accountRemaining === undefined
+      ? null
+      : ` / $${credits.accountRemaining.toFixed(2)} credits`;
 
   return (
     <div
@@ -89,13 +93,11 @@ export function OpenRouterCreditsIndicator({ handle }: OpenRouterCreditsIndicato
                     : 'text-foreground',
               )}
             >
-              ${credits.remaining.toFixed(2)}
+              ${credits.effectiveRemaining.toFixed(2)}
             </span>
-            {isLow && (
-              <span className="text-xs text-muted-foreground">
-                / ${credits.limit.toFixed(2)}
-              </span>
-            )}
+            <span className="text-xs text-muted-foreground">
+              (${credits.remaining.toFixed(2)} key limit{accountPart})
+            </span>
           </>
         )}
       </div>

--- a/packages/platform-ui/src/components/processes/start-run-button.tsx
+++ b/packages/platform-ui/src/components/processes/start-run-button.tsx
@@ -127,7 +127,7 @@ export function StartRunButton({
       namespaceSecretKeys,
       openRouterCredits: openRouterCredits.isLoading ? undefined : {
         available: openRouterCredits.available,
-        remaining: openRouterCredits.remaining,
+        effectiveRemaining: openRouterCredits.effectiveRemaining,
       },
       handle,
       workflowName,
@@ -135,7 +135,7 @@ export function StartRunButton({
       adminEmail: adminContact.email ?? undefined,
       modelValidation: modelValidation.isLoading ? undefined : { unknown: modelValidation.unknown },
     });
-  }, [effectiveDefinition, dockerImages, dockerAvailable, secretKeys, namespaceSecretKeys, openRouterCredits.isLoading, openRouterCredits.available, openRouterCredits.remaining, handle, workflowName, adminContact.email, modelValidation.isLoading, modelValidation.unknown]);
+  }, [effectiveDefinition, dockerImages, dockerAvailable, secretKeys, namespaceSecretKeys, openRouterCredits.isLoading, openRouterCredits.available, openRouterCredits.effectiveRemaining, handle, workflowName, adminContact.email, modelValidation.isLoading, modelValidation.unknown]);
 
   const preflightLoading = definitionLoading || dockerLoading || secretKeysLoading || openRouterCredits.isLoading || adminContact.isLoading || modelValidation.isLoading;
   const hasWarnings = warnings.length > 0;

--- a/packages/platform-ui/src/contexts/openrouter-credits-context.tsx
+++ b/packages/platform-ui/src/contexts/openrouter-credits-context.tsx
@@ -10,6 +10,8 @@ export interface OpenRouterCreditsState {
   remaining: number;
   limit: number;
   usage: number;
+  /** Real spendable budget — `min(key limit remaining, account credits)`. */
+  effectiveRemaining: number;
   isLoading: boolean;
   error?: string;
   refresh: () => void;
@@ -22,6 +24,7 @@ const OpenRouterCreditsContext = createContext<OpenRouterCreditsState>({
   remaining: 0,
   limit: 0,
   usage: 0,
+  effectiveRemaining: 0,
   isLoading: true,
   refresh: () => {},
 });
@@ -32,6 +35,7 @@ export function OpenRouterCreditsProvider({ children }: { children: ReactNode })
   const [remaining, setRemaining] = useState(0);
   const [limit, setLimit] = useState(0);
   const [usage, setUsage] = useState(0);
+  const [effectiveRemaining, setEffectiveRemaining] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | undefined>();
   const [activated, setActivated] = useState(false);
@@ -48,6 +52,7 @@ export function OpenRouterCreditsProvider({ children }: { children: ReactNode })
       setRemaining(data.remaining);
       setLimit(data.limit);
       setUsage(data.usage);
+      setEffectiveRemaining(data.effectiveRemaining);
       setIsLoading(false);
       setError(data.error);
     } catch {
@@ -73,10 +78,11 @@ export function OpenRouterCreditsProvider({ children }: { children: ReactNode })
     remaining,
     limit,
     usage,
+    effectiveRemaining,
     isLoading,
     error,
     refresh: fetchCredits,
-  }), [available, remaining, limit, usage, isLoading, error, fetchCredits]);
+  }), [available, remaining, limit, usage, effectiveRemaining, isLoading, error, fetchCredits]);
 
   return (
     <ActivateContext.Provider value={activate}>

--- a/packages/platform-ui/src/lib/preflight-checks.ts
+++ b/packages/platform-ui/src/lib/preflight-checks.ts
@@ -18,7 +18,8 @@ const TEMPLATE_RE = /^\{\{(?:[A-Z]+:)?([A-Za-z0-9_-]+)\}\}$/;
 
 export interface OpenRouterCreditsInfo {
   available: boolean;
-  remaining: number;
+  /** Real spendable budget — `min(key limit remaining, account credits)`. */
+  effectiveRemaining: number;
 }
 
 const LOW_CREDITS_THRESHOLD = 0.5;
@@ -132,12 +133,12 @@ export function runPreflightChecks(
     });
   }
 
-  if (options.openRouterCredits?.available && options.openRouterCredits.remaining <= LOW_CREDITS_THRESHOLD) {
+  if (options.openRouterCredits?.available && options.openRouterCredits.effectiveRemaining <= LOW_CREDITS_THRESHOLD) {
     const agentSteps = steps
       .filter((s) => s.executor === 'agent')
       .map((s) => s.name);
     if (agentSteps.length > 0) {
-      const remaining = options.openRouterCredits.remaining;
+      const remaining = options.openRouterCredits.effectiveRemaining;
       warnings.push({
         category: 'low-credits',
         resource: 'OPENROUTER_API_KEY',


### PR DESCRIPTION
## Problem

The OpenRouter credits indicator showed the **key-limit remaining** — a ceiling, not real spendable money. When the account prepaid balance is near-empty but the per-key limit is high, the UI showed a big number (e.g. \"\$16.63\") while requests actually 402'd with only ~\$0.13 usable. The runtime enforces `min(key limit remaining, account credit remaining)` per request.

## Fix

- Handler additionally fetches `GET /api/v1/credits` → `accountRemaining = total_credits - total_usage`.
- Returns `effectiveRemaining = min(keyRemaining, accountRemaining)` plus both breakdown figures.
- Graceful degradation: credits-call failure falls back to key-only (`effectiveRemaining = keyRemaining`); key-call failure still soft-fails `available:false`.
- UI headline = `effectiveRemaining`, with `(\$X key limit / \$Y credits)` breakdown.
- CLI prints the full breakdown.

## Tests

- Handler test: both-succeed → `min`, key-binding, credits-fail → degrade, credits-bad-shape → degrade, plus existing cases.
- Contract test: schema with/without optional `accountRemaining`.
- 16/16 pass; typecheck clean (platform-api, platform-ui, cli).

UI render + CLI string formatting are thin presentation over the tested contract — not separately unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)