### PR TITLE
fix(ui): stop Search icon overlapping text in Human Review and Assist badges

### DIFF
--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -187,7 +187,7 @@ function ExecutorChip({ executorType, autonomyLevel, plugin, runtime }: {
         icon: (
           <span className="inline-flex items-center gap-0.5">
             <Bot className="h-3 w-3 shrink-0" />
-            <span className="relative inline-flex shrink-0">
+            <span className="relative inline-flex shrink-0 mr-2">
               <User className="h-3 w-3" />
               <Search className="absolute -bottom-0.5 -right-1.5 h-1.5 w-1.5" strokeWidth={2.5} />
             </span>

--- a/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
@@ -89,7 +89,7 @@ function ExecutorIcon({ executor, autonomyLevel }: { executor: string; autonomyL
     if (mode === 'human-review') return (
       <span className="inline-flex items-center gap-0.5">
         <Bot className="h-3.5 w-3.5 shrink-0 text-indigo-500 dark:text-indigo-400" />
-        <span className="relative inline-flex shrink-0">
+        <span className="relative inline-flex shrink-0 mr-2">
           <User className="h-3.5 w-3.5 text-indigo-500 dark:text-indigo-400" />
           <Search className="absolute -bottom-0.5 -right-1.5 h-2 w-2 text-indigo-500 dark:text-indigo-400" strokeWidth={2.5} />
         </span>
@@ -872,7 +872,7 @@ export function WorkflowDiagram({ definition, className, style, onNodeClick, onN
             <div className="flex items-center gap-3 rounded-lg border border-border/40 px-2.5 py-1.5 opacity-50">
               <span className="w-14 shrink-0 flex items-center gap-0.5">
                 <User className="h-4 w-4 text-lime-500 dark:text-lime-400 shrink-0" />
-                <span className="relative inline-flex shrink-0">
+                <span className="relative inline-flex shrink-0 mr-2">
                   <Bot className="h-4 w-4 text-lime-500 dark:text-lime-400" />
                   <Search className="absolute -bottom-0.5 -right-1.5 h-2.5 w-2.5 text-lime-500 dark:text-lime-400" strokeWidth={2.5} />
                 </span>
@@ -906,7 +906,7 @@ export function WorkflowDiagram({ definition, className, style, onNodeClick, onN
             <div className="flex items-center gap-3 rounded-lg border border-border/40 px-2.5 py-1.5">
               <span className="w-14 shrink-0 flex items-center gap-0.5">
                 <Bot className="h-4 w-4 text-indigo-500 dark:text-indigo-400 shrink-0" />
-                <span className="relative inline-flex shrink-0">
+                <span className="relative inline-flex shrink-0 mr-2">
                   <User className="h-4 w-4 text-indigo-500 dark:text-indigo-400" />
                   <Search className="absolute -bottom-0.5 -right-1.5 h-2.5 w-2.5 text-indigo-500 dark:text-indigo-400" strokeWidth={2.5} />
                 </span>


### PR DESCRIPTION
## Summary

- The compound icon for Human Review (`Bot + User + Search`) and Assist (`User + Bot + Search`) uses an absolutely-positioned `Search` badge at `-right-1.5` (6 px outside the container's right edge), causing it to bleed into the label text that follows.
- Fix: add `mr-2` to each `relative` wrapper — gives the overhanging icon 8 px of clearance so it never touches the text.

## Locations fixed (4)

| File | Location |
|---|---|
| `step-status-panel.tsx` | `ExecutorChip` — Human Review badge icon in run history |
| `workflow-diagram.tsx` | `ExecutorIcon` — Human Review icon in step node label row |
| `workflow-diagram.tsx` | CM1 Assist row in the add-step popover |
| `workflow-diagram.tsx` | CM3 Human Review row in the add-step popover |

## Test plan

- [ ] Open the workflow designer and click the `+` edge button — confirm the Assist and Human Review rows in the popover show the icon without it touching the label text
- [ ] Open a workflow run with a Human Review step — confirm the executor badge in the history panel renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKn8npfNsaij721P9WELan