### PR TITLE
Compute peak context occupancy in claude-code-agent plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [2026-06-21]
 
 ### Fixed
+- Context-saturation logging now covers the `claude-code-agent` plugin, not just OpenCode. Peak per-turn context occupancy is computed from the stream's per-turn `assistant` usage (summing `input_tokens` + cache-read + cache-creation, since caching hides most of the prompt from `input_tokens`) and folded into the result event's usage as `peak_input_tokens`, so `logContextSaturation` reports a real peak instead of nothing. Previously only the final turn's `usage` was surfaced, which is not the peak — Claude Code steps produced no `[saturation]` line, leaving batch-size tuning blind.
 - Workflow-designer cowork chat no longer hangs on its mandatory first step: the `mediforce-mcp` server crashed on startup because `@mediforce/platform-core` was an undeclared (phantom) dependency and its `workflow-examples` loader had no subpath export, so `list_workflow_examples` was silently unavailable (the connection failure is swallowed). Declared the dependency, added the `./workflow-examples` export, and import it via the package specifier.
 - Postgres workflow definitions now persist imported workflow `source` provenance, so get/list calls keep the advertised url/path/commit after GitHub imports.
 - A malformed or legacy-shaped `source` (e.g. the pre-commit `{ repo, path, ref }`) no longer drops the entire workflow definition on read — the informational provenance is dropped best-effort and the workflow still loads and runs.

--- a/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/claude-code-agent-plugin.test.ts
@@ -227,6 +227,31 @@ describe('ClaudeCodeAgentPlugin', () => {
       const result = plugin.parseAgentOutput(stdout);
       expect(result).toBe('');
     });
