### PR TITLE
fix(ui): remove raw L-level identifiers from all user-facing surfaces

### DIFF
--- a/packages/platform-ui/e2e/ui/agent-oversight.journey.ts
+++ b/packages/platform-ui/e2e/ui/agent-oversight.journey.ts
@@ -22,10 +22,10 @@ test.describe('Agent Oversight Journey', () => {
     await click(page, page.getByRole('tab', { name: 'Run History' }));
     await expect(page.getByText('Narrative Summary').first()).toBeVisible({ timeout: 10_000 });
 
-    // Autonomy column and badges
+    // Autonomy column shows control mode labels, not raw L-level codes
     await expect(page.getByRole('columnheader', { name: 'Autonomy' })).toBeVisible();
-    await expect(page.getByText('L2').first()).toBeVisible();
-    await expect(page.getByText('L4').first()).toBeVisible();
+    await expect(page.getByText('Assist').first()).toBeVisible();
+    await expect(page.getByText('Autonomous agent').first()).toBeVisible();
 
     // Link to detail page
     const link = page.locator(`a[href*="/agents/${RUN_COMPLETED_1_ID}"]`);

--- a/packages/platform-ui/e2e/ui/run-detail.journey.ts
+++ b/packages/platform-ui/e2e/ui/run-detail.journey.ts
@@ -59,9 +59,9 @@ test.describe('Run Detail Journey', () => {
     const historyPanel = page.locator('.bg-card').filter({ has: page.locator('h3', { hasText: 'Execution History' }) });
     await expect(historyPanel.locator('ol > li')).toHaveCount(7, { timeout: 10_000 });
 
-    // Autonomy badges sourced from WorkflowDefinition steps
-    await expect(historyPanel.getByText('L2').first()).toBeVisible();
-    await expect(historyPanel.getByText('L3').first()).toBeVisible();
+    // Executor chips sourced from WorkflowDefinition steps (control mode labels, not raw L-levels)
+    await expect(historyPanel.getByText('Assist').first()).toBeVisible();
+    await expect(historyPanel.getByText('Human review').first()).toBeVisible();
     await showStep(page);
 
     // Executor label uses plugin from the WorkflowDefinition step (vendor-assessment → supply-data-collector)
@@ -76,9 +76,9 @@ test.describe('Run Detail Journey', () => {
     const wfHistoryPanel = page.locator('.bg-card').filter({ has: page.locator('h3', { hasText: 'Execution History' }) });
     await expect(wfHistoryPanel.locator('ol > li').first()).toBeVisible({ timeout: 10_000 });
 
-    // Virtual row shows the current step name and WD-sourced autonomy badge (narrative-summary → L3)
+    // Virtual row shows the current step name and executor chip (narrative-summary → Human review)
     await expect(wfHistoryPanel.getByText('Narrative Summary', { exact: true })).toBeVisible();
-    await expect(wfHistoryPanel.getByText('L3').first()).toBeVisible();
+    await expect(wfHistoryPanel.getByText('Human review').first()).toBeVisible();
     await showResult(page);
     await endRecording(page);
   });

--- a/packages/platform-ui/src/components/agents/agent-run-detail.tsx
+++ b/packages/platform-ui/src/components/agents/agent-run-detail.tsx
@@ -230,9 +230,7 @@ export function AgentRunDetail({
             <LightFormattedData data={envelope.result} />
           ) : (
             <p className="text-xs text-muted-foreground italic">
-              {run.autonomyLevel === 'L0' || run.autonomyLevel === 'L1'
-                ? `No structured output — ${run.autonomyLevel} agents are annotation-only`
-                : 'No output produced'}
+              {'No output produced'}
             </p>
           )}
         </CollapsibleSection>

--- a/packages/platform-ui/src/components/agents/agent-run-list-table.tsx
+++ b/packages/platform-ui/src/components/agents/agent-run-list-table.tsx
@@ -9,6 +9,7 @@ import { ConfidenceBadge } from './confidence-badge';
 import { cn } from '@/lib/utils';
 import { useHandleFromPath } from '@/hooks/use-handle-from-path';
 import { routes } from '@/lib/routes';
+import { getControlMode, CONTROL_MODE_LABELS } from '@/lib/control-mode';
 import type { LucideIcon } from 'lucide-react';
 
 function getPluginDisplay(pluginId: string): { Icon: LucideIcon; colorClass: string; label: string } {
@@ -98,7 +99,7 @@ export function AgentRunListTable({
                 </td>
                 <td className="px-4 py-3">
                   {run.autonomyLevel
-                    ? <span className="inline-flex rounded px-1.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">{run.autonomyLevel}</span>
+                    ? <span className="inline-flex rounded px-1.5 py-0.5 text-xs font-medium bg-muted text-muted-foreground">{CONTROL_MODE_LABELS[getControlMode('agent', run.autonomyLevel)]}</span>
                     : <span className="text-xs text-muted-foreground">—</span>}
                 </td>
                 <td className="px-4 py-3">

--- a/packages/platform-ui/src/components/processes/step-status-panel.tsx
+++ b/packages/platform-ui/src/components/processes/step-status-panel.tsx
@@ -209,7 +209,6 @@ function ExecutorChip({ executorType, autonomyLevel, plugin, runtime }: {
     <span className={cn('inline-flex items-center gap-1 whitespace-nowrap rounded-md py-0.5 px-2 text-xs font-semibold border', chip.className)}>
       {chip.icon}
       {chip.label}
-      {autonomyLevel && <span className="ml-0.5 opacity-60 font-normal">{autonomyLevel}</span>}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

- Autonomy level codes (L0–L4) are internal schema identifiers and should not appear in the UI — users should see human-readable Control Mode names only.
- Three surfaces cleaned up after the autonomy-levels refactor.

## Changes

| Location | Before | After |
|---|---|---|
| Step history `ExecutorChip` (`step-status-panel.tsx`) | "Human Review **L3**" | "Human Review" |
| Agent run table "Autonomy" column (`agent-run-list-table.tsx`) | Raw badge "L3" / "L4" | "Human review" / "Autonomous agent" |
| Agent run detail output section (`agent-run-detail.tsx`) | "No structured output — L0 agents are annotation-only" | "No output produced" |

## Test plan

- [ ] Open a workflow run with a Human Review step (e.g. the run linked in the issue) — confirm the executor badge reads "Human Review" with no trailing "L3"
- [ ] Open the agent runs table — confirm the Autonomy column shows "Human review" / "Autonomous agent" instead of "L3" / "L4"
- [ ] Open an agent run detail with no output — confirm the fallback text contains no L-level code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKn8npfNsaij721P9WELan