### PR TITLE
docs: add ADR-0013 and pin the workflow-verification vocabulary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every non-trivial PR adds a bullet under `## [Unreleased]`. Trivial edits (typos
 
 ## [Unreleased]
 
+### Added
+- The four checks that answer "is my workflow working?" now have distinct names and a documented order, so asking for one no longer gets you another: schema validation (`workflow validate`) → **Workflow readiness check** (`runPreflightChecks` — missing image/secret/model/credits) → **Dry Run** (a real Run with every agent and script step mocked, proving the graph and gates but never the agent's behaviour) → a real Run. `CONTEXT.md` gains both new terms plus the collision that motivated them — `workflow register --dry-run` is schema validation and executes nothing — and pins **Deployment** as per-environment: staging, production and each customer instance are peers, so a workflow is registered into each rather than "promoted" between them. **ADR-0013** (proposed) records that production workflow packages move out of `apps/` into their own repo, registered via the CLI because git import is unauthenticated and GitHub-only, with images built from `repo` + `commit` — without that swap the extraction silently breaks every Run at its first step [#1201](https://github.com/Appsilon/mediforce/pull/1201).
+
 ### Fixed
 - Workflow editors now provide an add-step action after all editable steps are removed, so an empty workflow can be rebuilt without refreshing or recreating it [#1024](https://github.com/Appsilon/mediforce/issues/1024).
 - Workshop step IDs now stay stable while a new step name is typed, then finalize to a unique slug on blur so prefix-overlapping names cannot corrupt graph transitions [#1025](https://github.com/Appsilon/mediforce/issues/1025).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,14 @@ concepts. **Not a spec, not implementation guide.**
 **Deployment**:
 A single running Mediforce installation. Typically dedicated to one customer
 (single-tenant). Contains many Namespaces.
+Each environment — Appsilon's own production instance, staging, and each
+per-customer instance — is a **separate Deployment** with its own database,
+Users, and Namespaces. They are **peers, not tiers of one installation**: a
+Workflow does not "promote" from staging to production, it is registered or
+imported into each Deployment independently.
+_Avoid_: "environment" as a synonym for a slice of one Deployment (it isn't —
+each is a whole Deployment), and "the instance" unqualified when more than one
+Deployment is in play.
 
 **Namespace** *(today canonical; rename to Workspace proposed in ADR-001)*:
 An isolated scope of work inside a Deployment. Owns workflow definitions,
@@ -60,6 +68,27 @@ implementation legacy and renames to `WorkflowRun` in ADR-0001.
 _Avoid_: "Workflow Instance" (briefly proposed but inconsistent with the
 project's own "Run" vocabulary), "Process Instance" (legacy schema name
 only), "Workflow" alone (ambiguous — Definition or Run?).
+
+**Dry Run**:
+A Workflow Run executed with `dryRun` set, in which **every** `agent` and
+`script` step is swapped for the mock plugin. The graph, transitions, gates,
+and human steps execute for real; only the expensive agent/script work is
+faked. It answers *"is the workflow structured as I intended?"* — never *"does
+the agent do what I want?"*, which only a real Run answers.
+_Code:_ `ProcessInstance.dryRun`; the swap lives in `mock-agent-plugin`
+(`packages/agent-runtime/src/plugins/mock-agent-plugin.ts`). Dry Runs are a
+first-class filter on the run listing surfaces, not a hidden mode.
+_Avoid_: `workflow register --dry-run` (that is **schema validation** of a
+definition, not a Run — it executes nothing), and "test run" (unclaimed term;
+the canonical name is Dry Run).
+
+**Workflow readiness check** *(pre-run, static)*:
+The static check run before a Run starts: missing container image, missing
+Secret, low model credits, unknown model — each reported with a fix action.
+Distinct from a **Dry Run**: readiness inspects the Definition without
+executing anything; a Dry Run executes the graph.
+_Code:_ `runPreflightChecks` (`packages/platform-ui/src/lib/preflight-checks.ts`).
+_Avoid_: "validation" (that is schema-shape checking, a third, earlier gate).
 
 **Trigger** *(detached mutable resource — ADR-0011)*:
 What causes a Workflow to run, or makes it hand-startable. Three live kinds:
@@ -435,6 +464,22 @@ the user-facing immutable log.
   many **Agent OAuth Tokens** (per server).
 
 ## Flagged ambiguities
+
+- **"Is my workflow working?" — four distinct gates, one overloaded word**
+  *(resolved 2026-08-11)*: "validate", "verify", "test", and "dry run" are used
+  interchangeably in conversation but name four different checks, each
+  answering a different question:
+  1. **Schema validation** (`workflow validate`) — is the definition legal?
+  2. **Workflow readiness check** (`runPreflightChecks`) — are the image,
+     Secrets, model, and credits it needs actually present?
+  3. **Dry Run** — is the graph structured as intended? (agent/script work
+     mocked)
+  4. **Run** — does the work itself produce what I wanted?
+
+  Only (4) answers behaviour. Nothing in the product currently tells a user
+  this ladder exists or which rung answers their question.
+  _Avoid_: "dry run" for (1) — `workflow register --dry-run` is schema
+  validation and executes nothing, which collides with the Dry Run entry above.
 
 - **Workflow Definition `source`** *(resolved 2026-06-02; commit pinning added
   2026-06-24)*: A Workflow Definition imported from a git repo carries an

--- a/docs/adr/0013-workflow-packages-outside-platform-repo.md
+++ b/docs/adr/0013-workflow-packages-outside-platform-repo.md
@@ -1,0 +1,102 @@
+---
+status: proposed
+---
+
+# Workflow packages live outside the platform repo
+
+Production Workflow packages move out of `apps/` in the platform repo into a
+separate repository. The platform repo keeps only the tutorial examples under
+`docs/workflow-examples/` (already the sole content of `workflows-index.json`)
+plus `apps/golden-standard-workflow` as the reference package. Extracted
+packages reach a Deployment by **CLI registration from their own CI**
+(`mediforce workflow register`), and their container images are built by the
+platform from `repo` + `commit` on the step, not from images pre-built on the
+Deployment host.
+
+**Driver:** the platform repo is what a customer's engineer reads to decide
+whether to trust the platform, and what an Appsilon engineer reads to learn how
+to build a workflow. Fifteen directories of half-live customer work sitting
+next to the engine makes both jobs harder, and couples every Deployment's
+runtime to the platform's release.
+
+## Considered options
+
+### Getting the definition into a Deployment
+
+- **Git import (status quo mechanism).** Rejected as the *primary* path.
+  `packages/platform-api/src/handlers/workflows/_github.ts` issues every request
+  unauthenticated — plain `fetch(url)` for raw content, and `fetch(apiUrl, {
+  headers: { Accept: 'application/vnd.github.sha' } })` for ref resolution. No
+  `Authorization` header exists in the file. A private extracted repo returns
+  404. It is additionally hardcoded to `github.com` (`url.hostname !==
+  GITHUB_HOST` throws) and subject to the unauthenticated GitHub API limit of 60
+  requests/hour **per server IP**, shared across every user of the Deployment —
+  the handler already carries a dedicated 403 branch for it.
+- **Make the extracted repo public so import works.** Rejected: that is a
+  security posture chosen to route around a missing feature. Production
+  Workflow packages for Appsilon and for customers carry process detail that
+  has no reason to be public.
+- **CLI registration from the extracted repo's CI (chosen).** A CI job runs
+  `mediforce workflow register --file … --namespace …` against the target
+  Deployment with an API key. Requires no platform change, works against a
+  private repo today, works against any git host, and is what AGENTS.md §4
+  already mandates ("any operation the CLI covers MUST go through it").
+- **Authenticated git import (chosen as a follow-up, not a prerequisite).**
+  A per-Namespace token on the import path, lifting both the private-repo and
+  rate-limit constraints. This is the right long-term shape — a pharma
+  customer's Workflow packages will live in a private, often non-GitHub repo —
+  but it is a feature, and blocking the extraction on it would re-expand scope.
+  Tracked separately.
+
+### Getting the container image onto the Deployment
+
+This is the part that makes the extraction a regression if it is skipped.
+
+- **Status quo (implicit, breaks on extraction).** Not one app Workflow
+  declares a build source: every step references a bare, unqualified local tag
+  (`mediforce-golden-image:latest`, `mediforce-agent:protocol-to-tfl`,
+  `mediforce-landing-zone:latest`, `mediforce-agent:tealflow`) with
+  `repo`/`commit` unset. Those images exist on a Deployment **only because
+  `apps/` rides along in the repo cloned to the host**: `scripts/deploy.sh`
+  runs `scripts/rebuild-docker-images.sh`, which builds them from hardcoded
+  `$REPO_ROOT/apps/*/container/` paths. CI publishes only three images —
+  `platform-ui`, `migrate`, `container-worker` — never app images. Extract
+  `apps/` without addressing this and definitions import cleanly while every
+  Run dies at its first `script` or `agent` step with `Unable to find image
+  '...' locally`.
+- **Publish app images to a registry and pin fully-qualified tags.** Rejected:
+  adds a registry, credentials, and a publish pipeline per package, and pins
+  each Deployment to image tags an operator must keep in sync by hand.
+- **Keep building on the Deployment host from a second clone.** Rejected:
+  couples every Deployment's deploy script to a second repository and keeps the
+  build on the production host.
+- **Build from `repo` + `commit` on the step (chosen).** The platform already
+  does this: `docker-image-builder.ts` builds an image from a repo at a pinned
+  commit, and `container-plugin.ts` resolves a `repoToken` from the step's env
+  / Secrets before cloning, with `git-clone.ts` supporting SSH and HTTPS and
+  redacting credentials from logs. It works against a **private** repo today,
+  needs no registry, and requires no change to `deploy.sh`. The existing error
+  message already names it as the intended fix.
+
+## Consequences
+
+- **`rebuild-docker-images.sh` loses its `apps/` build steps**, and with them
+  the instruction in `GETTING-STARTED.md` telling every new developer to run it
+  before a `script` step will work. The local-dev story for extracted packages
+  becomes "the platform builds the image from the pinned commit", which is a
+  first run that is slower and needs network.
+- **`pnpm-workspace.yaml` (`apps/*`, `apps/examples/*`) and `vitest.config.ts`
+  (`apps/*/vitest.config.ts`) shed their `apps/` entries.** CI references
+  `apps/` nowhere, so there is no pipeline change.
+- **A pinned `commit` becomes load-bearing rather than advisory.** The
+  `design-workflow` skill already fills each `commit` with an all-zeros
+  sentinel until a real SHA exists; after this ADR an unpinned package cannot
+  run at all, which is the intended forcing function.
+- **The platform loses its in-repo integration surface for real workflows.**
+  `apps/golden-standard-workflow` stays precisely so that one end-to-end
+  production-shaped package remains testable inside this repo.
+- **Recorded asymmetry:** the platform can clone a *private* repo to build a
+  container image (`repoToken`, SSH + HTTPS, any host) but cannot read a
+  `.wd.json` from that same repo (unauthenticated, `github.com` only). That gap
+  is not a design decision, and it is the concrete argument for the
+  authenticated-import follow-up above.


### PR DESCRIPTION
Groundwork for **#1184** — *Epic: Seamlessly working production instance for Appsilon*. Documentation only; no code paths touched.

## `CONTEXT.md`

The epic's success criterion is *"in one hour, an engineer knows how to create a workflow and can be confident it works as intended."* The second half turned out to rest on vocabulary the glossary didn't have.

- **Dry Run** (new) — a Run with `dryRun` set, where **every** agent and script step is swapped for `mock-agent-plugin`. The graph, transitions, gates, and human steps execute for real; only the expensive work is faked. It answers *"is this structured as I intended?"* and never *"does the agent do what I want?"*. Explicitly warns off `workflow register --dry-run`, which is schema validation and executes nothing — the two share a name and mean different things.
- **Workflow readiness check** (new) — `runPreflightChecks`: missing image, missing Secret, low credits, unknown model, each with a fix action. Distinct from a Dry Run: readiness inspects without executing.
- **Deployment** (sharpened) — each environment is a **separate Deployment**, peers rather than tiers of one installation. A Workflow does not "promote" from staging to production; it is registered or imported into each independently.
- **Flagged ambiguity** — the four gates ("validate", "verify", "test", "dry run" are used interchangeably but name four different checks), recording that only a real Run answers behaviour, and that nothing in the product currently tells a user this ladder exists.

## ADR-0013 (`proposed`)

**Workflow packages live outside the platform repo.** Production packages leave `apps/`; `docs/workflow-examples/` (already the entire content of `workflows-index.json`) and `apps/golden-standard-workflow` stay.

Two decisions, recorded separately because they fail differently:

- **Definitions reach a Deployment by CLI registration from the extracted repo's CI**, not git import. `_github.ts` issues every request unauthenticated — no `Authorization` header exists in the file — so a private extracted repo returns 404. It is also hardcoded to `github.com` and limited to 60 API req/hr per server IP.
- **Images build from `repo` + `commit` on the step.** Today no app workflow declares a build source; every step uses a bare local tag (`mediforce-golden-image:latest`, `mediforce-agent:protocol-to-tfl`, …) that exists only because `deploy.sh` runs `rebuild-docker-images.sh` against `apps/*/container/` on the Deployment host, and CI never publishes app images. Extracting `apps/` without this swap is a **regression**: definitions import and every Run dies at its first script or agent step. The platform already supports the fix — `docker-image-builder.ts` builds from a pinned commit and `container-plugin.ts` resolves a `repoToken`, so private repos work today.

Consequences note the resulting asymmetry: the platform can clone a *private* repo to build an image, but cannot read a `.wd.json` from that same repo. That gap is the argument for the authenticated-import follow-up, which is deliberately **not** in the epic.

Per `docs/adr/README.md` the ADR merges as `proposed` and flips to `accepted` when implemented — that step is in the scope of **#1189**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)