### PR TITLE
feat(auth): user directory + roles + invites on Postgres (ADR-0002 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Changed
+- User directory + global process-roles now read Postgres (`user_roles` + a minimal `auth_users`) instead of Firebase Admin, behind the unchanged `UserDirectoryService` port; ships a seed-based `PostgresInviteService` and a gated one-time seed of `user_roles` from current Firebase `customClaims.roles` so `getUsersByRole` escalation targeting stays identical. Member-list `lastSignInTime` is `null` until NextAuth sessions land (ADR-0002 PR1).
+
 ## [2026-06-21]
 
 ### Fixed

--- a/packages/platform-api/src/services/platform-services.ts
+++ b/packages/platform-api/src/services/platform-services.ts
@@ -27,7 +27,7 @@ import {
   createMailgunSender,
   createSmtpSender,
   EmailNotificationService,
-  FirebaseUserDirectoryService,
+  PostgresUserDirectoryService,
   getAdminAuth,
 } from '@mediforce/platform-infra';
 import type {
@@ -393,12 +393,11 @@ export function getPlatformServices(): PlatformServices {
   const notificationService = emailSender
     ? new EmailNotificationService(emailSender)
     : undefined;
-  // Wired whenever Firebase Auth is available — independent of email provider.
-  // Email-disabled deployments still need uid → email/lastSignInTime lookups
-  // for the namespace-members endpoint.
-  const userDirectoryService: UserDirectoryService = new FirebaseUserDirectoryService(
-    getAdminAuth(),
-  );
+  // ADR-0002 PR1: reads the global `user_roles` + `auth_users` from Postgres
+  // (off Firebase Auth) behind the same port. `getUsersByRole` targeting
+  // depends on the one-time `seed-user-roles` having populated `user_roles`.
+  // `lastSignInTime` is null until NextAuth sessions land (PR2).
+  const userDirectoryService: UserDirectoryService = new PostgresUserDirectoryService(pg);
 
   const engine = new WorkflowEngine(
     processRepo,

--- a/packages/platform-core/src/testing/in-memory-user-directory-service.ts
+++ b/packages/platform-core/src/testing/in-memory-user-directory-service.ts
@@ -1,0 +1,73 @@
+import type {
+  UserDirectoryService,
+  DirectoryUser,
+  UserAuthMetadata,
+} from '../interfaces/user-directory-service';
+
+export interface InMemoryDirectoryUser {
+  readonly uid: string;
+  readonly email: string;
+  readonly displayName?: string | null;
+  readonly image?: string | null;
+}
+
+/**
+ * In-memory double for the global-`user_roles` UserDirectoryService
+ * (ADR-0002 PR1). Mirrors `PostgresUserDirectoryService`: `getUsersByRole`
+ * inner-joins roles to users (a role row for an unknown uid yields nothing),
+ * `getUserMetadata.lastSignInTime` is always `null` (no sign-in record before
+ * NextAuth sessions). The Postgres backend MUST satisfy the same contract.
+ */
+export class InMemoryUserDirectoryService implements UserDirectoryService {
+  private readonly users = new Map<string, InMemoryDirectoryUser>();
+  private readonly roles: { uid: string; role: string }[] = [];
+
+  addUser(user: InMemoryDirectoryUser): void {
+    this.users.set(user.uid, user);
+  }
+
+  addRole(uid: string, role: string): void {
+    if (!this.roles.some((r) => r.uid === uid && r.role === role)) {
+      this.roles.push({ uid, role });
+    }
+  }
+
+  async getUsersByRole(role: string): Promise<DirectoryUser[]> {
+    return this.roles
+      .filter((r) => r.role === role)
+      .map((r) => this.users.get(r.uid))
+      .filter((u): u is InMemoryDirectoryUser => u !== undefined)
+      .map(toDirectoryUser);
+  }
+
+  async resolveUser(identifier: string): Promise<DirectoryUser | null> {
+    const match = identifier.includes('@')
+      ? [...this.users.values()].find((u) => u.email === identifier)
+      : this.users.get(identifier);
+    return match ? toDirectoryUser(match) : null;
+  }
+
+  async getUserMetadata(uid: string): Promise<UserAuthMetadata | null> {
+    const user = this.users.get(uid);
+    if (!user) return null;
+    return {
+      email: user.email !== '' ? user.email : null,
+      displayName:
+        typeof user.displayName === 'string' && user.displayName !== ''
+          ? user.displayName
+          : null,
+      lastSignInTime: null,
+      photoURL: user.image ?? null,
+    };
+  }
+}
+
+function toDirectoryUser(user: InMemoryDirectoryUser): DirectoryUser {
+  return {
+    uid: user.uid,
+    email: user.email,
+    ...(typeof user.displayName === 'string' && user.displayName !== ''
+      ? { displayName: user.displayName }
+      : {}),
+  };
+}

--- a/packages/platform-core/src/testing/index.ts
+++ b/packages/platform-core/src/testing/index.ts
@@ -25,6 +25,8 @@ export {
   decodeAgentRunCursor,
 } from '../cursors/agent-run-cursor';
 export { InMemoryUserProfileRepository } from './in-memory-user-profile-repository';
+export { InMemoryUserDirectoryService } from './in-memory-user-directory-service';
+export type { InMemoryDirectoryUser } from './in-memory-user-directory-service';
 
 // Test factories
 export {

--- a/packages/platform-infra/src/auth/__tests__/seed-user-roles.test.ts
+++ b/packages/platform-infra/src/auth/__tests__/seed-user-roles.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import type { Auth } from 'firebase-admin/auth';
+import { buildUserRolesSeed, type FirebaseUserExport } from '../seed-user-roles';
+import { FirebaseUserDirectoryService } from '../firebase-user-directory-service';
+
+const FIXTURE: FirebaseUserExport[] = [
+  {
+    uid: 'u1',
+    email: 'alice@x.com',
+    displayName: 'Alice',
+    photoURL: 'https://img/a',
+    customClaims: { roles: ['reviewer', 'approver'], role: 'admin' },
+  },
+  { uid: 'u2', email: 'bob@x.com', displayName: null, customClaims: { roles: ['reviewer'] } },
+  { uid: 'u3', email: 'carol@x.com', customClaims: { role: 'auditor' } },
+  { uid: 'u4', email: 'dan@x.com', customClaims: null },
+];
+
+describe('buildUserRolesSeed', () => {
+  it('emits one auth_users row per user with email, mapping displayName/photoURL', () => {
+    const seed = buildUserRolesSeed([FIXTURE[0]!]);
+    expect(seed.authUsers).toEqual([
+      { id: 'u1', email: 'alice@x.com', name: 'Alice', image: 'https://img/a' },
+    ]);
+  });
+
+  it('expands roles[] to one row each and ignores the role scalar when roles[] is present', () => {
+    const seed = buildUserRolesSeed([FIXTURE[0]!]);
+    expect(seed.userRoles).toEqual([
+      { uid: 'u1', role: 'reviewer' },
+      { uid: 'u1', role: 'approver' },
+    ]);
+  });
+
+  it('falls back to the role scalar only when roles[] is absent', () => {
+    const seed = buildUserRolesSeed([FIXTURE[2]!]);
+    expect(seed.userRoles).toEqual([{ uid: 'u3', role: 'auditor' }]);
+  });
+
+  it('emits no roles for a user without claims but still seeds the auth_users row', () => {
+    const seed = buildUserRolesSeed([FIXTURE[3]!]);
+    expect(seed.userRoles).toEqual([]);
+    expect(seed.authUsers).toEqual([{ id: 'u4', email: 'dan@x.com', name: null, image: null }]);
+  });
+
+  it('de-duplicates repeated roles within a user', () => {
+    const seed = buildUserRolesSeed([
+      { uid: 'u9', email: 'e@x.com', customClaims: { roles: ['reviewer', 'reviewer', ''] } },
+    ]);
+    expect(seed.userRoles).toEqual([{ uid: 'u9', role: 'reviewer' }]);
+  });
+
+  it('skips users without an email (auth_users.email is NOT NULL UNIQUE)', () => {
+    const seed = buildUserRolesSeed([
+      { uid: 'n1', email: null, customClaims: { roles: ['reviewer'] } },
+      { uid: 'n2', email: '', customClaims: { roles: ['reviewer'] } },
+    ]);
+    expect(seed.authUsers).toEqual([]);
+    expect(seed.userRoles).toEqual([]);
+    expect(seed.skippedNoEmail).toEqual(['n1', 'n2']);
+  });
+
+  it('is idempotent — same input yields deep-equal output', () => {
+    expect(buildUserRolesSeed(FIXTURE)).toEqual(buildUserRolesSeed(FIXTURE));
+  });
+
+  it('mirrors FirebaseUserDirectoryService.getUsersByRole for every role', async () => {
+    const firebase = new FirebaseUserDirectoryService(fakeAuth(FIXTURE));
+    const seed = buildUserRolesSeed(FIXTURE);
+
+    for (const role of ['reviewer', 'approver', 'auditor', 'admin', 'nonexistent']) {
+      const firebaseUids = (await firebase.getUsersByRole(role)).map((u) => u.uid).sort();
+      const seedUids = seed.userRoles
+        .filter((r) => r.role === role)
+        .map((r) => r.uid)
+        .sort();
+      expect(seedUids).toEqual(firebaseUids);
+    }
+  });
+});
+
+function fakeAuth(users: FirebaseUserExport[]): Auth {
+  return {
+    listUsers: async () => ({ users, pageToken: undefined }),
+  } as unknown as Auth;
+}

--- a/packages/platform-infra/src/auth/postgres-invite-service.ts
+++ b/packages/platform-infra/src/auth/postgres-invite-service.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import type { Database } from '../postgres/client';
+import { authUsers } from '../postgres/schema/auth-user';
+import { userRoles } from '../postgres/schema/user-role';
+import { workspaceMembers } from '../postgres/schema/workspace';
+
+export interface SeedInviteInput {
+  readonly email: string;
+  readonly displayName?: string;
+  readonly workspaceHandle: string;
+  readonly membership: 'owner' | 'admin' | 'member';
+  readonly roles?: readonly string[];
+}
+
+export interface SeededInvite {
+  readonly uid: string;
+  /** True when the `auth_users` row already existed (email collision). */
+  readonly isExisting: boolean;
+}
+
+/**
+ * Postgres seed-based invite (ADR-0002 §3.1, §5, PR1).
+ *
+ * Replaces the Firebase create-user-with-temp-password flow. An invite
+ * pre-seeds an `auth_users` row + the invitee's `workspace_members`
+ * membership + any global `user_roles`, all in one transaction. No temp
+ * password and no magic-link email — the invitee signs in later (Google
+ * verified-email auto-link in PR2) onto the pre-seeded row.
+ *
+ * Built and unit-tested in PR1 but NOT wired live: Firebase is still the
+ * login source until the PR2 cutover, so a seed-only invite would leave a new
+ * invitee unable to sign in. Wiring behind the (reshaped) invite port happens
+ * in PR2.
+ *
+ * Idempotent: re-seeding the same email reuses the existing uid and leaves
+ * the existing membership/roles untouched.
+ */
+export class PostgresInviteService {
+  constructor(private readonly db: Database) {}
+
+  async seedInvite(input: SeedInviteInput): Promise<SeededInvite> {
+    return this.db.transaction(async (tx) => {
+      const existing = await tx
+        .select({ id: authUsers.id })
+        .from(authUsers)
+        .where(eq(authUsers.email, input.email))
+        .limit(1);
+
+      const isExisting = existing.length > 0;
+      const uid = existing[0]?.id ?? randomUUID();
+
+      if (!isExisting) {
+        await tx.insert(authUsers).values({
+          id: uid,
+          email: input.email,
+          name: input.displayName ?? null,
+        });
+      }
+
+      await tx
+        .insert(workspaceMembers)
+        .values({
+          workspace: input.workspaceHandle,
+          uid,
+          role: input.membership,
+          ...(input.displayName !== undefined ? { displayName: input.displayName } : {}),
+        })
+        .onConflictDoNothing({
+          target: [workspaceMembers.workspace, workspaceMembers.uid],
+        });
+
+      for (const role of input.roles ?? []) {
+        await tx
+          .insert(userRoles)
+          .values({ uid, role })
+          .onConflictDoNothing({ target: [userRoles.uid, userRoles.role] });
+      }
+
+      return { uid, isExisting };
+    });
+  }
+
+  async getUserEmail(uid: string): Promise<string | null> {
+    const rows = await this.db
+      .select({ email: authUsers.email })
+      .from(authUsers)
+      .where(eq(authUsers.id, uid))
+      .limit(1);
+    return rows[0]?.email ?? null;
+  }
+}

--- a/packages/platform-infra/src/auth/postgres-user-directory-service.ts
+++ b/packages/platform-infra/src/auth/postgres-user-directory-service.ts
@@ -1,0 +1,72 @@
+import { eq } from 'drizzle-orm';
+import type {
+  UserDirectoryService,
+  DirectoryUser,
+  UserAuthMetadata,
+} from '@mediforce/platform-core';
+import type { Database } from '../postgres/client';
+import { authUsers } from '../postgres/schema/auth-user';
+import { userRoles } from '../postgres/schema/user-role';
+
+/**
+ * Postgres-backed UserDirectoryService (ADR-0002 §5, §3.1, PR1).
+ * Replaces FirebaseUserDirectoryService behind the same port — no consumer
+ * (`workflow-engine` escalation, `caller-scope`) changes.
+ *
+ * `getUsersByRole` reads the GLOBAL `user_roles` table (no namespace scope),
+ * matching today's Firebase `customClaims.roles` semantics — an empty table
+ * silently stops escalation notifications, so the one-time seed
+ * (`seed-user-roles`) MUST run when this goes live.
+ *
+ * `getUserMetadata.lastSignInTime` is `null` in PR1: there is no PG sign-in
+ * record until NextAuth database sessions land (PR2). `photoURL` comes from
+ * `auth_users.image` (seeded from Firebase `photoURL`) so the member-list
+ * avatar fallback does not regress.
+ */
+export class PostgresUserDirectoryService implements UserDirectoryService {
+  constructor(private readonly db: Database) {}
+
+  async getUsersByRole(role: string): Promise<DirectoryUser[]> {
+    const rows = await this.db
+      .select({ uid: authUsers.id, email: authUsers.email, name: authUsers.name })
+      .from(userRoles)
+      .innerJoin(authUsers, eq(userRoles.uid, authUsers.id))
+      .where(eq(userRoles.role, role));
+    return rows.map(toDirectoryUser);
+  }
+
+  async resolveUser(identifier: string): Promise<DirectoryUser | null> {
+    const column = identifier.includes('@') ? authUsers.email : authUsers.id;
+    const rows = await this.db
+      .select({ uid: authUsers.id, email: authUsers.email, name: authUsers.name })
+      .from(authUsers)
+      .where(eq(column, identifier))
+      .limit(1);
+    const row = rows[0];
+    return row ? toDirectoryUser(row) : null;
+  }
+
+  async getUserMetadata(uid: string): Promise<UserAuthMetadata | null> {
+    const rows = await this.db
+      .select({ email: authUsers.email, name: authUsers.name, image: authUsers.image })
+      .from(authUsers)
+      .where(eq(authUsers.id, uid))
+      .limit(1);
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      email: row.email !== '' ? row.email : null,
+      displayName: row.name !== null && row.name !== '' ? row.name : null,
+      lastSignInTime: null,
+      photoURL: row.image ?? null,
+    };
+  }
+}
+
+function toDirectoryUser(row: { uid: string; email: string; name: string | null }): DirectoryUser {
+  return {
+    uid: row.uid,
+    email: row.email,
+    ...(row.name !== null && row.name !== '' ? { displayName: row.name } : {}),
+  };
+}

--- a/packages/platform-infra/src/auth/seed-user-roles.ts
+++ b/packages/platform-infra/src/auth/seed-user-roles.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure mapping from a Firebase Auth user export to the rows that seed the
+ * Postgres `auth_users` + global `user_roles` tables (ADR-0002 §4, §5, PR1).
+ *
+ * The role extraction mirrors `FirebaseUserDirectoryService.getUsersByRole`
+ * EXACTLY so that, after the seed, `PostgresUserDirectoryService.getUsersByRole`
+ * returns the identical set for every role — the non-breaking guarantee for
+ * escalation-notification targeting:
+ *
+ *   - `customClaims.roles: string[]` present  → one row per entry (the `role`
+ *     scalar is ignored, matching the Firebase filter's `else` branch).
+ *   - otherwise `customClaims.role: string`   → a single row for that role.
+ *
+ * Users without an email are skipped: `auth_users.email` is `NOT NULL UNIQUE`
+ * and a user with no email cannot be an escalation notification target.
+ *
+ * Pure and idempotent: same input → same output, role rows de-duplicated per
+ * user. The script applies the rows with `ON CONFLICT DO NOTHING`, so a re-run
+ * is a no-op.
+ */
+
+export interface FirebaseCustomClaims {
+  readonly role?: unknown;
+  readonly roles?: unknown;
+}
+
+export interface FirebaseUserExport {
+  readonly uid: string;
+  readonly email: string | null;
+  readonly displayName?: string | null;
+  readonly photoURL?: string | null;
+  readonly customClaims?: FirebaseCustomClaims | null;
+}
+
+export interface AuthUserSeedRow {
+  readonly id: string;
+  readonly email: string;
+  readonly name: string | null;
+  readonly image: string | null;
+}
+
+export interface UserRoleSeedRow {
+  readonly uid: string;
+  readonly role: string;
+}
+
+export interface UserRolesSeed {
+  readonly authUsers: AuthUserSeedRow[];
+  readonly userRoles: UserRoleSeedRow[];
+  /** uids skipped because they had no email (cannot be seeded). */
+  readonly skippedNoEmail: string[];
+}
+
+function rolesFromClaims(claims: FirebaseCustomClaims | null | undefined): string[] {
+  if (claims === null || claims === undefined) return [];
+  if (Array.isArray(claims.roles)) {
+    const unique = new Set(
+      claims.roles.filter((r): r is string => typeof r === 'string' && r !== ''),
+    );
+    return [...unique];
+  }
+  if (typeof claims.role === 'string' && claims.role !== '') {
+    return [claims.role];
+  }
+  return [];
+}
+
+export function buildUserRolesSeed(users: readonly FirebaseUserExport[]): UserRolesSeed {
+  const authUsersRows: AuthUserSeedRow[] = [];
+  const userRolesRows: UserRoleSeedRow[] = [];
+  const skippedNoEmail: string[] = [];
+
+  for (const user of users) {
+    if (user.email === null || user.email === '') {
+      skippedNoEmail.push(user.uid);
+      continue;
+    }
+    authUsersRows.push({
+      id: user.uid,
+      email: user.email,
+      name: user.displayName ?? null,
+      image: user.photoURL ?? null,
+    });
+    for (const role of rolesFromClaims(user.customClaims)) {
+      userRolesRows.push({ uid: user.uid, role });
+    }
+  }
+
+  return { authUsers: authUsersRows, userRoles: userRolesRows, skippedNoEmail };
+}

--- a/packages/platform-infra/src/index.ts
+++ b/packages/platform-infra/src/index.ts
@@ -2,6 +2,17 @@
 // Firestore is fully removed (ADR-0001 final cutover, #534); only Auth and
 // Storage remain on Firebase.
 export { FirebaseUserDirectoryService } from './auth/firebase-user-directory-service';
+export { PostgresUserDirectoryService } from './auth/postgres-user-directory-service';
+export { PostgresInviteService } from './auth/postgres-invite-service';
+export type { SeedInviteInput, SeededInvite } from './auth/postgres-invite-service';
+export { buildUserRolesSeed } from './auth/seed-user-roles';
+export type {
+  FirebaseUserExport,
+  FirebaseCustomClaims,
+  UserRolesSeed,
+  AuthUserSeedRow,
+  UserRoleSeedRow,
+} from './auth/seed-user-roles';
 export { FirebaseInviteService } from './auth/firebase-invite-service';
 export { getAdminAuth } from './auth/firebase-admin-init';
 export {

--- a/packages/platform-infra/src/postgres/__tests__/postgres-invite-service.test.ts
+++ b/packages/platform-infra/src/postgres/__tests__/postgres-invite-service.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import postgres from 'postgres';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import { randomBytes } from 'node:crypto';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PostgresInviteService } from '../../auth/postgres-invite-service';
+import { authUsers } from '../schema/auth-user';
+import { userRoles } from '../schema/user-role';
+import { workspaces, workspaceMembers } from '../schema/workspace';
+import * as schema from '../schema/index';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = resolve(__dirname, '..', 'migrations');
+
+const DATABASE_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipPg = !DATABASE_URL;
+
+describe.skipIf(skipPg)('PostgresInviteService', () => {
+  const schemaName = `invite_${randomBytes(8).toString('hex')}`;
+  let adminClient: ReturnType<typeof postgres>;
+  let testClient: ReturnType<typeof postgres>;
+  let db: PostgresJsDatabase<typeof schema>;
+  let service: PostgresInviteService;
+
+  beforeAll(async () => {
+    adminClient = postgres(DATABASE_URL!, { max: 1, onnotice: () => {} });
+    await adminClient.unsafe(`CREATE SCHEMA "${schemaName}"`);
+    testClient = postgres(DATABASE_URL!, {
+      max: 4,
+      onnotice: () => {},
+      connection: { search_path: schemaName },
+    });
+    const files = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql')).sort();
+    for (const file of files) {
+      await testClient.unsafe(readFileSync(join(MIGRATIONS_DIR, file), 'utf-8'));
+    }
+    db = drizzle(testClient, { schema });
+    service = new PostgresInviteService(db);
+  });
+
+  afterAll(async () => {
+    if (testClient) await testClient.end();
+    if (adminClient) {
+      await adminClient.unsafe(`DROP SCHEMA "${schemaName}" CASCADE`);
+      await adminClient.end();
+    }
+  });
+
+  beforeEach(async () => {
+    await testClient.unsafe(
+      `TRUNCATE TABLE "${schemaName}"."user_roles", "${schemaName}"."workspace_members", "${schemaName}"."auth_users", "${schemaName}"."workspaces" CASCADE`,
+    );
+    await db.insert(workspaces).values({ handle: 'acme', type: 'team', displayName: 'Acme' });
+  });
+
+  it('seeds the auth_users row, workspace membership, and global roles in one go', async () => {
+    const { uid, isExisting } = await service.seedInvite({
+      email: 'new@acme.com',
+      displayName: 'New Person',
+      workspaceHandle: 'acme',
+      membership: 'admin',
+      roles: ['reviewer', 'approver'],
+    });
+
+    expect(isExisting).toBe(false);
+
+    const users = await db.select().from(authUsers).where(eq(authUsers.id, uid));
+    expect(users).toHaveLength(1);
+    expect(users[0]).toMatchObject({ id: uid, email: 'new@acme.com', name: 'New Person' });
+
+    const members = await db.select().from(workspaceMembers).where(eq(workspaceMembers.uid, uid));
+    expect(members).toHaveLength(1);
+    expect(members[0]).toMatchObject({ workspace: 'acme', uid, role: 'admin', displayName: 'New Person' });
+
+    const roles = (await db.select().from(userRoles).where(eq(userRoles.uid, uid)))
+      .map((r) => r.role)
+      .sort();
+    expect(roles).toEqual(['approver', 'reviewer']);
+  });
+
+  it('seeds no roles when none are given', async () => {
+    const { uid } = await service.seedInvite({
+      email: 'norole@acme.com',
+      workspaceHandle: 'acme',
+      membership: 'member',
+    });
+    expect(await db.select().from(userRoles).where(eq(userRoles.uid, uid))).toEqual([]);
+  });
+
+  it('is idempotent on email collision — reuses uid, no duplicate membership/roles', async () => {
+    const first = await service.seedInvite({
+      email: 'dup@acme.com',
+      workspaceHandle: 'acme',
+      membership: 'member',
+      roles: ['reviewer'],
+    });
+    const second = await service.seedInvite({
+      email: 'dup@acme.com',
+      workspaceHandle: 'acme',
+      membership: 'member',
+      roles: ['reviewer'],
+    });
+
+    expect(second.isExisting).toBe(true);
+    expect(second.uid).toBe(first.uid);
+    expect(await db.select().from(authUsers).where(eq(authUsers.email, 'dup@acme.com'))).toHaveLength(1);
+    expect(await db.select().from(workspaceMembers).where(eq(workspaceMembers.uid, first.uid))).toHaveLength(1);
+    expect(await db.select().from(userRoles).where(eq(userRoles.uid, first.uid))).toHaveLength(1);
+  });
+
+  it('getUserEmail returns the seeded email and null for unknown uids', async () => {
+    const { uid } = await service.seedInvite({
+      email: 'lookup@acme.com',
+      workspaceHandle: 'acme',
+      membership: 'member',
+    });
+    expect(await service.getUserEmail(uid)).toBe('lookup@acme.com');
+    expect(await service.getUserEmail('nope')).toBeNull();
+  });
+});

--- a/packages/platform-infra/src/postgres/__tests__/user-directory-parity.test.ts
+++ b/packages/platform-infra/src/postgres/__tests__/user-directory-parity.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import postgres from 'postgres';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { randomBytes } from 'node:crypto';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Auth } from 'firebase-admin/auth';
+import type { UserDirectoryService } from '@mediforce/platform-core';
+import { InMemoryUserDirectoryService } from '@mediforce/platform-core/testing';
+import { PostgresUserDirectoryService } from '../../auth/postgres-user-directory-service';
+import { FirebaseUserDirectoryService } from '../../auth/firebase-user-directory-service';
+import { buildUserRolesSeed, type FirebaseUserExport } from '../../auth/seed-user-roles';
+import { authUsers } from '../schema/auth-user';
+import { userRoles } from '../schema/user-role';
+import * as schema from '../schema/index';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = resolve(__dirname, '..', 'migrations');
+
+const DATABASE_URL = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const skipPg = !DATABASE_URL;
+
+interface SeedUser {
+  uid: string;
+  email: string;
+  displayName?: string | null;
+  image?: string | null;
+  roles: string[];
+}
+
+const FIXTURE: SeedUser[] = [
+  { uid: 'u1', email: 'alice@x.com', displayName: 'Alice', image: 'https://img/a', roles: ['reviewer', 'approver'] },
+  { uid: 'u2', email: 'bob@x.com', displayName: null, image: null, roles: ['reviewer'] },
+  { uid: 'u3', email: 'carol@x.com', roles: [] },
+];
+
+function byUid<T extends { uid: string }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => a.uid.localeCompare(b.uid));
+}
+
+/**
+ * Shared UserDirectoryService contract (ADR-0002 PR1). Both the in-memory
+ * double and the Postgres backend MUST satisfy it. `build()` returns a
+ * directory already seeded with FIXTURE.
+ */
+function contract(name: string, build: () => Promise<UserDirectoryService>) {
+  describe(`${name} — UserDirectoryService contract`, () => {
+    let dir: UserDirectoryService;
+
+    beforeEach(async () => {
+      dir = await build();
+    });
+
+    it('getUsersByRole returns exactly the seeded users for a role', async () => {
+      expect(byUid(await dir.getUsersByRole('reviewer'))).toEqual([
+        { uid: 'u1', email: 'alice@x.com', displayName: 'Alice' },
+        { uid: 'u2', email: 'bob@x.com' },
+      ]);
+    });
+
+    it('getUsersByRole returns a single user for a role only one user holds', async () => {
+      expect(await dir.getUsersByRole('approver')).toEqual([
+        { uid: 'u1', email: 'alice@x.com', displayName: 'Alice' },
+      ]);
+    });
+
+    it('getUsersByRole is empty for an unknown role', async () => {
+      expect(await dir.getUsersByRole('nonexistent')).toEqual([]);
+    });
+
+    it('resolveUser finds by email, by uid, and returns null for missing', async () => {
+      expect(await dir.resolveUser?.('alice@x.com')).toEqual({
+        uid: 'u1',
+        email: 'alice@x.com',
+        displayName: 'Alice',
+      });
+      expect(await dir.resolveUser?.('u2')).toEqual({ uid: 'u2', email: 'bob@x.com' });
+      expect(await dir.resolveUser?.('missing@x.com')).toBeNull();
+    });
+
+    it('getUserMetadata maps fields, with lastSignInTime null and photoURL from image', async () => {
+      expect(await dir.getUserMetadata('u1')).toEqual({
+        email: 'alice@x.com',
+        displayName: 'Alice',
+        lastSignInTime: null,
+        photoURL: 'https://img/a',
+      });
+      expect(await dir.getUserMetadata('u2')).toEqual({
+        email: 'bob@x.com',
+        displayName: null,
+        lastSignInTime: null,
+        photoURL: null,
+      });
+    });
+
+    it('getUserMetadata is null for an unknown uid', async () => {
+      expect(await dir.getUserMetadata('missing')).toBeNull();
+    });
+  });
+}
+
+contract('InMemoryUserDirectoryService', async () => {
+  const dir = new InMemoryUserDirectoryService();
+  for (const u of FIXTURE) {
+    dir.addUser({ uid: u.uid, email: u.email, displayName: u.displayName, image: u.image });
+    for (const role of u.roles) dir.addRole(u.uid, role);
+  }
+  return dir;
+});
+
+describe.skipIf(skipPg)('PostgresUserDirectoryService (parity)', () => {
+  const schemaName = `userdir_${randomBytes(8).toString('hex')}`;
+  let adminClient: ReturnType<typeof postgres>;
+  let testClient: ReturnType<typeof postgres>;
+  let db: PostgresJsDatabase<typeof schema>;
+
+  beforeAll(async () => {
+    adminClient = postgres(DATABASE_URL!, { max: 1, onnotice: () => {} });
+    await adminClient.unsafe(`CREATE SCHEMA "${schemaName}"`);
+    testClient = postgres(DATABASE_URL!, {
+      max: 4,
+      onnotice: () => {},
+      connection: { search_path: schemaName },
+    });
+    const files = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql')).sort();
+    for (const file of files) {
+      await testClient.unsafe(readFileSync(join(MIGRATIONS_DIR, file), 'utf-8'));
+    }
+    db = drizzle(testClient, { schema });
+  });
+
+  afterAll(async () => {
+    if (testClient) await testClient.end();
+    if (adminClient) {
+      await adminClient.unsafe(`DROP SCHEMA "${schemaName}" CASCADE`);
+      await adminClient.end();
+    }
+  });
+
+  async function resetAndSeed(rows: { authUsers: { id: string; email: string; name: string | null; image: string | null }[]; userRoles: { uid: string; role: string }[] }) {
+    await testClient.unsafe(`TRUNCATE TABLE "${schemaName}"."user_roles", "${schemaName}"."auth_users" CASCADE`);
+    if (rows.authUsers.length > 0) await db.insert(authUsers).values(rows.authUsers);
+    if (rows.userRoles.length > 0) await db.insert(userRoles).values(rows.userRoles);
+  }
+
+  contract('PostgresUserDirectoryService', async () => {
+    await resetAndSeed({
+      authUsers: FIXTURE.map((u) => ({
+        id: u.uid,
+        email: u.email,
+        name: u.displayName ?? null,
+        image: u.image ?? null,
+      })),
+      userRoles: FIXTURE.flatMap((u) => u.roles.map((role) => ({ uid: u.uid, role }))),
+    });
+    return new PostgresUserDirectoryService(db);
+  });
+
+  // Non-breaking guard: the Postgres directory, seeded from a Firebase export
+  // via `buildUserRolesSeed`, returns the SAME getUsersByRole set as the
+  // Firebase directory did — no silent change to escalation targeting.
+  it('getUsersByRole matches FirebaseUserDirectoryService on the same export', async () => {
+    const exported: FirebaseUserExport[] = [
+      { uid: 'f1', email: 'f1@x.com', displayName: 'F One', customClaims: { roles: ['reviewer', 'approver'], role: 'admin' } },
+      { uid: 'f2', email: 'f2@x.com', customClaims: { roles: ['reviewer'] } },
+      { uid: 'f3', email: 'f3@x.com', customClaims: { role: 'auditor' } },
+      { uid: 'f4', email: 'f4@x.com', customClaims: null },
+    ];
+    await resetAndSeed(buildUserRolesSeed(exported));
+    const pg = new PostgresUserDirectoryService(db);
+    const firebase = new FirebaseUserDirectoryService(fakeAuth(exported));
+
+    for (const role of ['reviewer', 'approver', 'auditor', 'admin', 'nope']) {
+      const pgUids = (await pg.getUsersByRole(role)).map((u) => u.uid).sort();
+      const fbUids = (await firebase.getUsersByRole(role)).map((u) => u.uid).sort();
+      expect(pgUids).toEqual(fbUids);
+    }
+  });
+});
+
+function fakeAuth(users: FirebaseUserExport[]): Auth {
+  return {
+    listUsers: async () => ({ users, pageToken: undefined }),
+  } as unknown as Auth;
+}

--- a/packages/platform-infra/src/postgres/migrations/0029_user_roles_and_auth_users.sql
+++ b/packages/platform-infra/src/postgres/migrations/0029_user_roles_and_auth_users.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "auth_users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"email" text NOT NULL,
+	"name" text,
+	"image" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "auth_users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "user_roles" (
+	"uid" text NOT NULL,
+	"role" text NOT NULL,
+	CONSTRAINT "user_roles_uid_role_pk" PRIMARY KEY("uid","role")
+);
+--> statement-breakpoint
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_uid_auth_users_id_fk" FOREIGN KEY ("uid") REFERENCES "auth_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_roles_role_idx" ON "user_roles" USING btree ("role");--> statement-breakpoint
+CREATE TRIGGER auth_users_set_updated_at
+	BEFORE UPDATE ON "auth_users"
+	FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/packages/platform-infra/src/postgres/migrations/meta/_journal.json
+++ b/packages/platform-infra/src/postgres/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1782391535832,
       "tag": "0028_task_attachments",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1782391535833,
+      "tag": "0029_user_roles_and_auth_users",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/platform-infra/src/postgres/schema/auth-user.ts
+++ b/packages/platform-infra/src/postgres/schema/auth-user.ts
@@ -1,0 +1,28 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Authenticated user identity (ADR-0002 §1.1, keep-uid §7).
+ *
+ * PR1 ships a deliberately MINIMAL subset: only the columns the PG
+ * `UserDirectoryService` needs to return `{ uid, email, displayName }` once
+ * Firebase Auth stops being read for the directory. `id` IS the Firebase uid
+ * (text, never uuid) so every existing reference (`workspace_members.uid`,
+ * `*.assigned_user_id`, `created_by`, audit actor) stays valid with no rewrite.
+ *
+ * `image` is included now (not deferred) so the directory's `getUserMetadata`
+ * keeps returning the member-list avatar fallback — dropping it would be a
+ * silent regression. `lastSignInTime` has no PG source until NextAuth sessions
+ * land (PR2), so the directory returns it as `null` in PR1.
+ *
+ * PR2 (NextAuth cutover) ALTERs this table to add the remaining
+ * `@auth/drizzle-adapter` columns (`email_verified`, `password_hash`) — it
+ * must ALTER, not CREATE, because PR1 already created the table.
+ */
+export const authUsers = pgTable('auth_users', {
+  id: text('id').primaryKey(),
+  email: text('email').notNull().unique(),
+  name: text('name'),
+  image: text('image'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/platform-infra/src/postgres/schema/index.ts
+++ b/packages/platform-infra/src/postgres/schema/index.ts
@@ -17,3 +17,5 @@ export * from './namespace-secret';
 export * from './workflow-secret';
 export * from './user-profile';
 export * from './platform-settings';
+export * from './auth-user';
+export * from './user-role';

--- a/packages/platform-infra/src/postgres/schema/user-role.ts
+++ b/packages/platform-infra/src/postgres/schema/user-role.ts
@@ -1,0 +1,28 @@
+import { pgTable, text, primaryKey, index } from 'drizzle-orm/pg-core';
+import { authUsers } from './auth-user';
+
+/**
+ * Global process-domain roles (ADR-0002 §1.4, §5).
+ *
+ * Replaces Firebase `customClaims.roles: string[]`. Global, NOT
+ * workspace-scoped: `getUsersByRole(role)` is a deployment-wide query with no
+ * namespace context (workflow-engine escalation-notification targeting). A
+ * global table is the faithful port — scoping to a workspace would silently
+ * change notification targeting, a regression.
+ *
+ * The index on `role` serves `getUsersByRole(role)` ("all reviewers in the
+ * deployment").
+ */
+export const userRoles = pgTable(
+  'user_roles',
+  {
+    uid: text('uid')
+      .notNull()
+      .references(() => authUsers.id, { onDelete: 'cascade' }),
+    role: text('role').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.uid, table.role] }),
+    roleIdx: index('user_roles_role_idx').on(table.role),
+  }),
+);

