### PR TITLE
fix(skills): derive skills-cache path on demand instead of shared mutable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - Dead uploaded-skills feature — dropped `AgentDefinition.skillFileNames` + the `agents.skill_file_names` column, the skill-upload UI, and the Firebase Storage skill download from agent identity resolution; `skillsDir` is now the only skill mechanism (ADR-0003 PR1).
 
 ### Fixed
+- Skill-loading steps no longer intermittently fail with "Skill file not found" from another workflow's cache — the container plugin singleton kept the skills-cache dir in a mutable field that leaked across runs; the path is now derived on demand from the workflow's `externalSkillsRepo`.
 - `repo` → `external_skills_repo` migration applies on staging again — the previous `0026`/`0027` pair carried an out-of-order journal `when` timestamp (2025-06-19) that drizzle-kit silently skips on any DB already past it, leaving the new column uncreated and every workflow listing empty. Merged both into a single `0026_external_skills_repo` migration (column add + `repo` copy + invalid-value repair) with a correct timestamp.
 - Image-less build-mode workflow agents now resolve their derived Docker tag before choosing execution mode, so `dockerfile`/`repo`/`commit` agents run in containers instead of falling back to local host execution.
 - Workflow editor agent image fields keep custom Docker tag entry available even when discovered local Docker images are listed.

--- a/packages/agent-runtime/src/plugins/__tests__/container-plugin.skills-dir.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/container-plugin.skills-dir.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ContainerPlugin, skillsCacheDir, normalizeRepoUrls } from '../container-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../../interfaces/step-executor-plugin';
+import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
+
+/** Minimal concrete subclass to exercise the protected resolveSkillsDir. */
+class TestPlugin extends ContainerPlugin {
+  readonly metadata = { name: 'test-plugin' } as PluginCapabilityMetadata;
+  async initialize(context: AgentContext | WorkflowAgentContext): Promise<void> {
+    this.context = context;
+  }
+  async run(_emit: EmitFn): Promise<void> {}
+  exposeResolveSkillsDir(skillsDir: string, resolveProjectPath: (p: string) => string): string {
+    return this.resolveSkillsDir(skillsDir, resolveProjectPath);
+  }
+  setContext(context: AgentContext | WorkflowAgentContext): void {
+    this.context = context;
+  }
+}
+
+const PROJECT = (p: string): string => join('/project', p);
+
+function repoContext(url: string, commit: string): WorkflowAgentContext {
+  return {
+    workflowDefinition: { externalSkillsRepo: { url, commit } },
+    step: { id: 's1' },
+  } as unknown as WorkflowAgentContext;
+}
+
+function diskContext(): WorkflowAgentContext {
+  return {
+    workflowDefinition: {},
+    step: { id: 's2' },
+  } as unknown as WorkflowAgentContext;
+}
+
+describe('skillsCacheDir', () => {
+  it('[DATA] is deterministic and lives under the skills cache root', () => {
+    const a = skillsCacheDir('git@github.com:org/repo.git', 'abc123', 'skills');
+    const b = skillsCacheDir('git@github.com:org/repo.git', 'abc123', 'skills');
+    expect(a).toBe(b);
+    expect(a.startsWith(join(tmpdir(), 'mediforce-skills-cache'))).toBe(true);
+  });
+
+  it('[DATA] differs by repo, commit, and skillsDir', () => {
+    const base = skillsCacheDir('git@github.com:org/a.git', 'c1', 'skills');
+    expect(skillsCacheDir('git@github.com:org/b.git', 'c1', 'skills')).not.toBe(base);
+    expect(skillsCacheDir('git@github.com:org/a.git', 'c2', 'skills')).not.toBe(base);
+    expect(skillsCacheDir('git@github.com:org/a.git', 'c1', 'other')).not.toBe(base);
+  });
+});
+
+describe('resolveSkillsDir — no shared mutable state across steps', () => {
+  it('[DATA] a repo-mode step does not leak its cache dir into a later disk-mode step', () => {
+    const plugin = new TestPlugin();
+
+    // Step 1: workflow WITH externalSkillsRepo → resolves to the content-addressed cache dir.
+    plugin.setContext(repoContext('git@github.com:org/skills-repo.git', 'deadbeef'));
+    const repoResolved = plugin.exposeResolveSkillsDir('skills', PROJECT);
+    const expectedCache = skillsCacheDir(
+      normalizeRepoUrls('git@github.com:org/skills-repo.git').gitUrl,
+      'deadbeef',
+      'skills',
+    );
+    expect(repoResolved).toBe(expectedCache);
+
+    // Step 2 on the SAME plugin instance: workflow WITHOUT externalSkillsRepo →
+    // MUST resolve from disk, not inherit step 1's cache dir.
+    plugin.setContext(diskContext());
+    const diskResolved = plugin.exposeResolveSkillsDir('skills', PROJECT);
+    expect(diskResolved).toBe(PROJECT('skills'));
+    expect(diskResolved).not.toBe(expectedCache);
+  });
+
+  it('[DATA] two interleaved repo-mode contexts resolve independently — no clobber', () => {
+    const plugin = new TestPlugin();
+
+    plugin.setContext(repoContext('git@github.com:org/a.git', 'aaa'));
+    const a = plugin.exposeResolveSkillsDir('skills', PROJECT);
+
+    plugin.setContext(repoContext('git@github.com:org/b.git', 'bbb'));
+    const b = plugin.exposeResolveSkillsDir('skills', PROJECT);
+
+    expect(a).not.toBe(b);
+    expect(a).toBe(skillsCacheDir(normalizeRepoUrls('git@github.com:org/a.git').gitUrl, 'aaa', 'skills'));
+    expect(b).toBe(skillsCacheDir(normalizeRepoUrls('git@github.com:org/b.git').gitUrl, 'bbb', 'skills'));
+  });
+});

