### PR TITLE
fix(scripts): follow OpenRouter rankings endpoint to /v1 path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Fixed
+- `sync-model-rankings.py` follows OpenRouter's rankings endpoint move to the versioned `/api/frontend/v1/rankings/performance` path (old path now 404s), so the model-registry ranking sync works again.
 - Cancelling a run now reaps any in-flight step execution and agent run rows, so cancelled runs no longer leave the current step rendering as `running` forever. The reap is also guarded against a late worker write: a still-executing agent/script whose plugin finishes *after* the cancel no longer resurrects the reaped `StepExecution`/`AgentRun` to `completed` or persists its output/cost onto the cancelled instance — the runtime bails once it sees the parent is no longer active, and terminal `AgentRun` writes only apply to a row still `running` [#912](https://github.com/Appsilon/mediforce/issues/912).
 ### Added
 - Output File preview modal gains a **fullscreen toggle**: large HTML reports rendered in the sandboxed iframe previously nested scrollbars inside the centered `max-w-4xl`/`max-h-[85vh]` box. The new maximize button (shown for any previewable file) expands the modal to fill the viewport, and in fullscreen the HTML iframe fills the available height and scrolls its own content — a single native scrollbar instead of the iframe's clamped-height scrollbar nested inside the modal's.

--- a/scripts/sync-model-rankings.py
+++ b/scripts/sync-model-rankings.py
@@ -15,7 +15,7 @@ import urllib.request
 
 DEFAULT_BASE_URL = "http://localhost:9003"
 MOCK_DEV_BASE_URL = "http://localhost:9007"
-OPENROUTER_RANKINGS_URL = "https://openrouter.ai/api/frontend/rankings/performance"
+OPENROUTER_RANKINGS_URL = "https://openrouter.ai/api/frontend/v1/rankings/performance"
 
 
 def sync_models(base_url: str, api_key: str) -> dict:


### PR DESCRIPTION
## What

OpenRouter moved the frontend rankings endpoint to a versioned path:

- `https://openrouter.ai/api/frontend/rankings/performance` → **404**
- `https://openrouter.ai/api/frontend/v1/rankings/performance` → 200, identical `{data:[{id, request_count}]}` shape

So `scripts/sync-model-rankings.py` step 2 (fetch rankings) was silently broken — the in-app banner showed rankings *34 days* stale. URL-only change; parsing untouched.

## Verified on staging

Ran the fixed script against `https://staging.mediforce.ai`:

- 342 models synced from OpenRouter
- 156 rankings updated (156/156 matched the registry)
- `rankingsUpdatedAt` refreshed to current

## Note

This sync is **not automated** — no cron/workflow runs it; it drifts whenever OpenRouter moves the endpoint (2nd such move, cf. #543). Out of scope here, but worth a follow-up scheduled job if we want it to self-heal.