### PR TITLE
refactor: migrate remaining client mutations to sendJson helper (#527)

### DIFF
--- a/packages/platform-api/src/client/__tests__/mediforce.test.ts
+++ b/packages/platform-api/src/client/__tests__/mediforce.test.ts
@@ -641,6 +641,51 @@ describe('Mediforce', () => {
     });
   });
 
+  describe('runs.start', () => {
+    it('POSTs the validated body as JSON to /api/processes', async () => {
+      const run = buildProcessInstance({ id: 'inst-a', status: 'running' });
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ run }));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.runs.start({
+        definitionName: 'def-1',
+        triggeredBy: 'user-1',
+      });
+
+      expect(result.run.id).toBe('inst-a');
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(`${TEST_BASE_URL}/api/processes`);
+      const init = fetchSpy.mock.calls[0]?.[1];
+      expect(init?.method).toBe('POST');
+      // Body-bearing mutations serialize the payload and tag it as JSON.
+      expect(new Headers(init?.headers).get('content-type')).toBe('application/json');
+      const body = init?.body !== undefined ? JSON.parse(String(init.body)) : {};
+      expect(body.definitionName).toBe('def-1');
+      expect(body.triggeredBy).toBe('user-1');
+    });
+  });
+
+  describe('cron.heartbeat', () => {
+    it('POSTs to /api/cron/heartbeat with no body or content-type', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(jsonResponse({ triggered: [], skipped: [] }));
+
+      const mediforce = new Mediforce({ apiKey: 'k', baseUrl: TEST_BASE_URL });
+      const result = await mediforce.cron.heartbeat();
+
+      expect(result.triggered).toEqual([]);
+      expect(fetchSpy.mock.calls[0]?.[0]).toBe(`${TEST_BASE_URL}/api/cron/heartbeat`);
+      const init = fetchSpy.mock.calls[0]?.[1];
+      // No-body mutations must not attach a Content-Type header or a body —
+      // the `sendJson` helper skips both when `body` is `undefined`.
+      expect(init?.method).toBe('POST');
+      expect(init?.body).toBeUndefined();
+      expect(new Headers(init?.headers).get('content-type')).toBeNull();
+    });
+  });
+
   describe('error envelope back-compat (legacy `{ error: string }`)', () => {
     it('extracts the message from the legacy string envelope', async () => {
       // Some Phase 1 routes still throw plain HandlerError with a custom

--- a/packages/platform-api/src/client/__tests__/mediforce.test.ts
+++ b/packages/platform-api/src/client/__tests__/mediforce.test.ts
@@ -652,6 +652,7 @@ describe('Mediforce', () => {
       const result = await mediforce.runs.start({
         definitionName: 'def-1',
         triggeredBy: 'user-1',
+        triggerName: 'manual',
       });
 
       expect(result.run.id).toBe('inst-a');

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -751,7 +751,7 @@ export class Mediforce {
         return this.sendJson(
           'POST',
           `/api/tasks/${encodeURIComponent(validated.taskId)}/complete`,
-          validated.payload as Record<string, unknown>,
+          validated.payload,
           CompleteTaskOutputSchema,
           'mediforce.tasks.complete',
         );
@@ -935,7 +935,7 @@ export class Mediforce {
         return this.sendJson(
           'POST',
           `/api/workflow-definitions${qs}`,
-          { ...validatedInput } as Record<string, unknown>,
+          { ...validatedInput },
           RegisterWorkflowOutputSchema,
           'mediforce.workflows.register',
         );
@@ -1129,7 +1129,7 @@ export class Mediforce {
         return this.sendJson(
           'PUT',
           `/api/agents/${encodeURIComponent(validatedInput.id)}`,
-          validatedBody as Record<string, unknown>,
+          validatedBody,
           UpdateAgentOutputSchema,
           'mediforce.agents.update',
         );
@@ -1139,7 +1139,7 @@ export class Mediforce {
         return this.sendJson(
           'POST',
           '/api/agents',
-          { ...v } as Record<string, unknown>,
+          { ...v },
           CreateAgentOutputSchema,
           'mediforce.agents.create',
         );
@@ -1155,7 +1155,7 @@ export class Mediforce {
         return this.sendJson(
           'PUT',
           `/api/agents/${encodeURIComponent(v.id)}/mcp-servers/${encodeURIComponent(v.name)}`,
-          v.binding as Record<string, unknown>,
+          v.binding,
           UpsertAgentMcpBindingOutputSchema,
           'mediforce.agents.upsertMcpBinding',
         );
@@ -1313,7 +1313,7 @@ export class Mediforce {
         return this.sendJson(
           'POST',
           '/api/processes',
-          validated as Record<string, unknown>,
+          validated,
           StartRunOutputSchema,
           'mediforce.runs.start',
         );
@@ -1838,7 +1838,7 @@ export class Mediforce {
   private async sendJson<TOut>(
     method: 'POST' | 'PATCH' | 'PUT' | 'DELETE',
     path: string,
-    body: Record<string, unknown> | undefined,
+    body: unknown,
     outputSchema: { parse: (b: unknown) => TOut },
     ctx: string,
   ): Promise<TOut> {

--- a/packages/platform-api/src/client/index.ts
+++ b/packages/platform-api/src/client/index.ts
@@ -738,25 +738,23 @@ export class Mediforce {
       },
       claim: async (input) => {
         const validated = ClaimTaskInputSchema.parse(input);
-        const res = await this.request(
+        return this.sendJson(
+          'POST',
           `/api/tasks/${encodeURIComponent(validated.taskId)}/claim`,
-          { method: 'POST' },
+          undefined,
+          ClaimTaskOutputSchema,
+          'mediforce.tasks.claim',
         );
-        const body = await parseJsonOrThrow(res, 'mediforce.tasks.claim');
-        return ClaimTaskOutputSchema.parse(body);
       },
       complete: async (input) => {
         const validated = CompleteTaskInputSchema.parse(input);
-        const res = await this.request(
+        return this.sendJson(
+          'POST',
           `/api/tasks/${encodeURIComponent(validated.taskId)}/complete`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(validated.payload),
-          },
+          validated.payload as Record<string, unknown>,
+          CompleteTaskOutputSchema,
+          'mediforce.tasks.complete',
         );
-        const body = await parseJsonOrThrow(res, 'mediforce.tasks.complete');
-        return CompleteTaskOutputSchema.parse(body);
       },
       attachments: {
         list: async (input) => {
@@ -1117,12 +1115,13 @@ export class Mediforce {
       },
       delete: async (input) => {
         const validated = DeleteAgentInputSchema.parse(input);
-        const res = await this.request(
+        return this.sendJson(
+          'DELETE',
           `/api/agents/${encodeURIComponent(validated.id)}`,
-          { method: 'DELETE' },
+          undefined,
+          DeleteAgentOutputSchema,
+          'mediforce.agents.delete',
         );
-        const body = await parseJsonOrThrow(res, 'mediforce.agents.delete');
-        return DeleteAgentOutputSchema.parse(body);
       },
       update: (input, updateBody) => {
         const validatedInput = UpdateAgentInputSchema.parse(input);
@@ -1311,45 +1310,44 @@ export class Mediforce {
       },
       start: async (input) => {
         const validated = StartRunInputSchema.parse(input);
-        const res = await this.request('/api/processes', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(validated),
-        });
-        const body = await parseJsonOrThrow(res, 'mediforce.runs.start');
-        return StartRunOutputSchema.parse(body);
+        return this.sendJson(
+          'POST',
+          '/api/processes',
+          validated as Record<string, unknown>,
+          StartRunOutputSchema,
+          'mediforce.runs.start',
+        );
       },
       cancel: async (input) => {
         const validated = CancelRunInputSchema.parse(input);
         const body = validated.reason !== undefined ? { reason: validated.reason } : {};
-        const res = await this.request(
+        return this.sendJson(
+          'POST',
           `/api/processes/${encodeURIComponent(validated.runId)}/cancel`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-          },
+          body,
+          CancelRunOutputSchema,
+          'mediforce.runs.cancel',
         );
-        const parsed = await parseJsonOrThrow(res, 'mediforce.runs.cancel');
-        return CancelRunOutputSchema.parse(parsed);
       },
       resume: async (input) => {
         const validated = ResumeRunInputSchema.parse(input);
-        const res = await this.request(
+        return this.sendJson(
+          'POST',
           `/api/processes/${encodeURIComponent(validated.runId)}/resume`,
-          { method: 'POST' },
+          undefined,
+          ResumeRunOutputSchema,
+          'mediforce.runs.resume',
         );
-        const parsed = await parseJsonOrThrow(res, 'mediforce.runs.resume');
-        return ResumeRunOutputSchema.parse(parsed);
       },
       retryStep: async (input) => {
         const validated = RetryStepInputSchema.parse(input);
-        const res = await this.request(
+        return this.sendJson(
+          'POST',
           `/api/processes/${encodeURIComponent(validated.runId)}/steps/${encodeURIComponent(validated.stepId)}/retry`,
-          { method: 'POST' },
+          undefined,
+          RetryStepOutputSchema,
+          'mediforce.runs.retryStep',
         );
-        const parsed = await parseJsonOrThrow(res, 'mediforce.runs.retryStep');
-        return RetryStepOutputSchema.parse(parsed);
       },
       archive: (input) => {
         const v = ArchiveRunInputSchema.parse(input);
@@ -1389,13 +1387,13 @@ export class Mediforce {
         const params: Record<string, string> = { namespace: validated.namespace };
         if (validated.workflow) params.workflow = validated.workflow;
         const qs = toSearchParams(params);
-        const res = await this.request(`/api/workflow-secrets${qs}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ key: validated.key, value: validated.value }),
-        });
-        const body = await parseJsonOrThrow(res, 'mediforce.secrets.set');
-        return SetSecretOutputSchema.parse(body);
+        return this.sendJson(
+          'PUT',
+          `/api/workflow-secrets${qs}`,
+          { key: validated.key, value: validated.value },
+          SetSecretOutputSchema,
+          'mediforce.secrets.set',
+        );
       },
       list: async (input) => {
         const validated = ListSecretKeysInputSchema.parse(input);
@@ -1411,9 +1409,13 @@ export class Mediforce {
         const params: Record<string, string> = { namespace: validated.namespace, key: validated.key };
         if (validated.workflow) params.workflow = validated.workflow;
         const qs = toSearchParams(params);
-        const res = await this.request(`/api/workflow-secrets${qs}`, { method: 'DELETE' });
-        const body = await parseJsonOrThrow(res, 'mediforce.secrets.delete');
-        return DeleteSecretOutputSchema.parse(body);
+        return this.sendJson(
+          'DELETE',
+          `/api/workflow-secrets${qs}`,
+          undefined,
+          DeleteSecretOutputSchema,
+          'mediforce.secrets.delete',
+        );
       },
       workspacePreviews: async (input) => {
         const validated = GetWorkspaceSecretPreviewsInputSchema.parse(input);
@@ -1484,9 +1486,13 @@ export class Mediforce {
     this.cron = {
       heartbeat: async (input) => {
         HeartbeatInputSchema.parse(input ?? {});
-        const res = await this.request('/api/cron/heartbeat', { method: 'POST' });
-        const body = await parseJsonOrThrow(res, 'mediforce.cron.heartbeat');
-        return HeartbeatOutputSchema.parse(body);
+        return this.sendJson(
+          'POST',
+          '/api/cron/heartbeat',
+          undefined,
+          HeartbeatOutputSchema,
+          'mediforce.cron.heartbeat',
+        );
       },
     };
 


### PR DESCRIPTION
## What

`packages/platform-api/src/client/index.ts` had 16 mutation methods repeating the identical `parse → request → parseJsonOrThrow → outputSchema.parse` pattern. PR #525 introduced the private `sendJson` helper and applied it to the 4 cowork mutations. Since then, several more mutations (workflows.register/archiveVersion/archiveAll/setVisibility/copy, agents.update, etc.) had already been migrated by other work.

This PR completes the refactor by applying `sendJson` to the remaining inline mutation methods still using the hand-rolled pattern:

- `tasks.claim` (POST, no body)
- `tasks.complete` (POST, body)
- `runs.start` (POST, body)
- `runs.cancel` (POST, body)
- `runs.resume` (POST, no body)
- `runs.retryStep` (POST, no body)
- `agents.delete` (DELETE, no body)
- `secrets.set` (PUT, body)
- `secrets.delete` (DELETE, no body)
- `cron.heartbeat` (POST, no body)

## Why

Mechanical, low-risk consolidation behind one shared seam so the mutation methods stop copy-pasting `request → parseJsonOrThrow → outputSchema.parse`. Behavior is unchanged — `sendJson` reproduces the prior flow exactly, including omitting `Content-Type`/body for verb-only mutations (body `undefined`) and serializing + tagging `application/json` when a body is present. `runs.cancel` still sends an empty `{}` body with `Content-Type` when no reason is given, matching the prior wire shape.

## Tests

Adds client tests pinning both `sendJson` branches: `runs.start` (body path — asserts `Content-Type: application/json` and serialized payload) and `cron.heartbeat` (no-body path — asserts no body and no `Content-Type`). Existing `tasks.claim` / `runs.cancel` tests continue to cover those migrations.

Closes #527

---

🤖 generated by mediforce-fullstack