### PR TITLE
fix: recover runs stranded in running via heartbeat re-kick (#892) (outdated)

### DIFF
--- a/packages/platform-api/src/handlers/cron/__tests__/heartbeat.test.ts
+++ b/packages/platform-api/src/handlers/cron/__tests__/heartbeat.test.ts
@@ -4,6 +4,7 @@ import {
   InMemoryCronTriggerStateRepository,
   InMemoryProcessInstanceRepository,
   InMemoryProcessRepository,
+  buildProcessInstance,
   buildWorkflowDefinition,
   resetFactorySequence,
 } from '@mediforce/platform-core/testing';
@@ -188,5 +189,81 @@ describe('heartbeat handler', () => {
     });
     expect(fireWorkflow).not.toHaveBeenCalled();
     expect(kicker.kicks).toHaveLength(0);
+  });
+
+  it('re-kicks a running run stranded past the idle bound and emits an audit', async () => {
+    const strandedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    await instanceRepo.create(
+      buildProcessInstance({
+        id: 'inst-stranded',
+        namespace: 'team-alpha',
+        status: 'running',
+        currentStepId: 'arm-timer',
+        updatedAt: strandedAt,
+      }),
+    );
+
+    const kicker = noopRunKicker();
+    const scope = createTestScope({
+      processRepo,
+      instanceRepo,
+      auditRepo,
+      cronTriggerStateRepo,
+      runKicker: kicker,
+    });
+    Object.assign(scope.system, { cronTrigger: { fireWorkflow: vi.fn() } });
+
+    const result = await heartbeat({}, scope);
+
+    expect(result.triggered).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+
+    expect(kicker.kicks).toEqual([
+      { instanceId: 'inst-stranded', triggeredBy: 'cron-heartbeat' },
+    ]);
+
+    const events = await auditRepo.getByProcess('inst-stranded');
+    const event = events.find((e) => e.action === 'instance.stranded_rekicked');
+    expect(event).toBeDefined();
+    expect(event!.actorId).toBe('cron-heartbeat');
+    expect(event!.actorType).toBe('system');
+    expect(event!.actorRole).toBe('scheduler');
+    expect(event!.entityType).toBe('processInstance');
+    expect(event!.entityId).toBe('inst-stranded');
+    expect(event!.processInstanceId).toBe('inst-stranded');
+    expect(event!.inputSnapshot).toMatchObject({
+      runId: 'inst-stranded',
+      currentStepId: 'arm-timer',
+      updatedAt: strandedAt,
+    });
+    expect(event!.outputSnapshot).toMatchObject({ reKick: true });
+  });
+
+  it('does not re-kick a recently-updated running run', async () => {
+    await instanceRepo.create(
+      buildProcessInstance({
+        id: 'inst-fresh',
+        namespace: 'team-alpha',
+        status: 'running',
+        currentStepId: 'arm-timer',
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    const kicker = noopRunKicker();
+    const scope = createTestScope({
+      processRepo,
+      instanceRepo,
+      auditRepo,
+      cronTriggerStateRepo,
+      runKicker: kicker,
+    });
+    Object.assign(scope.system, { cronTrigger: { fireWorkflow: vi.fn() } });
+
+    await heartbeat({}, scope);
+
+    expect(kicker.kicks).toHaveLength(0);
+    const events = await auditRepo.getByProcess('inst-fresh');
+    expect(events.filter((e) => e.action === 'instance.stranded_rekicked')).toEqual([]);
   });
 });

--- a/packages/platform-api/src/handlers/cron/heartbeat.ts
+++ b/packages/platform-api/src/handlers/cron/heartbeat.ts
@@ -167,5 +167,48 @@ export async function heartbeat(
     }
   }
 
+  // Sweep: re-kick runs stranded in `running` past the step-timeout bound.
+  // A `running` run whose driver request died mid-step (deploy, crash, OOM,
+  // gateway timeout) is invisible to every other sweep — only `paused` is
+  // swept — and would sit at its current step indefinitely. Re-kick, not
+  // fail: `/run` returns 409 while a live driver still holds the per-process
+  // lock, so only genuinely driverless runs advance. The bound sits well
+  // above the 30-minute default step timeout, so a legitimately long step is
+  // never mistaken for a stranded one.
+  const STRANDED_RUNNING_BOUND_MS = 45 * 60 * 1000;
+  const runningInstances = await scope.runs.getByStatus('running');
+  const strandedRunningInstances = runningInstances.filter((inst) => {
+    const idleMs = now.getTime() - new Date(inst.updatedAt).getTime();
+    return idleMs > STRANDED_RUNNING_BOUND_MS;
+  });
+
+  for (const inst of strandedRunningInstances) {
+    try {
+      await scope.system.runKicker.kick(inst.id, { triggeredBy: 'cron-heartbeat' });
+      await scope.system.audit.append({
+        actorId: 'cron-heartbeat',
+        actorType: 'system',
+        actorRole: 'scheduler',
+        action: 'instance.stranded_rekicked',
+        description: `Stranded running run '${inst.id}' re-kicked (idle past the ${STRANDED_RUNNING_BOUND_MS / 60000}-minute bound)`,
+        timestamp: now.toISOString(),
+        inputSnapshot: {
+          runId: inst.id,
+          currentStepId: inst.currentStepId,
+          updatedAt: inst.updatedAt,
+        },
+        outputSnapshot: { reKick: true },
+        basis: 'Heartbeat stranded-running sweep: run idle past the step-timeout bound',
+        entityType: 'processInstance',
+        entityId: inst.id,
+        processInstanceId: inst.id,
+        processDefinitionVersion: inst.definitionVersion,
+      });
+      console.log(`[cron-heartbeat] Re-kicked stranded running run '${inst.id}' (step: ${inst.currentStepId})`);
+    } catch (err) {
+      console.error(`[cron-heartbeat] Failed to re-kick stranded run '${inst.id}':`, err);
+    }
+  }
+
   return { triggered, skipped };
 }


### PR DESCRIPTION
Add a stranded-running sweep to the cron heartbeat: runs idle in status: running past a 45-minute bound (well above the 30-minute default step timeout) are re-kicked via runKicker. Only genuinely driverless runs advance because /run returns 409 while a live driver holds the per-process lock. Emits an instance.stranded_rekicked audit.

Closes #892

*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Description
*Clear and concise description of what changed and why.
If necessary, include screenshots and/or a step-by-step guide on how to test the changes.*

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
