### PR TITLE
fix(workflow-editor): restore adding steps to empty workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Fixed
+- Workflow editors now provide an add-step action after all editable steps are removed, so an empty workflow can be rebuilt without refreshing or recreating it [#1024](https://github.com/Appsilon/mediforce/issues/1024).
+
 ## [2026-08-09]
 
 ### Changed

--- a/packages/platform-ui/e2e/ui/workflow-editor.journey.ts
+++ b/packages/platform-ui/e2e/ui/workflow-editor.journey.ts
@@ -215,6 +215,29 @@ test.describe('Workflow Editor Journey', () => {
     await expect(page.locator('.react-flow__node')).toHaveCount(initialNodeCount + 1, { timeout: 5_000 });
   });
 
+  test('empty workflow canvas still allows adding a step', async ({ page }) => {
+    trackPageErrors(page);
+    await page.goto(`/${TEST_ORG_HANDLE}/workflows/new`);
+
+    await expect(page.locator('.react-flow__node')).toHaveCount(3, { timeout: 10_000 });
+
+    // Remove every editable starter step, leaving only the protected terminal.
+    for (let remainingEditableSteps = 2; remainingEditableSteps > 0; remainingEditableSteps -= 1) {
+      await page.locator('.react-flow__node').first().hover();
+      await page.getByRole('button', { name: 'Delete step' }).click();
+      await expect(page.locator('.react-flow__node')).toHaveCount(remainingEditableSteps, { timeout: 5_000 });
+    }
+
+    // There is no edge left to host the usual inline plus button. The empty
+    // canvas must provide an equivalent add-step affordance.
+    await expect(page.getByRole('button', { name: 'Add step here' })).toBeVisible();
+    await page.getByRole('button', { name: 'Add step here' }).click();
+    await expect(page.getByText('Executor', { exact: true })).toBeVisible({ timeout: 3_000 });
+    await executorButton(page, 'human').click();
+
+    await expect(page.locator('.react-flow__node')).toHaveCount(2, { timeout: 5_000 });
+  });
+
   // ── Undo ─────────────────────────────────────────────────────────────────
 
   test('undo reverses last canvas change', async ({ page }) => {

--- a/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
+++ b/packages/platform-ui/src/components/workflows/workflow-diagram.tsx
@@ -1018,6 +1018,7 @@ type FlowCanvasProps = {
 
 function FlowCanvas({ className, style, height, localNodes, edges, onNodesChange, onNodeClick, onPaneClick, onUndo, onRedo, canUndo, canRedo, onAddBlock, addBlockActive, onTidy }: FlowCanvasProps) {
   const { fitView } = useReactFlow();
+  const hasEditableSteps = localNodes.some((node) => (node.data as StepNodeData).stepType !== 'terminal');
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node<StepNodeData>) => {
@@ -1056,6 +1057,21 @@ function FlowCanvas({ className, style, height, localNodes, edges, onNodesChange
         proOptions={{ hideAttribution: true }}
       >
         <Background variant={BackgroundVariant.Dots} gap={24} size={1} className="!bg-white dark:!bg-background" />
+        {!hasEditableSteps && onAddBlock && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
+            <button
+              onClick={() => {
+                onAddBlock();
+                setTimeout(() => fitView({ padding: 0.2, duration: 300, maxZoom: 1 }), 60);
+              }}
+              className="pointer-events-auto inline-flex items-center gap-2 rounded-lg border border-dashed border-primary/50 bg-white/90 px-4 py-2.5 text-sm font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/5 dark:bg-background/90"
+              aria-label="Add step here"
+            >
+              <Plus className="h-4 w-4" />
+              Add your first step
+            </button>
+          </div>
+        )}
         <CanvasControls
           onUndo={onUndo}
           onRedo={onRedo}


### PR DESCRIPTION
## Summary

- Add a centered empty-canvas action after all editable workflow steps are deleted.
- Reuse the existing block picker so users can immediately create a replacement step.
- Add an end-to-end regression journey covering delete-all and add-again behavior.

Closes #1024

## Testing

- pnpm test:e2e --grep "empty workflow canvas still allows adding a step"
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/vitest run src/components/workflows/__tests__/workflow-diagram.test.tsx
- git diff --check