+
+    it('[DATA] folds peak per-turn context (input + cache) into result usage', () => {
+      const stdout = [
+        JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 40_000, cache_read_input_tokens: 10_000, output_tokens: 200 } } }),
+        JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 90_000, cache_read_input_tokens: 60_000, cache_creation_input_tokens: 5_000, output_tokens: 300 } } }),
+        JSON.stringify({ type: 'assistant', message: { usage: { input_tokens: 20_000, output_tokens: 100 } } }),
+        JSON.stringify({ type: 'result', subtype: 'success', result: 'done', usage: { input_tokens: 20_000, output_tokens: 100 } }),
+      ].join('\n');
+
+      const parsed = JSON.parse(plugin.parseAgentOutput(stdout));
+      // Peak is the largest single turn's full prompt: 90k + 60k + 5k = 155k,
+      // not the final turn (20k) that result.usage would otherwise report.
+      expect(parsed.usage.peak_input_tokens).toBe(155_000);
+      expect(parsed.usage.input_tokens).toBe(20_000);
+    });
+
+    it('[DATA] leaves usage untouched when no assistant turn reports tokens', () => {
+      const stdout = [
+        JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } }),
+        JSON.stringify({ type: 'result', subtype: 'success', result: 'done', usage: { input_tokens: 5_000, output_tokens: 50 } }),
+      ].join('\n');
+
+      const parsed = JSON.parse(plugin.parseAgentOutput(stdout));
+      expect(parsed.usage).toEqual({ input_tokens: 5_000, output_tokens: 50 });
+    });
   });
 
   describe('run', () => {

--- a/packages/agent-runtime/src/plugins/claude-code-agent-plugin.ts
+++ b/packages/agent-runtime/src/plugins/claude-code-agent-plugin.ts
@@ -12,6 +12,12 @@ interface StreamEvent {
   message?: {
     role?: string;
     content?: Array<{ type: string; name?: string; input?: unknown; text?: string }>;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
   };
   result?: string;
   tool_name?: string;
@@ -104,6 +110,21 @@ function formatLogEntries(event: StreamEvent): string[] {
     ...rest,
   });
   return entries.map((entry) => JSON.stringify(entry));
+}
+
+/** Context occupancy for one assistant turn: the whole prompt, not just the
+ *  uncached portion. With prompt caching on, `input_tokens` excludes cached
+ *  tokens (`cache_read`/`cache_creation`), so peak must sum all three or it
+ *  under-reports saturation by orders of magnitude. Pure. */
+export function turnContextTokens(usage: {
+  input_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+} | undefined): number {
+  if (!usage) return 0;
+  return (usage.input_tokens ?? 0)
+    + (usage.cache_read_input_tokens ?? 0)
+    + (usage.cache_creation_input_tokens ?? 0);
 }
 
 /** Extract a human-readable error from a stream-json result line (if any). */
@@ -267,18 +288,41 @@ export class ClaudeCodeAgentPlugin extends BaseContainerAgentPlugin {
   }
 
   parseAgentOutput(rawStdout: string): string {
-    // Claude CLI outputs NDJSON (stream-json). Scan for the last `result` event.
+    // Claude CLI outputs NDJSON (stream-json). Scan for the last `result` event,
+    // and track the peak per-turn context occupancy across all assistant turns.
+    // The final `result.usage` reports only the last turn, so peak saturation
+    // (what measures context against the model's window) must come from the
+    // per-turn `assistant` events — mirrors the OpenCode plugin.
     let lastResult = '';
+    let peakInputTokens = 0;
     for (const line of rawStdout.split('\n')) {
       const trimmed = line.trim();
       if (!trimmed) continue;
       try {
         const event = JSON.parse(trimmed) as StreamEvent;
+        if (event.type === 'assistant') {
+          peakInputTokens = Math.max(peakInputTokens, turnContextTokens(event.message?.usage));
+        }
         if (event.type === 'result') {
           lastResult = trimmed;
         }
       } catch {
         // Skip non-JSON lines (Docker/entrypoint output)
+      }
+    }
+
+    // Fold the peak into the result event's usage so base-container's token
+    // extraction surfaces it as `peakInputTokens` for logContextSaturation.
+    if (lastResult && peakInputTokens > 0) {
+      try {
+        const event = JSON.parse(lastResult) as Record<string, unknown>;
+        const usage = event.usage;
+        if (usage !== null && typeof usage === 'object') {
+          (usage as Record<string, unknown>).peak_input_tokens = peakInputTokens;
+          return JSON.stringify(event);
+        }
+      } catch {
+        // Fall through to the unmodified result line.
       }
     }
     return lastResult;


### PR DESCRIPTION
## What & why

Follow-up to #866 (context-saturation logging). That PR computes peak per-turn context occupancy **only in the OpenCode plugin**. The **`claude-code-agent`** plugin — which every `mediforce-fullstack` agent step runs on — only forwarded `usage.peak_input_tokens` from the final `result` event ([base-container-agent-plugin.ts:935](../blob/main/packages/agent-runtime/src/plugins/base-container-agent-plugin.ts#L935)), and Claude Code never emits that field. So Claude Code steps produced **no `[saturation]` line and no peak number**, leaving context-window headroom (and batch-size tuning) blind.

Surfaced while benchmarking `mediforce-fullstack` triage: a single-issue run reported `inputTokens: 197591` (the final turn's cumulative-ish usage), but no true peak occupancy — the metric needed to size how many issues one grounded triage call can hold before recall degrades.

## Change

`ClaudeCodeAgentPlugin.parseAgentOutput` now, in the same single pass it already does to find the last `result` event, tracks the **peak per-turn context** across all `assistant` events and folds it into the result event's `usage` as `peak_input_tokens` — which base-container already reads into `tokenUsage.peakInputTokens` and `logContextSaturation` logs.

- Peak per turn sums `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`. With prompt caching on, `input_tokens` excludes cached tokens, so the sum is the real prompt occupancy — same reasoning as the OpenCode plugin ([opencode-agent-plugin.ts:264-269](../blob/main/packages/agent-runtime/src/plugins/opencode-agent-plugin.ts#L264-L269)).
- **Backward compatible:** `usage` is left untouched when no assistant turn reports tokens (existing `parseAgentOutput` assertions unchanged), and the peak is only injected when the result event already carries a `usage` object.
- Pure `turnContextTokens` helper exported for clarity.

## Validation

- ✅ `@mediforce/agent-runtime` typecheck clean.
- ✅ 33/33 plugin unit tests, incl. 2 new: peak is the largest single turn (155k = 90k+60k+5k), not the 20k final turn; usage untouched when no turn reports tokens.
- Not exercised here (needs a live Docker run): that Claude Code via OpenRouter populates per-turn `message.usage` for GLM — expected, but confirm on the next staging benchmark by reading `peakInputTokens` off the triage agent-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)