--- a/scripts/migrate-firebase-auth-to-postgres/README.md
+++ b/scripts/migrate-firebase-auth-to-postgres/README.md
@@ -1,0 +1,31 @@
+# Firebase Auth → Postgres seed (ADR-0002 PR1)
+
+One-time seed of `auth_users` + the global `user_roles` table from current
+Firebase Auth users and their `customClaims.roles`.
+
+## Why
+
+PR1 swaps the live `UserDirectoryService` to Postgres. `getUsersByRole` now
+reads `user_roles`; an **empty table silently stops escalation notifications**
+(workflow-engine) — a regression. This seed must run when PR1 deploys so
+targeting keeps working. The role mapping is the same pure function
+(`buildUserRolesSeed`) the L2 tests pin against the old Firebase filter, so the
+post-seed `getUsersByRole` output is identical to today's.
+
+## Run
+
+```bash
+# dry-run (default): prints counts, writes nothing
+npx tsx scripts/migrate-firebase-auth-to-postgres/seed-user-roles.ts
+
+# apply
+npx tsx scripts/migrate-firebase-auth-to-postgres/seed-user-roles.ts --apply
+```
+
+Requires `DATABASE_URL` + Firebase admin credentials. Idempotent
+(`ON CONFLICT DO NOTHING`).
+
+## Gate
+
+**Do not run `--apply` on staging without per-action confirmation from the
+coordinator.** Never point it at production.

