### PR TITLE
[codex] Repair invalid external skills repo migration rows

### DIFF
--- a/packages/platform-infra/src/postgres/migrations/0027_repair_invalid_external_skills_repo.sql
+++ b/packages/platform-infra/src/postgres/migrations/0027_repair_invalid_external_skills_repo.sql
@@ -1,0 +1,26 @@
+-- Repair workflow definitions made invalid by 0026.
+--
+-- 0026 copied legacy workflow_definitions.repo into external_skills_repo.
+-- Legacy repo allowed { url } without a commit, but WorkflowDefinitionSchema
+-- now requires externalSkillsRepo.commit whenever externalSkillsRepo is present.
+-- Rows with external_skills_repo = {"url": "..."} therefore fail Zod parsing and
+-- disappear from workflow listings. Clear only invalid migrated values; valid
+-- pinned external skills repos are preserved.
+
+UPDATE "workflow_definitions"
+SET "external_skills_repo" = NULL
+WHERE "external_skills_repo" IS NOT NULL
+  AND (
+    jsonb_typeof("external_skills_repo") <> 'object'
+    OR NOT ("external_skills_repo" ? 'url')
+    OR NOT ("external_skills_repo" ? 'commit')
+    OR jsonb_typeof("external_skills_repo"->'url') <> 'string'
+    OR jsonb_typeof("external_skills_repo"->'commit') <> 'string'
+    OR "external_skills_repo"->>'url' = ''
+    OR "external_skills_repo"->>'url' !~ '^[A-Za-z][A-Za-z0-9+.-]*://[^[:space:]]+$'
+    OR "external_skills_repo"->>'commit' !~ '^[a-f0-9]{7,40}$'
+    OR (
+      "external_skills_repo" ? 'auth'
+      AND jsonb_typeof("external_skills_repo"->'auth') <> 'string'
+    )
+  );

--- a/packages/platform-infra/src/postgres/migrations/0027_repair_invalid_external_skills_repo.sql
+++ b/packages/platform-infra/src/postgres/migrations/0027_repair_invalid_external_skills_repo.sql
@@ -4,8 +4,8 @@
 -- Legacy repo allowed { url } without a commit, but WorkflowDefinitionSchema
 -- now requires externalSkillsRepo.commit whenever externalSkillsRepo is present.
 -- Rows with external_skills_repo = {"url": "..."} therefore fail Zod parsing and
--- disappear from workflow listings. Clear only invalid migrated values; valid
--- pinned external skills repos are preserved.
+-- disappear from workflow listings. Clear invalid or questionable migrated
+-- values; valid pinned http(s) external skills repos are preserved.
 
 UPDATE "workflow_definitions"
 SET "external_skills_repo" = NULL
@@ -17,7 +17,7 @@ WHERE "external_skills_repo" IS NOT NULL
     OR jsonb_typeof("external_skills_repo"->'url') <> 'string'
     OR jsonb_typeof("external_skills_repo"->'commit') <> 'string'
     OR "external_skills_repo"->>'url' = ''
-    OR "external_skills_repo"->>'url' !~ '^[A-Za-z][A-Za-z0-9+.-]*://[^[:space:]]+$'
+    OR "external_skills_repo"->>'url' !~ '^https?://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+(:[0-9]{1,5})?(/[^[:space:]]*)?$'
     OR "external_skills_repo"->>'commit' !~ '^[a-f0-9]{7,40}$'
     OR (
       "external_skills_repo" ? 'auth'

--- a/packages/platform-infra/src/postgres/migrations/meta/_journal.json
+++ b/packages/platform-infra/src/postgres/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1750329600000,
       "tag": "0026_repo_to_external_skills_repo",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1782086400000,
+      "tag": "0027_repair_invalid_external_skills_repo",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What changed

- Adds migration `0027_repair_invalid_external_skills_repo.sql`.
- Registers the migration in the Drizzle journal.
- The migration clears invalid `workflow_definitions.external_skills_repo` values to `NULL` so existing workflow rows parse again under the stricter #751 schema.

## Why

PR #751 migrated legacy `workflow_definitions.repo` into `external_skills_repo`, but legacy repo values could be `{ "url": "..." }` without a pinned `commit`. The new `WorkflowDefinitionSchema` makes `externalSkillsRepo.commit` required whenever `externalSkillsRepo` is present, so those rows still exist in Postgres but are rejected by Zod and skipped from workflow listings.

## Behavior

The migration preserves valid pinned external skills repos and clears malformed values, including missing `url`, missing `commit`, invalid URL shape, invalid lowercase-hex commit, non-object JSON, and non-string `auth`.

This restores workflow definition visibility. Workflows that actually depended on an external skills repo still need to be re-registered or backfilled with a real pinned commit to fetch those skills again.

## Validation

- Parsed `packages/platform-infra/src/postgres/migrations/meta/_journal.json` successfully.
- Ran self-review on the migration diff: SHIP, no findings.
- Did not run product tests; this is a SQL migration-only repair.