### PR TITLE
fix(ui): agent steps without autonomyLevel show "No agent" badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ### Added
 - Workflow authoring docs split into a process guide ([docs/how-to-create-workflow.md](docs/how-to-create-workflow.md)) and a production checklist ([docs/workflow-authoring-golden-rules.md](docs/workflow-authoring-golden-rules.md)), backed by the end-to-end `apps/golden-standard-workflow` reference package. A CI doc-lint test re-derives every cross-reference, the `executor`/`type` enum tables, the referenced `mediforce` CLI commands, and the ADR links from source, so the docs fail the build instead of silently drifting [#784](https://github.com/Appsilon/mediforce/pull/784).
 
+### Fixed
+- Run execution history now shows the correct control-mode badge for agent steps stored without an explicit `autonomyLevel` — previously they fell through to "No agent" (CM0) even though an agent was running; they now display as "Autonomous agent" (CM4), which matches the design intent that CM0 is reserved for `human | script | action` executors only.
+
 ## [2026-06-21]
 
 ### Fixed

--- a/packages/platform-ui/src/lib/__tests__/control-mode.test.ts
+++ b/packages/platform-ui/src/lib/__tests__/control-mode.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { getControlMode, controlModeToSchema } from '../control-mode';
+
+describe('getControlMode', () => {
+  it('maps non-agent executors to no-agent', () => {
+    expect(getControlMode('human')).toBe('no-agent');
+    expect(getControlMode('script')).toBe('no-agent');
+    expect(getControlMode('action')).toBe('no-agent');
+    expect(getControlMode(undefined)).toBe('no-agent');
+  });
+
+  it('maps cowork executor to cowork', () => {
+    expect(getControlMode('cowork')).toBe('cowork');
+  });
+
+  it('maps agent + L4 to autonomous-agent', () => {
+    expect(getControlMode('agent', 'L4')).toBe('autonomous-agent');
+  });
+
+  it('maps agent + L3 to human-review', () => {
+    expect(getControlMode('agent', 'L3')).toBe('human-review');
+  });
+
+  it('maps agent + L2 to assist', () => {
+    expect(getControlMode('agent', 'L2')).toBe('assist');
+  });
+
+  it('maps agent + L0/L1 to no-agent (developer-only flags)', () => {
+    expect(getControlMode('agent', 'L0')).toBe('no-agent');
+    expect(getControlMode('agent', 'L1')).toBe('no-agent');
+  });
+
+  // Regression: legacy agent steps registered without autonomyLevel must NOT show
+  // "No agent" — the step does run an agent. All three call shapes are tested because
+  // the TypeScript signature accepts string | null | undefined and callers use all three.
+  it('maps agent + undefined/null autonomyLevel to autonomous-agent', () => {
+    expect(getControlMode('agent', undefined)).toBe('autonomous-agent');
+    expect(getControlMode('agent', null)).toBe('autonomous-agent');
+    expect(getControlMode('agent')).toBe('autonomous-agent');
+  });
+
+  // Unknown future levels (e.g. 'L5' added to the engine before the UI catches up)
+  // fall to autonomous-agent rather than no-agent: less wrong to over-attribute
+  // autonomy to a step that genuinely runs an agent than to hide the agent entirely.
+  it('maps agent + unknown autonomyLevel to autonomous-agent', () => {
+    expect(getControlMode('agent', 'L5')).toBe('autonomous-agent');
+  });
+});
+
+describe('controlModeToSchema', () => {
+  it('maps autonomous-agent to agent + L4', () => {
+    expect(controlModeToSchema('autonomous-agent')).toEqual({ executor: 'agent', autonomyLevel: 'L4' });
+  });
+
+  it('maps human-review to agent + L3', () => {
+    expect(controlModeToSchema('human-review')).toEqual({ executor: 'agent', autonomyLevel: 'L3' });
+  });
+
+  it('maps assist to agent + L2', () => {
+    expect(controlModeToSchema('assist')).toEqual({ executor: 'agent', autonomyLevel: 'L2' });
+  });
+
+  it('maps cowork to cowork executor', () => {
+    expect(controlModeToSchema('cowork')).toEqual({ executor: 'cowork' });
+  });
+
+  it('maps no-agent to the chosen sub-executor (defaults to human)', () => {
+    expect(controlModeToSchema('no-agent')).toEqual({ executor: 'human' });
+    expect(controlModeToSchema('no-agent', 'script')).toEqual({ executor: 'script' });
+    expect(controlModeToSchema('no-agent', 'action')).toEqual({ executor: 'action' });
+  });
+
+  // Roundtrip: getControlMode(controlModeToSchema(mode)) ≈ mode for the modes the
+  // wizard can create. 'no-agent' sub-executors default to 'human'.
+  it('roundtrips correctly for wizard-creatable modes', () => {
+    const modes = ['autonomous-agent', 'human-review', 'cowork'] as const;
+    for (const mode of modes) {
+      const { executor, autonomyLevel } = controlModeToSchema(mode);
+      expect(getControlMode(executor, autonomyLevel)).toBe(mode);
+    }
+  });
+});

--- a/packages/platform-ui/src/lib/control-mode.ts
+++ b/packages/platform-ui/src/lib/control-mode.ts
@@ -6,10 +6,13 @@
  *
  * Mapping (ADR-0006: docs/adr/0006-control-mode-ui-concept.md):
  *   CM0  No agent          executor: human | script | action
+ *                          also: executor: agent, autonomyLevel: L0 | L1  (developer-only flags)
  *   CM1  Assist            not yet implemented — disabled in wizard UI
  *   CM2  Cowork            executor: cowork
  *   CM3  Human review      executor: agent, autonomyLevel: L3
  *   CM4  Autonomous agent  executor: agent, autonomyLevel: L4
+ *                          also: executor: agent, autonomyLevel: undefined | unknown
+ *                          (legacy steps without an explicit level default to autonomous)
  *
  * Note: executor: agent, autonomyLevel: L2 (old Ghost/Assist) maps to 'assist' for
  * display of existing steps, but is no longer creatable from the wizard.
@@ -59,6 +62,10 @@ export const CONTROL_MODE_DISABLED: Record<ControlMode, boolean> = {
 /**
  * Derive the UI control mode from stored schema values.
  * L0 and L1 silently map to 'no-agent' — developer-only flags set via raw JSON.
+ * undefined/null (no level set) and any unrecognised value (e.g. a future L5 the UI
+ * hasn't caught up to) map to 'autonomous-agent' — the step does run an agent, so
+ * "No agent" would be semantically wrong. Silent-fallback-to-autonomous is less harmful
+ * than silent-fallback-to-no-agent when the engine is ahead of the UI.
  * L2 maps to 'assist' for display of existing steps.
  */
 export function getControlMode(
@@ -71,7 +78,9 @@ export function getControlMode(
     case 'L2': return 'assist';
     case 'L3': return 'human-review';
     case 'L4': return 'autonomous-agent';
-    default:   return 'no-agent'; // L0, L1, undefined
+    case 'L0':
+    case 'L1': return 'no-agent'; // developer-only instrumentation flags
+    default:   return 'autonomous-agent'; // undefined, null, or unknown future level
   }
 }
 
@@ -79,6 +88,11 @@ export function getControlMode(
  * Map a control mode back to the executor/autonomyLevel values to write.
  * For 'no-agent', `subExecutor` selects between human/script/action.
  * 'assist' (CM1) is disabled in the wizard; this is kept for completeness.
+ *
+ * Roundtrip note: a legacy step stored as `{executor:'agent'}` (no autonomyLevel)
+ * displays as 'autonomous-agent' via getControlMode. If the user opens and saves
+ * that step in the wizard, controlModeToSchema writes back `autonomyLevel:'L4'`.
+ * This is intentional — it normalises legacy data on the next edit.
  */
 export function controlModeToSchema(
   mode: ControlMode,


### PR DESCRIPTION
## Summary

- **Bug**: In run execution history, agent steps stored without an explicit `autonomyLevel` displayed a lime-green "No agent" badge instead of "Autonomous agent". Reproduced on the `collecting-submission-documents` workflow (e.g. the "Draft Reminder Email" step).
- **Root cause**: `getControlMode('agent', undefined)` hit the `default:` branch and returned `'no-agent'`. `ExecutorChip` then displayed `CONTROL_MODE_LABELS['no-agent']` ("No agent") with the agent executor's lime-green chip style — semantically wrong because the step *does* run an agent.
- **Fix**: Separate `undefined`/`null`/unknown from L0/L1 in the switch. L0/L1 stay as `'no-agent'` per the design doc (developer-only instrumentation flags). `undefined`, `null`, and any unrecognised future value (e.g. a `L5` the UI hasn't caught up to) now fall to `'autonomous-agent'`.

One-line change to `getControlMode` covers all badge surfaces: `ExecutorChip` (run history), `ControlModeBadge` (agent-run detail), `ExecutorIcon`/`getExecutorLabel` (workflow diagram), `StepIcon`/`StepDescription` (next-step card).

## Test plan

- [x] New unit tests in `control-mode.test.ts` (14 assertions): all L0–L4 cases, `undefined`/`null`/omitted, unknown future level (`L5`), `controlModeToSchema` coverage, and roundtrip invariant
- [x] `pnpm --filter platform-ui exec vitest run src/lib/__tests__/control-mode.test.ts` — 14/14 pass
- [x] `pnpm --filter platform-ui typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)