### PR TITLE
fix(deploy): drop hardcoded arm64 platform in deploy-staging.sh

### DIFF
--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -18,7 +18,7 @@ echo "==> Ensuring /var/lib/mediforce exists on host"
 # sudo, so we use a rootful alpine container as a permission-elevation
 # trick — the docker daemon the deploy already has access to (deploy
 # is in the docker group) lets us write outside the user's home tree.
-docker run --rm --platform linux/arm64 -v /var/lib:/host/var/lib alpine:latest \
+docker run --rm -v /var/lib:/host/var/lib alpine:latest \
   sh -c "mkdir -p /host/var/lib/mediforce && chmod 755 /host/var/lib/mediforce"
 
 # Only prune when the Docker data volume is actually filling up — unconditional


### PR DESCRIPTION
First cdisc deploy failed at the /var/lib/mediforce mkdir step with `exec /bin/sh: exec format error` — the rootful-alpine permission trick hardcoded `--platform linux/arm64`, but cdisc (77.42.86.216) is x86_64 while staging is arm64.

Dropping the flag makes Docker pick the host architecture, so the script is arch-agnostic. Platform images are already multi-arch (build-images.yml builds amd64 + arm64 and creates a manifest), so the rest of the deploy is unaffected.

Verified: no other `--platform`/arm64 hardcodes in deploy scripts, compose files, or bootstrap-server.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)