### PR TITLE
fix(agent-runtime): clone public skills repos over anonymous HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Dead uploaded-skills feature — dropped `AgentDefinition.skillFileNames` + the `agents.skill_file_names` column, the skill-upload UI, and the Firebase Storage skill download from agent identity resolution; `skillsDir` is now the only skill mechanism (ADR-0003 PR1).
 
 ### Fixed
+- External skills repo now clones public repos over anonymous HTTPS — `fetchSkillsFromRepo` no longer forces an SSH clone (which fails in the agent container, where there is no `ssh` binary) when no auth token is configured; SSH/deploy-key transport is used only for genuine `git@` refs.
 - `repo` → `external_skills_repo` migration applies on staging again — the previous `0026`/`0027` pair carried an out-of-order journal `when` timestamp (2025-06-19) that drizzle-kit silently skips on any DB already past it, leaving the new column uncreated and every workflow listing empty. Merged both into a single `0026_external_skills_repo` migration (column add + `repo` copy + invalid-value repair) with a correct timestamp.
 - Image-less build-mode workflow agents now resolve their derived Docker tag before choosing execution mode, so `dockerfile`/`repo`/`commit` agents run in containers instead of falling back to local host execution.
 - Workflow editor agent image fields keep custom Docker tag entry available even when discovered local Docker images are listed.

