### PR TITLE
fix(e2e): isolate shared-namespace fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Fixed
+- Parallel E2E runs no longer hide Monitoring activity or workflow-status fixtures behind first-page pagination [#1134](https://github.com/Appsilon/mediforce/issues/1134).
+
 ## [2026-08-02]
 
 ### Security

--- a/packages/platform-ui/e2e/helpers/seed-data.ts
+++ b/packages/platform-ui/e2e/helpers/seed-data.ts
@@ -1147,7 +1147,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
     'audit-signin-password': {
       actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
-      actorRole: 'owner',
+      actorRole: 'member',
       action: 'user.signed_in',
       description: 'Signed in with email and password',
       timestamp: oneHourAgo,
@@ -1160,7 +1160,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
     'audit-signin-oauth': {
       actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
-      actorRole: 'owner',
+      actorRole: 'member',
       action: 'user.signed_in',
       description: 'Signed in via google (SSO)',
       timestamp: twoDaysAgo,
@@ -1173,7 +1173,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
     'audit-workflow-triggered': {
       actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
-      actorRole: 'owner',
+      actorRole: 'member',
       action: 'instance.started',
       description: `Started instance 'proc-running-1'`,
       timestamp: oneHourAgo,
@@ -1188,7 +1188,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
     'audit-workflow-cancelled': {
       actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
-      actorRole: 'owner',
+      actorRole: 'member',
       action: 'instance.cancelled',
       description: `Run cancelled by operator (was running at step 'data-quality')`,
       timestamp: twoDaysAgo,
@@ -1203,7 +1203,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
     'audit-task-completed': {
       actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
-      actorRole: 'owner',
+      actorRole: 'member',
       action: 'task.completed',
       description: `Task resolved for step 'manager-approval'`,
       timestamp: now,
@@ -1218,7 +1218,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
     'audit-task-claimed': {
       actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
-      actorRole: 'owner',
+      actorRole: 'member',
       action: 'task.claimed',
       description: `User '${MONITORING_ACTIVITY_ACTOR_ID}' claimed task 'task-claimed-1' for step 'approve-report'`,
       timestamp: oneHourAgo,

--- a/packages/platform-ui/e2e/helpers/seed-data.ts
+++ b/packages/platform-ui/e2e/helpers/seed-data.ts
@@ -1046,6 +1046,15 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
   };
 
   const MONITORING_LOADMORE_ACTOR_ID = 'monitoring-loadmore-actor';
+  // Dedicated actor for monitoring.journey.ts's Users/Tasks-tab activity
+  // assertions (`audit-signin-*`, `audit-workflow-*`, `audit-task-*`). Same
+  // isolation contract as the Load-More batch below: a unique `actorId` +
+  // the matching `namespaceMembers` entry lets the tab's own "User" filter
+  // <select> select it, so these six assertion rows are pinned to page 1
+  // regardless of how many fresh audit events other parallel journeys write
+  // to the shared `test` namespace. Isolation comes from the actor filter,
+  // not from recency.
+  const MONITORING_ACTIVITY_ACTOR_ID = 'monitoring-activity-actor';
   const MONITORING_LOADMORE_EVENT_COUNT = 21;
   // 21 audit events, one PAGE_SIZE(20) over the limit, shared by
   // monitoring.journey.ts's Users AND Tasks tab Load-More tests —
@@ -1126,11 +1135,17 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
       processInstanceId: 'proc-completed-1',
       processDefinitionVersion: '2.1.0',
     },
-    // Monitoring → Users tab fixtures. No processInstanceId, so
-    // postgres-seed.ts's workspace resolution falls back to TEST_ORG_HANDLE
-    // — same behaviour as a real sign-in event with no parent run.
+    // Monitoring → Users/Tasks-tab activity assertions. All six are pinned
+    // to a dedicated `actorId` (MONITORING_ACTIVITY_ACTOR_ID) so the tab's
+    // own "User" filter selects exactly this set regardless of how busy
+    // the shared `test` namespace gets during a full suite run. Row content
+    // is joined off `inputSnapshot` / `processInstanceId`, not the actor, so
+    // the Task/Workflow link assertions are unaffected by the actor change.
+    // No processInstanceId here, so postgres-seed.ts's workspace resolution
+    // falls back to TEST_ORG_HANDLE — same behaviour as a real sign-in event
+    // with no parent run.
     'audit-signin-password': {
-      actorId: testUserId,
+      actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
       actorRole: 'owner',
       action: 'user.signed_in',
@@ -1140,10 +1155,10 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
       outputSnapshot: {},
       basis: 'Password credential verified',
       entityType: 'user',
-      entityId: testUserId,
+      entityId: MONITORING_ACTIVITY_ACTOR_ID,
     },
     'audit-signin-oauth': {
-      actorId: testUserId,
+      actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
       actorRole: 'owner',
       action: 'user.signed_in',
@@ -1153,10 +1168,10 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
       outputSnapshot: {},
       basis: "OAuth provider 'google' verified the identity",
       entityType: 'user',
-      entityId: testUserId,
+      entityId: MONITORING_ACTIVITY_ACTOR_ID,
     },
     'audit-workflow-triggered': {
-      actorId: testUserId,
+      actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
       actorRole: 'owner',
       action: 'instance.started',
@@ -1171,7 +1186,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
       processDefinitionVersion: '1',
     },
     'audit-workflow-cancelled': {
-      actorId: testUserId,
+      actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
       actorRole: 'owner',
       action: 'instance.cancelled',
@@ -1186,7 +1201,7 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
       processDefinitionVersion: '2.1.0',
     },
     'audit-task-completed': {
-      actorId: testUserId,
+      actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
       actorRole: 'owner',
       action: 'task.completed',
@@ -1201,14 +1216,14 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
       stepId: 'manager-approval',
     },
     'audit-task-claimed': {
-      actorId: testUserId,
+      actorId: MONITORING_ACTIVITY_ACTOR_ID,
       actorType: 'user',
       actorRole: 'owner',
       action: 'task.claimed',
-      description: `User '${testUserId}' claimed task 'task-claimed-1' for step 'approve-report'`,
+      description: `User '${MONITORING_ACTIVITY_ACTOR_ID}' claimed task 'task-claimed-1' for step 'approve-report'`,
       timestamp: oneHourAgo,
-      inputSnapshot: { taskId: 'task-claimed-1', userId: testUserId, stepId: 'approve-report' },
-      outputSnapshot: { status: 'claimed', assignedUserId: testUserId },
+      inputSnapshot: { taskId: 'task-claimed-1', userId: MONITORING_ACTIVITY_ACTOR_ID, stepId: 'approve-report' },
+      outputSnapshot: { status: 'claimed', assignedUserId: MONITORING_ACTIVITY_ACTOR_ID },
       basis: 'User claimed task via UI',
       entityType: 'humanTask',
       entityId: 'task-claimed-1',
@@ -1853,6 +1868,17 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
     [MONITORING_LOADMORE_ACTOR_ID]: {
       id: MONITORING_LOADMORE_ACTOR_ID,
       uid: MONITORING_LOADMORE_ACTOR_ID,
+      role: 'member',
+      joinedAt: threeDaysAgo,
+    },
+    // Synthetic member for monitoring.journey.ts's Users/Tasks-tab activity
+    // assertions — same shape as the Load-More member above: no real auth
+    // account, exists only to make MONITORING_ACTIVITY_ACTOR_ID selectable
+    // in the tabs' "User" filter <select> so those tests can actor-scope the
+    // table before asserting on rows.
+    [MONITORING_ACTIVITY_ACTOR_ID]: {
+      id: MONITORING_ACTIVITY_ACTOR_ID,
+      uid: MONITORING_ACTIVITY_ACTOR_ID,
       role: 'member',
       joinedAt: threeDaysAgo,
     },

--- a/packages/platform-ui/e2e/ui/monitoring.journey.ts
+++ b/packages/platform-ui/e2e/ui/monitoring.journey.ts
@@ -98,13 +98,19 @@ test.describe('Monitoring Journey', () => {
 
     // Scoped to the table body throughout — the filter dropdowns added below
     // also render options labelled "Sign in" / "Task completed" etc., which
-    // would otherwise collide with a page-wide getByText. `.first()`
-    // everywhere: this table is namespace-wide and unscoped to this test's
-    // own fixtures, so in the full CI suite other journeys running against
-    // the same shared `test` namespace add their own matching rows (e.g.
-    // other cancelled runs) — these assertions only need to prove the real
-    // shape shows up somewhere, not that it's the only occurrence.
+    // would otherwise collide with a page-wide getByText. `.first()` on
+    // 'Sign in' because both seeded sign-in events (password + OAuth) carry
+    // that label; the rest are unique within the actor-scoped set.
     const rows = page.locator('tbody');
+
+    // Actor-scope the table FIRST (first combobox = User filter) onto the
+    // dedicated MONITORING_ACTIVITY_ACTOR_ID fixtures (seed-data.ts). The
+    // Users tab is workspace-wide and server-paginated at 20 rows, newest
+    // first — without this filter, fresh audit events other parallel
+    // journeys write to the shared `test` namespace push these seeded rows
+    // off page 1 mid-suite. The actor filter isolates exactly this test's
+    // own seeded rows (5 here — `task.claimed` is a Tasks-tab action only).
+    await page.getByRole('combobox').nth(0).selectOption({ value: 'monitoring-activity-actor' });
 
     // All four event types the table understands, each backed by a real
     // seeded audit_events row (see seed-data.ts's audit-signin-*,
@@ -124,8 +130,10 @@ test.describe('Monitoring Journey', () => {
     await expect(rows.getByText('Manager Approval').first()).toBeVisible();
 
     // Event-type filter actually narrows the rendered table, not just the
-    // dropdown's own state. First combobox is the User filter, second is
-    // Event.
+    // dropdown's own state. Second combobox is Event (the User filter set
+    // above stays applied, so these `not.toBeVisible()` checks are sound:
+    // the table is already actor-scoped to our fixtures, leaving no room
+    // for a concurrent journey's row to satisfy them by accident).
     const eventFilter = page.getByRole('combobox').nth(1);
     await eventFilter.selectOption({ label: 'Task completed' });
     await expect(rows.getByText('Manager Approval')).toBeVisible();
@@ -149,13 +157,17 @@ test.describe('Monitoring Journey', () => {
 
     const rows = page.locator('tbody');
 
+    // Actor-scope the table FIRST (first combobox = User filter) onto the
+    // dedicated MONITORING_ACTIVITY_ACTOR_ID fixtures (seed-data.ts). The
+    // Tasks tab is workspace-wide and server-paginated at 20 rows, newest
+    // first — without this filter, fresh task audit events other parallel
+    // journeys write to the shared `test` namespace push these seeded rows
+    // off page 1 mid-suite. The actor filter isolates exactly our two rows.
+    await page.getByRole('combobox').nth(0).selectOption({ value: 'monitoring-activity-actor' });
+
     // Two action types, each backed by a real seeded audit_events row (see
-    // seed-data.ts's audit-task-claimed / audit-task-completed fixtures).
-    // `.first()` on 'Completed': with server-side pagination this table is
-    // namespace-wide and unscoped to this test's own fixtures, so the top-20
-    // default page can (and, once the Load-More fixture batch below exists,
-    // reliably does) contain more than one `task.completed` row — this only
-    // needs to prove the badge shows up somewhere, not that it's unique.
+    // seed-data.ts's audit-task-claimed / audit-task-completed fixtures),
+    // now actor-scoped to exactly this pair.
     await expect(rows.getByText('Claimed')).toBeVisible({ timeout: 10_000 });
     await expect(rows.getByText('Completed').first()).toBeVisible();
 
@@ -175,8 +187,10 @@ test.describe('Monitoring Journey', () => {
       `/${TEST_ORG_HANDLE}/workflows/Supply%20Chain%20Review/runs/proc-running-1`,
     );
 
-    // Action filter narrows the rendered table. First combobox is the User
-    // filter, second is Action.
+    // Action filter narrows the rendered table. Second combobox is Action
+    // (the User filter set above stays applied, keeping the `not.toBeVisible()`
+    // check sound: the table is already actor-scoped to our two rows, so a
+    // concurrent journey's 'Approve Report' row can't satisfy it by accident).
     const actionFilter = page.getByRole('combobox').nth(1);
     await actionFilter.selectOption({ label: 'Completed' });
     await expect(rows.getByText('Manager Approval')).toBeVisible();

--- a/packages/platform-ui/e2e/ui/workflow-status-badges.journey.ts
+++ b/packages/platform-ui/e2e/ui/workflow-status-badges.journey.ts
@@ -2,21 +2,26 @@ import { test, expect } from '../helpers/test-fixtures';
 import { TEST_ORG_HANDLE } from '../helpers/constants';
 import { trackPageErrors } from '../helpers/page-errors';
 
+const STATUS_BADGES_WORKFLOW = 'Runs Page Journey Workflow';
+
 test.describe('Workflow Status Badges Journey', () => {
   test('process list shows all five semantic status badges', async ({ page }) => {
     trackPageErrors(page);
 
-    // The RunsTable (with status badges) lives at /runs, not /workflows
-    await page.goto(`/${TEST_ORG_HANDLE}/runs`);
-    await expect(page.getByText('All workflow runs across the platform.')).toBeVisible({ timeout: 30_000 });
+    // The five runs for this workflow are dedicated to display-status coverage,
+    // so the server-side workflow filter keeps parallel journeys from pushing
+    // the Cancelled fixture past the first page of the shared namespace.
+    await page.goto(`/${TEST_ORG_HANDLE}/runs?workflow=${encodeURIComponent(STATUS_BADGES_WORKFLOW)}`);
+    await expect(page.getByText('All runs for this workflow.')).toBeVisible({ timeout: 30_000 });
+    const rows = page.locator('tbody');
+    await expect(rows.locator('tr')).toHaveCount(5);
 
-    // Five display statuses visible in the list
-    await expect(page.getByText('In Progress').first()).toBeVisible();
-    await expect(page.getByText('Waiting for human').first()).toBeVisible();
-    await expect(page.getByText('Error').first()).toBeVisible();
-    await expect(page.getByText('Completed').first()).toBeVisible();
-    // proc-cancelled-1 is seeded as status=failed / error='Cancelled by user'
-    await expect(page.getByText('Cancelled').first()).toBeVisible();
+    // Five display statuses visible in the list.
+    await expect(rows.getByText('In Progress', { exact: true })).toBeVisible();
+    await expect(rows.getByText('Waiting for human', { exact: true })).toBeVisible();
+    await expect(rows.getByText('Error', { exact: true })).toBeVisible();
+    await expect(rows.getByText('Completed', { exact: true })).toBeVisible();
+    await expect(rows.getByText('Cancelled', { exact: true })).toBeVisible();
   });
 
   test('step_failure instance shows Error badge and error banner — no retry button', async ({ page }) => {


### PR DESCRIPTION
## Summary
- scope Monitoring Users and Tasks assertions to their dedicated actor
- scope workflow-status badge coverage to its dedicated five-run workflow
- align fixture roles and add the Unreleased changelog entry

## Verification
- pnpm test:e2e (184 passed, 1 skipped)

Closes #1134