--- a/scripts/migrate-firebase-auth-to-postgres/seed-user-roles.ts
+++ b/scripts/migrate-firebase-auth-to-postgres/seed-user-roles.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env npx tsx
+/**
+ * One-time seed: Firebase Auth custom claims -> Postgres `auth_users` +
+ * global `user_roles` (ADR-0002 §4, PR1).
+ *
+ * Why it exists: PR1 swaps the live UserDirectoryService to Postgres, so
+ * `getUsersByRole` reads `user_roles`. An empty table silently stops
+ * escalation notifications (workflow-engine) — a regression. This seed
+ * populates `user_roles` from today's Firebase claims so targeting keeps
+ * working, using the SAME pure mapping (`buildUserRolesSeed`) the L2 tests
+ * pin against the Firebase filter.
+ *
+ * GATED: dry-run by default. It prints what it WOULD write and exits. Pass
+ * `--apply` to actually upsert. Do NOT run `--apply` on staging without the
+ * coordinator's per-action confirmation. Never point it at production.
+ *
+ * Idempotent: upserts with ON CONFLICT DO NOTHING, safe to re-run.
+ *
+ * Usage:
+ *   npx tsx scripts/migrate-firebase-auth-to-postgres/seed-user-roles.ts            # dry-run
+ *   npx tsx scripts/migrate-firebase-auth-to-postgres/seed-user-roles.ts --apply    # write
+ *
+ * Requires: GOOGLE_APPLICATION_CREDENTIALS (or Firebase admin env) + DATABASE_URL.
+ */
+import { getAdminAuth, getSharedPostgresClient, buildUserRolesSeed } from '@mediforce/platform-infra';
+import type { FirebaseUserExport } from '@mediforce/platform-infra';
+import { authUsers } from '../../packages/platform-infra/src/postgres/schema/auth-user';
+import { userRoles } from '../../packages/platform-infra/src/postgres/schema/user-role';
+
+async function listAllFirebaseUsers(): Promise<FirebaseUserExport[]> {
+  const auth = getAdminAuth();
+  const users: FirebaseUserExport[] = [];
+  let pageToken: string | undefined;
+  do {
+    const page = await auth.listUsers(1000, pageToken);
+    for (const u of page.users) {
+      users.push({
+        uid: u.uid,
+        email: u.email ?? null,
+        displayName: u.displayName ?? null,
+        photoURL: u.photoURL ?? null,
+        customClaims: (u.customClaims as FirebaseUserExport['customClaims']) ?? null,
+      });
+    }
+    pageToken = page.pageToken;
+  } while (pageToken);
+  return users;
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+
+  const exported = await listAllFirebaseUsers();
+  const seed = buildUserRolesSeed(exported);
+
+  console.log(`Firebase users read:        ${exported.length}`);
+  console.log(`auth_users rows to seed:    ${seed.authUsers.length}`);
+  console.log(`user_roles rows to seed:    ${seed.userRoles.length}`);
+  console.log(`skipped (no email):         ${seed.skippedNoEmail.length}`);
+  if (seed.skippedNoEmail.length > 0) {
+    console.log(`  skipped uids: ${seed.skippedNoEmail.join(', ')}`);
+  }
+
+  if (!apply) {
+    console.log('\nDRY RUN — nothing written. Re-run with --apply to seed.');
+    return;
+  }
+
+  const db = getSharedPostgresClient().db;
+  if (seed.authUsers.length > 0) {
+    await db.insert(authUsers).values([...seed.authUsers]).onConflictDoNothing({ target: authUsers.id });
+  }
+  if (seed.userRoles.length > 0) {
+    await db
+      .insert(userRoles)
+      .values([...seed.userRoles])
+      .onConflictDoNothing({ target: [userRoles.uid, userRoles.role] });
+  }
+  console.log('\nApplied. Re-running is a no-op (ON CONFLICT DO NOTHING).');
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  },
+);