--- a/packages/agent-runtime/src/plugins/__tests__/container-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/container-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatExitInfo, deriveBuildTag } from '../container-plugin';
+import { formatExitInfo, deriveBuildTag, resolveSkillsCloneUrl } from '../container-plugin';
 
 describe('formatExitInfo', () => {
   it('[DATA] reports the exit code when the process exited normally', () => {
@@ -60,5 +60,43 @@ describe('deriveBuildTag', () => {
     const withUndefined = deriveBuildTag('git@github.com:org/repo.git', 'abc1234', undefined);
     const withEmpty = deriveBuildTag('git@github.com:org/repo.git', 'abc1234', '');
     expect(withUndefined).toBe(withEmpty);
+  });
+});
+
+describe('resolveSkillsCloneUrl', () => {
+  it('[DATA] clones an https ref over HTTPS as given, no SSH', () => {
+    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('https://github.com/Appsilon/mediforce');
+    expect(cloneUrl).toBe('https://github.com/Appsilon/mediforce');
+    expect(useSsh).toBe(false);
+  });
+
+  it('[DATA] clones a git@ ref over SSH as given, never converting to HTTPS', () => {
+    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('git@github.com:Appsilon/mediforce.git');
+    expect(cloneUrl).toBe('git@github.com:Appsilon/mediforce.git');
+    expect(useSsh).toBe(true);
+  });
+
+  it('[DATA] clones an owner/repo shorthand over anonymous HTTPS', () => {
+    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('Appsilon/mediforce');
+    expect(cloneUrl).toBe('https://github.com/Appsilon/mediforce');
+    expect(useSsh).toBe(false);
+  });
+
+  it('[DATA] uses authenticated HTTPS (PAT) when a token is provided, even for an https ref', () => {
+    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('https://github.com/Appsilon/mediforce', 'TOK');
+    expect(cloneUrl).toBe('https://x-access-token:TOK@github.com/Appsilon/mediforce.git');
+    expect(useSsh).toBe(false);
+  });
+
+  it('[DATA] a token forces HTTPS even when the ref is given in SSH form', () => {
+    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('git@github.com:Appsilon/mediforce.git', 'TOK');
+    expect(cloneUrl).toBe('https://x-access-token:TOK@github.com/Appsilon/mediforce.git');
+    expect(useSsh).toBe(false);
+  });
+
+  it('[DATA] clones a local path directly, no SSH', () => {
+    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('/path/to/bare.git');
+    expect(cloneUrl).toBe('/path/to/bare.git');
+    expect(useSsh).toBe(false);
   });
 });

--- a/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts
@@ -7,7 +7,7 @@ import type { AgentContext, WorkflowAgentContext, EmitFn } from '../interfaces/s
 import type { AgentConfig, StepConfig, PluginCapabilityMetadata, GitMetadata, McpServerConfig, ResolvedMcpConfig, Presentation, OutputSchemaShape } from '@mediforce/platform-core';
 import { resolveStepEnv, resolveValue, type ResolvedEnv } from './resolve-env';
 import { getDockerSpawnStrategy, type ImageBuildMeta } from './docker-spawn-strategy';
-import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, resolveRepoToken, normalizeRepoUrls, formatExitInfo, type ContainerPluginInit } from './container-plugin';
+import { ContainerPlugin, isWorkflowAgentContext, resolveImageBuild, resolveRepoToken, formatExitInfo, type ContainerPluginInit } from './container-plugin';
 import { INTERNAL_OUTPUT_FILE_NAMES, PRESENTATION_FILE_NAMES } from '../workspace/output-files';
 import { renderOAuthHeader } from '../oauth/resolve-oauth-token';
 import { createLineStreamReader } from '@mediforce/platform-core';
@@ -780,7 +780,7 @@ export abstract class BaseContainerAgentPlugin extends ContainerPlugin {
           const repoToken = resolveRepoToken(this.agentConfig, this.context, this.resolvedEnv.vars);
           await this.fetchSkillsFromRepo(
             this.agentConfig.skillsDir,
-            normalizeRepoUrls(wfRepo.url).gitUrl,
+            wfRepo.url,
             wfRepo.commit,
             repoToken,
           );

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -203,6 +203,33 @@ export function toHttpsWithToken(sshUrl: string, token: string): string {
 }
 
 /**
+ * Resolve the clone URL + transport for a skills repo reference, honouring the
+ * form the user supplied: an `https://` URL clones over HTTPS, a `git@` URL
+ * clones over SSH. We never silently convert one to the other.
+ *
+ *   - token present  → authenticated HTTPS (`x-access-token`); a PAT only works
+ *                      over HTTPS, mirroring the main-repo clone path
+ *   - `git@…`        → SSH as given (needs deploy key + `GIT_SSH_COMMAND`)
+ *   - `https://…` / local path → HTTPS / local as given
+ *   - `owner/repo` shorthand   → anonymous HTTPS (github default)
+ */
+export function resolveSkillsCloneUrl(
+  repoRef: string,
+  repoToken?: string,
+): { cloneUrl: string; useSsh: boolean } {
+  if (repoToken) {
+    return { cloneUrl: toHttpsWithToken(normalizeRepoUrls(repoRef).gitUrl, repoToken), useSsh: false };
+  }
+  if (repoRef.startsWith('git@')) {
+    return { cloneUrl: repoRef, useSsh: true };
+  }
+  if (repoRef.startsWith('https://') || repoRef.startsWith('/') || repoRef.startsWith('.')) {
+    return { cloneUrl: repoRef, useSsh: false };
+  }
+  return { cloneUrl: normalizeRepoUrls(repoRef).httpsUrl, useSsh: false };
+}
+
+/**
  * Human-readable exit descriptor for a finished container or child process.
  * A SIGTERM kill is annotated as a likely timeout when the step's limit is
  * known — the signal name alone doesn't tell the user we killed it for
@@ -408,11 +435,11 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
    */
   protected async fetchSkillsFromRepo(
     skillsDir: string,
-    repoUrl: string,
+    repoRef: string,
     commit: string,
     repoToken?: string,
   ): Promise<string> {
-    const hash = createHash('sha256').update(`${repoUrl}\0${commit}\0${skillsDir}`).digest('hex').slice(0, 16);
+    const hash = createHash('sha256').update(`${repoRef}\0${commit}\0${skillsDir}`).digest('hex').slice(0, 16);
     const cacheDir = join(SKILLS_CACHE_DIR, hash);
 
     // Cache hit
@@ -423,15 +450,17 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
     }
 
     // Cache miss — clone, copy, delete clone
-    console.log(`[container-plugin] Fetching skills from ${repoUrl}@${commit.slice(0, 8)} path=${skillsDir}`);
+    console.log(`[container-plugin] Fetching skills from ${repoRef}@${commit.slice(0, 8)} path=${skillsDir}`);
     const cloneDir = mkdtempSync(join(tmpdir(), 'mediforce-skills-clone-'));
 
     try {
-      const cloneUrl = repoToken ? toHttpsWithToken(repoUrl, repoToken) : repoUrl;
-      const deployKeyPath = prepareDeployKeyPath();
+      const { cloneUrl, useSsh } = resolveSkillsCloneUrl(repoRef, repoToken);
+      // SSH refs need a deploy key + GIT_SSH_COMMAND; HTTPS and local paths must not set it.
       const execOpts = {
         stdio: 'pipe' as const,
-        env: { ...process.env, GIT_SSH_COMMAND: `ssh -i ${deployKeyPath} -o StrictHostKeyChecking=no -o IdentitiesOnly=yes` },
+        env: useSsh
+          ? { ...process.env, GIT_SSH_COMMAND: `ssh -i ${prepareDeployKeyPath()} -o StrictHostKeyChecking=no -o IdentitiesOnly=yes` }
+          : { ...process.env },
       };
 
       execSync(`git init "${cloneDir}"`, execOpts);
@@ -442,7 +471,7 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
       const sourceDir = join(cloneDir, skillsDir);
       if (!existsSync(sourceDir)) {
         throw new Error(
-          `Skills directory "${skillsDir}" not found in repo ${repoUrl}@${commit.slice(0, 8)}`,
+          `Skills directory "${skillsDir}" not found in repo ${repoRef}@${commit.slice(0, 8)}`,
         );
       }
 


### PR DESCRIPTION
## Problem
`fetchSkillsFromRepo` (cloning a workflow's `externalSkillsRepo` into the skills cache) could not clone a **public** repo when no auth token was configured. Every repo ref was force-converted to its SSH form, and the agent container has no `ssh` binary:

```
ssh: not found
fatal: Could not read from remote repository.
```

Reproduced on staging with `appsilon/renovate-bot`, whose `externalSkillsRepo` points at the public `https://github.com/Appsilon/mediforce`.

## Root cause
The caller passed `normalizeRepoUrls(wfRepo.url).gitUrl` — collapsing **every** ref (including `https://…`) to the `git@…` SSH form — and `fetchSkillsFromRepo` always set `GIT_SSH_COMMAND`. So an HTTPS URL the user supplied was silently turned into an SSH clone that the container can't perform.

## Fix
Honour the transport the user supplied — never convert one form to another:

| ref | transport |
|-----|-----------|
| `https://…` | HTTPS as given |
| `git@…` | SSH as given (deploy key + `GIT_SSH_COMMAND`) |
| `owner/repo` shorthand | anonymous HTTPS (github default) |
| any ref **+ token** | authenticated HTTPS (`x-access-token`) — a PAT only works over HTTPS |

New `resolveSkillsCloneUrl(repoRef, repoToken) -> { cloneUrl, useSsh }` makes the decision; `fetchSkillsFromRepo` sets `GIT_SSH_COMMAND` **only** when `useSsh` (i.e. a `git@` ref). The caller now passes the raw `wfRepo.url`. The token path is identical to the main-repo clone in `workspace-manager.ts` (`resolveRemoteUrl`), keeping the two consistent.

Net effect: public `https://` skills repos clone over anonymous HTTPS (the bug), `git@` skills repos keep their SSH/deploy-key path, private repos authenticate via token over HTTPS.

## Test
Unit tests around `resolveSkillsCloneUrl`:
- `https://…` no token → HTTPS as given, `useSsh=false`
- `git@…` no token → SSH as given, `useSsh=true` (never converted to HTTPS)
- `owner/repo` shorthand → anonymous HTTPS
- `https://…` + token → `https://x-access-token:…@github.com/….git`, `useSsh=false`
- `git@…` + token → token forces HTTPS, `useSsh=false`
- local path → as given, `useSsh=false`

## Out of scope
Stale `repoSkillsDir` instance-var leak across steps — tracked separately.

## Verify on staging (never production)
`appsilon/renovate-bot` (manual trigger) — after the fix it must clone the skill over anonymous HTTPS and load `skills/renovate-review/SKILL.md`:
`MEDIFORCE_BASE_URL=https://staging.mediforce.ai pnpm exec mediforce run start --workflow renovate-bot --namespace appsilon --trigger manual`