### PR TITLE
Follow-up: L3 coverage + cleanups for output-files archive (self-review of #826)

### DIFF
--- a/packages/agent-runtime/src/workspace/__tests__/workspace-reader.test.ts
+++ b/packages/agent-runtime/src/workspace/__tests__/workspace-reader.test.ts
@@ -174,7 +174,7 @@ describe('WorkspaceReader', () => {
       const zipPath = join(dataDir, 'test-archive.zip');
       await writeFile(zipPath, zipBuffer);
       const { stdout } = await execFileAsync('zipinfo', ['-1', zipPath], { encoding: 'utf-8' });
-      return stdout.trim().split('\n').filter((e) => e !== '' && e.endsWith('/') === false).sort();
+      return stdout.trim().split('\n').filter((entry) => entry !== '' && entry.endsWith('/') === false).sort();
     }
 
     async function unzipFileContent(zipBuffer: Buffer, entryPath: string): Promise<Buffer> {

--- a/packages/platform-ui/e2e/api/run-output-files.journey.ts
+++ b/packages/platform-ui/e2e/api/run-output-files.journey.ts
@@ -4,8 +4,9 @@ import { TEST_ORG_HANDLE } from '../helpers/constants';
 import { seedOutputFiles } from '../helpers/seed-output-files';
 
 /**
- * API E2E for Output Files: list (`GET /api/runs/<runId>/files`) and download
- * (`GET /api/runs/<runId>/files/<path>`).
+ * API E2E for Output Files: list (`GET /api/runs/<runId>/files`), download one
+ * (`GET /api/runs/<runId>/files/<path>`), and download all as a zip
+ * (`GET /api/runs/<runId>/files/archive`).
  *
  * The run itself is driven end-to-end through the platform (agent step under
  * MOCK_AGENT=true), but the Output Files are SEEDED into the bare repo with
@@ -168,6 +169,19 @@ test.describe('Run Output Files — API E2E', () => {
     expect((await binRes.body()).equals(binaryContent)).toBe(true);
     expect(binRes.headers()['content-type']).toBe('application/octet-stream');
 
+    // -------- Download all as one zip archive --------
+    const archiveRes = await request.get(`/api/runs/${runId}/files/archive`, { headers: AUTH_HEADERS });
+    expect(archiveRes.status(), await archiveRes.text()).toBe(200);
+    expect(archiveRes.headers()['content-type']).toBe('application/zip');
+    expect(archiveRes.headers()['content-disposition']).toBe(
+      `attachment; filename="${wdName}-${runId.slice(0, 8)}-output.zip"; ` +
+        `filename*=UTF-8''${wdName}-${runId.slice(0, 8)}-output.zip`,
+    );
+    // Zip local-file-header magic — proves a real archive, not an error body.
+    const archiveBody = await archiveRes.body();
+    expect(archiveBody.subarray(0, 2).toString('latin1')).toBe('PK');
+    expect(archiveBody.byteLength).toBeGreaterThan(0);
+
     // -------- Missing file under the output root → 404, not bytes --------
     const ghostRes = await request.get(`/api/runs/${runId}/files/.mediforce/output/generate/ghost.txt`, {
       headers: AUTH_HEADERS,
@@ -194,13 +208,22 @@ test.describe('Run Output Files — API E2E', () => {
     // -------- Listing a missing run → 404 (anti-enumeration) --------
     const missingRunRes = await request.get('/api/runs/no-such-run/files', { headers: AUTH_HEADERS });
     expect(missingRunRes.status()).toBe(404);
+
+    // -------- Archiving a missing / out-of-scope run → 404 (anti-enumeration) --------
+    const missingArchiveRes = await request.get('/api/runs/no-such-run/files/archive', {
+      headers: AUTH_HEADERS,
+    });
+    expect(missingArchiveRes.status()).toBe(404);
   });
 
-  test('rejects unauthenticated access to both routes with 401', async ({ request }) => {
+  test('rejects unauthenticated access to all routes with 401', async ({ request }) => {
     const listRes = await request.get('/api/runs/any-run/files');
     expect(listRes.status()).toBe(401);
 
     const downloadRes = await request.get('/api/runs/any-run/files/.mediforce/output/step/file.txt');
     expect(downloadRes.status()).toBe(401);
+
+    const archiveRes = await request.get('/api/runs/any-run/files/archive');
+    expect(archiveRes.status()).toBe(401);
   });
 });

--- a/packages/platform-ui/src/app/api/runs/[runId]/files/[...path]/route.ts
+++ b/packages/platform-ui/src/app/api/runs/[runId]/files/[...path]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { WorkspaceReader, OUTPUT_FILES_REPO_ROOT } from '@mediforce/agent-runtime';
 import { HandlerError, NotFoundError, ValidationError } from '@mediforce/platform-api/errors';
-import { defaultBuildScope, defaultResolveCaller } from '@/lib/route-adapter';
+import { defaultBuildScope, defaultResolveCaller, jsonErrorResponse } from '@/lib/route-adapter';
 import { attachmentContentDisposition, contentTypeForFilePath } from '@/lib/file-content-type';
 
 interface RouteContext {
@@ -45,7 +45,7 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
       repoRelativePath.startsWith(OUTPUT_FILES_PATH_PREFIX) &&
       repoRelativePath.length > OUTPUT_FILES_PATH_PREFIX.length;
     if (hasTraversalSegment === true || isUnderOutputRoot === false) {
-      return errorResponse(
+      return jsonErrorResponse(
         new ValidationError(
           `Output File paths must live under ${OUTPUT_FILES_PATH_PREFIX} and contain no ".." segments`,
         ),
@@ -54,7 +54,7 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
 
     const run = await scope.runs.getById(runId);
     if (run === null) {
-      return errorResponse(new NotFoundError(`Run ${runId} not found`));
+      return jsonErrorResponse(new NotFoundError(`Run ${runId} not found`));
     }
 
     const fileBytes = await new WorkspaceReader().readOutputFile(
@@ -63,7 +63,7 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
       repoRelativePath,
     );
     if (fileBytes === null) {
-      return errorResponse(new NotFoundError(`Output File ${repoRelativePath} not found for run ${runId}`));
+      return jsonErrorResponse(new NotFoundError(`Output File ${repoRelativePath} not found for run ${runId}`));
     }
 
     const fileName = repoRelativePath.split('/').pop() ?? 'download';
@@ -76,12 +76,8 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
       },
     });
   } catch (err) {
-    if (err instanceof HandlerError) return errorResponse(err);
+    if (err instanceof HandlerError) return jsonErrorResponse(err);
     console.error('[run-output-file-route] handler error:', err);
-    return errorResponse(new HandlerError('internal', 'Internal error'));
+    return jsonErrorResponse(new HandlerError('internal', 'Internal error'));
   }
-}
-
-function errorResponse(err: HandlerError): NextResponse {
-  return NextResponse.json(err.toEnvelope(), { status: err.statusCode });
 }

--- a/packages/platform-ui/src/app/api/runs/[runId]/files/archive/route.ts
+++ b/packages/platform-ui/src/app/api/runs/[runId]/files/archive/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { WorkspaceReader } from '@mediforce/agent-runtime';
 import { HandlerError, NotFoundError } from '@mediforce/platform-api/errors';
-import { defaultBuildScope, defaultResolveCaller } from '@/lib/route-adapter';
+import { defaultBuildScope, defaultResolveCaller, jsonErrorResponse } from '@/lib/route-adapter';
 import { attachmentContentDisposition } from '@/lib/file-content-type';
 
 interface RouteContext {
@@ -24,7 +24,7 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
 
     const run = await scope.runs.getById(runId);
     if (run === null) {
-      return errorResponse(new NotFoundError(`Run ${runId} not found`));
+      return jsonErrorResponse(new NotFoundError(`Run ${runId} not found`));
     }
 
     const archive = await new WorkspaceReader().archiveOutputFiles(
@@ -32,7 +32,7 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
       runId,
     );
     if (archive === null) {
-      return errorResponse(new NotFoundError(`No output files found for run ${runId}`));
+      return jsonErrorResponse(new NotFoundError(`No output files found for run ${runId}`));
     }
 
     const fileName = `${run.definitionName}-${runId.slice(0, 8)}-output.zip`;
@@ -45,12 +45,8 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
       },
     });
   } catch (err) {
-    if (err instanceof HandlerError) return errorResponse(err);
+    if (err instanceof HandlerError) return jsonErrorResponse(err);
     console.error('[run-output-files-archive-route] handler error:', err);
-    return errorResponse(new HandlerError('internal', 'Internal error'));
+    return jsonErrorResponse(new HandlerError('internal', 'Internal error'));
   }
-}
-
-function errorResponse(err: HandlerError): NextResponse {
-  return NextResponse.json(err.toEnvelope(), { status: err.statusCode });
 }

--- a/packages/platform-ui/src/components/processes/run-output-files-panel.tsx
+++ b/packages/platform-ui/src/components/processes/run-output-files-panel.tsx
@@ -155,7 +155,7 @@ export function RunOutputFilesPanel({
     return null;
   }
 
-  const totalSize = files.reduce((sum, f) => sum + f.size, 0);
+  const totalSize = files.reduce((sum, file) => sum + file.size, 0);
 
   async function handleDownloadAll() {
     setDownloadingAll(true);

--- a/packages/platform-ui/src/lib/route-adapter.ts
+++ b/packages/platform-ui/src/lib/route-adapter.ts
@@ -121,8 +121,10 @@ export function createRouteAdapter<
 
 // `HandlerError.toEnvelope()` is the ADR-0005 §1 wire shape; `statusCode` is
 // derived from `code` via the §3 table inside the class. This adapter is the
-// only place that turns a HandlerError into an HTTP response.
-function jsonErrorResponse(err: HandlerError): NextResponse {
+// canonical place that turns a HandlerError into an HTTP response; the rare
+// binary routes that can't compose through `createRouteAdapter` reuse this so
+// their error envelopes stay byte-identical to the JSON routes'.
+export function jsonErrorResponse(err: HandlerError): NextResponse {
   return NextResponse.json(err.toEnvelope(), { status: err.statusCode });
 }
 


### PR DESCRIPTION
Follow-up to #826 (bulk download of run output files as a zip archive). A
post-merge self-review surfaced three items; this PR addresses them. No
user-observable change — test coverage + internal cleanup only.

## What self-review found & how it's addressed

1. **Missing L3 coverage for the new archive endpoint.** `GET
   /api/runs/<id>/files/archive` shipped with only L1 (`archiveOutputFiles`)
   coverage, while the sibling single-file download route it clones is
   L3-tested in the same journey. AGENTS.md mandates L3 for product features
   (proves storage backend + middleware + auth).
   → Extended `run-output-files.journey.ts` with archive cases: happy-path zip
   (200, `application/zip`, `Content-Disposition` filename, `PK` zip magic +
   non-empty body), out-of-scope/missing run → 404 (anti-enumeration), and
   401 unauthenticated.

2. **Duplicated `errorResponse` helper.** Both binary file routes
   (`archive/route.ts` and `[...path]/route.ts`) defined byte-identical local
   `errorResponse` functions, itself a copy of `jsonErrorResponse` inside
   `route-adapter.ts`.
   → Exported the existing `jsonErrorResponse` from `route-adapter` and reused
   it in both routes, deleting both local copies. Single source of truth.

3. **One-letter identifiers** (`f`, `e`) — AGENTS.md §9.
   → Renamed to `file` / `entry`.

## Verification

- `pnpm typecheck` — pass
- `@mediforce/agent-runtime` unit suite — 454 passed / 1 skipped
- e2e: the two archive/preview failures seen during review were a **stale
  `.next` build** (see #884), not code — resolved by a fresh `build:e2e`; the
  archive L3 cases pass against a current build.

Changelog intentionally skipped: no user-facing change (the feature itself was
logged with #826).
