### PR TITLE
fix: mark workflow name and description as required in new-workflow header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - The admin Tool catalog now renders a single “New catalog entry” button when the catalog is empty [#1043](https://github.com/Appsilon/mediforce/issues/1043).
 - User workflow-definition lists now return only definitions in their member workspaces, including hiding foreign public workflows [#1047](https://github.com/Appsilon/mediforce/issues/1047).
 - Parallel E2E runs no longer hide Monitoring activity or workflow-status fixtures behind first-page pagination [#1134](https://github.com/Appsilon/mediforce/issues/1134).
-- The "New Workflow" page now marks the Name and Description fields with a required-field asterisk while they're empty; Description blocked saving with no upfront indication it was mandatory, only a disabled-button tooltip on hover [#1026](https://github.com/Appsilon/mediforce/issues/1026).
+- The "New Workflow" page now marks the Name and Description fields with a required-field asterisk while they're empty, and the disabled "Save & Dry Run" / "Save & Start Run" buttons show a tooltip naming the missing field instead of just an unexplained disabled icon; Description blocked saving with no upfront indication it was mandatory, only a disabled-button tooltip on hover [#1026](https://github.com/Appsilon/mediforce/issues/1026).
 
 ### Security
 - Public workflow links are read/copy-only: non-members can no longer start runs in the owning workspace [#1141](https://github.com/Appsilon/mediforce/pull/1141).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 - The admin Tool catalog now renders a single “New catalog entry” button when the catalog is empty [#1043](https://github.com/Appsilon/mediforce/issues/1043).
 - User workflow-definition lists now return only definitions in their member workspaces, including hiding foreign public workflows [#1047](https://github.com/Appsilon/mediforce/issues/1047).
 - Parallel E2E runs no longer hide Monitoring activity or workflow-status fixtures behind first-page pagination [#1134](https://github.com/Appsilon/mediforce/issues/1134).
+- The "New Workflow" page now marks the Name and Description fields with a required-field asterisk while they're empty; Description blocked saving with no upfront indication it was mandatory, only a disabled-button tooltip on hover [#1026](https://github.com/Appsilon/mediforce/issues/1026).
 
 ### Security
 - Public workflow links are read/copy-only: non-members can no longer start runs in the owning workspace [#1141](https://github.com/Appsilon/mediforce/pull/1141).

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/new/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/new/page.tsx
@@ -180,6 +180,11 @@ export default function NewWorkflowPage() {
   };
 
   const canSave = saveState.status !== 'saving' && !!toWorkflowId(workflowName) && !!description.trim();
+  const missingFieldReason = !toWorkflowId(workflowName)
+    ? 'Enter a workflow name to save'
+    : !description.trim()
+      ? 'Add a description to save'
+      : undefined;
 
   return (
     <div className="flex h-full flex-col relative bg-white dark:bg-background">
@@ -252,13 +257,7 @@ export default function NewWorkflowPage() {
                 {saveState.message}
               </span>
             )}
-            <span
-              title={
-                !toWorkflowId(workflowName) ? 'Enter a workflow name to save' :
-                !description.trim() ? 'Add a description to save' :
-                undefined
-              }
-            >
+            <span title={missingFieldReason}>
               <button
                 onClick={() => setDialogOpen(true)}
                 disabled={!canSave}
@@ -277,6 +276,7 @@ export default function NewWorkflowPage() {
               label="Save & Dry Run"
               mode="dry-run"
               disabled={!canSave}
+              disabledTooltip={missingFieldReason}
               preflightEnabled={false}
               onBeforeStart={() => new Promise<number | undefined>((resolve) => {
                 startAfterSaveResolverRef.current = resolve;
@@ -289,6 +289,7 @@ export default function NewWorkflowPage() {
               label="Save & Start Run"
               mode="production"
               disabled={!canSave}
+              disabledTooltip={missingFieldReason}
               preflightEnabled={false}
               onBeforeStart={() => new Promise<number | undefined>((resolve) => {
                 startAfterSaveResolverRef.current = resolve;

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/new/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/new/page.tsx
@@ -188,18 +188,28 @@ export default function NewWorkflowPage() {
         <div className="flex items-start justify-between gap-6">
           {/* Left: workflow identity */}
           <div className="flex-1 min-w-0">
-            <input
-              value={workflowName}
-              onChange={(e) => setWorkflowName(e.target.value)}
-              placeholder="Add a Workflow Name…"
-              className="w-full bg-transparent text-xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground/30 border-0 outline-none px-0 py-0"
-            />
-            <input
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Add a workflow description…"
-              className="w-full bg-transparent text-sm text-muted-foreground placeholder:text-muted-foreground/40 placeholder:italic border-0 outline-none px-0 py-0"
-            />
+            <div className="flex items-baseline gap-1">
+              {!workflowName.trim() && (
+                <span className="text-destructive shrink-0" title="Required to save">*</span>
+              )}
+              <input
+                value={workflowName}
+                onChange={(e) => setWorkflowName(e.target.value)}
+                placeholder="Add a Workflow Name…"
+                className="flex-1 min-w-0 bg-transparent text-xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground/30 border-0 outline-none px-0 py-0"
+              />
+            </div>
+            <div className="flex items-baseline gap-1">
+              {!description.trim() && (
+                <span className="text-destructive text-sm shrink-0" title="Required to save">*</span>
+              )}
+              <input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Add a workflow description…"
+                className="flex-1 min-w-0 bg-transparent text-sm text-muted-foreground placeholder:text-muted-foreground/40 placeholder:italic border-0 outline-none px-0 py-0"
+              />
+            </div>
             {/* Secondary metadata row */}
             <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground/60 flex-wrap">
               <span className="shrink-0">Namespace:</span>

--- a/packages/platform-ui/src/app/(app)/[handle]/workflows/new/page.tsx
+++ b/packages/platform-ui/src/app/(app)/[handle]/workflows/new/page.tsx
@@ -189,24 +189,26 @@ export default function NewWorkflowPage() {
           {/* Left: workflow identity */}
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-1">
-              {!workflowName.trim() && (
-                <span className="text-destructive shrink-0" title="Required to save">*</span>
+              {!toWorkflowId(workflowName) && (
+                <span className="text-destructive shrink-0" aria-hidden="true" title="Required to save">*</span>
               )}
               <input
                 value={workflowName}
                 onChange={(e) => setWorkflowName(e.target.value)}
                 placeholder="Add a Workflow Name…"
+                aria-required="true"
                 className="flex-1 min-w-0 bg-transparent text-xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground/30 border-0 outline-none px-0 py-0"
               />
             </div>
             <div className="flex items-baseline gap-1">
               {!description.trim() && (
-                <span className="text-destructive text-sm shrink-0" title="Required to save">*</span>
+                <span className="text-destructive text-sm shrink-0" aria-hidden="true" title="Required to save">*</span>
               )}
               <input
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="Add a workflow description…"
+                aria-required="true"
                 className="flex-1 min-w-0 bg-transparent text-sm text-muted-foreground placeholder:text-muted-foreground/40 placeholder:italic border-0 outline-none px-0 py-0"
               />
             </div>

--- a/packages/platform-ui/src/components/processes/start-run-button.tsx
+++ b/packages/platform-ui/src/components/processes/start-run-button.tsx
@@ -31,6 +31,12 @@ interface StartRunButtonProps {
   archived?: boolean;
   label?: string;
   disabled?: boolean;
+  /**
+   * Tooltip shown while `disabled` is true and no more specific internal
+   * reason (archived, trigger stopped, no version) applies — e.g. the caller
+   * gating the button on unsaved required fields.
+   */
+  disabledTooltip?: string;
   onBeforeStart?: () => Promise<number | undefined>;
   /**
    * Whether to run workflow-scoped preflight fetches (versions, secrets, model
@@ -56,6 +62,7 @@ export function StartRunButton({
   archived = false,
   label,
   disabled = false,
+  disabledTooltip,
   onBeforeStart,
   preflightEnabled = true,
   mode,
@@ -245,7 +252,9 @@ export function StartRunButton({
         ? 'No workflow version available'
         : null;
   const isDisabled = disabledReason !== null || starting || preflightLoading || runningBeforeStart || disabled;
-  const tooltip = preflightLoading ? 'Checking workflow readiness...' : (disabledReason ?? undefined);
+  const tooltip = preflightLoading
+    ? 'Checking workflow readiness...'
+    : (disabledReason ?? (disabled ? disabledTooltip : undefined));
 
   const errorBanner = error ? (
     <p className="mt-1 text-xs text-destructive max-w-xs truncate" title={error}>{error}</p>


### PR DESCRIPTION
## Summary
- The workflow "description" field blocks saving but had no visual indicator that it's required, only a disabled-button tooltip on hover.
- Adds a destructive-colored asterisk next to the Name and Description inputs on the "New Workflow" page whenever they're empty, reusing the asterisk convention already used in `ParamField`.
- The asterisk disappears from each field as soon as it has content.

Fixes #1026.

## Test plan
- [x] Verified in browser (dev:mock, :9007): both fields show `*` when empty; typing a name clears its asterisk while description keeps showing its own until filled; Save/Save & Dry Run/Save & Start Run remain disabled until both are filled.
- [x] Verified in dark mode.
- [x] `tsc -b --noEmit` passes for platform-ui.
- No test added: this is a visual-only UI change (an indicator), no new behavior/logic to cover — the existing required-field validation (`new/page.tsx`) already enforces the save gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)