### PR DESCRIPTION
## ADR-0002 PR1 — user-management off Firebase-admin (additive, non-breaking)

PR1 of 2 in [ADR-0002](docs/adr/0002-firebase-auth-to-nextauth.md) (Firebase Auth → NextAuth). Moves global roles + user-directory + invites off Firebase-admin onto Postgres, **behind the existing ports**, while Firebase stays the **auth (login) source**. No auth-path / login / session / `resolveCallerIdentity` changes — that's PR2.

### What changed
- **`user_roles(uid, role)`** (global, PK `(uid,role)`, index on `role`) + a **minimal `auth_users(id, email, name, image, timestamps)`** table + hand-written Drizzle migration `0029`. `auth_users.id` **is** the Firebase uid (text, keep-uid §7). PR2 ALTERs `auth_users` (not CREATE) to add NextAuth columns.
- **`PostgresUserDirectoryService`** replaces `FirebaseUserDirectoryService` behind the unchanged `UserDirectoryService` port and is **wired live** in `platform-services.ts`. `getUsersByRole` reads `user_roles` **globally** (no namespace) — faithful to today's Firebase `customClaims.roles` semantics.
- **`PostgresInviteService`** (seed-based: `auth_users` + `workspace_members` + `user_roles` in one transaction) — **built + L2-tested, not yet wired live**. Firebase invite stays live in PR1 (a seed-only invite would leave a new invitee unable to log in via Firebase); it lands behind the port in PR2.
- **One-time seed** `scripts/migrate-firebase-auth-to-postgres/seed-user-roles.ts` populating `user_roles`/`auth_users` from current Firebase `customClaims.roles`, via the same tested pure fn (`buildUserRolesSeed`). **Dry-run by default, gated.**

