### PR TITLE
fix: scope workflow-definition lists to member workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 ## [Unreleased]
 
 ### Fixed
+- User workflow-definition lists now return only definitions in their member workspaces, including hiding foreign public workflows [#1047](https://github.com/Appsilon/mediforce/issues/1047).
 - Parallel E2E runs no longer hide Monitoring activity or workflow-status fixtures behind first-page pagination [#1134](https://github.com/Appsilon/mediforce/issues/1134).
 
 ## [2026-08-02]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Changed
+- Public workflow sharing now explains that it is link-based, shows a persistent shared state, and offers a canonical link to copy [#1141](https://github.com/Appsilon/mediforce/pull/1141).
+
 ### Fixed
 - User workflow-definition lists now return only definitions in their member workspaces, including hiding foreign public workflows [#1047](https://github.com/Appsilon/mediforce/issues/1047).
 - Parallel E2E runs no longer hide Monitoring activity or workflow-status fixtures behind first-page pagination [#1134](https://github.com/Appsilon/mediforce/issues/1134).
+
+### Security
+- Public workflow links are read/copy-only: non-members can no longer start runs in the owning workspace [#1141](https://github.com/Appsilon/mediforce/pull/1141).
 
 ## [2026-08-02]
 

--- a/packages/platform-api/src/handlers/runs/__tests__/start-run.test.ts
+++ b/packages/platform-api/src/handlers/runs/__tests__/start-run.test.ts
@@ -8,7 +8,7 @@ import {
   resetFactorySequence,
 } from '@mediforce/platform-core/testing';
 import { startRun } from '../start-run';
-import { HandlerError, NotFoundError } from '../../../errors';
+import { ForbiddenError, HandlerError, NotFoundError } from '../../../errors';
 import {
   createTestScope,
   userCaller,
@@ -355,6 +355,40 @@ describe('startRun handler', () => {
         scope,
       ),
     ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(fireWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('forbids a non-member from starting a public foreign-namespace workflow', async () => {
+    await processRepo.saveWorkflowDefinition(
+      buildWorkflowDefinition({
+        name: 'public-intake',
+        namespace: 'team-beta',
+        version: 1,
+        visibility: 'public',
+      }),
+    );
+
+    const fireWorkflow = vi.fn();
+    const scope = createTestScope({
+      processRepo,
+      instanceRepo,
+      auditRepo,
+      caller: userCaller('u-1', ['team-alpha']),
+    });
+    Object.assign(scope.system, { manualTrigger: { fireWorkflow } });
+
+    await expect(
+      startRun(
+        {
+          namespace: 'team-beta',
+          definitionName: 'public-intake',
+          triggerName: 'manual',
+          triggeredBy: 'u-1',
+        },
+        scope,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError);
 
     expect(fireWorkflow).not.toHaveBeenCalled();
   });

--- a/packages/platform-api/src/handlers/runs/start-run.ts
+++ b/packages/platform-api/src/handlers/runs/start-run.ts
@@ -44,10 +44,8 @@ export async function startRun(
     );
   }
 
-  if (!scope.caller.isSystemActor && definition.visibility !== 'public') {
-    if (!scope.caller.namespaces.has(definition.namespace)) {
-      throw new ForbiddenError();
-    }
+  if (!scope.caller.isSystemActor && !scope.caller.namespaces.has(definition.namespace)) {
+    throw new ForbiddenError();
   }
 
   // Unconditional (ADR-0012): `triggerInput` is the workflow's *total* input

--- a/packages/platform-api/src/handlers/workflows/__tests__/list-workflows.test.ts
+++ b/packages/platform-api/src/handlers/workflows/__tests__/list-workflows.test.ts
@@ -98,7 +98,7 @@ describe('listWorkflows handler', () => {
       ]);
     });
 
-    it('user callers see public + their-namespace workflows', async () => {
+    it('user callers only see workflows in their namespaces', async () => {
       const scope = createTestScope({
         processRepo,
         caller: userCaller('u-1', ['team-alpha']),
@@ -106,13 +106,10 @@ describe('listWorkflows handler', () => {
 
       const result = await listWorkflows({ includeCompletedRuns: true }, scope);
 
-      expect(result.definitions.map((d) => d.name).sort()).toEqual([
-        'alpha-private',
-        'beta-public',
-      ]);
+      expect(result.definitions.map((d) => d.name)).toEqual(['alpha-private']);
     });
 
-    it('user callers without namespace overlap only see public workflows', async () => {
+    it('user callers without namespace overlap see no workflows', async () => {
       const scope = createTestScope({
         processRepo,
         caller: userCaller('u-2', ['team-gamma']),
@@ -120,10 +117,10 @@ describe('listWorkflows handler', () => {
 
       const result = await listWorkflows({ includeCompletedRuns: true }, scope);
 
-      expect(result.definitions.map((d) => d.name)).toEqual(['beta-public']);
+      expect(result.definitions).toEqual([]);
     });
 
-    it('respects the optional namespace filter while honouring visibility', async () => {
+    it('does not grant access when filtering to a foreign namespace', async () => {
       const scope = createTestScope({
         processRepo,
         caller: userCaller('u-1', ['team-alpha']),
@@ -134,8 +131,7 @@ describe('listWorkflows handler', () => {
         scope,
       );
 
-      // team-alpha user can see team-beta's public workflow, scoped via filter.
-      expect(result.definitions.map((d) => d.name)).toEqual(['beta-public']);
+      expect(result.definitions).toEqual([]);
     });
 
     it('namespace filter applies for api-key callers too', async () => {

--- a/packages/platform-api/src/handlers/workflows/list-workflows.ts
+++ b/packages/platform-api/src/handlers/workflows/list-workflows.ts
@@ -7,9 +7,9 @@ import type {
 
 /**
  * List workflow definitions visible to the caller, grouped by name with the
- * latest version pre-resolved. The wrapper filters groups whose latest
- * version the caller cannot see (private + foreign workspace). The optional
- * `namespace` input narrows further but does not grant access.
+ * latest version pre-resolved. User callers receive only groups in their
+ * member namespaces. The optional `namespace` input narrows further but does
+ * not grant access.
  */
 export async function listWorkflows(
   input: ListWorkflowsInput,

--- a/packages/platform-api/src/repositories/authorized-workflow-definition-repository.ts
+++ b/packages/platform-api/src/repositories/authorized-workflow-definition-repository.ts
@@ -9,8 +9,7 @@ import { AuthorizedScope } from './authorized-repository';
 /**
  * Workspace + visibility-scoped view of `ProcessRepository`'s workflow-
  * definition surface. Routes to `listAllWorkflowDefinitions` for system
- * actors and `listWorkflowDefinitionsVisibleTo` for user callers — the
- * storage layer enforces the public-OR-allowed predicate.
+ * actors and `listWorkflowDefinitionsInNamespaces` for user callers.
  *
  * Out-of-scope reads return null (single) or are filtered out (list). The
  * handler turns null into 404 — so a non-member cannot distinguish "exists in
@@ -71,7 +70,7 @@ export class AuthorizedWorkflowDefinitionRepository extends AuthorizedScope {
   listGroups = async (includeArchived: boolean): Promise<WorkflowDefinitionGroup[]> => {
     const { definitions } = this.caller.isSystemActor
       ? await this.raw.listAllWorkflowDefinitions(includeArchived)
-      : await this.raw.listWorkflowDefinitionsVisibleTo(
+      : await this.raw.listWorkflowDefinitionsInNamespaces(
           [...this.caller.namespaces],
           includeArchived,
         );

--- a/packages/platform-core/src/interfaces/process-repository.ts
+++ b/packages/platform-core/src/interfaces/process-repository.ts
@@ -26,10 +26,9 @@ export interface ProcessRepository {
    *  them avoids spamming logs with safeParse failures on legacy data
    *  that nobody intends to fix. */
   listAllWorkflowDefinitions(includeArchived: boolean): Promise<WorkflowDefinitionListResult>;
-  /** Namespace + visibility-scoped variant. Returns groups whose latest
-   *  version is `visibility: 'public'` OR whose namespace is in `allowed`. */
-  listWorkflowDefinitionsVisibleTo(
-    allowed: readonly string[],
+  /** Namespace-scoped variant for ordinary user-facing lists. */
+  listWorkflowDefinitionsInNamespaces(
+    namespaces: readonly string[],
     includeArchived: boolean,
   ): Promise<WorkflowDefinitionListResult>;
   getLatestWorkflowVersion(namespace: string, name: string): Promise<number>;

--- a/packages/platform-core/src/testing/in-memory-process-repository.ts
+++ b/packages/platform-core/src/testing/in-memory-process-repository.ts
@@ -50,16 +50,11 @@ export class InMemoryProcessRepository implements ProcessRepository {
     return this.buildListResult(includeArchived, () => true);
   }
 
-  async listWorkflowDefinitionsVisibleTo(
-    allowed: readonly string[],
+  async listWorkflowDefinitionsInNamespaces(
+    namespaces: readonly string[],
     includeArchived: boolean,
   ): Promise<WorkflowDefinitionListResult> {
-    return this.buildListResult(includeArchived, (group) => {
-      const latest = group.versions.find((v) => v.version === group.latestVersion);
-      if (latest === undefined) return false;
-      if (latest.visibility === 'public') return true;
-      return allowed.includes(latest.namespace);
-    });
+    return this.buildListResult(includeArchived, (group) => namespaces.includes(group.namespace));
   }
 
   private buildListResult(

--- a/packages/platform-infra/src/postgres/__tests__/workflow-definition-parity.test.ts
+++ b/packages/platform-infra/src/postgres/__tests__/workflow-definition-parity.test.ts
@@ -120,29 +120,32 @@ function contract(
       expect(supplyAll?.versions.map((v) => v.version).sort()).toEqual([1, 2]);
     });
 
-    it('listWorkflowDefinitionsVisibleTo honours visibility + allowed', async () => {
+    it('listWorkflowDefinitionsInNamespaces excludes foreign public workflows', async () => {
       const { repo, registerWorkspace } = await factory();
       await registerWorkspace('ws-public');
-      await registerWorkspace('ws-private');
       await registerWorkspace('ws-allowed');
       await repo.saveWorkflowDefinition(
         definitionFor('ws-public', { name: 'public-wf', visibility: 'public' }),
       );
       await repo.saveWorkflowDefinition(
-        definitionFor('ws-private', { name: 'private-wf', visibility: 'private' }),
-      );
-      await repo.saveWorkflowDefinition(
         definitionFor('ws-allowed', { name: 'allowed-wf', visibility: 'private' }),
       );
 
-      const result = await repo.listWorkflowDefinitionsVisibleTo(
-        ['ws-allowed'],
-        false,
+      const result = await repo.listWorkflowDefinitionsInNamespaces(['ws-allowed'], false);
+
+      expect(result.definitions.map((definition) => definition.name)).toEqual(['allowed-wf']);
+    });
+
+    it('listWorkflowDefinitionsInNamespaces returns no workflows for an empty scope', async () => {
+      const { repo, registerWorkspace } = await factory();
+      await registerWorkspace('ws-public');
+      await repo.saveWorkflowDefinition(
+        definitionFor('ws-public', { name: 'public-wf', visibility: 'public' }),
       );
-      const names = result.definitions.map((d) => d.name);
-      expect(names).toContain('public-wf');
-      expect(names).toContain('allowed-wf');
-      expect(names).not.toContain('private-wf');
+
+      const result = await repo.listWorkflowDefinitionsInNamespaces([], false);
+
+      expect(result.definitions).toEqual([]);
     });
 
     it('getLatestWorkflowVersion returns 0 when no versions exist', async () => {
@@ -296,7 +299,7 @@ function contract(
       ).toBeUndefined();
     });
 
-    it('listWorkflowDefinitionsVisibleTo excludes soft-deleted workflows', async () => {
+    it('listWorkflowDefinitionsInNamespaces excludes soft-deleted workflows', async () => {
       const { repo, registerWorkspace } = await factory();
       await registerWorkspace('ws-1');
       await repo.saveWorkflowDefinition(
@@ -304,7 +307,7 @@ function contract(
       );
       await repo.setWorkflowDeleted('ws-1', 'supply-chain-review', true);
 
-      const visible = await repo.listWorkflowDefinitionsVisibleTo(['ws-1'], false);
+      const visible = await repo.listWorkflowDefinitionsInNamespaces(['ws-1'], false);
       expect(
         visible.definitions.find((d) => d.name === 'supply-chain-review'),
       ).toBeUndefined();

--- a/packages/platform-infra/src/postgres/repositories/process-repository.ts
+++ b/packages/platform-infra/src/postgres/repositories/process-repository.ts
@@ -120,26 +120,27 @@ export class PostgresProcessRepository implements ProcessRepository {
   async listAllWorkflowDefinitions(
     includeArchived: boolean,
   ): Promise<WorkflowDefinitionListResult> {
-    return this.fetchAndGroup(includeArchived, () => true);
+    return this.fetchAndGroup(includeArchived);
   }
 
-  async listWorkflowDefinitionsVisibleTo(
-    allowed: readonly string[],
+  async listWorkflowDefinitionsInNamespaces(
+    namespaces: readonly string[],
     includeArchived: boolean,
   ): Promise<WorkflowDefinitionListResult> {
-    return this.fetchAndGroup(includeArchived, (group) => {
-      const latest = group.versions.find((v) => v.version === group.latestVersion);
-      if (latest === undefined) return false;
-      if (latest.visibility === 'public') return true;
-      return allowed.includes(latest.namespace);
-    });
+    if (namespaces.length === 0) return { definitions: [] };
+    return this.fetchAndGroup(includeArchived, namespaces);
   }
 
   private async fetchAndGroup(
     includeArchived: boolean,
-    predicate: (group: WorkflowDefinitionGroup) => boolean,
+    namespaces?: readonly string[],
   ): Promise<WorkflowDefinitionListResult> {
-    const rows = await this.db.select().from(workflowDefinitions);
+    const rows = namespaces === undefined
+      ? await this.db.select().from(workflowDefinitions)
+      : await this.db
+          .select()
+          .from(workflowDefinitions)
+          .where(inArray(workflowDefinitions.workspace, namespaces));
 
     const grouped = new Map<string, WorkflowDefinition[]>();
     for (const row of rows) {
@@ -170,7 +171,7 @@ export class PostgresProcessRepository implements ProcessRepository {
       }),
     );
 
-    return { definitions: groups.filter(predicate) };
+    return { definitions: groups };
   }
 
   async getDefaultWorkflowVersion(

--- a/packages/platform-ui/e2e/api/workflow-definitions-anti-enum.journey.ts
+++ b/packages/platform-ui/e2e/api/workflow-definitions-anti-enum.journey.ts
@@ -55,4 +55,29 @@ test.describe('GET /api/workflow-definitions/[name] — visibility 404', () => {
     );
     expect(res.status()).toBe(404);
   });
+
+  test('outsider user list excludes public workflows from other namespaces', async ({ request }) => {
+    const name = `public-list-isolation-${Date.now()}`;
+    const create = await request.post(
+      `/api/workflow-definitions?namespace=${TEST_ORG_HANDLE}`,
+      {
+        headers: apiKeyHeaders(),
+        data: {
+          name,
+          description: 'Public workflow used to verify list isolation.',
+          visibility: 'public',
+          steps: [{ id: 'start', name: 'Start', type: 'creation', executor: 'human' }],
+          transitions: [],
+        },
+      },
+    );
+    expect(create.status(), await create.text()).toBe(201);
+
+    const list = await request.get('/api/workflow-definitions', {
+      headers: sessionCookieHeaders(callers.outsider),
+    });
+    expect(list.status(), await list.text()).toBe(200);
+    const body = await list.json() as { definitions: Array<{ name: string }> };
+    expect(body.definitions.map((definition) => definition.name)).not.toContain(name);
+  });
 });

--- a/packages/platform-ui/e2e/api/workflow-definitions-anti-enum.journey.ts
+++ b/packages/platform-ui/e2e/api/workflow-definitions-anti-enum.journey.ts
@@ -80,4 +80,35 @@ test.describe('GET /api/workflow-definitions/[name] — visibility 404', () => {
     const body = await list.json() as { definitions: Array<{ name: string }> };
     expect(body.definitions.map((definition) => definition.name)).not.toContain(name);
   });
+
+  test('outsider user cannot start a public workflow in another namespace', async ({ request }) => {
+    const name = `public-run-isolation-${Date.now()}`;
+    const create = await request.post(
+      `/api/workflow-definitions?namespace=${TEST_ORG_HANDLE}`,
+      {
+        headers: apiKeyHeaders(),
+        data: {
+          name,
+          description: 'Public workflow used to verify run isolation.',
+          visibility: 'public',
+          steps: [{ id: 'start', name: 'Start', type: 'creation', executor: 'human' }],
+          transitions: [],
+        },
+      },
+    );
+    expect(create.status(), await create.text()).toBe(201);
+
+    const start = await request.post('/api/processes', {
+      headers: sessionCookieHeaders(callers.outsider),
+      data: {
+        namespace: TEST_ORG_HANDLE,
+        definitionName: name,
+        triggerName: 'manual',
+        triggeredBy: callers.outsider.uid,
+      },
+    });
+    expect(start.status(), await start.text()).toBe(403);
+    const body = await start.json() as { error: { code: string } };
+    expect(body.error.code).toBe('forbidden');
+  });
 });

--- a/packages/platform-ui/e2e/helpers/seed-data.ts
+++ b/packages/platform-ui/e2e/helpers/seed-data.ts
@@ -1781,6 +1781,18 @@ export function buildSeedData(testUserId: string, options: SeedOptions = {}) {
       ],
       createdAt: twoDaysAgo,
     },
+    'test:Share by Link Test:1': {
+      name: 'Share by Link Test',
+      namespace: 'test',
+      version: 1,
+      description: 'Dedicated workflow for the share-by-link journey.',
+      steps: [
+        { id: 'start', name: 'Start', type: 'creation', executor: 'human' },
+        { id: 'done', name: 'Done', type: 'terminal', executor: 'human' },
+      ],
+      transitions: [{ from: 'start', to: 'done' }],
+      createdAt: twoDaysAgo,
+    },
     'test:Data Quality Review:2': {
       name: 'Data Quality Review',
       namespace: 'test',

--- a/packages/platform-ui/e2e/ui/workflow-share-by-link.journey.ts
+++ b/packages/platform-ui/e2e/ui/workflow-share-by-link.journey.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '../helpers/test-fixtures';
+import { TEST_ORG_HANDLE } from '../helpers/constants';
+import { getPageErrors, trackPageErrors } from '../helpers/page-errors';
+
+test.describe('Workflow share-by-link journey', () => {
+  test('shares a workflow by link after explaining its visibility', async ({ page }) => {
+    trackPageErrors(page);
+    const reset = await page.request.patch(
+      `/api/workflow-definitions/${encodeURIComponent('Share by Link Test')}?namespace=${TEST_ORG_HANDLE}`,
+      { data: { visibility: 'private' } },
+    );
+    expect(reset.status(), await reset.text()).toBe(200);
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.goto(`/${TEST_ORG_HANDLE}/workflows/Share%20by%20Link%20Test`);
+
+    await expect(page.getByText('Private', { exact: true })).toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: 'Workflow actions' }).click();
+    await page.getByRole('button', { name: 'Share by link...' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Share workflow by link' })).toBeVisible();
+    await expect(page.getByText(/will not appear in other workspaces' workflow lists/i)).toBeVisible();
+    await expect(page.getByText(/workflow runs remain private/i)).toBeVisible();
+
+    await page.getByRole('button', { name: 'Share workflow' }).click();
+    await expect(page.getByText('Shared by link', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Copy link' }).click();
+    await expect(page.getByRole('button', { name: 'Copied' })).toBeVisible();
+    await expect(page.evaluate(() => navigator.clipboard.readText())).resolves.toBe(
+      `${new URL(page.url()).origin}/${TEST_ORG_HANDLE}/workflows/Share%20by%20Link%20Test`,
+    );
+
+    await page.getByRole('button', { name: 'Workflow actions' }).click();
+    await page.getByRole('button', { name: 'Make private' }).click();
+    await expect(page.getByText('Private', { exact: true })).toBeVisible();
+    expect(getPageErrors(page)).toEqual([]);
+  });
+});

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/[name]/page.tsx
@@ -3,8 +3,9 @@
 import * as React from 'react';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { ArrowLeft, Layers, GitBranch, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Clock, Zap, Trash2, ArrowRightLeft, KeyRound, Eye, EyeOff, Copy } from 'lucide-react';
+import { ArrowLeft, Layers, GitBranch, ExternalLink, Archive, ArchiveRestore, MoreVertical, Play, Clock, Zap, Trash2, ArrowRightLeft, KeyRound, EyeOff, Copy, Link2 } from 'lucide-react';
 import * as Tabs from '@radix-ui/react-tabs';
+import * as Dialog from '@radix-ui/react-dialog';
 import { useWorkflowVersion, useWorkflowVersions } from '@/hooks/use-workflow-versions';
 import { useWorkflowTriggers } from '@/hooks/use-workflow-triggers';
 import { useWorkflowStatusCounts } from '@/hooks/use-workflow-status-counts';
@@ -84,6 +85,10 @@ function ProcessDefinitionPagePublic({ name, handle }: { name: string; handle: s
       <div className="border-b px-6 py-4">
         <div className="flex items-start justify-between gap-4">
           <div>
+            <span className="inline-flex items-center gap-1 rounded-full bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600">
+              <Link2 className="h-3 w-3" />
+              Shared by link
+            </span>
             {definition.description && (
               <p className="text-sm text-muted-foreground mt-0.5">{definition.description}</p>
             )}
@@ -111,22 +116,25 @@ function ProcessDefinitionPagePublic({ name, handle }: { name: string; handle: s
             </div>
           </div>
 
-          {namespaces.length > 0 && (
-            <button
-              onClick={() => {
-                setCopyName(decodedName);
-                setCopyError('');
-                setCopyOpen(true);
-              }}
-              className={cn(
-                'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
-                'hover:bg-accent hover:text-accent-foreground',
-              )}
-            >
-              <Copy className="h-3.5 w-3.5" />
-              Copy to...
-            </button>
-          )}
+          <div className="flex items-center gap-2">
+            <CopyWorkflowLinkButton handle={handle} workflowName={decodedName} />
+            {namespaces.length > 0 && (
+              <button
+                onClick={() => {
+                  setCopyName(decodedName);
+                  setCopyError('');
+                  setCopyOpen(true);
+                }}
+                className={cn(
+                  'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors',
+                  'hover:bg-accent hover:text-accent-foreground',
+                )}
+              >
+                <Copy className="h-3.5 w-3.5" />
+                Copy to...
+              </button>
+            )}
+          </div>
         </div>
       </div>
 
@@ -170,6 +178,43 @@ function ProcessDefinitionPagePublic({ name, handle }: { name: string; handle: s
             }
           }}
         />
+      )}
+    </div>
+  );
+}
+
+function CopyWorkflowLinkButton({ handle, workflowName }: { handle: string; workflowName: string }) {
+  const [copied, setCopied] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function copyWorkflowLink(): Promise<void> {
+    try {
+      const url = new URL(
+        `/${encodeURIComponent(handle)}/workflows/${encodeURIComponent(workflowName)}`,
+        window.location.origin,
+      ).toString();
+      await navigator.clipboard.writeText(url);
+      setError(null);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2_000);
+    } catch {
+      setError('Could not copy the link. Copy the URL from your browser instead.');
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => void copyWorkflowLink()}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        <Copy className="h-3.5 w-3.5" />
+        {copied ? 'Copied' : 'Copy link'}
+      </button>
+      {error !== null && (
+        <p role="alert" className="absolute right-0 top-full mt-2 w-72 text-sm text-destructive">
+          {error}
+        </p>
       )}
     </div>
   );
@@ -249,6 +294,7 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
   const [transferTarget, setTransferTarget] = React.useState('');
   const [transferring, setTransferring] = React.useState(false);
   const [togglingVisibility, setTogglingVisibility] = React.useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
   const [copyOpen, setCopyOpen] = React.useState(false);
   const [copyTarget, setCopyTarget] = React.useState('');
   const [copyName, setCopyName] = React.useState('');
@@ -271,6 +317,33 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
 
   const currentVisibility = visibilityOverride ?? latest?.visibility ?? 'private';
   const isPrivate = currentVisibility === 'private';
+
+  async function updateVisibility(visibility: 'public' | 'private'): Promise<boolean> {
+    setTogglingVisibility(true);
+    try {
+      const res = await apiFetch(
+        `/api/workflow-definitions/${encodeURIComponent(decodedName)}?namespace=${encodeURIComponent(handle)}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ visibility }),
+        },
+      );
+      if (res.ok) {
+        setVisibilityOverride(visibility);
+        return true;
+      }
+      const body = await res.json().catch(() => null);
+      const message = typeof body?.error === 'object' && body.error !== null
+        ? (body.error.message ?? 'Failed to update visibility')
+        : (body?.error ?? 'Failed to update visibility');
+      alert(message);
+      return false;
+    } finally {
+      setTogglingVisibility(false);
+    }
+  }
+
   // Hand-startable iff an enabled `manual` trigger row exists (ADR-0011 / Issue
   // #930). Stay optimistic while the rows load so the button doesn't flash
   // disabled; the server guard is the real gate.
@@ -304,9 +377,14 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
         <div className="flex items-start justify-between gap-4">
           <div>
             <div className="flex items-center gap-2">
-              {isPrivate && (
+              {isPrivate ? (
                 <span className="rounded-full bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-600">
                   Private
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1 rounded-full bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium text-blue-600">
+                  <Link2 className="h-3 w-3" />
+                  Shared by link
                 </span>
               )}
               {latest?.archived && (
@@ -390,9 +468,14 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
             </div>
           </div>
 
-          <div className="relative" ref={menuRef}>
+          <div className="flex items-center gap-2">
+            {!isPrivate && (
+              <CopyWorkflowLinkButton handle={handle} workflowName={decodedName} />
+            )}
+            <div className="relative" ref={menuRef}>
             <button
               onClick={() => setMenuOpen((prev) => !prev)}
+              aria-label="Workflow actions"
               className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             >
               <MoreVertical className="h-4 w-4" />
@@ -438,26 +521,11 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
 
                 <button
                   onClick={async () => {
-                    const newVisibility = isPrivate ? 'public' : 'private';
                     setMenuOpen(false);
-                    setTogglingVisibility(true);
-                    try {
-                      const res = await apiFetch(`/api/workflow-definitions/${encodeURIComponent(decodedName)}?namespace=${encodeURIComponent(handle)}`, {
-                        method: 'PATCH',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ visibility: newVisibility }),
-                      });
-                      if (res.ok) {
-                        setVisibilityOverride(newVisibility);
-                      } else {
-                        const body = await res.json().catch(() => null);
-                        const msg = typeof body?.error === 'object' && body?.error !== null
-                          ? (body.error.message ?? 'Failed to update visibility')
-                          : (body?.error ?? 'Failed to update visibility');
-                        alert(msg);
-                      }
-                    } finally {
-                      setTogglingVisibility(false);
+                    if (isPrivate) {
+                      setShareDialogOpen(true);
+                    } else {
+                      await updateVisibility('private');
                     }
                   }}
                   disabled={togglingVisibility}
@@ -468,7 +536,7 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
                   )}
                 >
                   {isPrivate ? (
-                    <><Eye className="h-3.5 w-3.5" />Make public</>
+                    <><Link2 className="h-3.5 w-3.5" />Share by link...</>
                   ) : (
                     <><EyeOff className="h-3.5 w-3.5" />Make private</>
                   )}
@@ -522,6 +590,7 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
                 </button>
               </div>
             )}
+            </div>
           </div>
         </div>
       </div>
@@ -614,6 +683,34 @@ function ProcessDefinitionPageMember({ name, handle }: { name: string; handle: s
         onOpenChange={setDeleteDialogOpen}
         onDeleted={() => router.push(`/${handle}`)}
       />
+
+      <Dialog.Root open={shareDialogOpen} onOpenChange={setShareDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border bg-background p-6 shadow-lg">
+            <Dialog.Title className="text-lg font-semibold">Share workflow by link</Dialog.Title>
+            <Dialog.Description className="mt-2 text-sm text-muted-foreground">
+              Anyone with this workflow&apos;s link can view and copy it. It will not appear in other workspaces&apos; workflow lists. Workflow runs remain private to this workspace.
+            </Dialog.Description>
+            <div className="mt-5 flex justify-end gap-2">
+              <Dialog.Close asChild>
+                <button className="rounded-md px-3 py-1.5 text-sm font-medium hover:bg-muted transition-colors">
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                onClick={async () => {
+                  if (await updateVisibility('public')) setShareDialogOpen(false);
+                }}
+                disabled={togglingVisibility}
+                className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+              >
+                {togglingVisibility ? 'Sharing...' : 'Share workflow'}
+              </button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
 
       {/* Copy to namespace dialog */}
       {copyOpen && (


### PR DESCRIPTION
## Summary

- scope ordinary user workflow-definition lists in the Postgres query
- exclude foreign public workflows while retaining system-actor access
- cover the isolation path with repository, handler, and API E2E tests

Closes #1047

## Validation

- pnpm typecheck
- pnpm test:affected
- pnpm test:e2e:api --grep 'outsider user list excludes public workflows from other namespaces'