### PR TITLE
fix(deps): repair ajv peer keys in lockfile broken by concurrent renovate merges

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,7 +360,7 @@ importers:
         version: 6.43.2
       '@hookform/resolvers':
         specifier: ^5.0.0
-        version: 5.7.1(@standard-schema/spec@1.1.0)(ajv@8.18.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)
+        version: 5.7.1(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
@@ -4699,13 +4699,13 @@ snapshots:
     dependencies:
       hono: 4.13.1
 
-  '@hookform/resolvers@5.7.1(@standard-schema/spec@1.1.0)(ajv@8.18.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)':
+  '@hookform/resolvers@5.7.1(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)':
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.85.0(react@19.2.8)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
-      ajv: 8.18.0
+      ajv: 8.20.0
       zod: 4.4.3
 
   '@img/colour@1.1.0':


### PR DESCRIPTION
`main` is red. Every CI job fails at `pnpm install --frozen-lockfile`, before any project code runs:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY
Broken lockfile: no entry for 'ajv@8.18.0' in pnpm-lock.yaml
```

Failing on `main` @ `95b9e6f9`: [run 32003529699](https://github.com/Appsilon/mediforce/actions/runs/32003529699) — `unit-tests`, `typecheck`, `e2e-tests`, `postgres-repository-tests`. Every open PR inherits it.

## Root cause — a bad merge, not a bad bump

| Commit | refs to `ajv@8.18.0` | `8.18.0` entry | `8.20.0` entry |
|---|---|---|---|
| `b32a678a` #1171 `@hookform/resolvers` → 5.7.1 | 6 | 2 | 0 |
| `b272ff4c` #1176 `@modelcontextprotocol/sdk` → 1.30.0 | 0 | 0 | 2 |
| **`95b9e6f9` merge of #1176 into `main`** | **2** | **0** | 2 |

#1171 keyed its `@hookform/resolvers` peer resolution against `ajv@8.18.0`. #1176 bumped `ajv` to 8.20.0 wholesale. Each branch was internally consistent; the **merge** text-merged the two lockfiles and kept #1171's peer key pointing at an `ajv` entry that #1176 had removed — exactly the "badly resolved merge conflict" pnpm's own error message names.

## Fix

Regenerated with `pnpm install --no-frozen-lockfile`. The whole diff is three lines, all `ajv@8.18.0` → `ajv@8.20.0` inside the `@hookform/resolvers` peer key:

```
363:      version: 5.7.1(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)
4702:  '@hookform/resolvers@5.7.1(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.85.0(react@19.2.8))(zod@4.4.3)':
4708:      ajv: 8.20.0
```

No package version changes. `pnpm-lock.yaml` carries `-diff` in `.gitattributes`, so GitHub renders it as binary — the three lines above are the complete change.

## Verification

`pnpm install --frozen-lockfile` — CI's exact command — now exits 0 locally (it failed before the fix). No changelog entry: dependency changes land as `chore(deps)` and this alters no user-observable behaviour.

Found while rebasing #836, whose CI was red for this reason and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