### Non-breaking guarantee
Swapping the live directory makes `getUsersByRole` read `user_roles`; an empty table silently stops escalation notifications (workflow-engine) — a regression. The mapping `buildUserRolesSeed` mirrors the Firebase `getUsersByRole` filter **exactly** (roles[] precedence, role-scalar fallback), pinned by tests that run **both** impls against the same export. **The gated seed must run when this deploys** so targeting stays identical. No silent fallback to Firebase.

The old Firebase `listUsers(1000)` had an unpaginated 1000-user cap; the PG query has none (parity improvement). The seed script paginates fully.

**Known, accepted PR1 gap:** member-list `lastSignInTime` is `null` until NextAuth database sessions land (PR2) — there is no PG sign-in source yet. `email`/`displayName`/`photoURL`(avatar) are preserved via `auth_users`, so member rows and avatar fallback do not regress.

### Tests (L2, RED→GREEN)
- `seed-user-roles.test.ts` (pure): filter mirror vs `FirebaseUserDirectoryService`, idempotent, de-dup, no-email skip.
- `user-directory-parity.test.ts`: in-memory double + Postgres contract parity, plus old-vs-new `getUsersByRole` diff on a seeded fixture.
- `postgres-invite-service.test.ts`: seeds user + membership + roles, idempotent on email collision.

### Deploy note
After merge + deploy, run the gated seed (`--apply`) on staging — **coordinator-confirmed per action**. It is NOT run by this PR.
