### PR TITLE
fix: image builder clones public repos over anonymous HTTPS (#1079)

### DIFF
--- a/packages/agent-runtime/src/plugins/__tests__/container-plugin.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/container-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatExitInfo, deriveBuildTag, resolveSkillsCloneUrl } from '../container-plugin';
+import { formatExitInfo, deriveBuildTag, resolveRepoCloneUrl } from '../container-plugin';
 
 describe('formatExitInfo', () => {
   it('[DATA] reports the exit code when the process exited normally', () => {
@@ -63,39 +63,39 @@ describe('deriveBuildTag', () => {
   });
 });
 
-describe('resolveSkillsCloneUrl', () => {
+describe('resolveRepoCloneUrl', () => {
   it('[DATA] clones an https ref over HTTPS as given, no SSH', () => {
-    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('https://github.com/Appsilon/mediforce');
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl('https://github.com/Appsilon/mediforce');
     expect(cloneUrl).toBe('https://github.com/Appsilon/mediforce');
     expect(useSsh).toBe(false);
   });
 
   it('[DATA] clones a git@ ref over SSH as given, never converting to HTTPS', () => {
-    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('git@github.com:Appsilon/mediforce.git');
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl('git@github.com:Appsilon/mediforce.git');
     expect(cloneUrl).toBe('git@github.com:Appsilon/mediforce.git');
     expect(useSsh).toBe(true);
   });
 
   it('[DATA] clones an owner/repo shorthand over anonymous HTTPS', () => {
-    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('Appsilon/mediforce');
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl('Appsilon/mediforce');
     expect(cloneUrl).toBe('https://github.com/Appsilon/mediforce');
     expect(useSsh).toBe(false);
   });
 
   it('[DATA] uses authenticated HTTPS (PAT) when a token is provided, even for an https ref', () => {
-    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('https://github.com/Appsilon/mediforce', 'TOK');
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl('https://github.com/Appsilon/mediforce', 'TOK');
     expect(cloneUrl).toBe('https://x-access-token:TOK@github.com/Appsilon/mediforce.git');
     expect(useSsh).toBe(false);
   });
 
   it('[DATA] a token forces HTTPS even when the ref is given in SSH form', () => {
-    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('git@github.com:Appsilon/mediforce.git', 'TOK');
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl('git@github.com:Appsilon/mediforce.git', 'TOK');
     expect(cloneUrl).toBe('https://x-access-token:TOK@github.com/Appsilon/mediforce.git');
     expect(useSsh).toBe(false);
   });
 
   it('[DATA] clones a local path directly, no SSH', () => {
-    const { cloneUrl, useSsh } = resolveSkillsCloneUrl('/path/to/bare.git');
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl('/path/to/bare.git');
     expect(cloneUrl).toBe('/path/to/bare.git');
     expect(useSsh).toBe(false);
   });

--- a/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/docker-image-builder.test.ts
@@ -152,6 +152,66 @@ describe('buildImageFromRepo', () => {
 
     expect(rmMock).toHaveBeenCalledWith('/tmp/mediforce-build-abc', { recursive: true, force: true });
   });
+
+  it('clones a public owner/repo repoRef over anonymous HTTPS, no SSH deploy key', async () => {
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await buildImageFromRepo({
+      image: 'test-image',
+      repoUrl: 'git@github.com:Appsilon/mediforce.git',
+      repoRef: 'Appsilon/mediforce',
+      commit: 'abc123',
+    });
+
+    const calls = execSyncMock.mock.calls;
+    const remoteAdd = calls.find(([cmd]) => String(cmd).includes('remote add origin'));
+    expect(remoteAdd).toBeDefined();
+    expect(String(remoteAdd![0])).toContain('"https://github.com/Appsilon/mediforce"');
+
+    // A public clone must not reference a deploy key — no GIT_SSH_COMMAND on any git call.
+    for (const callArgs of calls) {
+      const env = (callArgs[1] as { env?: Record<string, string> }).env ?? {};
+      expect(env.GIT_SSH_COMMAND).toBeUndefined();
+    }
+  });
+
+  it('uses authenticated HTTPS when a token is provided, no SSH deploy key', async () => {
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await buildImageFromRepo({
+      image: 'test-image',
+      repoUrl: 'git@github.com:Appsilon/mediforce.git',
+      repoRef: 'Appsilon/mediforce',
+      commit: 'abc123',
+      repoToken: 'TOK',
+    });
+
+    const remoteAdd = execSyncMock.mock.calls.find(([cmd]) => String(cmd).includes('remote add origin'));
+    expect(String(remoteAdd![0])).toContain('https://x-access-token:TOK@github.com/Appsilon/mediforce.git');
+
+    for (const callArgs of execSyncMock.mock.calls) {
+      const env = (callArgs[1] as { env?: Record<string, string> }).env ?? {};
+      expect(env.GIT_SSH_COMMAND).toBeUndefined();
+    }
+  });
+
+  it('clones a git@ repoRef over SSH and sets GIT_SSH_COMMAND', async () => {
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    await buildImageFromRepo({
+      image: 'test-image',
+      repoUrl: 'git@github.com:Appsilon/mediforce.git',
+      repoRef: 'git@github.com:Appsilon/mediforce.git',
+      commit: 'abc123',
+    });
+
+    const remoteAdd = execSyncMock.mock.calls.find(([cmd]) => String(cmd).includes('remote add origin'));
+    expect(String(remoteAdd![0])).toContain('"git@github.com:Appsilon/mediforce.git"');
+
+    const gitCall = execSyncMock.mock.calls.find(([cmd]) => String(cmd).startsWith('git '));
+    const env = (gitCall![1] as { env: Record<string, string> }).env;
+    expect(env.GIT_SSH_COMMAND).toBeDefined();
+  });
 });
 
 describe('ensureImage', () => {

--- a/packages/agent-runtime/src/plugins/__tests__/lazy-build-local.integration.test.ts
+++ b/packages/agent-runtime/src/plugins/__tests__/lazy-build-local.integration.test.ts
@@ -74,6 +74,7 @@ describe.skipIf(!dockerAvailable())('LocalDockerSpawnStrategy with lazy image bu
         imageBuild: {
           image,
           repoUrl: repo.repoPath,
+          repoRef: repo.repoPath,
           commit: repo.commitSha,
         },
       });

--- a/packages/agent-runtime/src/plugins/container-plugin.ts
+++ b/packages/agent-runtime/src/plugins/container-plugin.ts
@@ -168,6 +168,7 @@ export function resolveImageBuild(
     return {
       image: image ?? deriveBuildTag(repoUrl, commit, dockerfile),
       repoUrl,
+      repoRef: repo,
       commit,
       dockerfile,
       repoToken: resolveRepoToken(buildConfig, context, resolvedEnv),
@@ -177,10 +178,12 @@ export function resolveImageBuild(
   if (dockerfile && isWorkflowAgentContext(context)) {
     const wfRepo = context.workflowDefinition.externalSkillsRepo;
     if (wfRepo?.url && wfRepo?.commit) {
-      const repoUrl = repo ? normalizeRepoUrls(repo).gitUrl : normalizeRepoUrls(wfRepo.url).gitUrl;
+      const repoRef = repo ?? wfRepo.url;
+      const repoUrl = normalizeRepoUrls(repoRef).gitUrl;
       return {
         image: image ?? deriveBuildTag(repoUrl, commit ?? wfRepo.commit, dockerfile),
         repoUrl,
+        repoRef,
         commit: commit ?? wfRepo.commit,
         dockerfile,
         repoToken: resolveRepoToken(buildConfig, context, resolvedEnv),
@@ -214,17 +217,20 @@ export function toHttpsWithToken(sshUrl: string, token: string): string {
 }
 
 /**
- * Resolve the clone URL + transport for a skills repo reference, honouring the
- * form the user supplied: an `https://` URL clones over HTTPS, a `git@` URL
- * clones over SSH. We never silently convert one to the other.
+ * Resolve the clone URL + transport for a repo reference, honouring the form the
+ * user supplied: an `https://` URL clones over HTTPS, a `git@` URL clones over
+ * SSH. We never silently convert one to the other.
  *
  *   - token present  → authenticated HTTPS (`x-access-token`); a PAT only works
  *                      over HTTPS, mirroring the main-repo clone path
  *   - `git@…`        → SSH as given (needs deploy key + `GIT_SSH_COMMAND`)
  *   - `https://…` / local path → HTTPS / local as given
  *   - `owner/repo` shorthand   → anonymous HTTPS (github default)
+ *
+ * Shared by the skills-fetch and the lazy image-build clone paths so they pick
+ * the transport the same way — a public repo never needs a deploy key.
  */
-export function resolveSkillsCloneUrl(
+export function resolveRepoCloneUrl(
   repoRef: string,
   repoToken?: string,
 ): { cloneUrl: string; useSsh: boolean } {
@@ -462,7 +468,7 @@ export abstract class ContainerPlugin implements StepExecutorPlugin {
     const cloneDir = mkdtempSync(join(tmpdir(), 'mediforce-skills-clone-'));
 
     try {
-      const { cloneUrl, useSsh } = resolveSkillsCloneUrl(repoRef, repoToken);
+      const { cloneUrl, useSsh } = resolveRepoCloneUrl(repoRef, repoToken);
       // SSH refs need a deploy key + GIT_SSH_COMMAND; HTTPS and local paths must not set it.
       const execOpts = {
         stdio: 'pipe' as const,

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -9,11 +9,15 @@ import { execSync } from 'node:child_process';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { prepareDeployKeyPath, toHttpsWithToken } from './container-plugin';
+import { prepareDeployKeyPath, resolveRepoCloneUrl } from './container-plugin';
 
 export interface BuildImageOptions {
   image: string;
+  /** SSH-form git URL — cache-tag identity only, not the clone transport. */
   repoUrl: string;
+  /** Original user-supplied repo reference — decides the clone transport. Falls
+   *  back to `repoUrl` (SSH form) so legacy callers keep their previous behaviour. */
+  repoRef?: string;
   commit: string;
   dockerfile?: string;
   repoToken?: string;
@@ -22,6 +26,7 @@ export interface BuildImageOptions {
 export interface EnsureImageOptions {
   image: string;
   repoUrl?: string;
+  repoRef?: string;
   commit?: string;
   dockerfile?: string;
   repoToken?: string;
@@ -58,14 +63,18 @@ export async function getImageBuildCommit(image: string): Promise<string | null>
 }
 
 export async function buildImageFromRepo(options: BuildImageOptions): Promise<void> {
-  const { image, repoUrl, commit, dockerfile = 'Dockerfile', repoToken } = options;
+  const { image, repoUrl, repoRef, commit, dockerfile = 'Dockerfile', repoToken } = options;
   const buildDir = await mkdtemp(join(tmpdir(), 'mediforce-build-'));
 
   try {
-    const cloneUrl = repoToken ? toHttpsWithToken(repoUrl, repoToken) : repoUrl;
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl(repoRef ?? repoUrl, repoToken);
+    // SSH clones need a deploy key + GIT_SSH_COMMAND; anonymous/authenticated HTTPS
+    // and local paths must not reference the deploy key at all.
     const execOpts = {
       stdio: 'pipe' as const,
-      env: { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() },
+      env: useSsh
+        ? { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() }
+        : { ...process.env },
     };
 
     // Clone repo at specific commit (sparse — fetch only what we need)
@@ -120,7 +129,7 @@ export async function ensureImage(options: EnsureImageOptions): Promise<void> {
         console.log(`[docker-image-builder] Image "${image}" stale (${currentCommit?.slice(0, 8)} → ${commit.slice(0, 8)}), rebuilding`);
       }
 
-      await buildImageFromRepo({ image, repoUrl, commit, dockerfile, repoToken });
+      await buildImageFromRepo({ image, repoUrl, repoRef, commit, dockerfile, repoToken });
     } finally {
       buildLocks.delete(image);
     }

--- a/packages/agent-runtime/src/plugins/docker-image-builder.ts
+++ b/packages/agent-runtime/src/plugins/docker-image-builder.ts
@@ -98,7 +98,7 @@ export async function buildImageFromRepo(options: BuildImageOptions): Promise<vo
 }
 
 export async function ensureImage(options: EnsureImageOptions): Promise<void> {
-  const { image, repoUrl, commit, dockerfile, repoToken } = options;
+  const { image, repoUrl, repoRef, commit, dockerfile, repoToken } = options;
 
   // If repo+commit not provided, just check existence
   if (!repoUrl || !commit) {

--- a/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
+++ b/packages/agent-runtime/src/plugins/docker-spawn-strategy.ts
@@ -15,10 +15,17 @@ import { createLineStreamReader } from '@mediforce/platform-core';
 
 export interface ImageBuildMeta {
   image: string;
+  /** SSH-form git URL — used only as the cache-tag identity (deriveBuildTag + the
+   *  `mediforce.build.commit` label). Not the clone transport. */
   repoUrl: string;
+  /** Original user-supplied repo reference (pre-normalization): the step `repo` or
+   *  workflow `externalSkillsRepo.url`. Decides the clone transport — a public
+   *  `owner/repo` shorthand clones over anonymous HTTPS, exactly like skills-fetch. */
+  repoRef: string;
   commit: string;
   dockerfile?: string;
-  /** Resolved token for authenticated HTTPS clone. When absent, falls back to SSH deploy key. */
+  /** Resolved token for authenticated HTTPS clone. When absent, the transport falls
+   *  back to whatever the reference form implies (anonymous HTTPS / SSH). */
   repoToken?: string;
 }
 

--- a/packages/container-worker/src/docker-image-builder.ts
+++ b/packages/container-worker/src/docker-image-builder.ts
@@ -56,6 +56,30 @@ export async function getImageBuildCommit(image: string): Promise<string | null>
   }
 }
 
+/** Normalize a repo reference to SSH clone URL and HTTPS browsable URL.
+ *  Mirrors the copy in agent-runtime/plugins/container-plugin.ts — container-worker
+ *  cannot import from agent-runtime without dragging in its whole dependency tree. */
+function normalizeRepoUrls(repo: string): { gitUrl: string; httpsUrl: string } {
+  if (repo.startsWith('/') || repo.startsWith('.')) {
+    return { gitUrl: repo, httpsUrl: '' };
+  }
+  if (repo.startsWith('git@')) {
+    const match = repo.match(/git@github\.com:(.+?)(?:\.git)?$/);
+    const orgRepo = match ? match[1] : repo;
+    return { gitUrl: repo, httpsUrl: `https://github.com/${orgRepo}` };
+  }
+  if (repo.startsWith('https://')) {
+    const clean = repo.replace(/\.git$/, '');
+    const match = clean.match(/https:\/\/github\.com\/(.+)/);
+    const sshUrl = match ? `git@github.com:${match[1]}.git` : `${clean}.git`;
+    return { gitUrl: sshUrl, httpsUrl: clean };
+  }
+  return {
+    gitUrl: `git@github.com:${repo}.git`,
+    httpsUrl: `https://github.com/${repo}`,
+  };
+}
+
 function toHttpsWithToken(sshUrl: string, token: string): string {
   const match = sshUrl.match(/git@github\.com:(.+?)(?:\.git)?$/);
   if (match) {
@@ -64,21 +88,45 @@ function toHttpsWithToken(sshUrl: string, token: string): string {
   return sshUrl.replace('https://', `https://x-access-token:${token}@`);
 }
 
+/** Resolve the clone URL + transport for a repo reference, honouring the form the
+ *  user supplied. Mirrors resolveRepoCloneUrl in agent-runtime/plugins/container-plugin.ts
+ *  so the image-build clone path picks the transport the same way skills-fetch does. */
+function resolveRepoCloneUrl(
+  repoRef: string,
+  repoToken?: string,
+): { cloneUrl: string; useSsh: boolean } {
+  if (repoToken) {
+    return { cloneUrl: toHttpsWithToken(normalizeRepoUrls(repoRef).gitUrl, repoToken), useSsh: false };
+  }
+  if (repoRef.startsWith('git@')) {
+    return { cloneUrl: repoRef, useSsh: true };
+  }
+  if (repoRef.startsWith('https://') || repoRef.startsWith('/') || repoRef.startsWith('.')) {
+    return { cloneUrl: repoRef, useSsh: false };
+  }
+  return { cloneUrl: normalizeRepoUrls(repoRef).httpsUrl, useSsh: false };
+}
+
 export async function buildImageFromRepo(options: {
   image: string;
   repoUrl: string;
+  repoRef?: string;
   commit: string;
   dockerfile?: string;
   repoToken?: string;
 }): Promise<void> {
-  const { image, repoUrl, commit, dockerfile = 'Dockerfile', repoToken } = options;
+  const { image, repoUrl, repoRef, commit, dockerfile = 'Dockerfile', repoToken } = options;
   const buildDir = await mkdtemp(join(tmpdir(), 'mediforce-build-'));
 
   try {
-    const cloneUrl = repoToken ? toHttpsWithToken(repoUrl, repoToken) : repoUrl;
+    const { cloneUrl, useSsh } = resolveRepoCloneUrl(repoRef ?? repoUrl, repoToken);
+    // SSH clones need a deploy key + GIT_SSH_COMMAND; anonymous/authenticated HTTPS
+    // and local paths must not reference the deploy key at all.
     const execOpts = {
       stdio: 'pipe' as const,
-      env: { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() },
+      env: useSsh
+        ? { ...process.env, GIT_SSH_COMMAND: getGitSshCommand() }
+        : { ...process.env },
     };
 
     execSync(`git init "${buildDir}"`, execOpts);
@@ -102,11 +150,12 @@ export async function buildImageFromRepo(options: {
 export async function ensureImage(options: {
   image: string;
   repoUrl?: string;
+  repoRef?: string;
   commit?: string;
   dockerfile?: string;
   repoToken?: string;
 }): Promise<void> {
-  const { image, repoUrl, commit, dockerfile, repoToken } = options;
+  const { image, repoUrl, repoRef, commit, dockerfile, repoToken } = options;
 
   if (!repoUrl || !commit) {
     const exists = await imageExistsLocally(image);
@@ -126,5 +175,5 @@ export async function ensureImage(options: {
     console.log(`[docker-image-builder] Image "${image}" stale (${currentCommit?.slice(0, 8)} → ${commit.slice(0, 8)}), rebuilding`);
   }
 
-  await buildImageFromRepo({ image, repoUrl, commit, dockerfile, repoToken });
+  await buildImageFromRepo({ image, repoUrl, repoRef, commit, dockerfile, repoToken });
 }

--- a/packages/container-worker/src/schemas.ts
+++ b/packages/container-worker/src/schemas.ts
@@ -33,7 +33,12 @@ export const DockerJobDataSchema = z.object({
   /** Image build metadata — when present, worker ensures image exists before docker run. */
   imageBuild: z.object({
     image: z.string(),
+    /** SSH-form git URL — cache-tag identity only, not the clone transport. */
     repoUrl: z.string(),
+    /** Original user-supplied repo reference — decides the clone transport
+     *  (anonymous HTTPS for a public `owner/repo` shorthand). Optional for
+     *  backward compatibility with in-flight jobs; falls back to `repoUrl`. */
+    repoRef: z.string().optional(),
     commit: z.string(),
     dockerfile: z.string().optional(),
     repoToken: z.string().optional(),


### PR DESCRIPTION
## What

The lazy Docker image builder forced SSH (`git@github.com:…`) for any repo reference with no auth token, so building an image from a **public** repo demanded a deploy key it should never need — surfacing as a confusing `git@github.com: Permission denied (publickey)` from `buildImageFromRepo` (`/tmp/mediforce-build-*`).

## Why

`resolveImageBuild` pre-normalized the repo to `normalizeRepoUrls(repo).gitUrl` (SSH form), and `buildImageFromRepo` had only two modes: token-HTTPS or SSH. It threw away the user's original reference before deciding the transport, unlike the skills-fetch path (`resolveRepoCloneUrl`, formerly `resolveSkillsCloneUrl`), which keeps the reference and clones an `owner/repo` shorthand over **anonymous HTTPS**.

## Fix

Make the image-build clone path resolve transport the same way skills-fetch does.

1. **Preserve the original reference.** Added `repoRef: string` to `ImageBuildMeta` (`docker-spawn-strategy.ts`) carrying the pre-normalization `repo` / `wfRepo.url`. `repoUrl` (SSH form) stays as the cache-tag identity so `deriveBuildTag()` and the `mediforce.build.commit` label are unchanged — no cache invalidation, no rebuild storm.
2. **Route the clone through the shared resolver.** In `buildImageFromRepo()` (both the agent-runtime copy and the duplicated container-worker copy), replaced `cloneUrl = repoToken ? toHttpsWithToken(repoUrl) : repoUrl` with `const { cloneUrl, useSsh } = resolveRepoCloneUrl(repoRef, repoToken)` and set `GIT_SSH_COMMAND` only when `useSsh` is true — so a public/HTTPS clone never even references the deploy key.
3. Renamed `resolveSkillsCloneUrl` → `resolveRepoCloneUrl` since it is no longer skills-specific; it is now shared by both clone paths.
4. Mirrored the resolver (`normalizeRepoUrls` + `resolveRepoCloneUrl`) into `container-worker/docker-image-builder.ts` (kept duplicated per the existing convention — container-worker cannot import agent-runtime), and added `repoRef` (optional, backward compatible) to the `DockerJobDataSchema.imageBuild` wire schema.

The secondary infra improvement (deploy-key bind-mount materialized as an empty directory) is explicitly out of scope per the issue and left untouched.

Closes #1079

---

🤖 generated by mediforce-fullstack

### 🔁 CI fix history
- round 1: fixed undefined repoRef in ensureImage() destructure of packages/agent-runtime/src/plugins/docker-image-builder.ts (typecheck TS shorthand-property error + unit-tests ReferenceError at line 132) and added repoRef to the ImageBuildMeta fixture in lazy-build-local.integration.test.ts:74 (typecheck missing-property error). e2e-tests had no actionable file:line annotations — only a generic exit-code-1 and a missing playwright-report artifact warning, so not statically fixable from the error text; likely a cascade of the same image-builder ReferenceError now resolved.

### ❌ CI failing — needs a human
CI never completed after 4 poll(s)

- (see the Checks tab)