### PR TITLE
fix: omit empty client secret on OAuth provider edit (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ### Fixed
 - Run execution history now shows the correct control-mode badge for agent steps stored without an explicit `autonomyLevel` — previously they fell through to "No agent" (CM0) even though an agent was running; they now display as "Autonomous agent" (CM4), which matches the design intent that CM0 is reserved for `human | script | action` executors only.
+- Editing an OAuth provider no longer forces the admin to re-enter the `Client secret` — leaving the field blank on edit omits it from the PATCH body so the stored secret is preserved; the placeholder reads "Leave empty to keep current secret" to make the affordance obvious [#332](https://github.com/Appsilon/mediforce/issues/332).
 
 ## [2026-06-21]
 

--- a/packages/platform-infra/src/postgres/__tests__/oauth-provider-parity.test.ts
+++ b/packages/platform-infra/src/postgres/__tests__/oauth-provider-parity.test.ts
@@ -144,6 +144,9 @@ function contract(
       expect(updated?.name).toBe('Updated');
       expect(updated?.clientId).toBe(original.clientId);
       expect(updated?.scopes).toEqual(original.scopes);
+      // A PATCH that omits clientSecret must preserve the stored secret —
+      // the "leave empty to keep current secret" edit flow depends on this.
+      expect(updated?.clientSecret).toBe(original.clientSecret);
       expect(new Date(updated!.updatedAt).getTime()).toBeGreaterThan(
         new Date(original.updatedAt).getTime(),
       );

--- a/packages/platform-ui/src/components/admin/oauth-providers/__tests__/provider-form.test.tsx
+++ b/packages/platform-ui/src/components/admin/oauth-providers/__tests__/provider-form.test.tsx
@@ -215,6 +215,82 @@ describe('ProviderForm', () => {
     expect(onSubmit.mock.calls[0][0].scopes).toEqual(['repo', 'read:user', 'org:read']);
   });
 
+  it('omits clientSecret from the payload on edit when left empty', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    const provider = makeProvider({ id: 'github', clientSecret: undefined });
+
+    render(
+      <ProviderForm
+        provider={provider}
+        preset={null}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Edit a field other than the secret, leave the secret blank.
+    const nameInput = screen.getByLabelText(/^Name$/i) as HTMLInputElement;
+    await user.clear(nameInput);
+    await user.type(nameInput, 'GitHub Enterprise');
+    await user.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.name).toBe('GitHub Enterprise');
+    expect(payload.clientSecret).toBeUndefined();
+  });
+
+  it('includes clientSecret in the payload on edit when a new value is entered', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    const provider = makeProvider({ id: 'github', clientSecret: undefined });
+
+    render(
+      <ProviderForm
+        provider={provider}
+        preset={null}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^Client secret$/i), 'rotated-secret');
+    await user.click(screen.getByRole('button', { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onSubmit.mock.calls[0][0].clientSecret).toBe('rotated-secret');
+  });
+
+  it('still requires clientSecret when creating a new provider', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <ProviderForm
+        provider={null}
+        preset="github"
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/^Client id$/i), 'cid');
+    // Leave client secret empty on create.
+    await user.click(screen.getByRole('button', { name: /^Create$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Required/i)).toBeInTheDocument();
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('shows validation error when required fields are missing', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/packages/platform-ui/src/components/admin/oauth-providers/provider-form.tsx
+++ b/packages/platform-ui/src/components/admin/oauth-providers/provider-form.tsx
@@ -18,7 +18,9 @@ const FormSchema = z.object({
     .regex(idPattern, 'Lowercase letters, digits, or dashes (starting with letter/digit)'),
   name: z.string().min(1, 'Required'),
   clientId: z.string().min(1, 'Required'),
-  clientSecret: z.string().min(1, 'Required'),
+  // `clientSecret` is validated conditionally in `handleSubmit`: required on
+  // create, optional on edit (empty means "keep the existing secret").
+  clientSecret: z.string(),
   authorizeUrl: z.string().url('Must be a valid URL'),
   tokenUrl: z.string().url('Must be a valid URL'),
   userInfoUrl: z.string().url('Must be a valid URL'),
@@ -94,11 +96,17 @@ function valuesToPayload(
   const scopes = tokenizeScopes(values.scopes);
   const revokeUrl = (values.revokeUrl ?? '').trim();
   const iconUrl = (values.iconUrl ?? '').trim();
+  const isEditing = existingId !== undefined;
+  const trimmedSecret = values.clientSecret.trim();
+  // On edit, an empty `clientSecret` means "leave the stored secret untouched"
+  // — omit it from the PATCH body so the handler preserves the existing value.
+  const secretValue =
+    isEditing && trimmedSecret === '' ? undefined : values.clientSecret;
   return {
     id: existingId ?? values.id.trim(),
     name: values.name.trim(),
     clientId: values.clientId.trim(),
-    clientSecret: values.clientSecret,
+    ...(secretValue !== undefined ? { clientSecret: secretValue } : {}),
     authorizeUrl: values.authorizeUrl.trim(),
     tokenUrl: values.tokenUrl.trim(),
     userInfoUrl: values.userInfoUrl.trim(),
@@ -140,6 +148,12 @@ export function ProviderForm({
     const tokens = tokenizeScopes(values.scopes);
     if (tokens.length === 0) {
       form.setError('scopes', { message: 'At least one scope is required' });
+      return;
+    }
+    // `clientSecret` is only required when creating a new provider. On edit,
+    // leaving it blank preserves the stored secret (handled in valuesToPayload).
+    if (!isEditing && values.clientSecret.trim() === '') {
+      form.setError('clientSecret', { message: 'Required' });
       return;
     }
     const payload = valuesToPayload(values, isEditing ? provider!.id : undefined);
@@ -190,7 +204,7 @@ export function ProviderForm({
             id="provider-client-secret"
             type="password"
             {...form.register('clientSecret')}
-            placeholder="••••••••"
+            placeholder={isEditing ? 'Leave empty to keep current secret' : '••••••••'}
             className="rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
             autoComplete="new-password"
           />


### PR DESCRIPTION
## Problem

Editing an existing OAuth provider via `/{handle}/admin/oauth-providers` required the admin to re-enter the `Client secret` even when they only wanted to change the `Client ID` (or any other field). Leaving it blank rejected the save because the form schema marked `clientSecret` as `min(1, 'Required')` and always included it in the submit payload.

## Fix

The backend already handles this correctly: `UpdateOAuthProviderInputSchema` makes `clientSecret` optional, and the repository `update()` merges `{...current, ...patch}` so an absent `clientSecret` preserves the stored value. The bug was purely in the form.

In `packages/platform-ui/src/components/admin/oauth-providers/provider-form.tsx`:

- Relaxed the form schema's `clientSecret` to `z.string()` (no min-length) so an empty value validates.
- `clientSecret` is now required only on **create** — enforced in `handleSubmit` (mirrors the existing scopes guard).
- On **edit**, an empty `clientSecret` is omitted from the PATCH body in `valuesToPayload`, so the handler keeps the existing secret.
- A non-empty value on edit still replaces the secret.
- The secret input placeholder reads "Leave empty to keep current secret" on edit so the affordance is obvious.

No backend change was needed — confirmed the Postgres repo's `update` merges with the current row and only writes `clientSecret` when present in the patch.

## Tests

Added unit tests in `provider-form.test.tsx` covering: omitting `clientSecret` on edit when blank, including it on edit when a new value is entered, and still requiring it on create. Not run in-container (CI validates).

Closes #332

---

🤖 generated by mediforce-fullstack