### PR TITLE
fix: copy workflow-examples into Docker image for MCP tool

### DIFF
--- a/packages/platform-ui/Dockerfile
+++ b/packages/platform-ui/Dockerfile
@@ -93,6 +93,9 @@ COPY --from=builder /app/packages/platform-ui/public ./packages/platform-ui/publ
 # Not reliably picked up by Next.js output file tracing in this build, so copy explicitly.
 COPY --from=builder /app/data ./data
 
+# Workflow examples — CI-tested definitions served by mediforce-mcp list_workflow_examples tool
+COPY --from=builder /app/docs/workflow-examples ./docs/workflow-examples
+
 # mediforce-mcp — stdio MCP server providing platform tools to cowork agents.
 # Linked globally so `mediforce-mcp` command is on PATH (same pattern as
 # tealflow-mcp). Copies workspace source + node_modules from builder.


### PR DESCRIPTION
## Summary

One-line Dockerfile fix: `COPY --from=builder /app/docs/workflow-examples ./docs/workflow-examples`

The `list_workflow_examples` MCP tool reads from `docs/workflow-examples/` on disk. This directory wasn't copied into the Docker runner image, so the cowork agent on staging couldn't load examples — the MCP tool returned empty arrays silently.

## Test plan

- [ ] Docker build succeeds
- [ ] Staging: cowork agent calls `list_workflow_examples` and gets 11 examples + 6 anti-patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)