### PR TITLE
fix(authz): gate member email + last-sign-in to workspace admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Security
+- Workspace members list no longer exposes each member's email or last-sign-in timestamp to plain members: `listNamespaceMembers` now returns `email: null` and `lastSignInTime: null` for non-admin callers (owner/admin/apiKey still see them), and the settings page hides the "Email" and "Last sign in" columns for non-managers. The roster — name, avatar, role and join date — stays visible to all members. `getNamespace` now returns an `adminContact` field (the primary owner's name + email) so the run-start preflight "contact your admin" hint still works for a blocked non-admin — the one member email a plain member may see.
+
 ### Changed
 - Login page reorganized to a single focused view at a time: Google / password is the clear primary, "Email me a sign-in link" is one quiet secondary link, and the rare "resend setup link" recovery is a muted footer — each secondary action swaps the whole card to its own sub-view with a Back link (follow-up to [#1019](https://github.com/Appsilon/mediforce/issues/1019)).
 - `WebhookTriggerConfigSchema` (+ its `WebhookTriggerConfig` type) moved from `schemas/workflow-definition.ts` to `schemas/trigger.ts`, next to `TriggerResourceSchema` — its only consumers are the detached `webhook` trigger row and trigger-create validation, so it no longer belongs in the now trigger-free definition module. `HttpMethodSchema` stays in `workflow-definition.ts` (still shared with the `http` action step). Pure code-organization move; the `@mediforce/platform-core` barrel exports are unchanged [#932](https://github.com/Appsilon/mediforce/issues/932).

--- a/packages/platform-api/src/auth.ts
+++ b/packages/platform-api/src/auth.ts
@@ -96,13 +96,20 @@ export function filterByCaller<T>(
  * Per ADR-0004 §4 the wrapper layer (`AuthorizedScope`) does NOT consult roles;
  * this handler-resident helper is the only consumer.
  */
+export function callerIsNamespaceAdmin(
+  caller: CallerIdentity,
+  namespace: string,
+): boolean {
+  if (caller.isSystemActor) return true;
+  const role = caller.namespaceRoles.get(namespace);
+  return role === 'owner' || role === 'admin';
+}
+
 export function assertCallerIsNamespaceAdmin(
   caller: CallerIdentity,
   namespace: string,
 ): void {
-  if (caller.isSystemActor) return;
-  const role = caller.namespaceRoles.get(namespace);
-  if (role !== 'owner' && role !== 'admin') {
+  if (!callerIsNamespaceAdmin(caller, namespace)) {
     throw new ForbiddenError();
   }
 }

--- a/packages/platform-api/src/contract/namespaces.ts
+++ b/packages/platform-api/src/contract/namespaces.ts
@@ -8,14 +8,29 @@ import {
 } from '@mediforce/platform-core';
 
 export const GetNamespaceInputSchema = z.object({ handle: HandleSchema });
+
+/**
+ * Contact details of the workspace's primary owner (earliest-joined `owner`),
+ * exposed to every member so a non-admin can reach someone when a run is
+ * blocked or setup is missing. This is the ONE member email a plain member may
+ * see — the bulk `listNamespaceMembers` roster gates email/last-sign-in to
+ * admins. `null` when the workspace has no owner or no directory is wired.
+ */
+export const NamespaceAdminContactSchema = z.object({
+  displayName: z.string().nullable(),
+  email: z.string().nullable(),
+});
+
 export const GetNamespaceOutputSchema = z.object({
   namespace: NamespaceSchema,
   members: z.array(NamespaceMemberSchema),
   personalHandles: z.record(z.string(), z.string()).optional(),
+  adminContact: NamespaceAdminContactSchema.nullable(),
 });
 
 export type GetNamespaceInput = z.infer<typeof GetNamespaceInputSchema>;
 export type GetNamespaceOutput = z.infer<typeof GetNamespaceOutputSchema>;
+export type NamespaceAdminContact = z.infer<typeof NamespaceAdminContactSchema>;
 
 export const CreateNamespaceInputSchema = z.object({
   handle: HandleSchema,

--- a/packages/platform-api/src/contract/users.ts
+++ b/packages/platform-api/src/contract/users.ts
@@ -70,7 +70,17 @@ export const NamespaceMemberWithAuthSchema = NamespaceMemberSchema.extend({
    * chains `?? member.uid` to render a stable fallback.
    */
   displayName: z.string().nullable(),
+  /**
+   * Contact / PII, gated server-side to owner/admin (and apiKey) callers — see
+   * `listNamespaceMembers`. A plain member receives `null` for every row, so
+   * `null` means either "no email on file" or "caller not privileged"; the UI
+   * only shows the column to managers.
+   */
   email: z.string().nullable(),
+  /**
+   * Per-member activity data, gated the same way as `email`. `null` means
+   * either "never signed in" or "caller not privileged to see it".
+   */
   lastSignInTime: z.string().nullable(),
 });
 

--- a/packages/platform-api/src/handlers/namespaces/__tests__/get-namespace.test.ts
+++ b/packages/platform-api/src/handlers/namespaces/__tests__/get-namespace.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { Namespace, NamespaceMember } from '@mediforce/platform-core';
+import type { Namespace, NamespaceMember, UserDirectoryService } from '@mediforce/platform-core';
 import { InMemoryNamespaceRepo, createTestScope, userCaller } from '../../../testing/index';
 import { getNamespace } from '../get-namespace';
 import { NotFoundError } from '../../../errors';
+
+const directoryWithOwnerEmail: UserDirectoryService = {
+  async getUsersByRole() {
+    return [];
+  },
+  async getUserMetadata(uid: string) {
+    if (uid !== 'uid-owner') return null;
+    return {
+      displayName: 'Acme Owner',
+      email: 'owner@acme.test',
+      lastSignInTime: '2026-05-01T10:00:00.000Z',
+      photoURL: null,
+    };
+  },
+};
 
 const ACME: Namespace = {
   handle: 'acme',
@@ -43,6 +58,36 @@ describe('getNamespace handler', () => {
 
     expect(result.namespace.handle).toBe('acme');
     expect(result.members.map((m) => m.uid)).toEqual(['uid-owner', 'uid-member']);
+  });
+
+  it('exposes the primary owner as adminContact to a plain member', async () => {
+    const scope = createTestScope({
+      namespaceRepo,
+      userDirectory: directoryWithOwnerEmail,
+      caller: userCaller('uid-member', ['acme']),
+    });
+
+    const result = await getNamespace({ handle: 'acme' }, scope);
+
+    expect(result.adminContact).toEqual({
+      displayName: 'Acme Owner',
+      email: 'owner@acme.test',
+    });
+    // Roster is still email-free — email is only in adminContact, not per row.
+    expect(result.members.every((m) => !('email' in m))).toBe(true);
+  });
+
+  it('returns null adminContact when no directory is wired', async () => {
+    const scope = createTestScope({
+      namespaceRepo,
+      userDirectory: null,
+      caller: userCaller('uid-member', ['acme']),
+    });
+
+    const result = await getNamespace({ handle: 'acme' }, scope);
+
+    // Owner exists, but with no directory there is no email to resolve.
+    expect(result.adminContact).toEqual({ displayName: null, email: null });
   });
 
   it('throws NotFoundError when the namespace does not exist', async () => {

--- a/packages/platform-api/src/handlers/namespaces/get-namespace.ts
+++ b/packages/platform-api/src/handlers/namespaces/get-namespace.ts
@@ -1,11 +1,20 @@
 import { NotFoundError } from '../../errors';
 import type { CallerScope } from '../../repositories/index';
-import type { GetNamespaceInput, GetNamespaceOutput } from '../../contract/namespaces';
+import type {
+  GetNamespaceInput,
+  GetNamespaceOutput,
+  NamespaceAdminContact,
+} from '../../contract/namespaces';
 
 /**
  * Return a workspace's metadata + member list. Anti-enum on access:
  * non-members get the same 404 as a missing handle so namespace existence
  * does not leak to outsiders. apiKey callers bypass.
+ *
+ * `members` carries only the roster (no email / last-sign-in); those are
+ * gated to admins in `listNamespaceMembers`. `adminContact` is the single
+ * exception — the primary owner's name + email, surfaced to every member so a
+ * blocked non-admin has someone to reach.
  */
 export async function getNamespace(
   input: GetNamespaceInput,
@@ -40,5 +49,38 @@ export async function getNamespace(
     }
   }
 
-  return { namespace, members, personalHandles };
+  const adminContact = await resolveAdminContact(members, scope);
+
+  return { namespace, members, personalHandles, adminContact };
+}
+
+/**
+ * The earliest-joined `owner` is the workspace's primary contact. Returns
+ * `null` when there is no owner or no directory is wired; falls back to the
+ * member doc's displayName when the directory lookup yields none.
+ */
+async function resolveAdminContact(
+  members: Awaited<ReturnType<CallerScope['workspaces']['getMembers']>>,
+  scope: CallerScope,
+): Promise<NamespaceAdminContact | null> {
+  const owner = members
+    .filter((m) => m.role === 'owner')
+    .sort((a, b) => a.joinedAt.localeCompare(b.joinedAt))[0];
+  if (owner === undefined) return null;
+
+  const docDisplayName =
+    typeof owner.displayName === 'string' && owner.displayName.length > 0
+      ? owner.displayName
+      : null;
+
+  const directory = scope.system.userDirectory;
+  if (directory === null) {
+    return { displayName: docDisplayName, email: null };
+  }
+
+  const metadata = await directory.getUserMetadata(owner.uid).catch(() => null);
+  return {
+    displayName: docDisplayName ?? metadata?.displayName ?? null,
+    email: metadata?.email ?? null,
+  };
 }

--- a/packages/platform-api/src/handlers/users/__tests__/list-members.test.ts
+++ b/packages/platform-api/src/handlers/users/__tests__/list-members.test.ts
@@ -72,6 +72,13 @@ describe('listNamespaceMembers handler', () => {
     const result = await listNamespaceMembers({ namespace: 'alpha' }, scope);
 
     expect(result.members).toHaveLength(2);
+    // Manager fields are gated: a plain member sees no email / lastSignInTime.
+    for (const member of result.members) {
+      expect(member.email).toBeNull();
+      expect(member.lastSignInTime).toBeNull();
+    }
+    // Roster (uid/role/displayName) stays visible.
+    expect(result.members[0]).toMatchObject({ uid: 'uid-owner', role: 'owner', displayName: 'Alpha Owner' });
   });
 
   it('returns the list for an owner of the namespace', async () => {
@@ -88,6 +95,11 @@ describe('listNamespaceMembers handler', () => {
     const result = await listNamespaceMembers({ namespace: 'alpha' }, scope);
 
     expect(result.members.map((m) => m.uid)).toEqual(['uid-owner', 'uid-member']);
+    // Owner is privileged: real email + lastSignInTime come through.
+    expect(result.members[0]).toMatchObject({
+      email: 'owner@alpha.test',
+      lastSignInTime: '2026-05-01T10:00:00.000Z',
+    });
   });
 
   it('throws NotFoundError (anti-enum) when caller is not a namespace member', async () => {

--- a/packages/platform-api/src/handlers/users/list-members.ts
+++ b/packages/platform-api/src/handlers/users/list-members.ts
@@ -1,3 +1,4 @@
+import { callerIsNamespaceAdmin } from '../../auth';
 import { NotFoundError } from '../../errors';
 import type { CallerScope } from '../../repositories/index';
 import type {
@@ -11,6 +12,11 @@ import type {
  * metadata (email + lastSignInTime) merged in. Read-only — every active
  * member (any role) may read; non-members get an anti-enum 404 rather than
  * a 403 so that namespace existence does not leak to outsiders.
+ *
+ * `email` (contact / PII) and `lastSignInTime` (activity) are manager fields,
+ * gated to owner/admin (and apiKey) callers: a plain member receives `null`
+ * for both on every row. The roster — name, avatar, role and join date —
+ * stays visible to all members so collaboration still works.
  *
  * apiKey callers bypass the membership gate (server-to-server trust).
  *
@@ -30,10 +36,11 @@ export async function listNamespaceMembers(
 
   const memberDocs = await scope.workspaces.getMembers(input.namespace);
   const directory = scope.system.userDirectory;
+  const canSeeManagerFields = callerIsNamespaceAdmin(scope.caller, input.namespace);
 
   if (directory === null) {
     return {
-      members: memberDocs.map((doc) => withAuth(doc, null)),
+      members: memberDocs.map((doc) => withAuth(doc, null, canSeeManagerFields)),
     };
   }
 
@@ -42,13 +49,14 @@ export async function listNamespaceMembers(
   );
 
   return {
-    members: memberDocs.map((doc, index) => withAuth(doc, authData[index])),
+    members: memberDocs.map((doc, index) => withAuth(doc, authData[index], canSeeManagerFields)),
   };
 }
 
 function withAuth(
   doc: Awaited<ReturnType<CallerScope['workspaces']['getMembers']>>[number],
   metadata: { email: string | null; displayName?: string | null; lastSignInTime: string | null; photoURL?: string | null } | null,
+  canSeeManagerFields: boolean,
 ): NamespaceMemberWithAuth {
   const docDisplayName = typeof doc.displayName === 'string' && doc.displayName.length > 0
     ? doc.displayName
@@ -57,7 +65,7 @@ function withAuth(
     ...doc,
     avatarUrl: doc.avatarUrl ?? metadata?.photoURL ?? undefined,
     displayName: docDisplayName ?? metadata?.displayName ?? null,
-    email: metadata?.email ?? null,
-    lastSignInTime: metadata?.lastSignInTime ?? null,
+    email: canSeeManagerFields ? metadata?.email ?? null : null,
+    lastSignInTime: canSeeManagerFields ? metadata?.lastSignInTime ?? null : null,
   };
 }

--- a/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/settings/page.tsx
@@ -905,10 +905,14 @@ export default function WorkspaceConfigPage() {
                 <thead>
                   <tr className="border-b bg-muted/50">
                     <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">User</th>
-                    <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">Email</th>
+                    {canManageMembers && (
+                      <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">Email</th>
+                    )}
                     <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">Role</th>
                     <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">Joined</th>
-                    <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">Last sign in</th>
+                    {canManageMembers && (
+                      <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">Last sign in</th>
+                    )}
                     <th className="px-4 py-2.5 text-right text-xs font-medium text-muted-foreground whitespace-nowrap sr-only">Actions</th>
                   </tr>
                 </thead>
@@ -943,10 +947,12 @@ export default function WorkspaceConfigPage() {
                           </UserProfileLink>
                         </td>
 
-                        {/* Email */}
-                        <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
-                          {member.email ?? '—'}
-                        </td>
+                        {/* Email — owner/admin only; server returns null for members */}
+                        {canManageMembers && (
+                          <td className="px-4 py-3 text-xs text-muted-foreground whitespace-nowrap">
+                            {member.email ?? '—'}
+                          </td>
+                        )}
 
                         {/* Role */}
                         <td className="px-4 py-3 whitespace-nowrap">
@@ -969,12 +975,14 @@ export default function WorkspaceConfigPage() {
                           {formatDate(member.joinedAt)}
                         </td>
 
-                        {/* Last sign in */}
-                        <td className="px-4 py-3 whitespace-nowrap text-xs text-muted-foreground">
-                          {member.lastSignInTime === null || member.lastSignInTime === undefined
-                            ? <span className="text-muted-foreground/50">Never</span>
-                            : formatLastSignIn(member.lastSignInTime)}
-                        </td>
+                        {/* Last sign in — owner/admin only; server returns null for members */}
+                        {canManageMembers && (
+                          <td className="px-4 py-3 whitespace-nowrap text-xs text-muted-foreground">
+                            {member.lastSignInTime === null || member.lastSignInTime === undefined
+                              ? <span className="text-muted-foreground/50">Never</span>
+                              : formatLastSignIn(member.lastSignInTime)}
+                          </td>
+                        )}
 
                         {/* Actions */}
                         <td className="px-4 py-3 whitespace-nowrap">

--- a/packages/platform-ui/src/app/api/users/members/__tests__/route.test.ts
+++ b/packages/platform-ui/src/app/api/users/members/__tests__/route.test.ts
@@ -47,6 +47,16 @@ function memberCaller(handle = 'alpha') {
   };
 }
 
+function adminCaller(handle = 'alpha') {
+  return {
+    kind: 'user' as const,
+    uid: 'uid-admin',
+    namespaces: new Set([handle]),
+    namespaceRoles: new Map([[handle, 'admin' as const]]),
+    isSystemActor: false as const,
+  };
+}
+
 const apiKeyCaller = { kind: 'apiKey' as const, isSystemActor: true as const };
 
 function makeGetRequest(query: Record<string, string> = {}): NextRequest {
@@ -94,6 +104,35 @@ describe('GET /api/users/members', () => {
     const res = await GET(makeGetRequest({ namespace: 'alpha' }));
 
     expect(res.status).toBe(200);
+  });
+
+  it('[AUTHZ] member caller does not receive email or lastSignInTime (gated to admins)', async () => {
+    mockResolveCallerIdentity.mockResolvedValue(memberCaller('alpha'));
+
+    const res = await GET(makeGetRequest({ namespace: 'alpha' }));
+    const json = (await res.json()) as {
+      members: Array<{ uid: string; role: string; email: string | null; lastSignInTime: string | null }>;
+    };
+
+    expect(res.status).toBe(200);
+    expect(json.members).toHaveLength(1);
+    // Roster (uid/role) stays; manager fields are stripped.
+    expect(json.members[0]).toMatchObject({ uid: 'uid-member', role: 'member' });
+    expect(json.members[0]?.email).toBeNull();
+    expect(json.members[0]?.lastSignInTime).toBeNull();
+  });
+
+  it('[AUTHZ] admin caller does receive email and lastSignInTime', async () => {
+    mockResolveCallerIdentity.mockResolvedValue(adminCaller('alpha'));
+
+    const res = await GET(makeGetRequest({ namespace: 'alpha' }));
+    const json = (await res.json()) as {
+      members: Array<{ email: string | null; lastSignInTime: string | null }>;
+    };
+
+    expect(res.status).toBe(200);
+    expect(json.members[0]?.email).toBe('member@alpha.test');
+    expect(json.members[0]?.lastSignInTime).toBe('2026-05-01T00:00:00.000Z');
   });
 
   it('[AUTHZ] non-member gets 404 (anti-enum bug fix)', async () => {

--- a/packages/platform-ui/src/hooks/use-namespace-admin-contact.ts
+++ b/packages/platform-ui/src/hooks/use-namespace-admin-contact.ts
@@ -5,26 +5,28 @@ import { mediforce } from '@/lib/mediforce';
 import { queryKeys } from '@/lib/query-keys';
 import { stopRetryOn4xx } from '@/lib/retry';
 
+/**
+ * Primary-owner contact for a workspace, surfaced to any member (e.g. the
+ * run-start preflight "contact your admin" hint). Reads the workspace detail
+ * endpoint's `adminContact` — the member roster gates every other email to
+ * admins, so this dedicated field is the one contact a plain member may see.
+ */
 export function useNamespaceAdminContact(handle: string | undefined): {
   email: string | null;
   displayName: string | null;
   isLoading: boolean;
 } {
   const query = useQuery({
-    queryKey: queryKeys.namespaceMembers(handle ?? ''),
-    queryFn: async () => mediforce.users.listMembers({ namespace: handle as string }),
+    queryKey: queryKeys.namespace(handle ?? ''),
+    queryFn: async () => mediforce.namespaces.get({ handle: handle as string }),
     enabled: typeof handle === 'string' && handle.length > 0,
     retry: stopRetryOn4xx,
     staleTime: 5 * 60 * 1000,
   });
 
-  const owner = query.data?.members
-    .filter((m) => m.role === 'owner')
-    .sort((a, b) => a.joinedAt.localeCompare(b.joinedAt))[0] ?? null;
-
   return {
-    email: owner?.email ?? null,
-    displayName: owner?.displayName ?? null,
+    email: query.data?.adminContact?.email ?? null,
+    displayName: query.data?.adminContact?.displayName ?? null,
     isLoading: query.isLoading,
   };
 }

--- a/packages/platform-ui/src/hooks/use-namespace-mutations.ts
+++ b/packages/platform-ui/src/hooks/use-namespace-mutations.ts
@@ -62,7 +62,7 @@ export function useUpdateNamespace(handle: string) {
     },
     onSuccess: (data) => {
       qc.setQueryData<GetNamespaceOutput | undefined>(queryKeys.namespace(handle), (prev) => {
-        if (prev === undefined) return { namespace: data.namespace, members: [] };
+        if (prev === undefined) return { namespace: data.namespace, members: [], adminContact: null };
         return { ...prev, namespace: data.namespace };
       });
       qc.setQueryData<GetMeOutput | undefined>(queryKeys.users.me(), (prev) => {

--- a/packages/platform-ui/src/lib/query-keys.ts
+++ b/packages/platform-ui/src/lib/query-keys.ts
@@ -102,7 +102,6 @@ export const queryKeys = {
   },
   /** Single-namespace detail (members + metadata). */
   namespace: (handle: string) => ['namespace', handle] as const,
-  namespaceMembers: (handle: string) => ['namespace-members', handle] as const,
   agentRuns: {
     /** Prefix matcher — `['agent-runs']` invalidates every list slice. */
     all: () => ['agent-runs'] as const,


### PR DESCRIPTION
## Problem

In the workspace members list, a plain `member` (not admin/owner) could see every member's **email** and **last-sign-in** timestamp — contact PII + activity data a non-admin arguably shouldn't have.

## Decision

Split member-row fields into **roster** (visible to all members) vs **manager fields** (owner/admin only):

| Field | Visible to |
|-------|-----------|
| name, avatar, role, joined date | all members |
| **email**, **last sign in** | owner / admin (and apiKey) |

Enforced **server-side** in `listNamespaceMembers` — non-admin callers receive `email: null` / `lastSignInTime: null`. UI column-hiding in settings is defense-in-depth, not the boundary.

## Admin-contact exception

The run-start preflight "contact your workspace admin at `<email>`" hint (shown to a blocked non-admin) previously pulled the owner's email from the now-gated roster. Rather than a new endpoint, `getNamespace` (the existing workspace read, already fetched app-wide) gains an `adminContact` field = the primary owner's name + email. This is the one member email a plain member may see — a narrow, justified disclosure.

## Changes

- `listNamespaceMembers` gates `email` + `lastSignInTime` behind new `callerIsNamespaceAdmin` predicate (extracted from the existing `assert…` helper).
- `getNamespace` returns `adminContact`; `useNamespaceAdminContact` reads it instead of scanning `listMembers`.
- Settings page hides Email + Last-sign-in columns for non-managers.
- Removed orphaned `queryKeys.namespaceMembers`.

## Tests

- L3 route test: member caller receives `email: null` + `lastSignInTime: null`; admin receives real values.
- L2 handler tests for both `listNamespaceMembers` gating and `getNamespace.adminContact` (incl. no-directory fallback).

typecheck + affected tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)