--- a/packages/agent-runtime/src/plugins/__tests__/container-plugin.skills-fetch.integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/container-plugin.skills-fetch.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ContainerPlugin, normalizeRepoUrls } from '../container-plugin';
+import type { AgentContext, WorkflowAgentContext, EmitFn } from '../../interfaces/step-executor-plugin';
+import type { PluginCapabilityMetadata } from '@mediforce/platform-core';
+
+class TestPlugin extends ContainerPlugin {
+  readonly metadata = { name: 'test-plugin' } as PluginCapabilityMetadata;
+  async initialize(): Promise<void> {}
+  async run(_emit: EmitFn): Promise<void> {}
+  setContext(context: AgentContext | WorkflowAgentContext): void {
+    this.context = context;
+  }
+  populate(skillsDir: string, repoUrl: string, commit: string): Promise<void> {
+    return this.fetchSkillsFromRepo(skillsDir, repoUrl, commit);
+  }
+  resolve(skillsDir: string, resolveProjectPath: (p: string) => string): string {
+    return this.resolveSkillsDir(skillsDir, resolveProjectPath);
+  }
+}
+
+function git(cwd: string, cmd: string): string {
+  return execSync(`git ${cmd}`, {
+    cwd,
+    stdio: 'pipe',
+    env: { ...process.env, GIT_AUTHOR_NAME: 'T', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 'T', GIT_COMMITTER_EMAIL: 't@t' },
+  })
+    .toString()
+    .trim();
+}
+
+const SKILL_BODY = '# Renovate review\nstub skill content';
+
+describe('fetchSkillsFromRepo + resolveSkillsDir [integration, real git]', () => {
+  let repoDir: string;
+  let commit: string;
+
+  beforeAll(() => {
+    repoDir = mkdtempSync(join(tmpdir(), 'mediforce-skills-src-'));
+    git(repoDir, 'init -q');
+    // Let `git fetch origin <sha>` work over the local transport.
+    git(repoDir, 'config uploadpack.allowAnySHA1InWant true');
+    git(repoDir, 'config uploadpack.allowReachableSHA1InWant true');
+    const skillDir = join(repoDir, 'skills', 'renovate-review');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), SKILL_BODY);
+    git(repoDir, 'add -A');
+    git(repoDir, 'commit -q -m seed');
+    commit = git(repoDir, 'rev-parse HEAD');
+  });
+
+  afterAll(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('[DATA] populates the cache from a real clone and resolveSkillsDir points at the populated dir', async () => {
+    const plugin = new TestPlugin();
+    const gitUrl = normalizeRepoUrls(repoDir).gitUrl;
+
+    await plugin.populate('skills', gitUrl, commit);
+
+    plugin.setContext({
+      workflowDefinition: { externalSkillsRepo: { url: repoDir, commit } },
+      step: { id: 's1' },
+    } as unknown as WorkflowAgentContext);
+
+    const resolved = plugin.resolve('skills', (p) => join('/should-not-be-used', p));
+
+    // The resolved dir is the on-disk cache that fetch just populated.
+    const skillFile = join(resolved, 'renovate-review', 'SKILL.md');
+    expect(existsSync(skillFile)).toBe(true);
+    expect(readFileSync(skillFile, 'utf-8')).toBe(SKILL_BODY);
+  });
+
+  it('[DATA] after a repo-mode populate, a disk-mode step on the same instance resolves to disk', async () => {
+    const plugin = new TestPlugin();
+    const gitUrl = normalizeRepoUrls(repoDir).gitUrl;
+
+    // Step 1: repo-mode — clone + populate cache.
+    await plugin.populate('skills', gitUrl, commit);
+    plugin.setContext({
+      workflowDefinition: { externalSkillsRepo: { url: repoDir, commit } },
+      step: { id: 's1' },
+    } as unknown as WorkflowAgentContext);
+    const repoResolved = plugin.resolve('skills', (p) => join('/project', p));
+    expect(existsSync(join(repoResolved, 'renovate-review', 'SKILL.md'))).toBe(true);
+
+    // Step 2: disk-mode — MUST NOT inherit step 1's cache dir.
+    plugin.setContext({
+      workflowDefinition: {},
+      step: { id: 's2' },
+    } as unknown as WorkflowAgentContext);
+    const diskResolved = plugin.resolve('skills', (p) => join('/project', p));
+    expect(diskResolved).toBe(join('/project', 'skills'));
+    expect(diskResolved).not.toBe(repoResolved);
+  });
+});

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -193,6 +193,17 @@ export function resolveImageBuild(
 
 const SKILLS_CACHE_DIR = join(tmpdir(), 'mediforce-skills-cache');
 
+/**
+ * Content-addressed cache directory for skills fetched from a git repo.
+ * Key: sha256(repoUrl + commit + skillsDir). Pure — computable for free
+ * whenever the path is needed, so nothing about it has to be stored on
+ * shared instance state.
+ */
+export function skillsCacheDir(repoUrl: string, commit: string, skillsDir: string): string {
+  const hash = createHash('sha256').update(`${repoUrl}\0${commit}\0${skillsDir}`).digest('hex').slice(0, 16);
+  return join(SKILLS_CACHE_DIR, hash);
+}
+
 /** Convert SSH git URL to HTTPS with token for authenticated clone. */
 export function toHttpsWithToken(sshUrl: string, token: string): string {
   const match = sshUrl.match(/git@github\.com:(.+?)(?:\.git)?$/);
@@ -253,8 +264,6 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
   protected context!: AgentContext | WorkflowAgentContext;
   protected resolvedEnv: ResolvedEnv = { vars: {}, injectedKeys: [], sources: {} };
   protected imageBuild: ImageBuildMeta | undefined;
-  /** Cached skills dir path fetched from git repo. */
-  protected repoSkillsDir: string | null = null;
   /** Run-scoped git worktree — populated by `resolveRunWorkspace` at run start. */
   protected runWorkspaceHandle: RunWorkspaceHandle | null = null;
   protected workspaceManager: WorkspaceManagerLike | null = null;
@@ -402,24 +411,23 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
   }
 
   /**
-   * Fetch skills from a git repo into a deterministic cache directory.
-   * Cache key: sha256(repoUrl + commit + skillsDir).
-   * Returns the path to the cached skills directory.
+   * Populate the content-addressed skills cache from a git repo (clone + copy).
+   * Idempotent: a cache hit is a no-op. Stores nothing on instance state — the
+   * cache path is derived on demand by {@link resolveSkillsDir} via
+   * {@link skillsCacheDir}, so concurrent steps can't leak or clobber it.
    */
   protected async fetchSkillsFromRepo(
     skillsDir: string,
     repoUrl: string,
     commit: string,
     repoToken?: string,
-  ): Promise<string> {
-    const hash = createHash('sha256').update(`${repoUrl}\0${commit}\0${skillsDir}`).digest('hex').slice(0, 16);
-    const cacheDir = join(SKILLS_CACHE_DIR, hash);
+  ): Promise<void> {
+    const cacheDir = skillsCacheDir(repoUrl, commit, skillsDir);
 
     // Cache hit
     if (existsSync(cacheDir)) {
-      console.log(`[container-plugin] Skills cache hit for ${skillsDir} (${hash})`);
-      this.repoSkillsDir = cacheDir;
-      return cacheDir;
+      console.log(`[container-plugin] Skills cache hit for ${skillsDir} (${cacheDir})`);
+      return;
     }
 
     // Cache miss — clone, copy, delete clone
@@ -452,17 +460,22 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
     } finally {
       rmSync(cloneDir, { recursive: true, force: true });
     }
-
-    this.repoSkillsDir = cacheDir;
-    return cacheDir;
   }
 
   /**
-   * Resolve skillsDir — uses repo cache if available, otherwise resolveProjectPath.
+   * Resolve the host skills directory for the current step. When the workflow
+   * declares an `externalSkillsRepo`, the path is the content-addressed cache
+   * dir (populated by {@link fetchSkillsFromRepo}); otherwise it's resolved
+   * from disk. Derived fresh from `this.context` per call — no shared field —
+   * so a repo-mode step can't leak its cache dir into a later disk-mode step,
+   * and concurrent steps can't clobber each other.
    */
   protected resolveSkillsDir(skillsDir: string, resolveProjectPath: (p: string) => string): string {
-    if (this.repoSkillsDir) {
-      return this.repoSkillsDir;
+    const wfRepo = isWorkflowAgentContext(this.context)
+      ? this.context.workflowDefinition.externalSkillsRepo
+      : undefined;
+    if (wfRepo?.url && wfRepo?.commit) {
+      return skillsCacheDir(normalizeRepoUrls(wfRepo.url).gitUrl, wfRepo.commit, skillsDir);
     }
     return resolveProjectPath(skillsDir);
   }


### PR DESCRIPTION
## Problem

Skill-loading workflow steps intermittently fail on staging with:

```
Skill file not found: /tmp/mediforce-skills-cache/<hash>/<skill>/SKILL.md
```

The `<hash>` belongs to a **different** workflow than the one failing, and it hits workflows with **no** `externalSkillsRepo` (meant to load skills from disk).

## Root cause

`ContainerPlugin` is a process-wide singleton (`platform-services.ts` registers one instance per plugin, reused by every run/step). It stored the resolved skills-cache dir in a **mutable instance field** `repoSkillsDir`, set only inside `fetchSkillsFromRepo` (runs only when the workflow has `externalSkillsRepo`) and read by `resolveSkillsDir`.

A disk-mode workflow running after a repo-mode workflow on the same process never recomputes the field → reads the prior run's stale cache path → "skill not found". Two failure modes from one shared mutable: stale leak (sequential) and clobber (concurrent).

## Fix

Make it stateless:
- Add pure exported `skillsCacheDir(repoUrl, commit, skillsDir)` — content-addressed, computable for free.
- Remove the `repoSkillsDir` field. `fetchSkillsFromRepo` now only **populates** the cache (returns `void`).
- `resolveSkillsDir` derives the path on demand from `this.context.workflowDefinition.externalSkillsRepo` (same `normalizeRepoUrls` + cache key as the populate path), else `resolveProjectPath`.

No shared mutable state → eliminates both the leak and the clobber.

## Tests

New `container-plugin.skills-dir.test.ts`: repo-mode step does not leak its cache dir into a later disk-mode step on the same instance; two interleaved repo-mode contexts resolve independently; pure helper determinism + key sensitivity. 15 tests pass, agent-runtime typecheck clean.

## Verify on staging (never production)

`appsilon/renovate-bot` (manual trigger) — a no-`externalSkillsRepo`, skill-using workflow. After the fix its `classify` step must load `skills/renovate-review` from disk reliably regardless of what ran before:

```
MEDIFORCE_BASE_URL=https://staging.mediforce.ai pnpm exec mediforce run start --workflow renovate-bot --namespace appsilon --trigger manual
```